### PR TITLE
sync: v0.16.3 from internal

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,4 +1,4 @@
-# TeamAI — Git-native Team AI Experience Sharing
+# TeamAI — The team harness for AI agents
 
 > [English](README.en.md) | [简体中文](README.md)
 

--- a/README.en.md
+++ b/README.en.md
@@ -5,13 +5,11 @@
 [![CI](https://github.com/Tencent/teamai-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/Tencent/teamai-cli/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/teamai-cli.svg)](https://www.npmjs.com/package/teamai-cli)
 [![npm downloads](https://img.shields.io/npm/dm/teamai-cli.svg)](https://www.npmjs.com/package/teamai-cli)
-[![Node.js](https://img.shields.io/node/v/teamai-cli.svg)](https://nodejs.org)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 A Git-native tool for sharing AI experience across your team. Automatically syncs skills, rules, docs, and other AI-tool configuration between team members.
 
-**Supported AI tools:** Claude Code, Codex, Cursor, CodeBuddy IDE (plus their Internal variants), as well as Gemini CLI, Windsurf, Trae, Aider, Amp, OpenClaw, and 20+ other AI coding tools (skills sync).
-**Supported git hosts:** **GitHub** and Tencent Gongfeng TGit (`git.woa.com`), auto-detected from the repo URL or install channel.
+**Supported AI tools:** Claude Code, Codex, Cursor, CodeBuddy IDE, as well as Gemini CLI, Windsurf, Trae, Aider, Amp, OpenClaw, and 20+ other AI coding tools (skills sync).
 
 > 📖 **Full usage guide:** [docs/usage-guide.md](docs/usage-guide.md) — covers everything from team creation to day-to-day use.
 > 📚 **Provider notes:** [docs/providers.md](docs/providers.md) — GitHub / TGit differences and auth setup.

--- a/README.en.md
+++ b/README.en.md
@@ -7,9 +7,9 @@
 [![npm downloads](https://img.shields.io/npm/dm/teamai-cli.svg)](https://www.npmjs.com/package/teamai-cli)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-A Git-native tool for sharing AI experience across your team. Automatically syncs skills, rules, docs, and other AI-tool configuration between team members.
+Make every AI coding agent work by the same harness. Git-native management of skills, rules, and docs across 20+ AI tools — for you or your whole team.
 
-**Supported AI tools:** Claude Code, Codex, Cursor, CodeBuddy IDE, as well as Gemini CLI, Windsurf, Trae, Aider, Amp, OpenClaw, and 20+ other AI coding tools (skills sync).
+**Supports:** Claude Code, Codex, Cursor, CodeBuddy IDE, as well as Gemini CLI, Windsurf, Trae, Aider, Amp, OpenClaw, and 20+ other AI coding tools (skills sync).
 
 > 📖 **Full usage guide:** [docs/usage-guide.md](docs/usage-guide.md) — covers everything from team creation to day-to-day use.
 > 📚 **Provider notes:** [docs/providers.md](docs/providers.md) — GitHub / TGit differences and auth setup.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TeamAI — 基于 Git 的团队 AI 经验共享工具
+# TeamAI — The team harness for AI agents
 
 > [English](README.en.md) | [简体中文](README.md)
 

--- a/README.md
+++ b/README.md
@@ -5,13 +5,11 @@
 [![CI](https://github.com/Tencent/teamai-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/Tencent/teamai-cli/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/teamai-cli.svg)](https://www.npmjs.com/package/teamai-cli)
 [![npm downloads](https://img.shields.io/npm/dm/teamai-cli.svg)](https://www.npmjs.com/package/teamai-cli)
-[![Node.js](https://img.shields.io/node/v/teamai-cli.svg)](https://nodejs.org)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 基于 Git 的团队 AI 经验共享工具。自动在团队成员之间同步 skills、rules、docs 等 AI 工具配置。
 
-支持的 AI 工具：Claude Code、Codex、Cursor、CodeBuddy IDE（及各自的 Internal 版本），以及 Gemini CLI、Windsurf、Trae、Aider、Amp、OpenClaw 等 20+ 种 AI 编程工具（Skills 同步）。
-支持的 git 托管平台：**GitHub**、腾讯工蜂 TGit（`git.woa.com`），根据 repo URL 或安装来源自动识别。
+支持的 AI 工具：Claude Code、Codex、Cursor、CodeBuddy IDE，以及 Gemini CLI、Windsurf、Trae、Aider、Amp、OpenClaw 等 20+ 种 AI 编程工具（Skills 同步）。
 
 > 📖 **完整使用指南**：[docs/usage-guide.md](docs/usage-guide.md) — 涵盖从团队创建到日常使用的全流程。
 > 📚 **Provider 说明**：[docs/providers.md](docs/providers.md) — GitHub / TGit 差异与认证配置。

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 [![npm downloads](https://img.shields.io/npm/dm/teamai-cli.svg)](https://www.npmjs.com/package/teamai-cli)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-基于 Git 的团队 AI 经验共享工具。自动在团队成员之间同步 skills、rules、docs 等 AI 工具配置。
+让每个 AI 编程助手都按同一套标准工作。通过 Git 统一管理 skills、rules、docs，驾驭 20+ 种 AI 工具——一个人也能用，团队用更强。
 
-支持的 AI 工具：Claude Code、Codex、Cursor、CodeBuddy IDE，以及 Gemini CLI、Windsurf、Trae、Aider、Amp、OpenClaw 等 20+ 种 AI 编程工具（Skills 同步）。
+**支持：** Claude Code、Codex、Cursor、CodeBuddy IDE，以及 Gemini CLI、Windsurf、Trae、Aider、Amp、OpenClaw 等 20+ 种 AI 编程工具（skills 同步）。
 
 > 📖 **完整使用指南**：[docs/usage-guide.md](docs/usage-guide.md) — 涵盖从团队创建到日常使用的全流程。
 > 📚 **Provider 说明**：[docs/providers.md](docs/providers.md) — GitHub / TGit 差异与认证配置。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "teamai-cli",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "teamai-cli",
   "version": "0.16.2",
-  "description": "TeamAI — team AI experience sharing framework (skills, rules, docs, env sync across Claude Code, Cursor, Codex, etc.)",
+  "description": "TeamAI — the team harness for AI agents (skill sync + shared knowledge base, powered by Git)",
   "type": "module",
   "bin": {
     "teamai": "./dist/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teamai-cli",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "TeamAI — the team harness for AI agents (skill sync + shared knowledge base, powered by Git)",
   "type": "module",
   "bin": {

--- a/src/__tests__/pull-rules-role-filter.test.ts
+++ b/src/__tests__/pull-rules-role-filter.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import type { ResourceItem } from '../types.js';
+import { filterRulesByKnowledgeNamespaces } from '../pull.js';
+
+describe('filterRulesByKnowledgeNamespaces', () => {
+  function makeRule(name: string): ResourceItem {
+    return {
+      name,
+      type: 'rules',
+      sourcePath: `/fake/repo/rules/${name}.md`,
+      relativePath: `rules/${name}.md`,
+    };
+  }
+
+  it('should include rules whose namespace is in activeNamespaces.knowledge', () => {
+    const rules = [
+      makeRule('common/coding-style'),
+      makeRule('hai_dev/deploy-guide'),
+    ];
+    const knowledgeNamespaces = ['common', 'hai_dev'];
+
+    const result = filterRulesByKnowledgeNamespaces(rules, knowledgeNamespaces);
+
+    expect(result.map((r) => r.name)).toEqual([
+      'common/coding-style',
+      'hai_dev/deploy-guide',
+    ]);
+  });
+
+  it('should exclude rules whose namespace is NOT in activeNamespaces.knowledge', () => {
+    const rules = [
+      makeRule('common/coding-style'),
+      makeRule('cvm_dev/workflow'),
+      makeRule('cvm/testing'),
+    ];
+    const knowledgeNamespaces = ['common', 'hai_dev'];
+
+    const result = filterRulesByKnowledgeNamespaces(rules, knowledgeNamespaces);
+
+    expect(result.map((r) => r.name)).toEqual(['common/coding-style']);
+  });
+
+  it('should always include root-level rules (no namespace subdirectory)', () => {
+    const rules = [
+      makeRule('teamai-push-guidelines'),
+      makeRule('common/coding-style'),
+      makeRule('cvm_dev/workflow'),
+    ];
+    const knowledgeNamespaces = ['common', 'hai_dev'];
+
+    const result = filterRulesByKnowledgeNamespaces(rules, knowledgeNamespaces);
+
+    expect(result.map((r) => r.name)).toEqual([
+      'teamai-push-guidelines',
+      'common/coding-style',
+    ]);
+  });
+
+  it('should return all rules when knowledgeNamespaces is null (no role configured)', () => {
+    const rules = [
+      makeRule('teamai-push-guidelines'),
+      makeRule('common/coding-style'),
+      makeRule('cvm_dev/workflow'),
+      makeRule('hai_dev/deploy-guide'),
+    ];
+
+    const result = filterRulesByKnowledgeNamespaces(rules, null);
+
+    expect(result).toEqual(rules);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ const program = new Command();
 
 program
   .name('teamai')
-  .description('TeamAI — 团队 AI 经验共享框架')
+  .description('TeamAI — The team harness for AI agents')
   .version(version)
   .option('--dry-run', 'Preview mode, no changes made')
   .option('-v, --verbose', 'Verbose output')

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -80,6 +80,29 @@ async function buildRolePullContext(localConfig: LocalConfig): Promise<RolePullC
   return { activeNamespaces, activeSkillNames, inactiveSkillNames };
 }
 
+/**
+ * Filter rules by the user's active knowledge namespaces.
+ *
+ * Rules whose name starts with a namespace path (e.g. "common/coding-style")
+ * are filtered: only those in activeKnowledgeNamespaces pass through.
+ * Root-level rules (no "/" in name) are always included.
+ *
+ * When knowledgeNamespaces is null (no role configured), all rules pass through.
+ */
+export function filterRulesByKnowledgeNamespaces(
+  rules: ResourceItem[],
+  knowledgeNamespaces: string[] | null,
+): ResourceItem[] {
+  if (!knowledgeNamespaces) return rules;
+
+  return rules.filter((rule) => {
+    const slashIndex = rule.name.indexOf('/');
+    if (slashIndex === -1) return true; // root-level rule, always include
+    const namespace = rule.name.slice(0, slashIndex);
+    return knowledgeNamespaces.includes(namespace);
+  });
+}
+
 export async function scanRoleAwareSkills(localConfig: LocalConfig, namespaces: ResourceNamespaces): Promise<ResourceItem[]> {
   const items = new Map<string, ResourceItem>();
 
@@ -271,7 +294,10 @@ async function pullForScope(
     if (type === 'rules') {
       const rulesHandler = handler as RulesHandler;
       const allItems = await rulesHandler.scanTeamForPull(freshConfig, localConfig);
-      const { included: items, skipped } = filterByTags(allItems, tagsConfig, subscribedTags, 'rules');
+      // Filter by role knowledge namespaces first, then by tags
+      const knowledgeNs = roleContext ? roleContext.activeNamespaces.knowledge : null;
+      const roleFiltered = filterRulesByKnowledgeNamespaces(allItems, knowledgeNs);
+      const { included: items, skipped } = filterByTags(roleFiltered, tagsConfig, subscribedTags, 'rules');
       if (items.length > 0) {
         if (options.dryRun) {
           log.info(`[${scopeLabel}] [dry-run] Would sync ${items.length} rule(s)${skipped.length > 0 ? ` (skipped ${skipped.length} by tags)` : ''}`);


### PR DESCRIPTION
## Summary

Sync latest changes from internal repo to open-source (v0.16.2 → v0.16.3):

- **docs:** Update project tagline to "The team harness for AI agents"
- **docs:** Simplify supported tools description in README
- **docs:** Align README descriptions with new "harness" positioning (中英文)
- **fix:** Filter rules by role knowledge namespaces during pull
- **chore:** Bump version to 0.16.3

## Test plan

- [ ] CI passes
- [ ] `npm install -g teamai-cli` works with new version