### PR TITLE
docs: fix README blockquote spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Make every AI coding agent work by the same harness. Git-native management of sk
 **Supports:** Claude Code, Codex, Cursor, CodeBuddy IDE, as well as Gemini CLI, Windsurf, Trae, Aider, Amp, OpenClaw, and 20+ other AI coding tools (skills sync).
 
 > 📖 **Full usage guide:** [docs/usage-guide.md](docs/usage-guide.md) — covers everything from team creation to day-to-day use.
+
 > 📚 **Provider notes:** [docs/providers.md](docs/providers.md) — GitHub / TGit differences and auth setup.
 
 Questions or suggestions are welcome — please open a PR or an Issue and help build this project together.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,6 +12,7 @@
 **支持：** Claude Code、Codex、Cursor、CodeBuddy IDE，以及 Gemini CLI、Windsurf、Trae、Aider、Amp、OpenClaw 等 20+ 种 AI 编程工具（skills 同步）。
 
 > 📖 **完整使用指南**：[docs/usage-guide.md](docs/usage-guide.md) — 涵盖从团队创建到日常使用的全流程。
+
 > 📚 **Provider 说明**：[docs/providers.md](docs/providers.md) — GitHub / TGit 差异与认证配置。
 
 如有问题或建议，欢迎提交 PR 或 Issue，一起共建这个项目。


### PR DESCRIPTION
## Summary

- Separate the two `>` blockquote lines (📖 usage guide / 📚 provider notes) with a blank line
- Without the blank line, markdown renders them as one merged blockquote block with no visual separation
- Applied to both `README.md` (English) and `README.zh-CN.md` (Chinese)