### PR TITLE
docs: split tagline and description into separate paragraphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 [![npm downloads](https://img.shields.io/npm/dm/teamai-cli.svg)](https://www.npmjs.com/package/teamai-cli)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-Make every AI coding agent work by the same harness. Git-native management of skills, rules, and docs across 20+ AI tools — for you or your whole team.
+Make every AI coding agent work by the same harness.
+
+Git-native management of skills, rules, and docs across 20+ AI tools — for you or your whole team.
 
 **Supports:** Claude Code, Codex, Cursor, CodeBuddy IDE, as well as Gemini CLI, Windsurf, Trae, Aider, Amp, OpenClaw, and 20+ other AI coding tools (skills sync).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,7 +7,9 @@
 [![npm downloads](https://img.shields.io/npm/dm/teamai-cli.svg)](https://www.npmjs.com/package/teamai-cli)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-让每个 AI 编程助手都按同一套标准工作。通过 Git 统一管理 skills、rules、docs，驾驭 20+ 种 AI 工具——一个人也能用，团队用更强。
+让每个 AI 编程助手都按同一套标准工作。
+
+通过 Git 统一管理 skills、rules、docs，驾驭 20+ 种 AI 工具——一个人也能用，团队用更强。
 
 **支持：** Claude Code、Codex、Cursor、CodeBuddy IDE，以及 Gemini CLI、Windsurf、Trae、Aider、Amp、OpenClaw 等 20+ 种 AI 编程工具（skills 同步）。
 


### PR DESCRIPTION
## Summary

- Split the one-liner into two paragraphs: tagline ("Make every AI coding agent work by the same harness.") as its own line, description below
- Applied to both `README.md` and `README.zh-CN.md`
- Improves visual hierarchy on GitHub — the tagline stands out as a bold statement