### PR TITLE
ci: validate e2e pipeline with new secrets

### DIFF
--- a/src/__tests__/e2e/e2e.test.ts
+++ b/src/__tests__/e2e/e2e.test.ts
@@ -668,19 +668,25 @@ describe('init project scope (sandboxed)', () => {
         const stdinAllBlanks = '\n\n\n\n\n';
 
         const result = await runCLIWithEnv(
-          ['init', '--scope', 'project', '--repo', fullUrl, '--force'],
+          ['init', '--scope', 'project', '--repo', fullUrl, '--role', 'common', '--force'],
           {
             // GitHub: gh CLI / REST honors GITHUB_TOKEN
             // TGit: gf CLI honors TGIT_TOKEN
             GITHUB_TOKEN: process.env.TEAMAI_TEST_TOKEN ?? '',
             TGIT_TOKEN: process.env.TEAMAI_TEST_TOKEN ?? '',
             HOME: sandbox, // isolate from user-scope ~/.teamai
+            // Git identity must be set explicitly because HOME override
+            // hides the global .gitconfig written by CI setup steps.
+            GIT_AUTHOR_NAME: 'TeamAI CI',
+            GIT_AUTHOR_EMAIL: 'ci@teamai.test',
+            GIT_COMMITTER_NAME: 'TeamAI CI',
+            GIT_COMMITTER_EMAIL: 'ci@teamai.test',
           },
           stdinAllBlanks,
           sandbox, // cwd = sandbox, so .teamai/ lands here
         );
 
-        expect(result.code).toBe(0);
+        expect(result.code, `init failed with output:\n${result.output}`).toBe(0);
         expect(fs.existsSync(path.join(sandbox, '.teamai', 'config.yaml'))).toBe(true);
 
         // Verify the project-scope config has the expected shape

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -8,10 +8,12 @@ export default defineConfig({
     ],
     testTimeout: 60_000,
     hookTimeout: 30_000,
-    // E2E tests spawn child processes and touch the real filesystem; a few
-    // (notably auto-recall-e2e) are inherently slightly flaky on CI runners
-    // due to timing/state. Retry once: flaky tests recover, real bugs stay
-    // failed (since they'll fail both runs).
+    // E2E tests spawn child processes and touch the real filesystem.
+    // Run test files sequentially to avoid race conditions (parallel
+    // file-level execution causes intermittent "Cannot find module
+    // dist/index.js" on GitHub Actions CI runners).
+    fileParallelism: false,
+    // Retry once: flaky tests recover, real bugs stay failed.
     retry: 1,
   },
 });


### PR DESCRIPTION
Empty commit to trigger CI and validate e2e test configuration. Close after CI passes.