### PR TITLE
fix(push): exclude .git from copyDir to prevent submodule gitlink

### DIFF
--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -654,6 +654,30 @@ scope: 'user',
     const content = await fse.readFile(contribPath, 'utf-8');
     expect(content).toBe('testuser\n');
   });
+
+  it('should NOT copy .git directory when skill source is a git repo', async () => {
+    const localSkillDir = path.join(homeDir, '.claude/skills', 'git-skill');
+    await fse.ensureDir(localSkillDir);
+    await fse.writeFile(path.join(localSkillDir, 'SKILL.md'), '# Git Skill\nContent here');
+    await fse.writeFile(path.join(localSkillDir, 'helper.py'), 'print("hello")');
+    // Simulate a .git directory (as if skill was cloned from a git repo)
+    await fse.ensureDir(path.join(localSkillDir, '.git', 'objects'));
+    await fse.writeFile(path.join(localSkillDir, '.git', 'HEAD'), 'ref: refs/heads/main');
+
+    const item = {
+      name: 'git-skill',
+      type: 'skills' as const,
+      sourcePath: localSkillDir,
+      relativePath: 'skills/git-skill',
+    };
+
+    await handler.pushItem(item, teamConfig, localConfig);
+
+    const destDir = path.join(localConfig.repo.localPath, 'skills', 'git-skill');
+    expect(await fse.pathExists(path.join(destDir, 'SKILL.md'))).toBe(true);
+    expect(await fse.pathExists(path.join(destDir, 'helper.py'))).toBe(true);
+    expect(await fse.pathExists(path.join(destDir, '.git'))).toBe(false);
+  });
 });
 
 describe('SkillsHandler.readContributors', () => {

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -8,6 +8,7 @@ const IGNORED_NAMES = new Set([
   '.pyc',
   '.DS_Store',
   'node_modules',
+  '.git',
 ]);
 
 function isIgnored(name: string): boolean {


### PR DESCRIPTION
## Summary

- When a skill directory is itself a git repository (e.g. user cloned a repo into `.claude/skills/`), `copyDir` would copy the `.git` directory into the team repo
- Git then treats the nested `.git` as a gitlink (mode 160000 / submodule reference), causing `git add` to record only a commit hash instead of actual file content
- The resulting MR appears to contain only `Subproject commit <hash>` — no real files

**Fix:** Add `.git` to the `IGNORED_NAMES` filter in `src/utils/fs.ts`

## Test plan

- [x] Added unit test: `should NOT copy .git directory when skill source is a git repo`
- [x] All 936 existing tests pass
- [x] Type check passes (`tsc --noEmit`)

Fixes #10