### PR TITLE
fix: align wiki path to ~/.teamai/wiki/ for push compatibility

### DIFF
--- a/skills/teamai-wiki/SKILL.md
+++ b/skills/teamai-wiki/SKILL.md
@@ -243,10 +243,10 @@ When invoked, first determine the subcommand (init/ingest/query/lint/status/expo
 
 #### Step 1 — Parse arguments
 
-- `WIKI_DIR`: wiki 目录路径。按以下顺序检测：
-  1. team repo 中的 `wiki/` 目录（如果当前项目已通过 `teamai init` 配置）→ 首选
-  2. `~/.claude-internal/wiki/` 或 `~/.claude/wiki/`（本地 AI 工具 wiki 目录）
-  3. 当前目录的 `./wiki/`（fallback）
+- `WIKI_DIR`: 根据当前项目的 teamai scope 决定：
+  - 读取 `<projectRoot>/.teamai/config.yaml` 中的 `scope` 字段
+  - **project scope** → `<projectRoot>/.teamai/wiki/`
+  - **user scope**（或无项目配置时）→ `~/.teamai/wiki/`
 - `SOURCE_DIR`: 可选的 `dir` 参数
 
 如果 `WIKI_DIR` 已经存在且包含 `_metadata.json`，提示用户已经初始化过，询问是否要重新初始化。
@@ -1009,7 +1009,7 @@ Wiki exported to: <path>
 8. **_metadata.json 是真相来源** — 页面列表、文件哈希、链接图都以此为准。
 9. **命名一致性** — 文件名 kebab-case，标题 Title Case 或人类可读中文。
 10. **幂等性** — 重复 ingest 同一源目录应产生相同结果（不会重复创建页面）。
-11. **wiki 路径推断** — 优先使用 team repo 的 wiki/ 目录（通过 `teamai pull` 同步到本地）；其次检查 `~/.claude-internal/wiki/` 或 `~/.claude/wiki/`；最后 fallback 到 `./wiki/`。
+11. **wiki 路径** — 读取 `<projectRoot>/.teamai/config.yaml` 的 `scope` 字段：project scope 用 `<projectRoot>/.teamai/wiki/`，user scope 用 `~/.teamai/wiki/`。与 teamai push/pull 的 `WikiHandler.getSharedWikiDir()` 逻辑对齐。
 12. **Obsidian 兼容** — 所有 `[[links]]` 使用 Obsidian 格式，方便用户在 Obsidian 中直接浏览。
 13. **语言** — Wiki 页面内容默认使用中文撰写，技术术语保持英文原文。
 14. **智能分类** — LLM 根据内容自动判断页面归属哪个分类目录，无需用户指定。


### PR DESCRIPTION
## Summary

- Fix wiki skill path resolution: use fixed `~/.teamai/wiki/` instead of fallback chain that included `~/.claude-internal/wiki/` and `~/.claude/wiki/`
- This aligns the wiki skill's output path with `teamai push`'s `WikiHandler` scan path

Fixes #13

## Test plan

- [x] Run `/teamai-wiki init` → verify wiki created at `~/.teamai/wiki/`
- [x] Run `teamai push --dry-run` → verify wiki pages appear in push list