### PR TITLE
feat(init): display storage paths when prompting for scope

### DIFF
--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -410,4 +410,58 @@ describe('init', () => {
       }));
     });
   });
+
+  describe('scope path display', () => {
+    it('should display storage paths when scope is not provided via flag', async () => {
+      let cloneDone = false;
+      pathExistsFn = (p: string) => {
+        if (p === localPath) return cloneDone;
+        return false;
+      };
+
+      mockGfRepoClone.mockImplementation(() => {
+        cloneDone = true;
+      });
+
+      // Answers: scope (user via default), configure reviewers (n), primary role (1), no additional
+      questionAnswers = ['user', 'n', '1', ''];
+
+      const { log } = await import('../utils/logger.js');
+
+      await init({ repo: 'https://git.woa.com/HyperAI/teamai-test.git' });
+
+      // Verify that path hints were displayed
+      expect(log.info).toHaveBeenCalledWith(expect.stringContaining('user'));
+      expect(log.info).toHaveBeenCalledWith(expect.stringContaining('.teamai/'));
+      expect(log.info).toHaveBeenCalledWith(expect.stringContaining('project'));
+    });
+
+    it('should not display storage paths when scope is provided via --scope flag', async () => {
+      let cloneDone = false;
+      pathExistsFn = (p: string) => {
+        if (p === localPath) return cloneDone;
+        return false;
+      };
+
+      mockGfRepoClone.mockImplementation(() => {
+        cloneDone = true;
+      });
+
+      // Answers: configure reviewers (n), primary role (1), no additional
+      questionAnswers = ['n', '1', ''];
+
+      const { log } = await import('../utils/logger.js');
+      vi.mocked(log.info).mockClear();
+
+      await init({ repo: 'https://git.woa.com/HyperAI/teamai-test.git', scope: 'user' });
+
+      // When --scope is provided, the path hints are NOT shown before the prompt
+      // (they appear in the "Scope: user" line only)
+      const infoCalls = vi.mocked(log.info).mock.calls.map(c => c[0]);
+      const pathHintCalls = infoCalls.filter(
+        (msg: string) => msg.includes('user    →') || msg.includes('project →'),
+      );
+      expect(pathHintCalls).toHaveLength(0);
+    });
+  });
 });

--- a/src/init.ts
+++ b/src/init.ts
@@ -114,6 +114,10 @@ export async function init(options: GlobalOptions & { repo?: string; scope?: str
   if (options.scope === 'project' || options.scope === 'user') {
     scope = options.scope as Scope;
   } else {
+    const userPath = getTeamaiHome('user');
+    const projectPath = getTeamaiHome('project', process.cwd());
+    log.info(`  user    → ${userPath}/`);
+    log.info(`  project → ${projectPath}/`);
     const scopeAnswer = await askQuestion('Scope [user/project] (default: user): ', 'user');
     if (scopeAnswer.toLowerCase() === 'project') {
       scope = 'project';


### PR DESCRIPTION
## Summary

- Display `user → ~/.teamai/` and `project → $PWD/.teamai/` storage paths before the scope selection prompt during `teamai init`
- Only shown when scope is interactively prompted (not when `--scope` flag is provided)
- Helps users understand where their data will be stored before making a choice

Closes #7

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All 938 existing tests pass
- [x] Added 2 new test cases for path display behavior
  - Verifies paths are shown when scope is prompted interactively
  - Verifies paths are NOT shown when `--scope` flag is used