### PR TITLE
fix(test): sync hooks-e2e expected counts after PR #28

### DIFF
--- a/src/__tests__/hooks-e2e.test.ts
+++ b/src/__tests__/hooks-e2e.test.ts
@@ -39,7 +39,7 @@ async function readResult(filePath: string): Promise<Record<string, unknown>> {
 
 describe('hooks E2E — real file I/O', () => {
   describe('inject — full injection to temp directories', () => {
-    it('creates Claude settings.json with all 4 events and 13 hooks', async () => {
+    it('creates Claude settings.json with all 4 events and 15 hooks', async () => {
       const p = claudePath();
       await injectHooks(p, 'claude');
 
@@ -47,13 +47,13 @@ describe('hooks E2E — real file I/O', () => {
       const hooks = result.hooks as Record<string, unknown[]>;
 
       expect(Object.keys(hooks)).toEqual(['SessionStart', 'Stop', 'PostToolUse', 'UserPromptSubmit']);
-      expect(hooks.SessionStart).toHaveLength(2);
+      expect(hooks.SessionStart).toHaveLength(3);
       expect(hooks.Stop).toHaveLength(3);
-      expect(hooks.PostToolUse).toHaveLength(6);
+      expect(hooks.PostToolUse).toHaveLength(7);
       expect(hooks.UserPromptSubmit).toHaveLength(2);
     });
 
-    it('creates Cursor hooks.json with all 4 events and 13 hooks', async () => {
+    it('creates Cursor hooks.json with all 4 events and 15 hooks', async () => {
       const p = cursorPath();
       await injectHooks(p, 'cursor');
 
@@ -62,9 +62,9 @@ describe('hooks E2E — real file I/O', () => {
       const hooks = result.hooks as Record<string, unknown[]>;
 
       expect(Object.keys(hooks)).toEqual(['sessionStart', 'stop', 'postToolUse', 'beforeSubmitPrompt']);
-      expect(hooks.sessionStart).toHaveLength(2);
+      expect(hooks.sessionStart).toHaveLength(3);
       expect(hooks.stop).toHaveLength(3);
-      expect(hooks.postToolUse).toHaveLength(6);
+      expect(hooks.postToolUse).toHaveLength(7);
       expect(hooks.beforeSubmitPrompt).toHaveLength(2);
     });
 


### PR DESCRIPTION
## 背景

PR #28 (`Phase 0+Phase 1+P4.4`) 在 `src/hooks.ts` 中新增了 2 个 hook 注册：
- 1× `SessionStart` (MR hint — 会话启动时提醒 AI 哪些 merged MR 还没导入)
- 1× `PostToolUse` (TodoWrite hint — 提醒调用 teamai-recall subagent)

PR #28 同步更新了 `hooks.test.ts`、`usage-tracking.test.ts`、`doctor.test.ts`，但漏改了 `hooks-e2e.test.ts`，导致 `main` 分支 CI 中 `E2E (GitHub provider, full surface)` job 失败：[run 27407172848](https://github.com/Tencent/teamai-cli/actions/runs/27407172848)

```
src/__tests__/hooks-e2e.test.ts:50
  expect(hooks.SessionStart).toHaveLength(2);
  AssertionError: expected ... to have a length of 2 but got 3
```

## 修复

仅改测试期望值，业务逻辑不动：

| 事件 | 老期望 | 新期望 |
|------|--------|--------|
| SessionStart | 2 | **3** |
| Stop | 3 | 3 |
| PostToolUse | 6 | **7** |
| UserPromptSubmit | 2 | 2 |
| **Total** | 13 | **15** |

注：CI 报告里只看到 SessionStart 失败，是因为 vitest `expect` 在第一次断言失败时抛出，同 `it` 内后续的 PostToolUse 断言不再执行——属于隐藏的次生失败，本 PR 一并修掉。

测试标题中的 "13 hooks" 也同步改为 "15 hooks"。

## 本地验证

- `npx vitest run --config vitest.e2e.config.ts src/__tests__/hooks-e2e.test.ts` → **14 passed (14)**
- `npx vitest run` → **1356 passed | 4 skipped | 0 failed (1360)**
- `npx tsc --noEmit` → clean

## Test plan

- [x] CI `E2E (GitHub provider, full surface)` 在该 PR 上转绿
- [x] CI 其它 job (Lint & Test, Build) 保持绿