### PR TITLE
fix(env): shell-quote values written to env.sh to prevent injection

### DIFF
--- a/src/__tests__/env-handler.test.ts
+++ b/src/__tests__/env-handler.test.ts
@@ -208,8 +208,24 @@ scope: 'user',
       ]);
 
       expect(content).toBe(
-        'export API_URL="https://example.com"\nexport TOKEN="abc123"\n',
+        "export API_URL='https://example.com'\nexport TOKEN='abc123'\n",
       );
+    });
+
+    it('should shell-quote values containing shell metacharacters', () => {
+      // Values flow from the team repo's env/env.yaml into env.sh, which every
+      // member sources from their shell profile. Quotes / `$` / backticks must
+      // be taken literally and must not break or inject into the sourced shell.
+      const content = handler.generateEnvFile([
+        { key: 'CONN', value: 'a"b$c' },
+        { key: 'GREETING', value: "it's" },
+      ]);
+
+      expect(content).toBe(
+        "export CONN='a\"b$c'\nexport GREETING='it'\\''s'\n",
+      );
+      // No raw double-quote wrapping that the old code produced.
+      expect(content).not.toContain('="a');
     });
 
     it('should return just a newline for empty variables', () => {
@@ -257,8 +273,8 @@ scope: 'user',
       const envShPath = path.join(homeDir, '.teamai', 'env.sh');
       expect(await fse.pathExists(envShPath)).toBe(true);
       const content = await fse.readFile(envShPath, 'utf-8');
-      expect(content).toContain('export TGIT_API_BASE="https://git.woa.com/api/v3"');
-      expect(content).toContain('export MODEL_ENDPOINT="https://api.example.com"');
+      expect(content).toContain("export TGIT_API_BASE='https://git.woa.com/api/v3'");
+      expect(content).toContain("export MODEL_ENDPOINT='https://api.example.com'");
     });
 
     it('should inject source line into shell profile (bash)', async () => {

--- a/src/resources/env.ts
+++ b/src/resources/env.ts
@@ -22,6 +22,16 @@ const EnvYamlSchema = z.object({
 export type EnvVariable = z.infer<typeof EnvVariableSchema>;
 export type EnvYaml = z.infer<typeof EnvYamlSchema>;
 
+/**
+ * Quote a string so it is safe to interpolate into a POSIX shell (bash/zsh/sh).
+ * Wraps the value in single quotes and encodes any embedded single quote as
+ * `'\''`, leaving all other characters (including `"`, `$`, `` ` ``, `\`)
+ * literal. Used when generating env.sh, which every team member sources.
+ */
+function shellQuoteValue(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
 // ─── Handler ─────────────────────────────────────────────
 
 export class EnvHandler extends ResourceHandler {
@@ -173,9 +183,15 @@ export class EnvHandler extends ResourceHandler {
 
   /**
    * Generate the content of ~/.teamai/env.sh with export statements.
+   *
+   * Values are single-quoted so shell metacharacters in an env value (quotes,
+   * `$`, backticks, `\`, …) are taken literally and cannot break or inject into
+   * the sourced script. An embedded single quote is encoded with the standard
+   * `'\''` sequence. env.sh is sourced from every team member's shell profile,
+   * so values (which originate from the team repo's env/env.yaml) must be safe.
    */
   generateEnvFile(variables: EnvVariable[]): string {
-    const lines = variables.map(v => `export ${v.key}="${v.value}"`);
+    const lines = variables.map(v => `export ${v.key}=${shellQuoteValue(v.value)}`);
     return lines.join('\n') + '\n';
   }
 


### PR DESCRIPTION
## Summary

`EnvHandler.generateEnvFile` writes `~/.teamai/env.sh` with `export KEY="VALUE"` lines and **no escaping of the value**. This file is sourced from every team member's shell profile (see `pullItem` → `generateShellBlock` / `injectShellProfile`), and the values originate from the team repo's `env/env.yaml`. A value that contains `"`, `$`, a backtick, or `\` will either break the sourced script or run injected commands.

## Problem

`src/resources/env.ts`:

```ts
generateEnvFile(variables: EnvVariable[]): string {
  const lines = variables.map(v => `export ${v.key}="${v.value}"`);
  return lines.join('\n') + '\n';
}
```

Concrete example — a value `x"; echo PWNED #` produces:

```sh
export INJECT="x"; echo PWNED #"
```

When any member runs `teamai pull` and later opens a shell, sourcing `env.sh` executes `echo PWNED`. Less maliciously, a perfectly normal value containing `$` (e.g. a connection string) gets variable-expanded, and a value containing `"` truncates the line and yields a broken/unclosed quote that errors on source.

## Fix

Single-quote each value so shell metacharacters are taken literally, encoding an embedded single quote as the standard `'\''` sequence (works in bash/zsh/sh):

```ts
function shellQuoteValue(value: string): string {
  return `'${value.replace(/'/g, "'\\''")}'`;
}

generateEnvFile(variables: EnvVariable[]): string {
  const lines = variables.map(v => `export ${v.key}=${shellQuoteValue(v.value)}`);
  return lines.join('\n') + '\n';
}
```

Verified end-to-end — sourcing the generated file stores every value literally with no injection:

```
CONN=[a"b$c]
GREETING=[it's a test]
INJECT=[x"; echo PWNED #]
OK: no injection, all metacharacters stored literally
```

## Tests

- Updated the existing `generateEnvFile` / `pullItem` assertions to the single-quote output format.
- Added a regression test (`should shell-quote values containing shell metacharacters`) covering `"`, `$`, and an embedded single quote.
- `npm test` → 1436 passed | 4 skipped; `tsc --noEmit` → clean.

## Notes

- Only the value is quoted; keys are env-var names from `env.yaml` and are left as-is (unchanged behavior).
- The separate `~/.teamai/env` `KEY=VALUE` backup file (`loadEnvFile` compatibility) is a different code path and intentionally untouched.
