### PR TITLE
docs: clarify where to change default branch in providers guide

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -68,7 +68,7 @@ token 需要 `repo` 权限。`GH_TOKEN` 作为别名也会被识别。
 
 ### 默认分支
 
-GitHub 新仓库默认分支通常是 `main`。TeamAI 当前实现中 `push` 的目标分支硬编码为 `master`（历史遗留）。如果你的 GitHub 仓库使用 `main`，请手动改默认分支为 `master`，或等待后续版本支持可配置目标分支。
+GitHub 新仓库默认分支通常是 `main`。TeamAI 当前实现中 `push` 的目标分支硬编码为 `master`（历史遗留）。如果你的 GitHub 仓库使用 `main`，可以在仓库 **Settings → Branches** 中将默认分支改为 `master`，或等待后续版本支持可配置目标分支。
 
 ## TGit Provider（腾讯工蜂）
 


### PR DESCRIPTION
The default branch section in `docs/providers.md` mentions changing the default branch manually but doesn't specify where in GitHub settings.

Adding the specific path (**Settings → Branches**) so new users don't have to hunt for it.