### PR TITLE
docs: add teamai-cli logo to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="assets/teamai-cli-logo.svg" alt="teamai-cli" width="430">
+</p>
+
 # TeamAI — The team harness for AI agents
 
 > [English](README.md) | [简体中文](README.zh-CN.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="assets/teamai-cli-logo.svg" alt="teamai-cli" width="430">
+</p>
+
 # TeamAI — The team harness for AI agents
 
 > [English](README.md) | [简体中文](README.zh-CN.md)

--- a/assets/teamai-cli-icon.svg
+++ b/assets/teamai-cli-icon.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="115" fill="#15161a"></rect>
+  <g transform="translate(96,96) scale(3.33333)">
+    <g stroke="#FAFAFB" stroke-width="2.6" stroke-linecap="round" opacity="0.9">
+      <line x1="30" y1="30" x2="48" y2="48"></line>
+      <line x1="66" y1="30" x2="48" y2="48"></line>
+      <line x1="30" y1="66" x2="48" y2="48"></line>
+      <line x1="66" y1="66" x2="48" y2="48"></line>
+    </g>
+    <g fill="#FAFAFB">
+      <circle cx="30" cy="30" r="5.6"></circle>
+      <circle cx="66" cy="30" r="5.6"></circle>
+      <circle cx="30" cy="66" r="5.6"></circle>
+      <circle cx="66" cy="66" r="5.6"></circle>
+    </g>
+    <rect x="39" y="39" width="18" height="18" rx="2.6" fill="#3D96EA"></rect>
+  </g>
+</svg>

--- a/assets/teamai-cli-logo.svg
+++ b/assets/teamai-cli-logo.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="470" height="160" viewBox="0 0 470 160" role="img" aria-label="teamai-cli — The team harness for AI agents">
+  <rect x="0.5" y="0.5" width="469" height="159" rx="28" fill="#15161a" stroke="#ffffff" stroke-opacity="0.06"></rect>
+  <g transform="translate(40,36) scale(0.91667)">
+    <g stroke="#FAFAFB" stroke-width="2.6" stroke-linecap="round" opacity="0.9">
+      <line x1="30" y1="30" x2="48" y2="48"></line>
+      <line x1="66" y1="30" x2="48" y2="48"></line>
+      <line x1="30" y1="66" x2="48" y2="48"></line>
+      <line x1="66" y1="66" x2="48" y2="48"></line>
+    </g>
+    <g fill="#FAFAFB">
+      <circle cx="30" cy="30" r="5.6"></circle>
+      <circle cx="66" cy="30" r="5.6"></circle>
+      <circle cx="30" cy="66" r="5.6"></circle>
+      <circle cx="66" cy="66" r="5.6"></circle>
+    </g>
+    <rect x="39" y="39" width="18" height="18" rx="2.6" fill="#3D96EA"></rect>
+  </g>
+  <text x="166" y="76" font-family="'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="46" font-weight="700" letter-spacing="-1.5">
+    <tspan fill="#FAFAFB">teamai</tspan><tspan fill="#3D96EA">-cli</tspan>
+  </text>
+  <text x="168" y="108" font-family="'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="14.5" letter-spacing="0.2" fill="#ffffff" fill-opacity="0.5">The team harness for AI agents</text>
+</svg>

--- a/assets/teamai-cli-mark.svg
+++ b/assets/teamai-cli-mark.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96">
+  <g stroke="#15161a" stroke-width="2.6" stroke-linecap="round" opacity="0.9">
+    <line x1="30" y1="30" x2="48" y2="48"></line>
+    <line x1="66" y1="30" x2="48" y2="48"></line>
+    <line x1="30" y1="66" x2="48" y2="48"></line>
+    <line x1="66" y1="66" x2="48" y2="48"></line>
+  </g>
+  <g fill="#15161a">
+    <circle cx="30" cy="30" r="5.6"></circle>
+    <circle cx="66" cy="30" r="5.6"></circle>
+    <circle cx="30" cy="66" r="5.6"></circle>
+    <circle cx="66" cy="66" r="5.6"></circle>
+  </g>
+  <rect x="39" y="39" width="18" height="18" rx="2.6" fill="#3D96EA"></rect>
+</svg>


### PR DESCRIPTION
## Summary

Adds the official `teamai-cli` brand logo to the project README.

- Sourced from the final Claude Design project (network-core mark: four nodes converging on a brand-blue center square).
- New assets under `assets/`:
  - `teamai-cli-logo.svg` — horizontal lockup banner (icon + wordmark + tagline) on a dark rounded card; renders cleanly on both light and dark GitHub themes.
  - `teamai-cli-icon.svg` — 512×512 rounded app icon (favicon / social use).
  - `teamai-cli-mark.svg` — bare mark (dark foreground, for light backgrounds).
- Embeds the lockup centered above the H1 in both `README.md` and `README.zh-CN.md`.
- Brand colors: ink `#15161a`, brand blue `#3D96EA`, foreground `#FAFAFB`.

## Test Plan

- [x] Rendered `teamai-cli-logo.svg` to PNG locally (rsvg-convert) and visually confirmed it matches the design: mark geometry, two-tone wordmark (`-cli` in brand blue), tagline alignment.
- [x] Verified both READMEs reference `assets/teamai-cli-logo.svg` via a centered `<p align="center">` block; relative path resolves from repo root.
- [ ] Reviewer to confirm the logo displays correctly in GitHub's README preview (light + dark mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)