### PR TITLE
refactor(cli): hide internal hook commands from --help output

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { createRequire } from 'node:module';
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import { setVerbose, setSilent, log } from './utils/logger.js';
 import type { GlobalOptions } from './types.js';
 
@@ -431,7 +431,7 @@ hooksCmd
 // ─── Usage tracking commands ────────────────────────────
 
 program
-  .command('track [toolName] [toolInput]')
+  .command('track [toolName] [toolInput]', { hidden: true })
   .description('Track a tool usage event (called by PostToolUse hook)')
   .option('--stdin', 'Read hook data from STDIN (Claude Code hook format)')
   .option('--tool <name>', 'Tool identifier for usage attribution (e.g. claude, claude-internal)')
@@ -446,7 +446,7 @@ program
   });
 
 program
-  .command('track-slash')
+  .command('track-slash', { hidden: true })
   .description('Track a slash command usage (called by UserPromptSubmit hook)')
   .option('--stdin', 'Read hook data from STDIN')
   .option('--tool <name>', 'Tool identifier for usage attribution (e.g. claude, claude-internal)')
@@ -466,7 +466,7 @@ program
   });
 
 program
-  .command('save-session')
+  .command('save-session', { hidden: true })
   .description('Save current session tool usage summary')
   .option('--summary <text>', 'Session summary text')
   .action(async (cmdOpts) => {
@@ -495,7 +495,7 @@ program
   });
 
 program
-  .command('dashboard-report')
+  .command('dashboard-report', { hidden: true })
   .description('Report session state to dashboard (called by hooks)')
   .option('--stdin', 'Read hook data from STDIN')
   .option('--tool <name>', 'Tool identifier (e.g. claude, claude-internal)')
@@ -509,7 +509,7 @@ program
 // ─── Contribute commands ──────────────────────────────────
 
 program
-  .command('contribute-check')
+  .command('contribute-check', { hidden: true })
   .description('Check if session qualifies for contribution (called by PostToolUse hook)')
   .option('--stdin', 'Read hook data from STDIN')
   .option('--tool <name>', 'Tool identifier (e.g. claude, claude-internal)')
@@ -546,7 +546,7 @@ program
   });
 
 program
-  .command('auto-recall')
+  .command('auto-recall', { hidden: true })
   .description('Auto-recall team knowledge on tool errors (called by PostToolUse hook)')
   .option('--stdin', 'Read hook data from STDIN')
   .action(async (cmdOpts) => {
@@ -557,7 +557,7 @@ program
   });
 
 program
-  .command('todowrite-hint')
+  .command('todowrite-hint', { hidden: true })
   .description('Remind the agent to invoke teamai-recall when TodoWrite is used (PostToolUse hook)')
   .option('--stdin', 'Read hook data from STDIN')
   .option('--tool <name>', 'Source AI tool (claude / codebuddy / cursor)')
@@ -572,18 +572,18 @@ program
   .command('import')
   .description('Import knowledge from local files, Claude/Cursor rules, git workspace, MRs, or iWiki')
   .option('--dir <path>', 'Scan local directory for importable Markdown files')
-  .option('--from-claude', 'Scan Claude/Cursor rule directories (~/.claude/rules, ~/.cursor/rules)')
-  .option('--workspace', 'Generate codebase.md from current git workspace')
+  .addOption(new Option('--from-claude', 'Scan Claude/Cursor rule directories').hideHelp())
+  .addOption(new Option('--workspace', 'Generate codebase.md from current git workspace').hideHelp())
   .option('--from-mr <url>', 'Extract learning and codebase suggestions from a merged MR/PR URL')
   .option('--from-iwiki <space-id-or-url>', 'Import documents from iWiki Space ID or page URL (requires TAI_PAT_TOKEN)')
-  .option('--resume', 'Resume an interrupted import session')
+  .addOption(new Option('--resume', 'Resume an interrupted import session').hideHelp())
   .option('--all', 'Accept all suggestions without interactive confirmation')
-  .option('--output <path>', 'Write drafts to this directory instead of pushing to team repo')
-  .option('--existing-codebase <path>', 'Path to existing codebase.md (used with --from-mr; overrides auto-detection from team repo)')
+  .addOption(new Option('--output <path>', 'Write drafts to this directory').hideHelp())
+  .addOption(new Option('--existing-codebase <path>', 'Path to existing codebase.md').hideHelp())
   .option('--from-repo <url>', 'Clone a remote repo and generate per-repo codebase summary')
   .option('--depth <n>', 'Shallow clone depth for --from-repo (default 1)', '1')
-  .option('--ssh', 'Force SSH clone even if HTTPS token is available')
-  .option('--domain <name>', 'Skip AI recommendation and assign repo to this domain explicitly')
+  .addOption(new Option('--ssh', 'Force SSH clone').hideHelp())
+  .addOption(new Option('--domain <name>', 'Skip AI recommendation').hideHelp())
   .option('--from-repo-list <path>', 'Batch import repos from a YAML whitelist')
   .option('--concurrency <n>', 'Concurrent repos for --from-repo-list (default 3)', '3')
   .option('--skip-aggregate', 'Skip domain-*.md / index.md regeneration')
@@ -594,9 +594,9 @@ program
   .option('--exclude-archived', 'Exclude archived repos from --from-org (default true)')
   .option('--include-pattern <re>', 'Regex to include repos by full name (used with --from-org)')
   .option('--exclude-pattern <re>', 'Regex to exclude repos by full name (used with --from-org)')
-  .option('--skip-import', 'Only write drafts; skip the actual --from-repo-list run')
-  .option('--iwiki-dual', 'Enable dual-output mode for --from-iwiki (write codebase sections in addition to learning)')
-  .option('--require-review', 'Defer codebase section writes to .teamai/pending-review.jsonl for human review')
+  .addOption(new Option('--skip-import', 'Only write drafts').hideHelp())
+  .addOption(new Option('--iwiki-dual', 'Enable dual-output mode').hideHelp())
+  .addOption(new Option('--require-review', 'Defer writes to pending-review').hideHelp())
   .action(async (cmdOpts) => {
     const globalOpts = program.opts() as GlobalOptions;
     const { importCmd } = await import('./import.js');
@@ -604,7 +604,7 @@ program
   });
 
 program
-  .command('mr-hint')
+  .command('mr-hint', { hidden: true })
   .description('Hint AI about recently merged but un-imported MRs (SessionStart hook)')
   .option('--stdin', 'Read hook data from STDIN')
   .option('--tool <name>', 'Source AI tool (claude / codebuddy / cursor)')
@@ -662,7 +662,7 @@ program
     });
 
 program
-    .command('domains <subcommand> [repoUrl]')
+    .command('domains <subcommand> [repoUrl]', { hidden: true })
     .description('Inspect / accept / reject domain-drift signals (subcommand: drift)')
     .option('--apply', 'Apply drift for the given repoUrl')
     .option('--apply-all', 'Apply all drift items above confidence threshold')
@@ -685,7 +685,7 @@ program
 // ─── Unified hook dispatch (replaces individual hook subcommands) ────
 
 program
-  .command('hook-dispatch <event>')
+  .command('hook-dispatch <event>', { hidden: true })
   .description('Unified hook dispatcher — handles all teamai hooks for a given event in one process')
   .option('--tool <name>', 'Tool identifier (e.g. claude, claude-internal, cursor)')
   .option('--matcher <matcher>', 'Hook matcher for PostToolUse (e.g. Skill, Bash)')


### PR DESCRIPTION
## Summary

**Independent PR — can be merged separately from the feature series (#54→#55→#56).**

Pure cosmetic/UX improvement. No behavioral change.

- Hide 10 internal hook commands from `teamai --help`: track, track-slash, save-session, dashboard-report, contribute-check, auto-recall, todowrite-hint, mr-hint, hook-dispatch, domains
- Convert 10+ rarely-used import options to `.addOption(...).hideHelp()` while keeping them fully functional
- All hidden commands still work when called directly

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `teamai --help` — hidden commands no longer appear