### PR TITLE
fix(tgit): shell-quote every gf CLI arg to prevent injection

### DIFF
--- a/src/__tests__/gf-cli.test.ts
+++ b/src/__tests__/gf-cli.test.ts
@@ -155,6 +155,36 @@ describe('gfMrCreate', () => {
     expect(cmd).toContain("'it'\\''s a\ndescription'");
   });
 
+  it('should shell-quote repo/branch args to prevent argument injection into bash -c', () => {
+    mockSpawnSync.mockReturnValue({
+      stdout: 'https://git.woa.com/team/repo/-/merge_requests/3',
+      stderr: '',
+      status: 0,
+    } as any);
+
+    gfMrCreate({
+      // Values with shell metacharacters that would break out of the command
+      // if interpolated raw into `bash -c "<gfPath> <args>"`.
+      repo: 'team/repo;echo PWNED',
+      source: 'feat;rm -rf / #',
+      target: 'master|cat /etc/passwd',
+      title: 't',
+    });
+
+    const cmd = mockSpawnSync.mock.calls[0][1]![1] as string;
+    // Each dangerous value must be a single single-quoted token so bash -c
+    // treats its metacharacters (`;`, `|`, `#`, spaces) as literal argument
+    // content rather than command separators.
+    expect(cmd).toContain("'team/repo;echo PWNED'");
+    expect(cmd).toContain("'feat;rm -rf / #'");
+    expect(cmd).toContain("'master|cat /etc/passwd'");
+    // No bare (unquoted) `;` that bash could interpret as a command separator:
+    // every `;` must sit inside a single-quoted token.
+    const outsideQuotes = cmd.replace(/'[^']*'/g, '');
+    expect(outsideQuotes).not.toContain(';');
+    expect(outsideQuotes).not.toContain('|');
+  });
+
   it('should return MR URL from gf output', () => {
     mockSpawnSync.mockReturnValue({
       stdout: 'Created: https://git.woa.com/team/repo/-/merge_requests/42',

--- a/src/providers/tgit/gf-cli.ts
+++ b/src/providers/tgit/gf-cli.ts
@@ -35,7 +35,11 @@ export function gfExec(
   options?: { inheritStdio?: boolean; cwd?: string },
 ): { stdout: string; stderr: string; status: number } {
   const gfPath = getGfPath();
-  const cmd = `${gfPath} ${args.join(' ')}`;
+  // Shell-quote every token (including the binary path) so values such as repo
+  // paths, branch names, titles, and descriptions cannot inject shell
+  // metacharacters (`;`, `|`, `$()`, …) into the `bash -c` string. Callers pass
+  // raw values; quoting centrally here keeps every entry point safe.
+  const cmd = [shellQuote(gfPath), ...args.map(shellQuote)].join(' ');
   log.debug(`gf exec: ${cmd}`);
 
   if (options?.inheritStdio) {
@@ -398,11 +402,11 @@ export function gfMrCreate(opts: GfMrCreateOptions): string {
     '-R', opts.repo,
     '-s', opts.source,
     '-T', opts.target,
-    '-t', shellQuote(opts.title),
+    '-t', opts.title,
   ];
 
   if (opts.description) {
-    args.push('-d', shellQuote(opts.description));
+    args.push('-d', opts.description);
   }
 
   if (opts.reviewers && opts.reviewers.length > 0) {


### PR DESCRIPTION
## Summary

`gfExec` (`src/providers/tgit/gf-cli.ts`) runs the gf CLI via `bash -c "<gfPath> <args.join(' ')'>"`. Only the MR **title** and **description** were shell-quoted (in `gfMrCreate`); **repo**, **source/target branch**, **reviewers**, and the clone **local-path** were interpolated raw. A repo or branch value containing shell metacharacters (`;`, `|`, `$()`, backticks, …) was therefore executed by `bash -c`.

The values originate from user input (`--repo`, branch names, reviewers), so this is an argument-injection / arbitrary-command-execution vector.

### Proof (real bash + fake `gf`)

`gfMrCreate({ repo: "team/repo;echo PWNED", source: "feat", target: "master", title: "my title" })`

**Before** — the constructed command is:
```
gf mr create -R team/repo;echo PWNED -s feat -T master -t 'my title'
```
`bash -c` prints `PWNED …` (the injected `echo` runs) and `gf` receives split args:
```
PWNED -s feat -T master -t my title      ← stdout (command executed)
ARG:[team/repo]                           ← gf only got the pre-`;` fragment
```

**After** — every token is single-quoted:
```
'/…/gf' 'mr' 'create' '-R' 'team/repo;echo PWNED' '-s' 'feat' '-T' 'master' '-t' 'my title'
```
nothing extra executes and `gf` receives the value as one literal argument:
```
ARG:[team/repo;echo PWNED]                ← single literal arg, no injection
```

## Fix

Shell-quote **every** token (including the binary path) centrally in `gfExec`, and drop the now-redundant per-call `shellQuote()` in `gfMrCreate`:

```ts
const cmd = [shellQuote(gfPath), ...args.map(shellQuote)].join(' ');
```

```ts
// gfMrCreate — title/description are now quoted by gfExec
const args = ['mr', 'create', '-R', opts.repo, '-s', opts.source, '-T', opts.target, '-t', opts.title];
if (opts.description) args.push('-d', opts.description);
```

This keeps the existing `bash -c` execution mechanism (chosen for launcher compatibility) and covers every call site at once:
- The two-segment `gf repo clone` path (`gfExec(['repo','clone', repo, localPath])`) is now safe.
- The multi-segment clone path already used a `spawnSync('git', [...])` argv array (no shell) — unchanged.

## Tests

- Added a regression test (`gf-cli.test.ts`) asserting repo/source/target metacharacters are single-quoted as single tokens, with **no unquoted `;`/`|`** remaining for `bash -c` to interpret. Fails on the old code (`team/repo;echo PWNED` was unquoted).
- Existing `gf-cli.test.ts` cases (newline preservation in description, single-quote escaping, MR-URL extraction) still pass — the title/description quoting result is unchanged.
- `npm test` → 1440 passed; `tsc --noEmit` → clean.

Co-Authored-By: Claude <noreply@anthropic.com>
