### PR TITLE
feat(hooks): add hooks list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The CLI picks a provider automatically from the repo URL:
 | `teamai review [id] [--apply \| --reject \| --all-apply]` | Inspect and process pending codebase changes from `.teamai/pending-review.jsonl`; `--apply` patches in place via section anchors |
 | `teamai domains drift [url] [--apply \| --lock \| --apply-all]` | Inspect and resolve domain-drift signals; `--apply` reassigns the repo to the recommended domain and refreshes the aggregate views |
 | `teamai digest` | Generate a team AI usage weekly digest (skill leaderboard, new/updated skills, session summaries) |
-| `teamai hooks` | Manage AI-tool hooks (list / inject / remove) |
+| `teamai hooks` | Manage AI-tool hooks (`list` shows installation status; `inject`/`remove` update settings) |
 | `teamai ci extract-mr --url <url> [--mode comment\|write\|both] [--individual-comments]` | CI pipeline integration: extract knowledge from MR/PR, post as comments, and write to team repo after merge. With `--individual-comments`, each suggestion is posted separately with reaction/reject support (GitHub 👎 / TGit ☝️) |
 | `teamai uninstall [--force]` | Uninstall teamai: remove hooks, rules, skills, env, docs, and `~/.teamai/` |
 | `teamai doctor` | Diagnose configuration problems |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -92,7 +92,7 @@ CLI 会根据用户传入的 repo URL 自动选择 provider：
 | `teamai review [id] [--apply \| --reject \| --all-apply]` | 浏览并处理 `.teamai/pending-review.jsonl` 中的待审 codebase 变更；`--apply` 通过章节锚点原地写入 |
 | `teamai domains drift [url] [--apply \| --lock \| --apply-all]` | 浏览并处理域漂移信号；`--apply` 把仓库重新归类到推荐域并刷新聚合视图 |
 | `teamai digest` | 生成团队 AI 使用周报（skill 排行、新增/更新 skill、session 摘要） |
-| `teamai hooks` | 管理 AI 工具 hooks（list / inject / remove） |
+| `teamai hooks` | 管理 AI 工具 hooks（`list` 查看安装状态；`inject`/`remove` 更新配置） |
 | `teamai ci extract-mr --url <url> [--mode comment\|write\|both] [--individual-comments]` | CI 流水线集成：从 MR/PR 中提取知识，发布为评论，合并后写入团队知识仓库。使用 `--individual-comments` 时每条建议单独发布，支持 reaction/reject 交互（GitHub 👎 / TGit ☝️） |
 | `teamai uninstall [--force]` | 卸载 teamai：移除 hooks、rules、skills、env、docs、~/.teamai/ |
 | `teamai doctor` | 诊断配置问题 |

--- a/src/__tests__/hooks-cmd.test.ts
+++ b/src/__tests__/hooks-cmd.test.ts
@@ -8,6 +8,7 @@ vi.mock('../config.js', () => ({
 }));
 
 vi.mock('../hooks.js', () => ({
+    getHookStatus: vi.fn(),
     injectHooksToAllTools: vi.fn(),
     removeHooks: vi.fn(),
 }));
@@ -25,11 +26,12 @@ vi.mock('../utils/logger.js', () => ({
 // ── Imports (after mocks) ────────────────────────────────
 
 import { autoDetectInit } from '../config.js';
-import { injectHooksToAllTools, removeHooks } from '../hooks.js';
+import { getHookStatus, injectHooksToAllTools, removeHooks } from '../hooks.js';
 import { log } from '../utils/logger.js';
-import { hooksInject, hooksRemove } from '../hooks-cmd.js';
+import { hooksInject, hooksList, hooksRemove } from '../hooks-cmd.js';
 
 const mockedAutoDetectInit = autoDetectInit as Mock;
+const mockedGetHookStatus = getHookStatus as Mock;
 const mockedInjectHooksToAllTools = injectHooksToAllTools as Mock;
 const mockedRemoveHooks = removeHooks as Mock;
 const mockedLog = log as unknown as {
@@ -52,6 +54,7 @@ const mockTeamConfig = {
         claude: { settings: '.claude/settings.json', skills: '.claude/skills' },
         'claude-internal': { settings: '.claude-internal/settings.json', skills: '.claude-internal/skills' },
         cursor: { settings: '.cursor/hooks.json', skills: '.cursor/skills' },
+        codex: { skills: '.codex/skills' },
     },
 };
 
@@ -72,6 +75,7 @@ function mockHome(home: string): () => void {
 beforeEach(() => {
     vi.clearAllMocks();
     mockedAutoDetectInit.mockResolvedValue({ localConfig: mockLocalConfig, teamConfig: mockTeamConfig });
+    mockedGetHookStatus.mockResolvedValue('missing');
     mockedInjectHooksToAllTools.mockResolvedValue(undefined);
     mockedRemoveHooks.mockResolvedValue(undefined);
 });
@@ -131,6 +135,81 @@ describe('hooksInject', () => {
             mockTeamConfig.toolPaths,
             '/home/testuser',
         );
+    });
+});
+
+describe('hooksList', () => {
+    it('should list hook status for configured tools', async () => {
+        const restoreHome = mockHome('/home/testuser');
+        const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+        mockedGetHookStatus
+            .mockResolvedValueOnce('installed')
+            .mockResolvedValueOnce('missing')
+            .mockResolvedValueOnce('installed');
+
+        try {
+            await hooksList({});
+
+            expect(mockedGetHookStatus).toHaveBeenCalledTimes(3);
+            expect(mockedGetHookStatus).toHaveBeenCalledWith(
+                path.join('/home/testuser', '.claude/settings.json'),
+                'claude',
+            );
+            expect(mockedGetHookStatus).toHaveBeenCalledWith(
+                path.join('/home/testuser', '.claude-internal/settings.json'),
+                'claude-internal',
+            );
+            expect(mockedGetHookStatus).toHaveBeenCalledWith(
+                path.join('/home/testuser', '.cursor/hooks.json'),
+                'cursor',
+            );
+
+            const output = consoleLog.mock.calls.map((call) => String(call[0])).join('\n');
+            expect(output).toContain('claude');
+            expect(output).toContain('installed');
+            expect(output).toContain('claude-internal');
+            expect(output).toContain('missing');
+            expect(output).toContain('codex');
+            expect(output).toContain('not configured');
+            expect(output).toContain('no settings configured');
+        } finally {
+            restoreHome();
+            consoleLog.mockRestore();
+        }
+    });
+
+    it('should list project and user base dirs when project config detected', async () => {
+        const restoreHome = mockHome('/home/testuser');
+        const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+        const projectConfig = {
+            ...mockLocalConfig,
+            scope: 'project',
+            projectRoot: '/path/to/project',
+        };
+        mockedAutoDetectInit.mockResolvedValue({ localConfig: projectConfig, teamConfig: mockTeamConfig });
+
+        try {
+            await hooksList({});
+
+            expect(mockedGetHookStatus).toHaveBeenCalledTimes(6);
+            expect(mockedGetHookStatus).toHaveBeenCalledWith(
+                path.join('/path/to/project', '.claude/settings.json'),
+                'claude',
+            );
+            expect(mockedGetHookStatus).toHaveBeenCalledWith(
+                path.join('/home/testuser', '.claude/settings.json'),
+                'claude',
+            );
+        } finally {
+            restoreHome();
+            consoleLog.mockRestore();
+        }
+    });
+
+    it('should propagate error when not initialized', async () => {
+        mockedAutoDetectInit.mockRejectedValue(new Error('teamai is not initialized'));
+
+        await expect(hooksList({})).rejects.toThrow('not initialized');
     });
 });
 

--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import path from 'node:path';
 
 // ── Mocks ────────────────────────────────────────────────
 
@@ -23,7 +24,7 @@ vi.mock('../utils/logger.js', () => ({
   },
 }));
 
-import { injectHooks, removeHooks, injectHooksToAllTools, TEAMAI_HOOK_SUBCOMMANDS, TEAMAI_LEGACY_HOOK_SUBCOMMANDS, CLAUDE_TO_CURSOR_EVENTS } from '../hooks.js';
+import { getHookStatus, injectHooks, removeHooks, injectHooksToAllTools, TEAMAI_HOOK_SUBCOMMANDS, TEAMAI_LEGACY_HOOK_SUBCOMMANDS, CLAUDE_TO_CURSOR_EVENTS } from '../hooks.js';
 
 // ── Helpers ──────────────────────────────────────────────
 
@@ -338,17 +339,19 @@ describe('hooks', () => {
       const originalHome = process.env.HOME;
       process.env.HOME = '/test-home';
 
-      await injectHooksToAllTools({
-        claude: { settings: '.claude/settings.json' },
-        codex: {},
-        cursor: { settings: '.cursor/hooks.json' },
-      });
+      try {
+        await injectHooksToAllTools({
+          claude: { settings: '.claude/settings.json' },
+          codex: {},
+          cursor: { settings: '.cursor/hooks.json' },
+        });
 
-      expect(mockFiles['/test-home/.claude/settings.json']).toBeDefined();
-      expect(mockFiles['/test-home/.cursor/hooks.json']).toBeDefined();
-      expect(Object.keys(mockFiles)).toHaveLength(2);
-
-      process.env.HOME = originalHome;
+        expect(mockFiles[path.join('/test-home', '.claude/settings.json')]).toBeDefined();
+        expect(mockFiles[path.join('/test-home', '.cursor/hooks.json')]).toBeDefined();
+        expect(Object.keys(mockFiles)).toHaveLength(2);
+      } finally {
+        process.env.HOME = originalHome;
+      }
     });
   });
 
@@ -475,6 +478,26 @@ describe('hooks', () => {
       expect(TEAMAI_LEGACY_HOOK_SUBCOMMANDS).toContain('dashboard-report');
       expect(TEAMAI_LEGACY_HOOK_SUBCOMMANDS).toContain('contribute-check');
       expect(TEAMAI_LEGACY_HOOK_SUBCOMMANDS).toContain('auto-recall');
+    });
+  });
+
+  describe('getHookStatus', () => {
+    it('reports installed for current Claude hooks', async () => {
+      await injectHooks('/test/settings.json', 'claude');
+
+      await expect(getHookStatus('/test/settings.json', 'claude')).resolves.toBe('installed');
+    });
+
+    it('reports installed for current Cursor hooks', async () => {
+      await injectHooks('/test/hooks.json', 'cursor');
+
+      await expect(getHookStatus('/test/hooks.json', 'cursor')).resolves.toBe('installed');
+    });
+
+    it('reports missing when settings exist without teamai hooks', async () => {
+      mockFiles['/test/settings.json'] = { hooks: {} };
+
+      await expect(getHookStatus('/test/settings.json', 'claude')).resolves.toBe('missing');
     });
   });
 

--- a/src/hooks-cmd.ts
+++ b/src/hooks-cmd.ts
@@ -1,9 +1,17 @@
 import path from 'node:path';
 import { autoDetectInit } from './config.js';
-import { injectHooksToAllTools, removeHooks } from './hooks.js';
+import { getHookStatus, injectHooksToAllTools, removeHooks, type HookStatus } from './hooks.js';
 import { log } from './utils/logger.js';
 import type { GlobalOptions, LocalConfig } from './types.js';
 import { resolveBaseDir } from './types.js';
+
+type HookListStatus = HookStatus | 'not configured';
+
+interface HookListRow {
+    tool: string;
+    status: HookListStatus;
+    settingsPath: string;
+}
 
 function resolveHookBaseDirs(localConfig: LocalConfig): string[] {
     const baseDir = resolveBaseDir(localConfig) ?? '';
@@ -35,6 +43,35 @@ async function removeHooksFromAllTools(
     }
 }
 
+function formatDisplayPath(settingsPath: string): string {
+    const home = process.env.HOME;
+    if (!home) return settingsPath;
+
+    if (settingsPath === home) return '~';
+    if (settingsPath.startsWith(home + path.sep) || settingsPath.startsWith(home + '/')) {
+        return `~${settingsPath.slice(home.length)}`;
+    }
+    return settingsPath;
+}
+
+function formatHooksList(rows: HookListRow[]): string {
+    const toolWidth = Math.max('tool'.length, ...rows.map((row) => row.tool.length));
+    const statusWidth = Math.max('status'.length, ...rows.map((row) => row.status.length));
+
+    const lines = [
+        `${'tool'.padEnd(toolWidth)}  ${'status'.padEnd(statusWidth)}  settings`,
+        `${'-'.repeat(toolWidth)}  ${'-'.repeat(statusWidth)}  ${'-'.repeat('settings'.length)}`,
+    ];
+
+    for (const row of rows) {
+        lines.push(
+            `${row.tool.padEnd(toolWidth)}  ${row.status.padEnd(statusWidth)}  ${row.settingsPath}`,
+        );
+    }
+
+    return lines.join('\n');
+}
+
 /**
  * Handler for `teamai hooks inject`.
  * Loads config and injects teamai hooks into all configured AI tool settings.
@@ -63,4 +100,36 @@ export async function hooksRemove(_options: GlobalOptions): Promise<void> {
     }
 
     log.success('Hooks removed from all AI tool settings');
+}
+
+/**
+ * Handler for `teamai hooks list`.
+ * Lists hook installation status for each configured AI tool.
+ */
+export async function hooksList(_options: GlobalOptions): Promise<void> {
+    const { localConfig, teamConfig } = await autoDetectInit();
+    const baseDirs = resolveHookBaseDirs(localConfig);
+    const rows: HookListRow[] = [];
+
+    for (const [tool, paths] of Object.entries(teamConfig.toolPaths)) {
+        if (!paths.settings) {
+            rows.push({
+                tool,
+                status: 'not configured',
+                settingsPath: 'no settings configured',
+            });
+            continue;
+        }
+
+        for (const baseDir of baseDirs) {
+            const settingsPath = path.join(baseDir, paths.settings);
+            rows.push({
+                tool,
+                status: await getHookStatus(settingsPath, tool),
+                settingsPath: formatDisplayPath(settingsPath),
+            });
+        }
+    }
+
+    console.log(formatHooksList(rows));
 }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -200,12 +200,31 @@ function buildCursorHooks(tool: string): Record<string, CursorHookEntry[]> {
 // ─── Tool format detection ──────────────────────────────────
 
 type ToolFormat = 'claude' | 'cursor';
+export type HookStatus = 'installed' | 'missing';
 
 const CURSOR_TOOLS = new Set(['cursor']);
 
 function detectFormat(tool: string): ToolFormat {
   if (CURSOR_TOOLS.has(tool)) return 'cursor';
   return 'claude';
+}
+
+function hasExpectedClaudeHook(settings: ClaudeSettingsJson, def: ClaudeHookDef): boolean {
+  const matchers = settings.hooks?.[def.eventType] ?? [];
+  const expectedCmd = def.hook.hooks[0].command;
+  const expectedMatcher = def.hook.matcher;
+
+  return matchers.some((h) =>
+    h.matcher === expectedMatcher &&
+    h.hooks?.some((hook) => hook.command === expectedCmd),
+  );
+}
+
+function hasExpectedCursorHook(entries: CursorHookEntry[], expected: CursorHookEntry): boolean {
+  return entries.some((entry) =>
+    entry.command === expected.command &&
+    entry.matcher === expected.matcher,
+  );
 }
 
 function extractTeamaiSubcommand(command: string): string | null {
@@ -494,6 +513,37 @@ export async function removeHooks(settingsPath: string, tool?: string): Promise<
     // Both claude and codebuddy use the same settings.json structure for removal
     await removeClaudeHooks(settingsPath);
   }
+}
+
+/**
+ * Report whether the current teamai hook set is present in a tool settings file.
+ */
+export async function getHookStatus(settingsPath: string, tool?: string): Promise<HookStatus> {
+  const toolName = tool ?? 'claude';
+  const format = detectFormat(toolName);
+  const expanded = expandHome(settingsPath);
+
+  if (format === 'cursor') {
+    const hooksJson = await readJson<CursorHooksJson>(expanded);
+    if (!hooksJson?.hooks) return 'missing';
+
+    const desiredHooks = buildCursorHooks(toolName);
+    const installed = Object.entries(desiredHooks).every(([event, expectedEntries]) => {
+      const entries = hooksJson.hooks[event] ?? [];
+      return expectedEntries.every((expected) => hasExpectedCursorHook(entries, expected));
+    });
+
+    return installed ? 'installed' : 'missing';
+  }
+
+  const settings = await readJson<ClaudeSettingsJson>(expanded);
+  if (!settings?.hooks) return 'missing';
+
+  const installed = getClaudeHooks(toolName).every((def) =>
+    hasExpectedClaudeHook(settings, def),
+  );
+
+  return installed ? 'installed' : 'missing';
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -409,6 +409,15 @@ const hooksCmd = program
   .description('Manage teamai hooks in AI tool settings');
 
 hooksCmd
+  .command('list')
+  .description('List teamai hook installation status')
+  .action(async () => {
+    const globalOpts = program.opts() as GlobalOptions;
+    const { hooksList } = await import('./hooks-cmd.js');
+    await hooksList(globalOpts);
+  });
+
+hooksCmd
   .command('inject')
   .description('Inject teamai hooks into all AI tool settings')
   .option('--silent', 'Silent mode (suppress success message)')


### PR DESCRIPTION
## Summary

Adds `teamai hooks list` to show hook installation status for each AI tool configured in `teamai.yaml`.

The README already documents hooks as supporting `list / inject / remove`, but the CLI only implemented `inject` and `remove`.

The new list command reports whether each tool has the current teamai hook set installed, is missing the expected hook set, or has no settings path configured.

## Type of Change

* [ ] Bug fix (non-breaking change that fixes an issue)
* [x] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature causing existing behavior to change)
* [ ] Documentation only
* [ ] Refactor / internal cleanup

## Test Plan

* [x] `npm.cmd test -- src/__tests__/hooks-cmd.test.ts src/__tests__/hooks.test.ts`
* [x] `npm.cmd run typecheck`
* [x] `npm.cmd run build`
* [x] Added/updated tests for the change

Targeted hooks tests pass: 44 tests passed.

## Related Issues

Refs #19

## Notes for Reviewers

`teamai hooks list` checks for the expected current hook entries rather than treating an existing settings file as installed. This avoids reporting empty, stale, or incomplete settings files as installed.
