### PR TITLE
feat(tools): add tclaude/tcodex support + fix recall scope priority

### DIFF
--- a/src/__tests__/tclaude-tcodex.test.ts
+++ b/src/__tests__/tclaude-tcodex.test.ts
@@ -1,0 +1,102 @@
+// -*- coding: utf-8 -*-
+import { describe, it, expect } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'fs-extra';
+
+describe('tclaude/tcodex adapter integration', () => {
+  describe('toolPaths defaults include tclaude/tcodex', () => {
+    it('tclaude has full claude-compatible paths', async () => {
+      const { TeamaiConfigSchema } = await import('../types.js');
+      const config = TeamaiConfigSchema.parse({ team: 'test', repo: 'test/repo' });
+      expect(config.toolPaths.tclaude).toEqual({
+        skills: '.tclaude/skills',
+        rules: '.tclaude/rules',
+        settings: '.tclaude/settings.json',
+        claudemd: '.tclaude/CLAUDE.md',
+        wiki: '.tclaude/wiki',
+        agents: '.tclaude/agents',
+      });
+    });
+
+    it('tcodex has codex-compatible paths (no settings)', async () => {
+      const { TeamaiConfigSchema } = await import('../types.js');
+      const config = TeamaiConfigSchema.parse({ team: 'test', repo: 'test/repo' });
+      expect(config.toolPaths.tcodex).toEqual({
+        skills: '.tcodex/skills',
+        rules: '.tcodex/rules',
+        agents: '.tcodex/agents',
+      });
+    });
+  });
+
+  describe('agent rendering dispatches correctly', () => {
+    it('tclaude renders as claude format (.md)', async () => {
+      const { renderForTool } = await import('../resources/agent-format.js');
+      const spec = {
+        name: 'test-agent',
+        description: 'A test agent',
+        tools: ['Read', 'Bash'],
+        instructions: 'You are a test agent.',
+      };
+      const result = renderForTool(spec, 'tclaude');
+      expect(result.ext).toBe('.md');
+      expect(result.content).toContain('name: test-agent');
+    });
+
+    it('tcodex renders as codex format (.toml)', async () => {
+      const { renderForTool } = await import('../resources/agent-format.js');
+      const spec = {
+        name: 'test-agent',
+        description: 'A test agent',
+        tools: ['Read', 'Bash'],
+        instructions: 'You are a test agent.',
+      };
+      const result = renderForTool(spec, 'tcodex');
+      expect(result.ext).toBe('.toml');
+      expect(result.content).toContain('name = "test-agent"');
+    });
+  });
+
+  describe('known-agents includes tclaude/tcodex', () => {
+    it('KNOWN_AGENTS has tclaude entry', async () => {
+      const { KNOWN_AGENTS } = await import('../known-agents.js');
+      const tclaude = KNOWN_AGENTS.find(a => a.id === 'tclaude');
+      expect(tclaude).toBeDefined();
+      expect(tclaude!.skillsPath).toBe('.tclaude/skills');
+    });
+
+    it('KNOWN_AGENTS has tcodex entry', async () => {
+      const { KNOWN_AGENTS } = await import('../known-agents.js');
+      const tcodex = KNOWN_AGENTS.find(a => a.id === 'tcodex');
+      expect(tcodex).toBeDefined();
+      expect(tcodex!.skillsPath).toBe('.tcodex/skills');
+    });
+  });
+
+  describe('hooks injection targets tclaude', () => {
+    it('tclaude settings path enables hook injection', async () => {
+      const { TeamaiConfigSchema } = await import('../types.js');
+      const config = TeamaiConfigSchema.parse({ team: 'test', repo: 'test/repo' });
+      // tclaude has settings → hooks will be injected
+      expect(config.toolPaths.tclaude.settings).toBe('.tclaude/settings.json');
+      // tcodex has no settings → hooks will NOT be injected
+      expect(config.toolPaths.tcodex.settings).toBeUndefined();
+    });
+  });
+
+  describe('AI CLI detection includes tclaude/tcodex', () => {
+    it('tclaude uses -p flag (claude-style invocation)', async () => {
+      // We test by checking the source logic indirectly
+      // buildCliArgs is not exported, but we can verify through callClaude behavior
+      // For now, just verify the whitelist includes our tools
+      const aiClientSrc = await fs.readFile(
+        path.join(process.cwd(), 'src/utils/ai-client.ts'), 'utf8'
+      );
+      expect(aiClientSrc).toContain("'tclaude'");
+      expect(aiClientSrc).toContain("'tcodex'");
+      // tcodex should be in the exec branch
+      expect(aiClientSrc).toContain("cmd === 'tcodex'");
+    });
+  });
+});

--- a/src/known-agents.ts
+++ b/src/known-agents.ts
@@ -35,8 +35,10 @@ export const KNOWN_AGENTS: KnownAgent[] = [
   // Coding agents already wired through teamConfig.toolPaths defaults
   { id: 'claude', displayName: 'Claude Code', category: 'coding', skillsPath: '.claude/skills' },
   { id: 'claude-internal', displayName: 'Claude Code Internal', category: 'coding', skillsPath: '.claude-internal/skills' },
+  { id: 'tclaude', displayName: 'TClaude', category: 'coding', skillsPath: '.tclaude/skills' },
   { id: 'codex', displayName: 'Codex CLI', category: 'coding', skillsPath: '.codex/skills' },
   { id: 'codex-internal', displayName: 'Codex CLI Internal', category: 'coding', skillsPath: '.codex-internal/skills' },
+  { id: 'tcodex', displayName: 'TCodex', category: 'coding', skillsPath: '.tcodex/skills' },
   { id: 'cursor', displayName: 'Cursor', category: 'coding', skillsPath: '.cursor/skills' },
   { id: 'codebuddy', displayName: 'CodeBuddy', category: 'coding', skillsPath: '.codebuddy/skills' },
 

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -231,21 +231,11 @@ export async function recall(
     return;
   }
 
-  // Collect indexes from both scopes
+  // Collect indexes from both scopes (project first — when both scopes share
+  // the same team repo, project wins dedup so results show project-local paths)
   const scopeIndexes: Array<{ index: SearchIndex; scope: 'user' | 'project'; config: LocalConfig; learningsBase: string }> = [];
 
-  // Try user scope
-  try {
-    const { localConfig: userConfig } = await requireInit();
-    const result = await loadOrBuildScopeIndex(userConfig, 'user');
-    if (result && result.index.entries.length > 0) {
-      scopeIndexes.push({ index: result.index, scope: 'user', config: userConfig, learningsBase: result.learningsBase });
-    }
-  } catch {
-    log.debug('recall: user scope not available');
-  }
-
-  // Try project scope (only when cwd has project-scope config)
+  // Try project scope first (only when cwd has project-scope config)
   try {
     const projectConfig = await detectProjectConfig();
     if (projectConfig) {
@@ -256,6 +246,17 @@ export async function recall(
     }
   } catch {
     log.debug('recall: project scope not available');
+  }
+
+  // Try user scope
+  try {
+    const { localConfig: userConfig } = await requireInit();
+    const result = await loadOrBuildScopeIndex(userConfig, 'user');
+    if (result && result.index.entries.length > 0) {
+      scopeIndexes.push({ index: result.index, scope: 'user', config: userConfig, learningsBase: result.learningsBase });
+    }
+  } catch {
+    log.debug('recall: user scope not available');
   }
 
   const hasWiki = await pathExists(path.join(process.cwd(), 'teamwiki'));

--- a/src/resources/agent-format.ts
+++ b/src/resources/agent-format.ts
@@ -5,14 +5,16 @@ import { stringify as stringifyToml, parse as parseToml } from 'smol-toml';
 
 // ─── Tool name type ──────────────────────────────────────────────────────────
 
-export type ToolName = 'claude' | 'claude-internal' | 'codebuddy' | 'codex' | 'codex-internal' | 'cursor';
+export type ToolName = 'claude' | 'claude-internal' | 'tclaude' | 'codebuddy' | 'codex' | 'codex-internal' | 'tcodex' | 'cursor';
 
 export const ALL_SUPPORTED_TOOLS: ToolName[] = [
   'claude',
   'claude-internal',
+  'tclaude',
   'codebuddy',
   'codex',
   'codex-internal',
+  'tcodex',
   'cursor',
 ];
 
@@ -42,9 +44,11 @@ export interface AgentSpec {
   tool_extras?: {
     claude?: Record<string, unknown>;
     'claude-internal'?: Record<string, unknown>;
+    tclaude?: Record<string, unknown>;
     codebuddy?: Record<string, unknown>;
     codex?: Record<string, unknown>;
     'codex-internal'?: Record<string, unknown>;
+    tcodex?: Record<string, unknown>;
     cursor?: Record<string, unknown>;
   };
   /**
@@ -489,9 +493,11 @@ export function renderForTool(spec: AgentSpec, tool: ToolName): RenderResult {
   switch (tool) {
     case 'claude': return renderForClaude(spec);
     case 'claude-internal': return renderForClaudeInternal(spec);
+    case 'tclaude': return renderForClaude(spec);
     case 'codebuddy': return renderForCodebuddy(spec);
     case 'codex': return renderForCodex(spec);
     case 'codex-internal': return renderForCodexInternal(spec);
+    case 'tcodex': return renderForCodex(spec);
     case 'cursor': return renderForCursor(spec);
   }
 }

--- a/src/resources/agents.ts
+++ b/src/resources/agents.ts
@@ -358,7 +358,7 @@ export class AgentsHandler extends ResourceHandler {
     teamConfig: TeamaiConfig,
     baseDir: string,
   ): Promise<void> {
-    const legacyTools = new Set(['claude', 'claude-internal', 'codebuddy']);
+    const legacyTools = new Set(['claude', 'claude-internal', 'tclaude', 'codebuddy']);
 
     for (const [tool, toolPath] of Object.entries(teamConfig.toolPaths)) {
       if (!legacyTools.has(tool)) continue;
@@ -410,11 +410,13 @@ function reverseByTool(tool: ToolName, filePath: string, content: string): Rever
   switch (tool) {
     case 'claude':
     case 'claude-internal':
+    case 'tclaude':
       return reverseFromClaude(filePath, content);
     case 'codebuddy':
       return reverseFromCodebuddy(filePath, content);
     case 'codex':
     case 'codex-internal':
+    case 'tcodex':
       return reverseFromCodex(filePath, content);
     case 'cursor':
       return reverseFromCursor(filePath, content);

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,6 +99,8 @@ export const TeamaiConfigSchema = z.object({
     codex: { skills: '.codex/skills', rules: '.codex/rules', agents: '.codex/agents' },
     'codex-internal': { skills: '.codex-internal/skills', rules: '.codex-internal/rules', agents: '.codex-internal/agents' },
     'claude-internal': { skills: '.claude-internal/skills', rules: '.claude-internal/rules', settings: '.claude-internal/settings.json', claudemd: '.claude-internal/CLAUDE.md', wiki: '.claude-internal/wiki', agents: '.claude-internal/agents' },
+    tclaude: { skills: '.tclaude/skills', rules: '.tclaude/rules', settings: '.tclaude/settings.json', claudemd: '.tclaude/CLAUDE.md', wiki: '.tclaude/wiki', agents: '.tclaude/agents' },
+    tcodex: { skills: '.tcodex/skills', rules: '.tcodex/rules', agents: '.tcodex/agents' },
     cursor: { skills: '.cursor/skills', rules: '.cursor/rules', settings: '.cursor/hooks.json', agents: '.cursor/agents' },
     codebuddy: { skills: '.codebuddy/skills', rules: '.codebuddy/rules', settings: '.codebuddy/settings.json', claudemd: '.codebuddy/CODEBUDDY.md', agents: '.codebuddy/agents' },
     openclaw: { skills: '.openclaw/skills', rules: '.openclaw/rules' },

--- a/src/usage-tracker.ts
+++ b/src/usage-tracker.ts
@@ -112,10 +112,12 @@ export function isValidSkillName(name: string): boolean {
 const SKILL_DIRS = [
   '.claude/skills',
   '.claude-internal/skills',
+  '.tclaude/skills',
   '.cursor/skills',
   '.codebuddy/skills',
   '.codex/skills',
   '.codex-internal/skills',
+  '.tcodex/skills',
   '.openclaw/skills',
 ];
 

--- a/src/utils/ai-client.ts
+++ b/src/utils/ai-client.ts
@@ -3,7 +3,7 @@ import { existsSync } from 'node:fs';
 
 /** 白名单：允许探测的 CLI 名称，防止意外执行任意命令。 */
 const ALLOWED_CLI_CANDIDATES = [
-  'claude', 'claude-internal', 'codex', 'codex-internal', 'codebuddy', 'workbuddy', 'openclaw',
+  'claude', 'claude-internal', 'tclaude', 'codex', 'codex-internal', 'tcodex', 'codebuddy', 'workbuddy', 'openclaw',
 ] as const;
 
 /** CLI 探测超时（毫秒），防止 execFileSync 挂死。 */
@@ -101,7 +101,7 @@ function detectClaudeCli(): CliInfo {
  * @returns      参数数组
  */
 function buildCliArgs(cmd: string, prompt: string): string[] {
-  if (cmd === 'codex' || cmd === 'codex-internal') {
+  if (cmd === 'codex' || cmd === 'codex-internal' || cmd === 'tcodex') {
     return ['exec', prompt];
   }
   return ['-p', prompt];


### PR DESCRIPTION
## Summary

- Add `tclaude` and `tcodex` as new AI tool adapters (coexist with `claude-internal`/`codex-internal`)
- Fix recall scope dedup priority: project scope now wins when both scopes share the same team repo

### tclaude / tcodex support

`@tencent/tclaude` (bin: `tclaude`, config: `~/.tclaude/`) and `@tencent/tcodex` (bin: `tcodex`, config: `~/.tcodex/`) are new Tencent internal AI coding tools based on Claude Code and OpenAI Codex respectively. They use `CLAUDE_CONFIG_DIR=~/.tclaude` to isolate their config from the upstream `claude` CLI.

Changes:
- Register in `ToolName` type, `ALL_SUPPORTED_TOOLS`, `tool_extras`
- Add default `toolPaths` (tclaude: full claude-compatible with hooks; tcodex: codex-compatible without hooks)
- Add to `KNOWN_AGENTS` registry, AI CLI detection whitelist, agent render/reverse dispatch
- Add skill directories to usage tracker

### Fix recall scope priority (Closes #58)

When user and project scopes point to the same team repo, filename-based dedup was keeping user-scope results (searched first) and discarding project-scope results. This made project-scoped installations always show `[user]` labels with `~/.teamai/learnings/` paths.

Fix: search project scope first so it wins dedup.

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `npx vitest run` — 1528 passed (108 files)
- [x] Integration tests: toolPaths defaults, agent render dispatch, KNOWN_AGENTS, hook eligibility, CLI whitelist
- [x] Recall dedup verified: project-first dedup correctly labels results as `[project]`
- [x] `teamai init --scope project` injects hooks to `.tclaude/settings.json` with `--tool tclaude`
- [x] `teamai pull` syncs skills to `.tclaude/skills/` and injects recall rules to `.tclaude/CLAUDE.md`
- [x] `tcodex` correctly skipped when `~/.tcodex/` not installed