### PR TITLE
fix(hooks): normalize IDE-style tool names from CodeBuddy Craft Agent

### DIFF
--- a/src/__tests__/tool-names.test.ts
+++ b/src/__tests__/tool-names.test.ts
@@ -1,0 +1,73 @@
+// -*- coding: utf-8 -*-
+import { describe, it, expect } from 'vitest';
+import { normalizeToolName } from '../utils/tool-names.js';
+import { parseHookInput } from '../auto-recall.js';
+
+describe('normalizeToolName', () => {
+  it('maps IDE-style names to CLI-style', () => {
+    expect(normalizeToolName('execute_command')).toBe('Bash');
+    expect(normalizeToolName('search_content')).toBe('Grep');
+    expect(normalizeToolName('write_to_file')).toBe('Write');
+    expect(normalizeToolName('replace_in_file')).toBe('Edit');
+    expect(normalizeToolName('list_dir')).toBe('Glob');
+    expect(normalizeToolName('web_search')).toBe('WebSearch');
+    expect(normalizeToolName('web_fetch')).toBe('WebFetch');
+    expect(normalizeToolName('read_file')).toBe('Read');
+    expect(normalizeToolName('task')).toBe('Task');
+  });
+
+  it('passes through CLI-style names unchanged', () => {
+    expect(normalizeToolName('Bash')).toBe('Bash');
+    expect(normalizeToolName('Grep')).toBe('Grep');
+    expect(normalizeToolName('Write')).toBe('Write');
+    expect(normalizeToolName('Skill')).toBe('Skill');
+    expect(normalizeToolName('WebSearch')).toBe('WebSearch');
+  });
+
+  it('passes through unknown names unchanged', () => {
+    expect(normalizeToolName('SomeNewTool')).toBe('SomeNewTool');
+    expect(normalizeToolName('')).toBe('');
+  });
+});
+
+describe('parseHookInput normalizes IDE tool names', () => {
+  it('normalizes execute_command to Bash', () => {
+    const result = parseHookInput({
+      tool_name: 'execute_command',
+      tool_input: { command: 'ls -la' },
+      tool_response: { stdout: 'file.txt', stderr: '' },
+    });
+    expect(result).not.toBeNull();
+    expect(result!.toolName).toBe('Bash');
+  });
+
+  it('normalizes search_content to Grep', () => {
+    const result = parseHookInput({
+      tool_name: 'search_content',
+      tool_input: { pattern: 'TODO' },
+      tool_response: { stdout: 'src/main.ts:5: // TODO fix', stderr: '' },
+    });
+    expect(result).not.toBeNull();
+    expect(result!.toolName).toBe('Grep');
+  });
+
+  it('normalizes web_search to WebSearch', () => {
+    const result = parseHookInput({
+      tool_name: 'web_search',
+      tool_input: { query: 'node.js streams' },
+      tool_response: { stdout: '...', stderr: '' },
+    });
+    expect(result).not.toBeNull();
+    expect(result!.toolName).toBe('WebSearch');
+  });
+
+  it('keeps CLI-style names as-is', () => {
+    const result = parseHookInput({
+      tool_name: 'Bash',
+      tool_input: { command: 'echo hello' },
+      tool_response: { stdout: 'hello', stderr: '' },
+    });
+    expect(result).not.toBeNull();
+    expect(result!.toolName).toBe('Bash');
+  });
+});

--- a/src/auto-recall.ts
+++ b/src/auto-recall.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import { log } from './utils/logger.js';
 import { getTeamaiHome } from './types.js';
 import { deriveSessionId } from './utils/session-id.js';
+import { normalizeToolName } from './utils/tool-names.js';
 
 // ─── Auto-recall data flow ──────────────────────────────
 //
@@ -428,8 +429,9 @@ export interface HookInput {
  * Returns null when the payload does not identify a tool.
  */
 export function parseHookInput(data: Record<string, unknown>): HookInput | null {
-    const toolName = typeof data.tool_name === 'string' ? data.tool_name : '';
-    if (!toolName) return null;
+    const rawToolName = typeof data.tool_name === 'string' ? data.tool_name : '';
+    if (!rawToolName) return null;
+    const toolName = normalizeToolName(rawToolName);
 
     // Parse tool_input (the parameters passed to the tool)
     const rawInput = data.tool_input;

--- a/src/dashboard-collector.ts
+++ b/src/dashboard-collector.ts
@@ -4,6 +4,7 @@ import { log } from './utils/logger.js';
 import { deriveSessionId } from './utils/session-id.js';
 import { ensureDir } from './utils/fs.js';
 import { resolveMonitorPid } from './pid-monitor.js';
+import { normalizeToolName } from './utils/tool-names.js';
 import {
   DASHBOARD_EVENTS_PATH,
   DASHBOARD_EVENTS_DIR,
@@ -165,9 +166,9 @@ export async function parseHookEvent(
     cwd,
   };
 
-  // Extract tool name from PostToolUse
+  // Extract tool name from PostToolUse (normalize IDE-style names)
   if (eventType === 'tool_use' && typeof hookData.tool_name === 'string') {
-    event.toolName = hookData.tool_name;
+    event.toolName = normalizeToolName(hookData.tool_name);
   }
 
   // Resolve AI tool PID for liveness monitoring on session start

--- a/src/hook-handlers.ts
+++ b/src/hook-handlers.ts
@@ -11,6 +11,7 @@
 
 import type { HookHandler } from './hook-dispatch.js';
 import { deriveSessionId } from './utils/session-id.js';
+import { normalizeToolName } from './utils/tool-names.js';
 
 // ─── Public types ───────────────────────────────────────
 
@@ -88,26 +89,25 @@ const trackHandler: HookHandler = {
   async execute(stdin, tool) {
     const { extractSkillName, isValidSkillName, appendUsageEvent, updateKnownSkills } = await import('./usage-tracker.js');
 
-    const toolName = stdin.tool_name;
-    if (typeof toolName !== 'string') return null;
+    const rawToolName = stdin.tool_name;
+    if (typeof rawToolName !== 'string') return null;
+    const toolName = normalizeToolName(rawToolName);
 
     const toolInput = stdin.tool_input;
     if (!toolInput || typeof toolInput !== 'object') return null;
 
-    // Only track Skill (Claude) or Read+SKILL.md (Cursor)
+    // Only track Skill (Claude/CodeBuddy) or Read+SKILL.md (Cursor)
     let skillName: string | null = null;
     let toolSource = tool;
 
     if (toolName === 'Skill') {
       skillName = extractSkillName(toolInput as Record<string, unknown>);
     } else if (toolName === 'Read') {
+      const input = toolInput as Record<string, unknown>;
       const filePath =
-        (typeof (toolInput as Record<string, unknown>).file_path === 'string'
-          ? (toolInput as Record<string, unknown>).file_path
-          : null) ??
-        (typeof (toolInput as Record<string, unknown>).path === 'string'
-          ? (toolInput as Record<string, unknown>).path
-          : null);
+        (typeof input.file_path === 'string' ? input.file_path : null) ??
+        (typeof input.filePath === 'string' ? input.filePath : null) ??
+        (typeof input.path === 'string' ? input.path : null);
       if (typeof filePath === 'string' && /\/SKILL\.md$/i.test(filePath)) {
         skillName = extractSkillName({ skill: filePath });
         toolSource = 'cursor';
@@ -180,7 +180,7 @@ const todowriteHintHandler: HookHandler = {
   async execute(stdin, _tool) {
     if (process.env.TEAMAI_RECALL_DISABLED === '1') return null;
 
-    const toolName = typeof stdin.tool_name === 'string' ? stdin.tool_name : '';
+    const toolName = normalizeToolName(typeof stdin.tool_name === 'string' ? stdin.tool_name : '');
     if (toolName !== 'TodoWrite') return null;
 
     const { shouldSkipTodoWriteHint, buildHintMessage } = await import('./todowrite-hint.js');

--- a/src/usage-tracker.ts
+++ b/src/usage-tracker.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { log } from './utils/logger.js';
+import { normalizeToolName } from './utils/tool-names.js';
 import {
   SKILL_NAME_REGEX,
   type UsageEvent,
@@ -272,7 +273,8 @@ async function readStdin(): Promise<string> {
  * Handle the `teamai track` CLI command.
  * Called by PostToolUse hook with CLI args (legacy) or STDIN JSON (current).
  */
-export async function track(toolName: string, toolInput: string, tool?: string): Promise<void> {
+export async function track(rawToolName: string, toolInput: string, tool?: string): Promise<void> {
+  const toolName = normalizeToolName(rawToolName);
   // Only track Skill tool calls
   if (toolName !== 'Skill') {
     return;
@@ -327,8 +329,9 @@ export async function trackFromStdin(toolArg?: string): Promise<void> {
     return;
   }
 
-  const toolName = hookData.tool_name;
-  if (typeof toolName !== 'string') return;
+  const rawName = hookData.tool_name;
+  if (typeof rawName !== 'string') return;
+  const toolName = normalizeToolName(rawName);
 
   const toolInput = hookData.tool_input;
   if (!toolInput || typeof toolInput !== 'object') {
@@ -346,6 +349,7 @@ export async function trackFromStdin(toolArg?: string): Promise<void> {
   } else if (toolName === 'Read') {
     const filePath =
       (typeof toolInput.file_path === 'string' ? toolInput.file_path : null) ??
+      (typeof toolInput.filePath === 'string' ? toolInput.filePath : null) ??
       (typeof toolInput.path === 'string' ? toolInput.path : null);
     if (filePath && /\/SKILL\.md$/i.test(filePath)) {
       skillName = extractSkillName({ skill: filePath });

--- a/src/utils/tool-names.ts
+++ b/src/utils/tool-names.ts
@@ -1,0 +1,23 @@
+// -*- coding: utf-8 -*-
+/**
+ * Normalize IDE-style tool names (CodeBuddy Craft Agent) to CLI-style names.
+ *
+ * CodeBuddy IDE passes tool names like `execute_command`, `search_content` etc.
+ * while teamai hooks expect CLI-style names like `Bash`, `Grep`.
+ */
+
+const IDE_TO_CLI: Record<string, string> = {
+  execute_command: 'Bash',
+  search_content: 'Grep',
+  write_to_file: 'Write',
+  replace_in_file: 'Edit',
+  list_dir: 'Glob',
+  web_search: 'WebSearch',
+  web_fetch: 'WebFetch',
+  read_file: 'Read',
+  task: 'Task',
+};
+
+export function normalizeToolName(name: string): string {
+  return IDE_TO_CLI[name] ?? name;
+}


### PR DESCRIPTION
## Summary

CodeBuddy IDE (Craft Agent) passes IDE-style tool names via STDIN (e.g. `execute_command`, `search_content`) while teamai hooks only recognize CLI-style names (`Bash`, `Grep`). This caused auto-recall, skill tracking, and dashboard stats to silently no-op in CodeBuddy IDE.

### Fix

Add `normalizeToolName()` mapping layer (per [CodeBuddy docs Appendix E](https://www.codebuddy.cn/docs/ide/Features/Hooks)) applied at all hook entry points before existing dispatch logic:

| IDE Style | CLI Style |
|-----------|-----------|
| `execute_command` | `Bash` |
| `search_content` | `Grep` |
| `write_to_file` | `Write` |
| `replace_in_file` | `Edit` |
| `list_dir` | `Glob` |
| `web_search` | `WebSearch` |
| `web_fetch` | `WebFetch` |
| `read_file` | `Read` |
| `task` | `Task` |

### Entry points patched

- `src/auto-recall.ts` — `parseHookInput()`: normalizes before RECALL_TOOLS whitelist check
- `src/hook-handlers.ts` — `trackHandler` + `todowriteHintHandler`: normalizes before Skill/Read/TodoWrite dispatch
- `src/usage-tracker.ts` — `track()` + `trackFromStdin()`: normalizes before Skill gate
- `src/dashboard-collector.ts` — tool_use event: normalizes before recording to stats

### Secondary fix

Accept both `file_path` (CLI snake_case) and `filePath` (IDE camelCase) in Read tool handlers for SKILL.md detection.

Closes #63

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `npx vitest run` — 1523 passed (108 files)
- [x] Unit tests: all 9 IDE→CLI mappings + passthrough for CLI-style + unknown names
- [x] Integration test: `parseHookInput({ tool_name: 'execute_command', ... })` returns `toolName: 'Bash'`