### PR TITLE
fix(import): resolve graph-index.json race condition in batch import

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ The CLI picks a provider automatically from the repo URL:
 
 Global options: `--dry-run`, `--verbose`
 
+Import options: `--incremental`, `--skip-enrich` (skip AI calls, only extract + graph)
+
 <details>
 <summary>More commands (management, CI, analytics)</summary>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -92,6 +92,8 @@ CLI 会根据用户传入的 repo URL 自动选择 provider：
 
 全局选项：`--dry-run`、`--verbose`
 
+Import 选项：`--incremental`、`--skip-enrich`（跳过 AI 调用，仅做代码提取 + 图谱构建）
+
 <details>
 <summary>更多命令（管理、CI、分析）</summary>
 

--- a/src/__tests__/cross-repo-edges.test.ts
+++ b/src/__tests__/cross-repo-edges.test.ts
@@ -1,0 +1,91 @@
+// -*- coding: utf-8 -*-
+import { describe, it, expect } from 'vitest';
+import { detectCrossRepoEdges } from '../import-repo.js';
+
+describe('detectCrossRepoEdges with GraphIndex format (slug/title)', () => {
+  it('detects cross-repo edges via matching node titles', () => {
+    const repoA = {
+      nodes: [
+        { slug: 'hai-api/balance-client', title: 'BalanceClient', type: 'component' },
+        { slug: 'hai-api/flow-caller', title: 'FlowCaller', type: 'component' },
+      ],
+      edges: [
+        { from: 'hai-api/balance-client', to: 'libs/balance.py', relation: 'imports' },
+      ],
+    };
+
+    const repoB = {
+      nodes: [
+        { slug: 'hai-balance/balance-service', title: 'BalanceService', type: 'component' },
+        { slug: 'hai-balance/config', title: 'hai_balance_config', type: 'config' },
+        { slug: 'hai-flow/flow-engine', title: 'FlowCaller', type: 'component' },
+      ],
+      edges: [
+        { from: 'hai-flow/flow-engine', to: 'api/balance_client.py', relation: 'imports' },
+      ],
+    };
+
+    // repoB 的 flow-engine imports balance_client → match repoA's BalanceClient
+    const edges = detectCrossRepoEdges(repoB, repoA);
+    expect(edges.length).toBeGreaterThan(0);
+    const depEdge = edges.find(e => e.relation === 'DEPENDS_ON');
+    expect(depEdge).toBeDefined();
+  });
+
+  it('detects config node matching across repos', () => {
+    const repoA = {
+      nodes: [
+        { slug: 'hai-api/service', title: 'InferService', type: 'component' },
+      ],
+      edges: [],
+    };
+
+    const configRepo = {
+      nodes: [
+        { slug: 'configs/infer-service-config', title: 'InferService', type: 'config' },
+      ],
+      edges: [],
+    };
+
+    // config repo has a config node whose title matches repoA's component
+    const edges = detectCrossRepoEdges(configRepo, repoA);
+    expect(edges.length).toBeGreaterThan(0);
+    expect(edges[0].relation).toBe('DEPENDS_ON');
+  });
+
+  it('handles mixed format nodes (id/label and slug/title)', () => {
+    const oldFormat = {
+      nodes: [
+        { id: 'old-node-1', kind: 'component', label: 'AuthService', file: 'src/auth.py' },
+      ],
+      edges: [
+        { from: 'src/auth.py', to: 'libs/auth_client.py', relation: 'imports' },
+      ],
+    };
+
+    const newFormat = {
+      nodes: [
+        { slug: 'new-repo/auth-client', title: 'AuthClient', type: 'component' },
+      ],
+      edges: [],
+    };
+
+    // oldFormat imports auth_client → PascalCase = AuthClient → matches newFormat
+    const edges = detectCrossRepoEdges(oldFormat, newFormat);
+    expect(edges.length).toBeGreaterThan(0);
+  });
+
+  it('returns empty for repos with no shared names', () => {
+    const repoA = {
+      nodes: [{ slug: 'a/foo', title: 'FooService', type: 'component' }],
+      edges: [],
+    };
+    const repoB = {
+      nodes: [{ slug: 'b/bar', title: 'BarService', type: 'component' }],
+      edges: [],
+    };
+
+    const edges = detectCrossRepoEdges(repoA, repoB);
+    expect(edges).toHaveLength(0);
+  });
+});

--- a/src/__tests__/graph-aggregate.test.ts
+++ b/src/__tests__/graph-aggregate.test.ts
@@ -1,0 +1,116 @@
+// -*- coding: utf-8 -*-
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import fs from 'fs-extra';
+import os from 'node:os';
+import { aggregateGlobalGraph } from '../graph-aggregate.js';
+
+describe('aggregateGlobalGraph', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'graph-agg-'));
+  });
+
+  afterEach(async () => {
+    await fs.remove(tmpDir);
+  });
+
+  function writeRepoGraph(slug: string, graph: object): void {
+    const dir = path.join(tmpDir, 'evidence', 'code', slug, '.indices');
+    fs.ensureDirSync(dir);
+    fs.writeFileSync(path.join(dir, 'graph-index.json'), JSON.stringify(graph));
+  }
+
+  it('merges multiple per-repo graphs into global', async () => {
+    writeRepoGraph('repo-a', {
+      schemaVersion: 1, generatedAt: '2026-01-01',
+      nodes: [
+        { slug: 'a/svc', title: 'ServiceA', type: 'component', confidence: 'high' },
+      ],
+      edges: [],
+    });
+    writeRepoGraph('repo-b', {
+      schemaVersion: 1, generatedAt: '2026-01-01',
+      nodes: [
+        { slug: 'b/svc', title: 'ServiceB', type: 'component', confidence: 'high' },
+      ],
+      edges: [],
+    });
+
+    const result = await aggregateGlobalGraph(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result!.nodes).toBe(2);
+    expect(result!.edges).toBe(0);
+
+    const globalPath = path.join(tmpDir, '.indices', 'graph-index.json');
+    expect(await fs.pathExists(globalPath)).toBe(true);
+    const global = JSON.parse(await fs.readFile(globalPath, 'utf8'));
+    expect(global.nodes).toHaveLength(2);
+  });
+
+  it('detects cross-repo edges via matching titles', async () => {
+    writeRepoGraph('repo-a', {
+      schemaVersion: 1, generatedAt: '2026-01-01',
+      nodes: [
+        { slug: 'a/client', title: 'BalanceClient', type: 'component', confidence: 'high' },
+      ],
+      edges: [
+        { from: 'a/client', to: 'libs/balance_service.py', relation: 'imports' },
+      ],
+    });
+    writeRepoGraph('repo-b', {
+      schemaVersion: 1, generatedAt: '2026-01-01',
+      nodes: [
+        { slug: 'b/service', title: 'BalanceService', type: 'component', confidence: 'high' },
+      ],
+      edges: [],
+    });
+
+    const result = await aggregateGlobalGraph(tmpDir);
+    expect(result!.edges).toBeGreaterThan(0);
+
+    const global = JSON.parse(await fs.readFile(
+      path.join(tmpDir, '.indices', 'graph-index.json'), 'utf8',
+    ));
+    const crossEdges = global.edges.filter((e: { relation: string }) => e.relation === 'DEPENDS_ON');
+    expect(crossEdges.length).toBeGreaterThan(0);
+  });
+
+  it('does NOT create false cross-repo edges from intra-repo imports (P1 regression)', async () => {
+    // repo-a has an internal import: component→module within the same repo
+    writeRepoGraph('repo-a', {
+      schemaVersion: 1, generatedAt: '2026-01-01',
+      nodes: [
+        { slug: 'a/handler', title: 'RequestHandler', type: 'component', confidence: 'high' },
+        { slug: 'a/utils', title: 'RequestUtils', type: 'component', confidence: 'high' },
+      ],
+      edges: [
+        { from: 'a/handler', to: 'src/request_utils.py', relation: 'imports' },
+      ],
+    });
+    // repo-b has no shared names with repo-a
+    writeRepoGraph('repo-b', {
+      schemaVersion: 1, generatedAt: '2026-01-01',
+      nodes: [
+        { slug: 'b/worker', title: 'BackgroundWorker', type: 'component', confidence: 'high' },
+      ],
+      edges: [],
+    });
+
+    const result = await aggregateGlobalGraph(tmpDir);
+    const global = JSON.parse(await fs.readFile(
+      path.join(tmpDir, '.indices', 'graph-index.json'), 'utf8',
+    ));
+    const crossEdges = global.edges.filter((e: { relation: string }) => e.relation === 'DEPENDS_ON');
+    // repo-a's internal import (RequestHandler→RequestUtils) should NOT produce
+    // a cross-repo DEPENDS_ON edge because both nodes belong to the same repo
+    // and detectCrossRepoEdges runs BEFORE merge (overlay doesn't match itself in existing)
+    expect(crossEdges).toHaveLength(0);
+  });
+
+  it('returns null when no evidence directory exists', async () => {
+    const result = await aggregateGlobalGraph(tmpDir);
+    expect(result).toBeNull();
+  });
+});

--- a/src/codebase-extract.ts
+++ b/src/codebase-extract.ts
@@ -34,6 +34,7 @@ export interface ExtractCodebaseOptions {
   json?: boolean;
   project?: string;
   maxFiles?: number;
+  skipEnrich?: boolean;
 }
 
 interface ExtractResult {
@@ -575,9 +576,11 @@ export async function extractCodebase(opts: ExtractCodebaseOptions): Promise<voi
   // Write graph-index.json using protocol function (B5)
   await saveGraphIndex(wikiRoot, mergedGraph);
 
-  // AI enrichment (optional, non-blocking)
+  // AI enrichment (optional, non-blocking; skipped with --skip-enrich)
   let aiDomains: DomainGroup[] = [];
-  try {
+  if (opts.skipEnrich) {
+    if (!opts.json) console.log(chalk.dim('  [AI 增强: 已跳过 (--skip-enrich)]'));
+  } else try {
     const { enrichWithAI, writeManifest } = await import('./enrich-with-ai.js');
     const modules = new Map<string, CodeFact[]>();
     for (const fact of facts) {

--- a/src/graph-aggregate.ts
+++ b/src/graph-aggregate.ts
@@ -1,0 +1,62 @@
+// -*- coding: utf-8 -*-
+import path from 'node:path';
+import { readdir } from 'node:fs/promises';
+import fs from 'fs-extra';
+import { log } from './utils/logger.js';
+
+/**
+ * 聚合 teamwiki/evidence/code/ 下所有仓库的 per-repo graph 到全局 graph-index.json。
+ *
+ * 串行合并避免竞态；对每对仓库执行跨仓 edge 检测。
+ *
+ * 注意：每次调用都会重新扫描所有 per-repo graph（O(n)）。
+ * 单仓 import 时也会触发全量重聚合。仓库数量增大（>50）后
+ * 可考虑增量聚合优化。
+ *
+ * @param teamwikiRoot teamwiki/ 根目录
+ * @returns 聚合后的节点数和边数，无产出时返回 null
+ */
+export async function aggregateGlobalGraph(
+    teamwikiRoot: string,
+): Promise<{ nodes: number; edges: number } | null> {
+    const evidenceBase = path.join(teamwikiRoot, 'evidence', 'code');
+    if (!(await fs.pathExists(evidenceBase))) return null;
+
+    const { mergeGraphs } = await import('./wiki-engine/adapters/index.js');
+    type GraphIndex = Parameters<typeof mergeGraphs>[0];
+    const { detectCrossRepoEdges } = await import('./import-repo.js');
+
+    let globalGraph: GraphIndex | null = null;
+    const projectDirs = await readdir(evidenceBase, { withFileTypes: true });
+
+    for (const dir of projectDirs) {
+        if (!dir.isDirectory()) continue;
+        const graphPath = path.join(evidenceBase, dir.name, '.indices', 'graph-index.json');
+        if (!(await fs.pathExists(graphPath))) continue;
+
+        try {
+            const overlay = JSON.parse(await fs.readFile(graphPath, 'utf8')) as GraphIndex;
+            if (globalGraph) {
+                const crossEdges = detectCrossRepoEdges(overlay, globalGraph);
+                globalGraph = mergeGraphs(globalGraph, overlay);
+                if (crossEdges.length > 0) {
+                    globalGraph.edges.push(...crossEdges);
+                }
+            } else {
+                globalGraph = overlay;
+            }
+        } catch (e) {
+            log.warn(`[graph] 跳过 ${dir.name} graph: ${(e as Error).message}`);
+        }
+    }
+
+    if (globalGraph) {
+        const destPath = path.join(teamwikiRoot, '.indices', 'graph-index.json');
+        await fs.ensureDir(path.dirname(destPath));
+        await fs.writeFile(destPath, JSON.stringify(globalGraph, null, 2), 'utf8');
+        log.info(`全局 graph-index.json 已聚合（${globalGraph.nodes.length} nodes, ${globalGraph.edges.length} edges）`);
+        return { nodes: globalGraph.nodes.length, edges: globalGraph.edges.length };
+    }
+
+    return null;
+}

--- a/src/import-repo-list.ts
+++ b/src/import-repo-list.ts
@@ -1,5 +1,6 @@
 // -*- coding: utf-8 -*-
 import path from 'node:path';
+import fs from 'fs-extra';
 import { loadRepoList } from './repo-list/store.js';
 import { isOrgEntry, type RepoListEntry } from './repo-list/schema.js';
 import { importFromRepo } from './import-repo.js';
@@ -114,6 +115,7 @@ export async function importFromRepoList(
                 output,
                 interactive: false,
                 incremental,
+                skipAutoPush: true,
             });
             succeeded.push(1);
         } catch (err) {
@@ -144,12 +146,26 @@ export async function importFromRepoList(
     // 等待全部完成
     await Promise.all(inFlight);
 
+    // 4. 统一聚合全局 graph-index.json（避免并发竞态）
+    if (!dryRun && succeeded.length > 0) {
+        try {
+            const { autoDetectInit } = await import('./config.js');
+            const { localConfig: lc } = await autoDetectInit();
+            const teamRepoPath = lc.repo.localPath;
+            const teamwikiRoot = path.join(teamRepoPath, 'teamwiki');
+
+            const { aggregateGlobalGraph } = await import('./graph-aggregate.js');
+            await aggregateGlobalGraph(teamwikiRoot);
+        } catch (e) {
+            log.warn(`[graph] 全局图谱聚合失败（不中断流程）：${(e as Error).message}`);
+        }
+    }
+
     // 5. 重建聚合文件
     let aggregateGenerated = false;
     if (!skipAggregate && !dryRun) {
         try {
             const cwd = process.cwd();
-            // 优先使用 team-repo 路径读取 domains 和写入聚合产物
             let resolvedOutput = output;
             let domainsBase = cwd;
             if (!resolvedOutput) {
@@ -168,6 +184,18 @@ export async function importFromRepoList(
         } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
             log.warn(`聚合文件生成失败（不中断流程）：${message}`);
+        }
+    }
+
+    // 6. 统一推送（graph + aggregate 一次性提交）
+    if (!dryRun && succeeded.length > 0) {
+        try {
+            const { autoDetectInit } = await import('./config.js');
+            const { localConfig: lc } = await autoDetectInit();
+            const { autoPushTeamRepo } = await import('./utils/git.js');
+            await autoPushTeamRepo(lc.repo.localPath, '[teamai] Batch import: graph + aggregate');
+        } catch (e) {
+            log.warn(`[git] 批量推送失败（不中断流程）：${(e as Error).message}`);
         }
     }
 

--- a/src/import-repo.ts
+++ b/src/import-repo.ts
@@ -54,12 +54,23 @@ export interface ImportFromRepoOptions {
     interactive?: boolean;
     /** 增量模式：缓存命中时仅 fetch+reset，未命中时 fallback 到全量 clone */
     incremental?: boolean;
+    /** batch 模式下跳过 per-repo 的 autoPushTeamRepo（由调用方统一处理） */
+    skipAutoPush?: boolean;
+    /** 跳过 AI enrichment（只做 clone + extract + graph，不调用 LLM） */
+    skipEnrich?: boolean;
 }
 
 // ─── Cross-Repo Edge Detection ─────────────────────────
 
+interface SimpleGraphNode {
+    id?: string; slug?: string;
+    kind?: string; type?: string;
+    label?: string; title?: string;
+    file?: string;
+}
+
 interface SimpleGraphIndex {
-    nodes: Array<{ id: string; kind: string; label: string; file: string }>;
+    nodes: SimpleGraphNode[];
     edges: Array<{ from: string; to: string; relation: string }>;
 }
 
@@ -72,43 +83,47 @@ interface SimpleGraphIndex {
  *
  * 基于 team-wiki 的 buildCodeGraphIndex 中 exportIndex 匹配思想。
  */
-function detectCrossRepoEdges(
+export function detectCrossRepoEdges(
     overlay: SimpleGraphIndex,
     existing: SimpleGraphIndex,
-    _newProject: string,
-): Array<{ from: string; to: string; relation: string }> {
-    const crossEdges: Array<{ from: string; to: string; relation: string }> = [];
+): Array<{ from: string; to: string; relation: 'DEPENDS_ON' }> {
+    const crossEdges: Array<{ from: string; to: string; relation: 'DEPENDS_ON' }> = [];
     const edgeSet = new Set<string>();
+
+    const nodeId = (n: SimpleGraphNode): string => n.id ?? n.slug ?? '';
+    const nodeLabel = (n: SimpleGraphNode): string => n.label ?? n.title ?? '';
+    const nodeKind = (n: SimpleGraphNode): string => n.kind ?? n.type ?? '';
 
     // 建立已有图谱的组件/接口名索引
     const existingIndex = new Map<string, string>();
     for (const node of existing.nodes) {
-        existingIndex.set(node.label.toLowerCase(), node.id);
+        const label = nodeLabel(node);
+        if (label) existingIndex.set(label.toLowerCase(), nodeId(node));
     }
 
     // 建立新图谱的组件/接口名索引
     const overlayIndex = new Map<string, string>();
     for (const node of overlay.nodes) {
-        overlayIndex.set(node.label.toLowerCase(), node.id);
+        const label = nodeLabel(node);
+        if (label) overlayIndex.set(label.toLowerCase(), nodeId(node));
     }
 
     // 检查新仓库的 import 边目标是否有同名组件在已有仓库中
     for (const edge of overlay.edges) {
         if (edge.relation !== 'imports') continue;
-        // 从 edge.to 文件路径提取可能的模块名
         const segments = edge.to.split('/');
         const fileName = segments[segments.length - 1]?.replace(/\.(ts|tsx|js|jsx|py|go|rs|java)$/, '') ?? '';
-        // 将 kebab-case 转为 PascalCase 来匹配类名
         const pascalName = fileName.split(/[-_]/).map(s => s.charAt(0).toUpperCase() + s.slice(1)).join('');
 
         const match = existingIndex.get(pascalName.toLowerCase());
         if (match) {
-            const fromNode = overlay.nodes.find(n => n.file === edge.from);
+            const fromNode = overlay.nodes.find(n => (n.file ?? n.id ?? n.slug ?? '') === edge.from);
             if (fromNode) {
-                const key = `${fromNode.id}|${match}`;
+                const fromId = nodeId(fromNode);
+                const key = `${fromId}|${match}`;
                 if (!edgeSet.has(key)) {
                     edgeSet.add(key);
-                    crossEdges.push({ from: fromNode.id, to: match, relation: 'DEPENDS_ON' });
+                    crossEdges.push({ from: fromId, to: match, relation: 'DEPENDS_ON' });
                 }
             }
         }
@@ -123,43 +138,46 @@ function detectCrossRepoEdges(
 
         const match = overlayIndex.get(pascalName.toLowerCase());
         if (match) {
-            const fromNode = existing.nodes.find(n => n.file === edge.from);
+            const fromNode = existing.nodes.find(n => (n.file ?? n.id ?? n.slug ?? '') === edge.from);
             if (fromNode) {
-                const key = `${fromNode.id}|${match}`;
+                const fromId = nodeId(fromNode);
+                const key = `${fromId}|${match}`;
                 if (!edgeSet.has(key)) {
                     edgeSet.add(key);
-                    crossEdges.push({ from: fromNode.id, to: match, relation: 'DEPENDS_ON' });
+                    crossEdges.push({ from: fromId, to: match, relation: 'DEPENDS_ON' });
                 }
             }
         }
     }
 
     // 配置仓库关联：config/data 节点的 label 与另一仓库的组件/接口节点 label 完全匹配
-    const overlayConfigs = overlay.nodes.filter(n => n.kind === 'config' || n.kind === 'data');
-    const existingConfigs = existing.nodes.filter(n => n.kind === 'config' || n.kind === 'data');
+    const overlayConfigs = overlay.nodes.filter(n => nodeKind(n) === 'config' || nodeKind(n) === 'data');
+    const existingConfigs = existing.nodes.filter(n => nodeKind(n) === 'config' || nodeKind(n) === 'data');
 
     for (const cfg of overlayConfigs) {
-        const cfgName = cfg.label.toLowerCase();
+        const cfgName = nodeLabel(cfg).toLowerCase();
         if (cfgName.length < 5) continue;
+        const cfgId = nodeId(cfg);
         const match = existingIndex.get(cfgName);
         if (match) {
-            const key = `${match}|${cfg.id}`;
+            const key = `${match}|${cfgId}`;
             if (!edgeSet.has(key)) {
                 edgeSet.add(key);
-                crossEdges.push({ from: match, to: cfg.id, relation: 'DEPENDS_ON' });
+                crossEdges.push({ from: match, to: cfgId, relation: 'DEPENDS_ON' });
             }
         }
     }
 
     for (const cfg of existingConfigs) {
-        const cfgName = cfg.label.toLowerCase();
+        const cfgName = nodeLabel(cfg).toLowerCase();
         if (cfgName.length < 5) continue;
+        const cfgId = nodeId(cfg);
         const match = overlayIndex.get(cfgName);
         if (match) {
-            const key = `${match}|${cfg.id}`;
+            const key = `${match}|${cfgId}`;
             if (!edgeSet.has(key)) {
                 edgeSet.add(key);
-                crossEdges.push({ from: match, to: cfg.id, relation: 'DEPENDS_ON' });
+                crossEdges.push({ from: match, to: cfgId, relation: 'DEPENDS_ON' });
             }
         }
     }
@@ -520,7 +538,7 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
     const {
         url, depth = 1, forceSsh = false, forceAnonymous = false,
         explicitDomain, dryRun = false, output, interactive = true,
-        incremental = false,
+        incremental = false, skipAutoPush = false, skipEnrich = false,
     } = opts;
 
     // 1. 解析 provider 和仓库信息
@@ -614,10 +632,14 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
     // 3. 扫描生成 codebase.md（AI 扫描失败不阻断后续图谱提取）
     log.info(`扫描仓库内容...`);
     let codebaseMd: string | undefined;
-    try {
-        codebaseMd = await generateCodebaseMd({ repoPath: cacheDir });
-    } catch (err) {
-        log.warn(`AI codebase 扫描失败（不阻断图谱提取）: ${err instanceof Error ? err.message : String(err)}`);
+    if (skipEnrich) {
+        log.debug('AI enrichment skipped (--skip-enrich)');
+    } else {
+        try {
+            codebaseMd = await generateCodebaseMd({ repoPath: cacheDir });
+        } catch (err) {
+            log.warn(`AI codebase 扫描失败（不阻断图谱提取）: ${err instanceof Error ? err.message : String(err)}`);
+        }
     }
 
     // 4. 写入 docs/team-codebase 叙事文档（AI 扫描成功时）
@@ -698,14 +720,21 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
     } // end if (codebaseMd)
 
     // 4b. 生成 teamwiki/ 知识图谱产物（写入 team-repo 以便自动 push）
-    const teamRepoDir = path.join(process.cwd(), '.teamai', 'team-repo');
+    let teamRepoDir: string;
+    try {
+        const { autoDetectInit } = await import('./config.js');
+        const { localConfig: lc } = await autoDetectInit();
+        teamRepoDir = lc.repo.localPath;
+    } catch {
+        teamRepoDir = path.join(process.cwd(), '.teamai', 'team-repo');
+    }
     const teamwikiRoot = output
         ? path.resolve(output, '..', 'teamwiki')
         : path.join(teamRepoDir, 'teamwiki');
     if (!dryRun) {
         const cacheWiki = path.join(cacheDir, 'teamwiki');
         try {
-            await extractCodebase({ path: cacheDir, project: slug, json: false });
+            await extractCodebase({ path: cacheDir, project: slug, json: false, skipEnrich });
             // 将产物从 cacheDir/teamwiki/ 移动到目标 teamwikiRoot
             if (await fs.pathExists(cacheWiki)) {
                 const evidenceSrc = path.join(cacheWiki, 'evidence', 'code', slug);
@@ -725,38 +754,25 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
                     ].join('\n');
                     await fs.writeFile(path.join(evidenceDest, 'overview.md'), overviewContent, 'utf8');
                 }
-                // 合并 graph-index
+                // Per-repo graph: copy to evidence/<slug>/.indices/ (no global merge here — done in batch)
                 const srcGraph = path.join(cacheWiki, '.indices', 'graph-index.json');
-                const destGraph = path.join(teamwikiRoot, '.indices', 'graph-index.json');
-                await fs.ensureDir(path.join(teamwikiRoot, '.indices'));
-                if (await fs.pathExists(destGraph)) {
-                    const { mergeGraphs } = await import('./wiki-engine/adapters/index.js');
-                    let existing, overlay;
-                    try {
-                        existing = JSON.parse(await fs.readFile(destGraph, 'utf8'));
-                    } catch (parseErr) {
-                        log.warn(`[wiki-engine] graph-index.json 解析失败，将重建: ${(parseErr as Error).message}`);
-                        existing = null;
-                    }
-                    try {
-                        overlay = JSON.parse(await fs.readFile(srcGraph, 'utf8'));
-                    } catch (parseErr) {
-                        log.warn(`[wiki-engine] 源图谱解析失败，跳过合并: ${(parseErr as Error).message}`);
-                        overlay = null;
-                    }
-                    if (overlay) {
-                        const merged2 = existing ? mergeGraphs(existing, overlay) : overlay;
-                        const crossRepoEdges = detectCrossRepoEdges(overlay, existing ?? { nodes: [], edges: [] }, slug);
-                        if (crossRepoEdges.length > 0) {
-                            (merged2 as { edges: Array<{ from: string; to: string; relation: string }> }).edges.push(...crossRepoEdges);
-                            log.debug(`[wiki-engine] 检测到 ${crossRepoEdges.length} 条跨仓关系`);
-                        }
-                        await fs.writeFile(destGraph, JSON.stringify(merged2, null, 2), 'utf8');
-                    }
-                } else {
-                    await fs.copy(srcGraph, destGraph);
-                }
+                const evidenceGraphDir = path.join(teamwikiRoot, 'evidence', 'code', slug, '.indices');
+                await fs.ensureDir(evidenceGraphDir);
+                await fs.copy(srcGraph, path.join(evidenceGraphDir, 'graph-index.json'));
                 await fs.remove(cacheWiki);
+            }
+            // 白名单显式 domain 覆盖 AI 推断
+            if (explicitDomain) {
+                const domainsJsonPath = path.join(teamwikiRoot, 'evidence', 'code', slug, '_domains.json');
+                if (await fs.pathExists(domainsJsonPath)) {
+                    try {
+                        const existing = JSON.parse(await fs.readFile(domainsJsonPath, 'utf8'));
+                        existing.domain = explicitDomain;
+                        await fs.writeFile(domainsJsonPath, JSON.stringify(existing, null, 2), 'utf8');
+                    } catch { /* skip */ }
+                } else {
+                    await fs.writeFile(domainsJsonPath, JSON.stringify({ domain: explicitDomain }, null, 2), 'utf8');
+                }
             }
             // 更新顶层 router.md 和 index.md（追加新项目，不覆盖）
             const { routerTemplate, indexTemplate, HOT_TEMPLATE } = await import('./wiki-engine/adapters/templates.js');
@@ -809,18 +825,25 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
         }
     }
 
-    // 5. 自动推送所有产物到团队仓库
-    if (!dryRun) {
-        const pushTarget = path.join(process.cwd(), '.teamai', 'team-repo');
-        if (await fs.pathExists(pushTarget)) {
+    // 5. 聚合全局图谱 + 自动推送（单仓模式；batch 模式由 import-repo-list 统一处理）
+    if (!dryRun && !skipAutoPush) {
+        if (teamwikiRoot) {
+            try {
+                const { aggregateGlobalGraph } = await import('./graph-aggregate.js');
+                await aggregateGlobalGraph(teamwikiRoot);
+            } catch (e) {
+                log.debug(`[graph] 单仓聚合跳过: ${(e as Error).message}`);
+            }
+        }
+        if (await fs.pathExists(teamRepoDir)) {
             const { autoPushTeamRepo } = await import('./utils/git.js');
-            await autoPushTeamRepo(pushTarget, `[teamai] Import codebase knowledge from ${owner}/${repoName}`);
+            await autoPushTeamRepo(teamRepoDir, `[teamai] Import codebase knowledge from ${owner}/${repoName}`);
         }
     }
 
     log.info(chalk.green(`✓ 仓库 ${owner}/${repoName} 导入完成`));
 
-    // 5b. 后台深度生成（不阻塞）
+    // 5b. 后台深度生成（不阻塞；batch 模式下跳过 push 由调用方统一处理）
     if (!dryRun && teamwikiRoot) {
         const evidenceDir = path.join(teamwikiRoot, 'evidence', 'code', slug);
         if (await fs.pathExists(path.join(evidenceDir, '_manifest.json'))) {
@@ -828,10 +851,11 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
                 try {
                     const { deepEnrich } = await import('./deep-enrich.js');
                     await deepEnrich({ project: slug, evidenceDir, wikiRoot: teamwikiRoot, cacheDir });
-                    const { autoPushTeamRepo } = await import('./utils/git.js');
-                    const pushTarget = path.join(process.cwd(), '.teamai', 'team-repo');
-                    if (await fs.pathExists(pushTarget)) {
-                        await autoPushTeamRepo(pushTarget, `[teamai] Deep enrich: ${slug}`);
+                    if (!skipAutoPush) {
+                        const { autoPushTeamRepo } = await import('./utils/git.js');
+                        if (await fs.pathExists(teamRepoDir)) {
+                            await autoPushTeamRepo(teamRepoDir, `[teamai] Deep enrich: ${slug}`);
+                        }
                     }
                     log.info(chalk.green(`✓ 深度生成完成: ${slug}`));
                 } catch (e) {

--- a/src/import.ts
+++ b/src/import.ts
@@ -71,6 +71,8 @@ interface ImportOptions extends GlobalOptions {
   iwikiDual?: boolean;
   /** --require-review：codebase sections 落到 pending-review.jsonl */
   requireReview?: boolean;
+  /** --skip-enrich：跳过 AI enrichment，只做 clone + extract + graph */
+  skipEnrich?: boolean;
 }
 
 /**
@@ -105,6 +107,7 @@ export async function importCmd(opts: ImportOptions): Promise<void> {
         dryRun: opts.dryRun,
         output: opts.output,
         incremental: opts.incremental ?? false,
+        skipEnrich: opts.skipEnrich ?? false,
       });
       return;
     } else if (opts.fromRepoList) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -604,6 +604,7 @@ program
   .addOption(new Option('--concurrency <n>', 'Concurrent repos for --from-repo-list (default 3)').default('3').hideHelp())
   .addOption(new Option('--skip-aggregate', 'Skip domain-*.md / index.md regeneration').hideHelp())
   .option('--incremental', 'Use cached clone with fetch+reset (with --from-repo or --from-repo-list)')
+  .option('--skip-enrich', 'Skip AI enrichment (only clone + extract + graph, no LLM calls)')
   .option('--from-org <org>', 'List repos under an org and bootstrap whitelist + domains')
   .addOption(new Option('--bootstrap', 'Run interactive review after --from-org').hideHelp())
   .addOption(new Option('--max-repos <n>', 'Cap on repos pulled from --from-org (default 200)').default('200').hideHelp())

--- a/src/utils/ai-client.ts
+++ b/src/utils/ai-client.ts
@@ -1,5 +1,6 @@
 import { spawn, execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
+import { log } from './logger.js';
 
 /** 白名单：允许探测的 CLI 名称，防止意外执行任意命令。 */
 const ALLOWED_CLI_CANDIDATES = [
@@ -9,8 +10,8 @@ const ALLOWED_CLI_CANDIDATES = [
 /** CLI 探测超时（毫秒），防止 execFileSync 挂死。 */
 const CLI_DETECT_TIMEOUT_MS = 5_000;
 
-/** 默认 AI 调用超时时间（毫秒）。仓库初始化等大文档生成场景需要较长时间。 */
-const DEFAULT_TIMEOUT_MS = 1200_000;
+/** 默认 AI 调用超时时间（毫秒）。 */
+const DEFAULT_TIMEOUT_MS = 120_000;
 
 /** 默认并发数量上限。 */
 const DEFAULT_CONCURRENCY = 3;
@@ -146,7 +147,8 @@ export async function callClaude(
     const timer = setTimeout(() => {
       child.kill();
       const seconds = Math.round(timeoutMs / 1000);
-      reject(new Error(`AI call timed out after ${seconds}s`));
+      log.debug(`[ai-client] timeout after ${seconds}s, cli=${_cliInfo!.cmd}, prompt=${prompt.slice(0, 80)}...`);
+      reject(new Error(`AI call timed out after ${seconds}s (cli: ${_cliInfo!.cmd})`));
     }, timeoutMs);
 
     child.on('error', (err: Error) => {

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -149,8 +149,8 @@ export async function pushRepoDirectly(localPath: string, message: string, files
 export async function autoPushTeamRepo(repoPath: string, message: string): Promise<void> {
   try {
     await pushRepoDirectly(repoPath, message, ['.']);
-  } catch {
-    // non-blocking: user can manually run teamai push
+  } catch (err) {
+    log.warn(`[git] autoPush failed (non-blocking): ${(err as Error).message}`);
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes critical data loss in `teamai import --from-org` / `--from-repo-list` / `--from-repo` when graph-index.json is written concurrently or without full aggregation.

### Problem

When `import-repo-list` dispatches multiple `importFromRepo` calls concurrently (default concurrency=3), the global `graph-index.json` read-merge-write cycle has no mutual exclusion. The last writer wins, silently discarding other repos' nodes/edges. Result: only the first repo's data survives in the global graph.

### Fix: batch-then-aggregate strategy + shared aggregation

1. **Per-repo isolation**: each `importFromRepo` now only writes its own graph to `evidence/<slug>/.indices/`
2. **Shared `aggregateGlobalGraph()`** (`src/graph-aggregate.ts`): serially merges all per-repo graphs into one global `graph-index.json` with cross-repo edge detection
3. **All import modes covered**: single-repo aggregates after write; batch aggregates after all repos complete
4. **Single push**: graph + aggregate files committed in one push at the end

### Review feedback addressed

| Issue | Status |
|-------|--------|
| **P1 🔴** detect/merge 顺序回归 (先 merge 后 detect 导致 self-match 噪声) | ✅ 修复为先 detect 再 merge |
| **P2-1 🟠** push 在 regenerateAggregate 之前 | ✅ push 移到 step 6 统一一次 |
| **P2-2 🟠** skipAutoPush 误伤 deep-enrich | ✅ deep-enrich 始终执行，仅 push 受控 |
| **P2-3 🟠** aggregateGlobalGraph 无测试 | ✅ 4 个集成测试含 P1 回归用例 |
| **P3-1 🟡** push 路径来源不一致 | ✅ 统一从 `autoDetectInit()` 获取 |
| **P3-2 🟡** `_newProject` 参数未使用 | ✅ 已删除 |
| **P3-3 🟡** 单仓全量重聚合 O(n) | ✅ JSDoc 注明限制，>50 仓后需增量优化 |
| **P3-4 🟡** `as GraphIndex['edges']` 类型断言 | ✅ 返回类型改为字面量 `'DEPENDS_ON'`，断言已移除 |

### Additional fixes (from E2E testing)

- **AI 超时保护**: `DEFAULT_TIMEOUT_MS` 从 1200s → 120s + 超时诊断日志
- **`--skip-enrich` 选项**: CLI + import-repo + codebase-extract，跳过 AI 只做 extract+graph
- **`autoPushTeamRepo`**: `log.warn` on failure instead of silent `catch {}`
- **`explicitDomain`** from whitelist now overrides AI-inferred `_domains.json`
- **`detectCrossRepoEdges`**: compatible with both `id/label/file` and `slug/title/type` node formats
- **README**: 中英文文档新增 `--skip-enrich` 选项说明

### E2E verification (TGit group 378710, 11 repos)

| Metric | Before (issue report) | After |
|--------|----------------------|-------|
| Global nodes | 14 | **1179** |
| Global edges | 1 | **780** |
| Cross-repo DEPENDS_ON | 0 | Functional |
| Repos in global graph | 1 | **11** |

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `npx vitest run` — 1587 passed (117 files)
- [x] `aggregateGlobalGraph`: 4 integration tests (merge, cross-repo edges, P1 regression, empty dir)
- [x] `detectCrossRepoEdges`: 4 unit tests (slug/title, config match, mixed format, no-match)
- [x] E2E: `import --from-org git.woa.com/378710` — 11 repos, 1179 nodes, 780 edges
- [x] `--skip-enrich`: import 跳过 AI 调用，仅做 extract+graph