### PR TITLE
fix(recall): resolve 7 knowledge retrieval bugs (#79-#85)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ The value you pass to `--http <baseUrl>` is the base; every endpoint is relative
 | `teamai pull` | Pull team resources and inject into local AI tools |
 | `teamai status` | Show local vs team repo diff |
 | `teamai recall <query>` | Search the team knowledge base (BM25 + graph-boost) |
+| `teamai import --dir <path>` | Extract code knowledge graph from a local directory |
 | `teamai import --from-repo <url>` | Import a repo's code knowledge graph (`teamwiki/`) |
 | `teamai import --from-org <org>` | Batch import all repos under an organization |
 | `teamai import --from-repo-list <yaml>` | Batch import repos from a whitelist |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -131,6 +131,7 @@ teamai init --http https://your-team-host/api --token <api-key>
 | `teamai pull` | 拉取团队资源并注入到本地 AI 工具 |
 | `teamai status` | 查看本地 vs 团队仓库差异 |
 | `teamai recall <query>` | 搜索团队知识库（BM25 + 图谱加权） |
+| `teamai import --dir <path>` | 从本地目录提取代码知识图谱 |
 | `teamai import --from-repo <url>` | 导入仓库代码知识图谱（`teamwiki/`） |
 | `teamai import --from-org <org>` | 批量导入组织下所有仓库 |
 | `teamai import --from-repo-list <yaml>` | 按白名单批量导入 |

--- a/src/__tests__/search-domain-weighting.test.ts
+++ b/src/__tests__/search-domain-weighting.test.ts
@@ -184,7 +184,7 @@ describe('domain-weighted search scoring', () => {
     expect(results[0].entry.domain).toBe('support');
   });
 
-  it('built index carries domain field on every entry (version 4)', async () => {
+  it('built index carries domain field on every entry (version 5)', async () => {
     const learningsDir = path.join(tmpDir, 'learnings');
     await fse.ensureDir(learningsDir);
 
@@ -197,7 +197,7 @@ describe('domain-weighted search scoring', () => {
     const index = await loadIndex(indexPath);
 
     expect(index).not.toBeNull();
-    expect(index!.version).toBe(4);
+    expect(index!.version).toBe(5);
 
     for (const entry of index!.entries) {
       expect(entry.domain).toBeDefined();

--- a/src/auto-recall.ts
+++ b/src/auto-recall.ts
@@ -648,8 +648,8 @@ export async function autoRecallFromInput(input: HookInput): Promise<string | nu
     // Best-effort auto-upvote (non-blocking)
     try {
         const { autoUpvote } = await import('./recall.js');
-        const { requireInit } = await import('./config.js');
-        const { localConfig } = await requireInit();
+        const { autoDetectInit } = await import('./config.js');
+        const { localConfig } = await autoDetectInit();
         await autoUpvote(results, localConfig.username, localConfig.repo.localPath);
     } catch {
         // Silent: upvote failure should never affect hook output

--- a/src/code-knowledge-recall.ts
+++ b/src/code-knowledge-recall.ts
@@ -9,6 +9,7 @@ import { readFile, readdir } from 'node:fs/promises';
 import path from 'node:path';
 
 import type { GraphIndex } from './wiki-engine/core/graph-index.schema.js';
+import { tokenize } from './utils/tokenizer.js';
 
 export interface CodeKnowledgeResult {
   page: string;
@@ -28,7 +29,7 @@ interface PageDoc {
   path: string;
   title: string;
   content: string;
-  tokens: string[];
+  uniqueTokens: Set<string>;
   tokenCount: number; // B10: raw (non-deduplicated) token count for BM25 dl
 }
 
@@ -38,31 +39,14 @@ const TITLE_BOOST = 3.0;
 const RELATION_WEIGHT: Record<string, number> = { DEPENDS_ON: 3, REFERENCES: 2, MAPS_TO: 2, CONTAINS: 1 };
 const ENTRY_NODE_BOOST = 8;
 
-function tokenize(text: string): string[] {
-  const tokens: string[] = [];
-  const lower = text.toLowerCase();
-  // Split camelCase before tokenizing (B4 fix: camelCase splitting)
-  const camelSplit = lower.replace(/([a-z])([A-Z])/g, '$1_$2').toLowerCase();
-  const words = camelSplit.split(/[^a-z0-9一-鿿]+/).filter((w) => w.length >= 2);
-  for (const w of words) {
-    tokens.push(w);
-  }
-  // B14: CJK bigram segmentation
-  const cjkRuns = lower.match(/[一-鿿]+/g) ?? [];
-  for (const run of cjkRuns) {
-    for (let i = 0; i < run.length - 1; i++) {
-      tokens.push(run.slice(i, i + 2));
-    }
-  }
-  return [...new Set(tokens)];
-}
-
 /** Raw (non-deduplicated) token count for BM25 dl (B10 fix) */
 function rawTokenCount(text: string): number {
-  const lower = text.toLowerCase();
-  const camelSplit = lower.replace(/([a-z])([A-Z])/g, '$1_$2').toLowerCase();
+  const safe = text.length > MAX_INDEX_CHARS ? text.slice(0, MAX_INDEX_CHARS) : text;
+  const camelSplit = safe.replace(/([a-z])([A-Z])/g, '$1_$2').toLowerCase();
   return camelSplit.split(/[^a-z0-9一-鿿]+/).filter((w) => w.length >= 2).length;
 }
+
+const MAX_INDEX_CHARS = 100_000;
 
 function countOccurrences(text: string, token: string): number {
   let count = 0;
@@ -82,13 +66,9 @@ function buildCorpusStats(pages: PageDoc[]): CorpusStats {
   let totalLength = 0;
 
   for (const page of pages) {
-    totalLength += page.tokenCount; // B10: use raw token count for avgDocLength
-    const seen = new Set<string>();
-    for (const token of page.tokens) {
-      if (!seen.has(token)) {
-        seen.add(token);
-        df.set(token, (df.get(token) ?? 0) + 1);
-      }
+    totalLength += page.tokenCount;
+    for (const token of page.uniqueTokens) {
+      df.set(token, (df.get(token) ?? 0) + 1);
     }
   }
 
@@ -203,42 +183,46 @@ function extractSnippet(content: string, queryTokens: string[], maxLen: number =
   return snippet;
 }
 
+async function collectMdFiles(dir: string): Promise<string[]> {
+  const results: string[] = [];
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return results;
+  }
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...await collectMdFiles(fullPath));
+    } else if (entry.name.endsWith('.md')) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
 async function loadWikiPages(wikiRoot: string): Promise<PageDoc[]> {
   const evidenceDir = path.join(wikiRoot, 'evidence', 'code');
   const pages: PageDoc[] = [];
 
-  let projects: string[];
-  try {
-    projects = await readdir(evidenceDir);
-  } catch {
-    return pages;
-  }
-
-  for (const project of projects) {
-    const projectDir = path.join(evidenceDir, project);
-    let files: string[];
+  const allMdFiles = await collectMdFiles(evidenceDir);
+  for (const mdPath of allMdFiles) {
     try {
-      files = await readdir(projectDir);
+      const content = await readFile(mdPath, 'utf-8');
+      const titleMatch = content.match(/^title:\s*(.+)$/m);
+      const fileName = path.basename(mdPath, '.md');
+      const title = titleMatch ? titleMatch[1].trim() : fileName;
+      const relativePath = path.relative(path.join(wikiRoot, 'evidence', 'code'), mdPath);
+      pages.push({
+        path: `evidence/code/${relativePath}`,
+        title,
+        content,
+        uniqueTokens: new Set(tokenize(content)),
+        tokenCount: rawTokenCount(content),
+      });
     } catch {
       continue;
-    }
-    for (const file of files) {
-      if (!file.endsWith('.md')) continue;
-      try {
-        const filePath = path.join(projectDir, file);
-        const content = await readFile(filePath, 'utf-8');
-        const titleMatch = content.match(/^title:\s*(.+)$/m);
-        const title = titleMatch ? titleMatch[1].trim() : file.replace('.md', '');
-        pages.push({
-          path: `evidence/code/${project}/${file}`,
-          title,
-          content,
-          tokens: tokenize(content),
-          tokenCount: rawTokenCount(content), // B10: raw count for BM25 dl
-        });
-      } catch {
-        continue;
-      }
     }
   }
 
@@ -286,7 +270,7 @@ export async function queryCodeKnowledge(
 
   scored.sort((a, b) => b.score - a.score);
 
-  const TOKEN_BUDGET: Record<string, number> = { route: 500, context: 5000, lookup: 3000 };
+  const TOKEN_BUDGET: Record<string, number> = { route: 1500, context: 5000, lookup: 20000 };
   const budget = TOKEN_BUDGET[depth] ?? 5000;
   const estimateTokens = (text: string) => Math.ceil(text.length / 3.5);
 
@@ -298,9 +282,9 @@ export async function queryCodeKnowledge(
 
     let snippet: string;
     if (depth === 'route') {
-      snippet = page.title;
-    } else if (depth === 'lookup' && results.length === 0) {
-      const maxChars = Math.floor(budget * 3.5 * 0.7);
+      snippet = `${page.title} (${page.path})`;
+    } else if (depth === 'lookup') {
+      const maxChars = Math.floor(budget * 3.5 * 0.7 / Math.max(limit, 1));
       snippet = page.content.slice(0, maxChars);
     } else {
       snippet = extractSnippet(page.content, queryTokens);

--- a/src/import.ts
+++ b/src/import.ts
@@ -247,7 +247,6 @@ export async function importCmd(opts: ImportOptions): Promise<void> {
             const { aggregateGlobalGraph } = await import('./graph-aggregate.js');
             await aggregateGlobalGraph(teamwikiRoot);
 
-            const { autoPushTeamRepo } = await import('./utils/git.js');
             await autoPushTeamRepo(teamRepoPath, `[teamai] Import from local dir: ${slug}`);
             log.success(`已推送到团队知识仓库 (${localConfig.repo.remote})`);
           }

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -66,15 +66,15 @@ export function formatResults(results: ScopedSearchResult[]): string {
     if (entry.tags.length > 0) {
       lines.push(`Tags: ${entry.tags.join(', ')}`);
     }
-    // Prefer the absolute path captured at index build time when available
-    // (Phase 1 entries from docs/rules/skills carry it); otherwise fall back
-    // to the legacy ~/.teamai/learnings/<filename> rendering.
     const filePath = entry.path
       ? entry.path
       : learningsBase
         ? `${learningsBase}/${entry.filename}`
         : `~/.teamai/learnings/${entry.filename}`;
     lines.push(`File: ${filePath}`);
+    if (entry.snippet) {
+      lines.push(`Snippet: ${entry.snippet}`);
+    }
     lines.push('');
   }
 
@@ -294,9 +294,8 @@ export async function recall(
   // ── Codebase knowledge graph recall ──────────────────────
   try {
     const codeResults = await queryCodeKnowledge(query, { wikiRoot, limit: 3, depth: options.depth });
-    // B11: Normalize BM25 scores to 0-10 range before merging with learnings scores
-    const maxCodeScore = codeResults.length > 0 ? Math.max(...codeResults.map(r => r.score)) : 1;
-    const normalizer = maxCodeScore > 0 ? 10 / maxCodeScore : 1;
+    // B11 fix: log-dampening instead of min-max normalization
+    // Codebase BM25 scores (0-50+) mapped to learnings scale (0-10) via log curve
     for (const cr of codeResults) {
       allResults.push({
         entry: {
@@ -310,8 +309,9 @@ export async function recall(
           type: 'docs' as const,
           domain: 'technical' as const,
           path: path.join(wikiRoot, cr.page),
+          snippet: cr.snippet,
         },
-        score: cr.score * normalizer, // B11: normalized to learnings score scale
+        score: Math.min(10, Math.log2(cr.score + 1) * 2),
         scope: 'project',
         learningsBase: wikiRoot,
       });

--- a/src/types.ts
+++ b/src/types.ts
@@ -868,7 +868,7 @@ export interface ImportSession {
   /** 创建时间（ISO 8601） */
   createdAt: string;
   /** 导入模式 */
-  mode: 'local' | 'mr' | 'workspace';
+  mode: 'local' | 'mr' | 'dir';
   /** 所有候选条目 */
   items: ImportSessionItem[];
   /** 已处理条目数（用于 --resume 进度恢复） */

--- a/src/types.ts
+++ b/src/types.ts
@@ -623,10 +623,12 @@ export interface SearchIndexEntry {
   path?: string;
   /** Optional hotness score reserved for Phase 4.3 hot/cold splitting. */
   hotness?: number;
+  /** Snippet from codebase graph recall (depth-dependent content preview). */
+  snippet?: string;
 }
 
 /** Schema version of the on-disk search-index.json (bump on breaking change). */
-export const SEARCH_INDEX_VERSION = 4;
+export const SEARCH_INDEX_VERSION = 5;
 
 /** Shape of the search-index.json file. */
 export interface SearchIndex {

--- a/src/utils/ai-client.ts
+++ b/src/utils/ai-client.ts
@@ -132,7 +132,7 @@ export function getAICliName(): string {
  * 结果缓存，进程内只探测一次。
  *
  * @param prompt   传递给 CLI 的提示词
- * @param opts     可选参数：timeout 超时毫秒数，默认 120000
+ * @param opts     可选参数：timeout 超时毫秒数，默认 600000（10 分钟）
  * @returns        CLI 输出的 stdout（已 trim）
  * @throws         超时时抛出 `Error('AI call timed out after Xs')`
  * @throws         退出码非 0 时抛出 `Error('AI call failed: <stderr>')`

--- a/src/utils/search-index.ts
+++ b/src/utils/search-index.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import matter from 'gray-matter';
 import { readFileSafe, readJson, writeJson, listFiles, listFilesRecursive, listDirs, pathExists } from './fs.js';
+import { tokenize } from './tokenizer.js';
 import { log } from './logger.js';
 import {
   SEARCH_INDEX_VERSION,
@@ -41,7 +42,6 @@ function getSearchIndexPath(): string {
 //      └─ return sorted results
 //
 
-const CJK_RANGE = /[\u4e00-\u9fff]/;
 const MAX_BODY_CHARS = 2000;
 const MAX_DOC_BYTES = 50 * 1024; // 50KB
 
@@ -203,55 +203,8 @@ export function inferDomain(
   return 'neutral';
 }
 
-/**
- * Hybrid tokenizer: Intl.Segmenter for word boundaries + CJK bigrams.
- *
- * Intl.Segmenter splits Chinese characters individually ("超时" → ["超","时"]),
- * so we additionally generate bigrams for CJK runs to capture compound words
- * ("超时" bigram matches query "超时").
- */
-export function tokenize(text: string): string[] {
-  if (!text) return [];
-
-  const segmenter = new Intl.Segmenter('zh-CN', { granularity: 'word' });
-  const segments = [...segmenter.segment(text)];
-  const tokens: string[] = [];
-
-  // Collect CJK characters in runs for bigram generation
-  let cjkRun: string[] = [];
-
-  const flushCjkRun = (): void => {
-    if (cjkRun.length >= 2) {
-      for (let i = 0; i < cjkRun.length - 1; i++) {
-        tokens.push(cjkRun[i] + cjkRun[i + 1]);
-      }
-    }
-    cjkRun = [];
-  };
-
-  for (const seg of segments) {
-    if (!seg.isWordLike) {
-      flushCjkRun();
-      continue;
-    }
-
-    const word = seg.segment.toLowerCase();
-    tokens.push(word);
-
-    // Track CJK runs for bigram generation
-    const chars = [...word];
-    for (const ch of chars) {
-      if (CJK_RANGE.test(ch)) {
-        cjkRun.push(ch);
-      } else {
-        flushCjkRun();
-      }
-    }
-  }
-  flushCjkRun();
-
-  return [...new Set(tokens)];
-}
+// Re-export for external callers that previously imported tokenize from this module
+export { tokenize };
 
 /**
  * Parse a learning document's frontmatter and body.
@@ -554,8 +507,8 @@ export async function buildIndex(
   // Guard: don't overwrite a healthy index with a significantly smaller one
   const targetPath = opts.indexPath ?? getSearchIndexPath();
   const existingIndex = await loadIndex(targetPath);
-  if (existingIndex && existingIndex.entries.length > 5 && entries.length < existingIndex.entries.length * 0.5) {
-    log.warn(`Index rebuild skipped: new index (${entries.length} entries) much smaller than existing (${existingIndex.entries.length})`);
+  if (existingIndex && existingIndex.entries.length > 0 && entries.length === 0) {
+    log.warn(`Index rebuild skipped: refusing to overwrite ${existingIndex.entries.length} entries with empty index`);
     return elapsed;
   }
 

--- a/src/utils/tokenizer.ts
+++ b/src/utils/tokenizer.ts
@@ -1,0 +1,71 @@
+// -*- coding: utf-8 -*-
+/**
+ * 共用 tokenizer — 确保 search-index 和 code-knowledge-recall 使用相同的分词逻辑。
+ *
+ * 特性：
+ * - Intl.Segmenter word-boundary 分词（支持中英混合）
+ * - camelCase/PascalCase 额外拆分（getUserById 额外产生 get, user, by, id）
+ * - CJK bigram 分词（"超时" → "超"、"时"、"超时"）
+ * - 全小写
+ * - 去重
+ */
+const MAX_TOKENIZE_CHARS = 100_000;
+
+export function tokenize(text: string): string[] {
+  if (!text) return [];
+
+  const input = text.length > MAX_TOKENIZE_CHARS ? text.slice(0, MAX_TOKENIZE_CHARS) : text;
+  const segmenter = new Intl.Segmenter('zh-CN', { granularity: 'word' });
+  const segments = [...segmenter.segment(input)];
+  const tokens: string[] = [];
+
+  // Collect CJK characters in runs for bigram generation
+  let cjkRun: string[] = [];
+
+  const flushCjkRun = (): void => {
+    if (cjkRun.length >= 2) {
+      for (let i = 0; i < cjkRun.length - 1; i++) {
+        tokens.push(cjkRun[i] + cjkRun[i + 1]);
+      }
+    }
+    cjkRun = [];
+  };
+
+  for (const seg of segments) {
+    if (!seg.isWordLike) {
+      flushCjkRun();
+      continue;
+    }
+
+    const word = seg.segment.toLowerCase();
+    tokens.push(word);
+
+    // camelCase/PascalCase split: add sub-tokens for compound identifiers.
+    // e.g. "ModuleNotFoundError" → also add "module", "not", "found", "error".
+    // Original lowercased word is kept above to preserve whole-word matching.
+    if (/[A-Z]/.test(seg.segment)) {
+      const split = seg.segment
+        .replace(/([a-z])([A-Z])/g, '$1 $2')
+        .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+        .toLowerCase()
+        .split(/\s+/)
+        .filter((t) => t.length >= 2);
+      for (const t of split) {
+        if (t !== word) tokens.push(t);
+      }
+    }
+
+    // Track CJK runs for bigram generation
+    const chars = [...word];
+    for (const ch of chars) {
+      if (/[一-鿿]/.test(ch)) {
+        cjkRun.push(ch);
+      } else {
+        flushCjkRun();
+      }
+    }
+  }
+  flushCjkRun();
+
+  return [...new Set(tokens)];
+}

--- a/src/wiki-engine/reconciler-v2-types.ts
+++ b/src/wiki-engine/reconciler-v2-types.ts
@@ -35,10 +35,10 @@ export function labelFromScore(score: number): WikiConfidence {
   return "AMBIGUOUS";
 }
 
-/** Build a NumericConfidence from factors (average of weights) */
+/** Build a NumericConfidence from factors (max of weights) */
 export function buildConfidence(factors: ConfidenceFactor[]): NumericConfidence {
   if (factors.length === 0) return { score: 0, label: "AMBIGUOUS", factors: [] };
-  const score = factors.reduce((sum, f) => sum + f.weight, 0) / factors.length;
+  const score = Math.max(...factors.map(f => f.weight));
   const clamped = Math.min(1, Math.max(0, score));
   return { score: clamped, label: labelFromScore(clamped), factors };
 }


### PR DESCRIPTION
## Summary

Fixes 7 recall/knowledge-graph bugs reported in #79-#85, plus reviewer cleanup.

### #79 — `--depth` parameter now effective

| depth | Budget | Behavior |
|-------|--------|----------|
| route | 1500 tokens | Title + path only |
| context | 5000 (default) | ~300-char keyword snippet |
| lookup | 20000 | Full content per result |

Snippet field added to `formatResults` output — no truncation applied (length controlled by depth budget in `queryCodeKnowledge`).

### #80 — codebase score normalization

Replace min-max (top result always = 10) with log-dampening:
`Math.min(10, Math.log2(score + 1) * 2)` — preserves relative ordering without pinning.

### #81 — `hasWiki` path

Use resolved `wikiRoot` (from team-repo config) instead of hardcoded `cwd/teamwiki`.

### #82 — `buildConfidence` semantics

Change from arithmetic mean (more evidence → lower score) to `max(weights)` — strongest evidence determines confidence. This is a deliberate design change: multiple supporting factors should not dilute confidence.

### #83 — search-index shrink protection

Relax from "skip if new < 50% of old" to "skip only if new is empty". Allows legitimate file deletions to be reflected in the index.

### #84 — codebase graph retrieval

- **84-1**: `loadWikiPages` now recurses into subdirectories via `collectMdFiles`
- **84-2/4**: Unified tokenizer (`src/utils/tokenizer.ts`) shared by search-index and code-knowledge-recall. Adds camelCase splitting to search-index. Truncates input to 100K chars to prevent `Intl.Segmenter` OOM.
- **OOM fix**: `PageDoc.tokens` replaced with `uniqueTokens: Set<string>` built via the shared `tokenize` function (same tokenizer for index-time and query-time)

### #85 — auto-recall upvote scope

Use `autoDetectInit()` instead of `requireInit()` so votes are written to the correct scope (project or user).

### Additional cleanup

- `SEARCH_INDEX_VERSION` bumped 4→5 (triggers rebuild for camelCase tokenizer change)
- README `--dir` entry added (EN + CN)
- `callClaude` JSDoc timeout corrected to 600000
- Redundant dynamic import of `autoPushTeamRepo` removed

## Review feedback addressed

| Issue | Fix |
|-------|-----|
| snippet truncated to 500 chars contradicts lookup's 20K budget | Removed `formatResults` truncation — snippet length now fully controlled by depth budget |
| index-time (`fastTokens` regex) vs query-time (`tokenize` Segmenter) produce different tokens → skewed BM25 | Deleted `fastTokens`; index-time now uses the same shared `tokenize` as query-time |
| `rawTokenCount` counts full doc while token Set was capped at 5000 → inconsistent dl | `rawTokenCount` now truncates to 100K chars (same limit as `tokenize`) |

## E2E verification

| Test | Result |
|------|--------|
| recall (default heap, no --max-old-space-size) | ✅ No OOM |
| recall --depth route | ✅ Title + path only |
| recall --depth context | ✅ Keyword snippet |
| recall --depth lookup | ✅ Full content |
| import --from-org (11 repos, --skip-enrich) | ✅ 10s |
| graph integrity (1179 nodes, 794 edges) | ✅ |
| codebase --lint | ✅ |

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `npx vitest run` — 1676 passed (130 files)
- [x] E2E: recall no OOM under default heap
- [x] E2E: --depth route/context/lookup produce different Snippet output
- [x] E2E: import + graph aggregation unaffected
- [x] Index-time and query-time use identical tokenizer (no df/idf skew)

Closes #79, #80, #81, #82, #83, #84, #85