### PR TITLE
fix: recursively deploy built-in skill directories

### DIFF
--- a/src/__tests__/skip-uninstalled-tools.test.ts
+++ b/src/__tests__/skip-uninstalled-tools.test.ts
@@ -446,4 +446,41 @@ describe('deployBuiltinSkills — skip uninstalled tools', () => {
 
     expect(await fse.pathExists(path.join(homeDir, '.claude'))).toBe(true);
   });
+
+  it('should recursively deploy nested built-in skill files', async () => {
+    const { deployBuiltinSkills } = await import('../builtin-skills.js');
+
+    const teamConfig = {
+      team: 'test',
+      description: '',
+      repo: 'https://git.woa.com/test/repo.git',
+      provider: 'tgit' as const,
+      reviewers: [],
+      sharing: {
+        skills: {},
+        rules: { enforced: [] },
+        docs: { localDir: '' },
+        env: { injectShellProfile: true },
+      },
+      toolPaths: {
+        claude: { skills: '.claude/skills' },
+      },
+    };
+
+    const localConfig = {
+      repo: { localPath: path.join(tmpDir, 'repo'), remote: 'https://git.woa.com/test/repo.git' },
+      username: 'testuser',
+      updatePolicy: 'auto' as const,
+      additionalRoles: [],
+      scope: 'user' as const,
+    };
+
+    const deployed = await deployBuiltinSkills(teamConfig, localConfig);
+    const skillDir = path.join(homeDir, '.claude/skills/team-wiki-codebase');
+
+    expect(deployed).toBeGreaterThan(0);
+    expect(await fse.pathExists(path.join(skillDir, 'SKILL.md'))).toBe(true);
+    expect(await fse.pathExists(path.join(skillDir, 'references/methodology/phase0-collection.md'))).toBe(true);
+    expect(await fse.pathExists(path.join(skillDir, 'scripts/scan_repo.py'))).toBe(true);
+  });
 });

--- a/src/builtin-skills.ts
+++ b/src/builtin-skills.ts
@@ -1,6 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { ensureDir, pathExists } from './utils/fs.js';
+import { fileURLToPath } from 'node:url';
+import fse from 'fs-extra';
+import { pathExists } from './utils/fs.js';
 import { log } from './utils/logger.js';
 import type { TeamaiConfig, LocalConfig } from './types.js';
 import { resolveBaseDir } from './types.js';
@@ -32,13 +34,20 @@ import { ensureSkillFrontmatter } from './resources/skills.js';
  */
 function getBuiltinSkillsDir(): string {
   // __dirname equivalent for ESM: import.meta.url → file path → parent
-  const distDir = path.dirname(new URL(import.meta.url).pathname);
+  const distDir = path.dirname(fileURLToPath(import.meta.url));
   // skills/ is at package root, dist/ is one level down
   return path.join(distDir, '..', 'skills');
 }
 
 /** Names of CLI built-in skills. Used by push to exclude them from team repo push. */
 export const BUILTIN_SKILL_NAMES = new Set(['teamai-share-learnings', 'team-wiki-codebase']);
+
+async function copyBuiltinSkillDir(srcDir: string, destDir: string): Promise<void> {
+  await fse.copy(srcDir, destDir, {
+    overwrite: true,
+    filter: (srcPath: string) => !path.basename(srcPath).startsWith('.'),
+  });
+}
 
 /**
  * Deploy CLI built-in skills to all configured AI tool skill directories.
@@ -103,19 +112,7 @@ export async function deployBuiltinSkills(teamConfig: TeamaiConfig, localConfig?
       const destDir = path.join(targetSkillsDir, skillName);
 
       try {
-        await ensureDir(destDir);
-
-        // Copy all files in the skill directory
-        const files = await fs.promises.readdir(srcDir);
-        for (const file of files) {
-          const srcFile = path.join(srcDir, file);
-          const destFile = path.join(destDir, file);
-
-          const stat = await fs.promises.stat(srcFile);
-          if (stat.isFile()) {
-            await fs.promises.copyFile(srcFile, destFile);
-          }
-        }
+        await copyBuiltinSkillDir(srcDir, destDir);
 
         // Ensure SKILL.md has proper YAML frontmatter (name + description)
         await ensureSkillFrontmatter(destDir, skillName);


### PR DESCRIPTION
## Summary

Fixes #88.

`deployBuiltinSkills` previously copied only top-level files from each built-in skill directory. This caused `team-wiki-codebase` to be deployed without its nested `references/` and `scripts/` directories, leaving the skill incomplete after `teamai pull`.

This PR changes built-in skill deployment to recursively copy the full skill directory while skipping `.`-prefixed files/directories as suggested in #88.

It also updates ESM path resolution to use `fileURLToPath(import.meta.url)`, which keeps the built-in skills path valid on Windows and remains correct on Linux/macOS.

## Changes

- Recursively copy built-in skill directories during deployment.
- Skip `.`-prefixed files/directories during recursive copy.
- Add a regression test that verifies `team-wiki-codebase` deploys nested `references/` and `scripts/` files.
- Use `fileURLToPath(import.meta.url)` for cross-platform built-in skills path resolution.

## Testing

- `npx vitest run src/__tests__/skip-uninstalled-tools.test.ts`
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`