### PR TITLE
fix(recall): resolve remaining bugs from #82, #84, #94

### DIFF
--- a/src/__tests__/issue-82-84-94-regression.test.ts
+++ b/src/__tests__/issue-82-84-94-regression.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Regression tests for issues #82, #84, #94 bug fixes.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildConfidence, labelFromScore } from '../wiki-engine/reconciler-v2-types.js';
+
+describe('buildConfidence (issue #82 bug1 + #94 issue3)', () => {
+  it('single factor preserves its weight as score', () => {
+    const result = buildConfidence([{ name: 'direct_match', weight: 0.9 }]);
+    expect(result.score).toBe(0.9);
+    expect(result.label).toBe('EXTRACTED');
+  });
+
+  it('adding positive evidence increases (not decreases) the score', () => {
+    const single = buildConfidence([{ name: 'direct_match', weight: 0.9 }]);
+    const multi = buildConfidence([
+      { name: 'direct_match', weight: 0.9 },
+      { name: 'title_proximity', weight: 0.1 },
+    ]);
+    expect(multi.score).toBeGreaterThanOrEqual(single.score);
+  });
+
+  it('cumulative weights are capped at 1.0', () => {
+    const result = buildConfidence([
+      { name: 'a', weight: 0.7 },
+      { name: 'b', weight: 0.5 },
+    ]);
+    expect(result.score).toBe(1.0);
+    expect(result.label).toBe('EXTRACTED');
+  });
+
+  it('empty factors returns score 0 with AMBIGUOUS label', () => {
+    const result = buildConfidence([]);
+    expect(result.score).toBe(0);
+    expect(result.label).toBe('AMBIGUOUS');
+  });
+
+  it('path_match + method_match yields higher score than path_match alone', () => {
+    const pathOnly = buildConfidence([{ name: 'path_match', weight: 0.7 }]);
+    const combined = buildConfidence([
+      { name: 'path_match', weight: 0.7 },
+      { name: 'method_match', weight: 0.3 },
+    ]);
+    expect(combined.score).toBeGreaterThan(pathOnly.score);
+  });
+});
+
+describe('labelFromScore thresholds', () => {
+  it('score >= 0.8 → EXTRACTED', () => {
+    expect(labelFromScore(0.8)).toBe('EXTRACTED');
+    expect(labelFromScore(1.0)).toBe('EXTRACTED');
+  });
+
+  it('score >= 0.5 and < 0.8 → INFERRED', () => {
+    expect(labelFromScore(0.5)).toBe('INFERRED');
+    expect(labelFromScore(0.79)).toBe('INFERRED');
+  });
+
+  it('score < 0.5 → AMBIGUOUS', () => {
+    expect(labelFromScore(0.49)).toBe('AMBIGUOUS');
+    expect(labelFromScore(0)).toBe('AMBIGUOUS');
+  });
+});
+
+describe('camelCase tokenize (issue #84 bug2)', () => {
+  it('splits camelCase identifiers into separate sub-tokens', async () => {
+    const { tokenize } = await import('../utils/tokenizer.js');
+    const tokens = tokenize('getUserName');
+    // Should contain both the whole word and sub-tokens
+    expect(tokens).toContain('getusername');
+    expect(tokens).toContain('get');
+    expect(tokens).toContain('user');
+    expect(tokens).toContain('name');
+  });
+
+  it('splits PascalCase identifiers (e.g. ModuleNotFoundError)', async () => {
+    const { tokenize } = await import('../utils/tokenizer.js');
+    const tokens = tokenize('ModuleNotFoundError');
+    expect(tokens).toContain('module');
+    expect(tokens).toContain('not');
+    expect(tokens).toContain('found');
+    expect(tokens).toContain('error');
+  });
+
+  it('does NOT split when text is already lowercased', async () => {
+    const { tokenize } = await import('../utils/tokenizer.js');
+    const tokens = tokenize('getusername');
+    // All-lowercase has no uppercase transitions to split on
+    expect(tokens).not.toContain('get');
+    expect(tokens).toContain('getusername');
+  });
+});
+
+describe('stale detection (issue #82 bug2)', () => {
+  it('measures drift between two sides, not age from today', () => {
+    // The fix changes: Math.abs(now - max(from, to)) → Math.abs(fromMs - toMs)
+    // Simulate the calculation
+    const fromMs = new Date('2025-01-01').getTime();
+    const toMs = new Date('2025-03-15').getTime();
+    const MS_PER_DAY = 86_400_000;
+
+    // New logic: drift between sides
+    const daysDrift = Math.abs(fromMs - toMs) / MS_PER_DAY;
+    expect(daysDrift).toBeCloseTo(73, 0); // ~73 days apart
+
+    // Old logic would have used: Math.abs(now - Math.max(fromMs, toMs))
+    // which gives hundreds of days (age) — completely different semantics
+    const now = Date.now();
+    const oldDrift = Math.abs(now - Math.max(fromMs, toMs)) / MS_PER_DAY;
+    expect(oldDrift).toBeGreaterThan(400); // way off from the actual drift
+  });
+
+  it('simultaneously updated pages have zero drift', () => {
+    const sameTime = new Date('2025-06-01').getTime();
+    const MS_PER_DAY = 86_400_000;
+    const daysDrift = Math.abs(sameTime - sameTime) / MS_PER_DAY;
+    expect(daysDrift).toBe(0);
+  });
+});
+
+describe('loadGraphIndex schema validation (issue #84 bug5)', () => {
+  it('returns null for non-existent directory', async () => {
+    const { loadGraphIndex } = await import('../wiki-engine/core/graph-index.schema.js');
+    const result = await loadGraphIndex('/tmp/nonexistent-wiki-root-' + Date.now());
+    expect(result).toBeNull();
+  });
+
+  it('returns null when file exists but nodes/edges are not arrays', async () => {
+    const { writeFile, mkdir, rm } = await import('node:fs/promises');
+    const { join } = await import('node:path');
+    const { loadGraphIndex } = await import('../wiki-engine/core/graph-index.schema.js');
+
+    const tmpRoot = `/tmp/graph-schema-test-${Date.now()}`;
+    const indicesDir = join(tmpRoot, '.indices');
+    await mkdir(indicesDir, { recursive: true });
+
+    // Write a JSON file with wrong structure (nodes is not an array)
+    await writeFile(join(indicesDir, 'graph-index.json'), JSON.stringify({ nodes: 'invalid', edges: [] }));
+    const result1 = await loadGraphIndex(tmpRoot);
+    expect(result1).toBeNull();
+
+    // Write a JSON file with missing edges field
+    await writeFile(join(indicesDir, 'graph-index.json'), JSON.stringify({ nodes: [] }));
+    const result2 = await loadGraphIndex(tmpRoot);
+    expect(result2).toBeNull();
+
+    // Write a valid graph — should return it
+    await writeFile(join(indicesDir, 'graph-index.json'), JSON.stringify({ nodes: [], edges: [] }));
+    const result3 = await loadGraphIndex(tmpRoot);
+    expect(result3).not.toBeNull();
+    expect(result3!.nodes).toEqual([]);
+    expect(result3!.edges).toEqual([]);
+
+    await rm(tmpRoot, { recursive: true });
+  });
+});

--- a/src/__tests__/pull-scope-isolation.test.ts
+++ b/src/__tests__/pull-scope-isolation.test.ts
@@ -70,7 +70,7 @@ import { pullSources } from '../source.js';
 import { log } from '../utils/logger.js';
 import type { TeamaiConfig, LocalConfig } from '../types.js';
 
-const SKIP_MSG = '检测到 project scope，已跳过 user scope';
+const SKIP_MSG = 'project scope detected, skipped user scope';
 
 describe('pull scope isolation (issue #73)', () => {
   let tmpDir: string;

--- a/src/__tests__/review-cmd.test.ts
+++ b/src/__tests__/review-cmd.test.ts
@@ -195,7 +195,7 @@ describe('review-cmd', () => {
         expect(removePendingReview).not.toHaveBeenCalledWith(expect.stringContaining('teamai-review-cmd-test-'), 'highriskitem1');
 
         const output = consoleSpy.mock.calls.map((c) => c.join(' ')).join('\n');
-        expect(output).toContain('跳过');
+        expect(output).toContain('skipped');
     });
 
     it('--json 输出有效 JSON（apply 模式）', async () => {

--- a/src/code-knowledge-recall.ts
+++ b/src/code-knowledge-recall.ts
@@ -9,7 +9,7 @@ import { readFile, readdir } from 'node:fs/promises';
 import path from 'node:path';
 
 import type { GraphIndex } from './wiki-engine/core/graph-index.schema.js';
-import { tokenize } from './utils/tokenizer.js';
+import { tokenize, tokenCount, MAX_TOKENIZE_CHARS } from './utils/tokenizer.js';
 
 export interface CodeKnowledgeResult {
   page: string;
@@ -29,7 +29,7 @@ interface PageDoc {
   path: string;
   title: string;
   content: string;
-  uniqueTokens: Set<string>;
+  tokens: string[];
   tokenCount: number; // B10: raw (non-deduplicated) token count for BM25 dl
 }
 
@@ -39,19 +39,10 @@ const TITLE_BOOST = 3.0;
 const RELATION_WEIGHT: Record<string, number> = { DEPENDS_ON: 3, REFERENCES: 2, MAPS_TO: 2, CONTAINS: 1 };
 const ENTRY_NODE_BOOST = 8;
 
-/** Raw (non-deduplicated) token count for BM25 dl (B10 fix) */
-function rawTokenCount(text: string): number {
-  const safe = text.length > MAX_INDEX_CHARS ? text.slice(0, MAX_INDEX_CHARS) : text;
-  const camelSplit = safe.replace(/([a-z])([A-Z])/g, '$1_$2').toLowerCase();
-  return camelSplit.split(/[^a-z0-9一-鿿]+/).filter((w) => w.length >= 2).length;
-}
-
-const MAX_INDEX_CHARS = 100_000;
-
 function countOccurrences(text: string, token: string): number {
   let count = 0;
   let idx = 0;
-  const lower = text.toLowerCase();
+  const lower = (text.length > MAX_TOKENIZE_CHARS ? text.slice(0, MAX_TOKENIZE_CHARS) : text).toLowerCase();
   while (true) {
     idx = lower.indexOf(token, idx);
     if (idx === -1) break;
@@ -67,8 +58,12 @@ function buildCorpusStats(pages: PageDoc[]): CorpusStats {
 
   for (const page of pages) {
     totalLength += page.tokenCount;
-    for (const token of page.uniqueTokens) {
-      df.set(token, (df.get(token) ?? 0) + 1);
+    const seen = new Set<string>();
+    for (const token of page.tokens) {
+      if (!seen.has(token)) {
+        seen.add(token);
+        df.set(token, (df.get(token) ?? 0) + 1);
+      }
     }
   }
 
@@ -183,50 +178,49 @@ function extractSnippet(content: string, queryTokens: string[], maxLen: number =
   return snippet;
 }
 
-async function collectMdFiles(dir: string): Promise<string[]> {
-  const results: string[] = [];
-  let entries;
-  try {
-    entries = await readdir(dir, { withFileTypes: true });
-  } catch {
-    return results;
-  }
-  for (const entry of entries) {
-    const fullPath = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      results.push(...await collectMdFiles(fullPath));
-    } else if (entry.name.endsWith('.md')) {
-      results.push(fullPath);
-    }
-  }
-  return results;
-}
-
 async function loadWikiPages(wikiRoot: string): Promise<PageDoc[]> {
   const evidenceDir = path.join(wikiRoot, 'evidence', 'code');
   const pages: PageDoc[] = [];
 
-  const allMdFiles = await collectMdFiles(evidenceDir);
-  for (const mdPath of allMdFiles) {
-    try {
-      const content = await readFile(mdPath, 'utf-8');
-      const titleMatch = content.match(/^title:\s*(.+)$/m);
-      const fileName = path.basename(mdPath, '.md');
-      const title = titleMatch ? titleMatch[1].trim() : fileName;
-      const relativePath = path.relative(path.join(wikiRoot, 'evidence', 'code'), mdPath);
-      pages.push({
-        path: `evidence/code/${relativePath}`,
-        title,
-        content,
-        uniqueTokens: new Set(tokenize(content)),
-        tokenCount: rawTokenCount(content),
-      });
-    } catch {
-      continue;
-    }
+  let projectDirs: string[];
+  try {
+    const entries = await readdir(evidenceDir, { withFileTypes: true });
+    projectDirs = entries.filter(e => e.isDirectory()).map(e => e.name);
+  } catch {
+    return pages;
+  }
+
+  for (const project of projectDirs) {
+    const projectDir = path.join(evidenceDir, project);
+    await loadPagesRecursive(projectDir, `evidence/code/${project}`, pages);
   }
 
   return pages;
+}
+
+async function loadPagesRecursive(dir: string, relativePath: string, pages: PageDoc[]): Promise<void> {
+  const entries = await readdir(dir, { withFileTypes: true }).catch(() => [] as import('node:fs').Dirent[]);
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await loadPagesRecursive(fullPath, `${relativePath}/${entry.name}`, pages);
+    } else if (entry.name.endsWith('.md')) {
+      try {
+        const content = await readFile(fullPath, 'utf-8');
+        const titleMatch = content.match(/^title:\s*(.+)$/m);
+        const title = titleMatch ? titleMatch[1].trim() : entry.name.replace('.md', '');
+        pages.push({
+          path: `${relativePath}/${entry.name}`,
+          title,
+          content,
+          tokens: tokenize(content),
+          tokenCount: tokenCount(content),
+        });
+      } catch {
+        continue;
+      }
+    }
+  }
 }
 
 // B7: Use protocol loadGraphIndex instead of local implementation

--- a/src/codebase-extract.ts
+++ b/src/codebase-extract.ts
@@ -22,6 +22,7 @@ import {
   mergeGraphs,
   createGraphIndex,
   saveGraphIndex,
+  loadGraphIndex,
 } from './wiki-engine/adapters/index.js';
 import type { CodeFact, InterfaceInventory, CallChain } from './wiki-engine/adapters/index.js';
 import type { GraphIndex } from './wiki-engine/core/graph-index.schema.js';
@@ -527,17 +528,17 @@ export async function extractCodebase(opts: ExtractCodebaseOptions): Promise<voi
         if (opts.json) {
           console.log(JSON.stringify({ status: 'up-to-date', project }));
         } else {
-          console.log(chalk.green(`[extract] ${project}: 无变更，跳过。`));
+          console.log(chalk.green(`[extract] ${project}: no changes, skipped.`));
         }
         return;
       }
       changedFiles = [...changes.added, ...changes.changed];
       if (!opts.json) {
-        console.log(chalk.dim(`[extract] 增量模式：${changedFiles.length} 文件变更`));
+        console.log(chalk.dim(`[extract] incremental: ${changedFiles.length} files changed`));
       }
     } catch {
       if (!opts.json) {
-        console.log(chalk.dim('[extract] 无历史 manifest，执行全量提取'));
+        console.log(chalk.dim('[extract] no manifest history, running full extraction'));
       }
     }
   }
@@ -547,7 +548,7 @@ export async function extractCodebase(opts: ExtractCodebaseOptions): Promise<voi
     if (opts.json) {
       console.log(JSON.stringify({ status: 'no-files', project }));
     } else {
-      console.log(chalk.yellow(`[extract] ${project}: 未发现可提取的源代码文件。`));
+      console.log(chalk.yellow(`[extract] ${project}: no extractable source files found.`));
     }
     return;
   }
@@ -573,8 +574,12 @@ export async function extractCodebase(opts: ExtractCodebaseOptions): Promise<voi
   const pageSlugs = [...pages.keys()].map(p => `evidence/code/${project}/${p.replace('.md', '')}`);
   const overlay = buildIndexHubOverlay(project, 'evidence/code', pageSlugs);
 
-  // Merge overlay into the unified GraphIndex
-  const mergedGraph = mergeGraphs(graph, overlay);
+  // Merge overlay into the per-repo graph
+  const repoGraph = mergeGraphs(graph, overlay);
+
+  // Load existing global graph and merge to avoid overwriting other repos' data
+  const existingGraph = await loadGraphIndex(wikiRoot) ?? createGraphIndex();
+  const mergedGraph = mergeGraphs(existingGraph, repoGraph);
 
   // Write graph-index.json using protocol function (B5)
   await saveGraphIndex(wikiRoot, mergedGraph);
@@ -582,7 +587,7 @@ export async function extractCodebase(opts: ExtractCodebaseOptions): Promise<voi
   // AI enrichment (optional, non-blocking; skipped with --skip-enrich)
   let aiDomains: DomainGroup[] = [];
   if (opts.skipEnrich) {
-    if (!opts.json) console.log(chalk.dim('  [AI 增强: 已跳过 (--skip-enrich)]'));
+    if (!opts.json) console.log(chalk.dim('  [AI enrich: skipped (--skip-enrich)]'));
   } else try {
     const { enrichWithAI, writeManifest } = await import('./enrich-with-ai.js');
     const modules = new Map<string, CodeFact[]>();
@@ -608,12 +613,12 @@ export async function extractCodebase(opts: ExtractCodebaseOptions): Promise<voi
       await writeFile(path.join(evidenceDir, '_domains.json'), JSON.stringify(domainMeta, null, 2), 'utf-8');
       if (!opts.json) {
         const domainLabel = domainMeta.domain || '未分类';
-        console.log(`  AI 增强: ${enrichResult.manifest.components.length} 模块, 域=${domainLabel}`);
+        console.log(`  AI enrich: ${enrichResult.manifest.components.length} modules, domain=${domainLabel}`);
       }
     }
   } catch (e) {
     if (!opts.json) {
-      console.log(chalk.dim(`  [AI 增强跳过: ${(e as Error).message}]`));
+      console.log(chalk.dim(`  [AI enrich skipped: ${(e as Error).message}]`));
     }
   }
 

--- a/src/codebase-upgrade-wiki.ts
+++ b/src/codebase-upgrade-wiki.ts
@@ -27,7 +27,7 @@ export async function upgradeCodebaseWiki(opts: UpgradeCodebaseWikiOptions): Pro
     if (opts.json) {
       console.log(JSON.stringify({ status: 'nothing-to-migrate', reason: 'docs/team-codebase/repos/ not found' }));
     } else {
-      log.info('未发现 docs/team-codebase/repos/ 目录，无需迁移。');
+      log.info('no docs/team-codebase/repos/ directory found, no migration needed.');
     }
     return;
   }
@@ -39,13 +39,13 @@ export async function upgradeCodebaseWiki(opts: UpgradeCodebaseWikiOptions): Pro
     if (opts.json) {
       console.log(JSON.stringify({ status: 'nothing-to-migrate', reason: 'no .md files in repos/' }));
     } else {
-      log.info('repos/ 下无 .md 文件，无需迁移。');
+      log.info('no .md files under repos/, no migration needed.');
     }
     return;
   }
 
   if (!opts.json) {
-    log.info(`发现 ${mdFiles.length} 个旧格式仓库文档，开始迁移到 teamwiki/ 图谱格式...`);
+    log.info(`found ${mdFiles.length} legacy repo docs, starting migration to teamwiki/ graph format...`);
   }
 
   const result: MigrationResult = { migrated: [], skipped: [], errors: [] };
@@ -95,13 +95,13 @@ export async function upgradeCodebaseWiki(opts: UpgradeCodebaseWikiOptions): Pro
       }
     }
     if (result.skipped.length > 0) {
-      console.log(chalk.yellow(`跳过 ${result.skipped.length} 个：`));
+      console.log(chalk.yellow(`skipped ${result.skipped.length}:`));
       for (const s of result.skipped) {
         console.log(chalk.yellow(`  - ${s}`));
       }
     }
     if (result.errors.length > 0) {
-      console.log(chalk.red(`失败 ${result.errors.length} 个：`));
+      console.log(chalk.red(`failed ${result.errors.length}:`));
       for (const e of result.errors) {
         console.log(chalk.red(`  ✗ ${e}`));
       }
@@ -109,8 +109,8 @@ export async function upgradeCodebaseWiki(opts: UpgradeCodebaseWikiOptions): Pro
 
     if (!opts.dryRun && result.migrated.length > 0) {
       log.info('');
-      log.info('迁移完成。旧的 docs/team-codebase/ 目录已保留（未删除）。');
-      log.info('确认新图谱工作正常后，可手动删除 docs/team-codebase/ 目录。');
+      log.info('migration complete. old docs/team-codebase/ directory preserved (not deleted).');
+      log.info('after confirming the new graph works, you can manually delete docs/team-codebase/.');
     }
   }
 }

--- a/src/drift-cmd.ts
+++ b/src/drift-cmd.ts
@@ -54,10 +54,10 @@ function truncate(str: string, maxLen: number): string {
 function renderDriftList(items: PendingReviewItem[]): void {
     const driftItems = items.filter((item) => item.kind === 'domain-drift');
     if (driftItems.length === 0) {
-        console.log(chalk.gray('[drift] 暂无待处理漂移项'));
+        console.log(chalk.gray('[drift] no pending drift items'));
         return;
     }
-    console.log(chalk.cyan(`[drift] 共 ${driftItems.length} 项`));
+    console.log(chalk.cyan(`[drift] ${driftItems.length} items`));
     const header = [
         '  ' + 'URL'.padEnd(40),
         '旧域'.padEnd(12),
@@ -252,7 +252,7 @@ export async function driftCmd(opts: DriftCmdOptions): Promise<void> {
             console.log(
                 chalk.cyan('[drift] apply-all 完成：') +
                 chalk.green(`${okCount} 成功`) + '  ' +
-                chalk.yellow(`${skippedCount} 跳过`) + '  ' +
+                chalk.yellow(`${skippedCount} skipped`) + '  ' +
                 chalk.red(`${failedCount} 失败`),
             );
         }
@@ -268,7 +268,7 @@ export async function driftCmd(opts: DriftCmdOptions): Promise<void> {
 
         if (apply) {
             if (driftItems.length === 0) {
-                log.error(`[drift] 未找到 ${repoUrlArg} 的漂移项`);
+                log.error(`[drift] no drift items found for ${repoUrlArg}`);
                 process.exitCode = 1;
                 return;
             }
@@ -296,7 +296,7 @@ export async function driftCmd(opts: DriftCmdOptions): Promise<void> {
 
         // show 单条
         if (driftItems.length === 0) {
-            console.log(chalk.gray(`[drift] 未找到 ${repoUrlArg} 的漂移项`));
+            console.log(chalk.gray(`[drift] no drift items found for ${repoUrlArg}`));
             return;
         }
         if (json) {

--- a/src/graph-aggregate.ts
+++ b/src/graph-aggregate.ts
@@ -46,7 +46,7 @@ export async function aggregateGlobalGraph(
                 globalGraph = overlay;
             }
         } catch (e) {
-            log.warn(`[graph] 跳过 ${dir.name} graph: ${(e as Error).message}`);
+            log.warn(`[graph] skipped ${dir.name} graph: ${(e as Error).message}`);
         }
     }
 
@@ -54,7 +54,7 @@ export async function aggregateGlobalGraph(
         const destPath = path.join(teamwikiRoot, '.indices', 'graph-index.json');
         await fs.ensureDir(path.dirname(destPath));
         await fs.writeFile(destPath, JSON.stringify(globalGraph, null, 2), 'utf8');
-        log.info(`全局 graph-index.json 已聚合（${globalGraph.nodes.length} nodes, ${globalGraph.edges.length} edges）`);
+        log.info(`global graph-index.json aggregated (${globalGraph.nodes.length} nodes, ${globalGraph.edges.length} edges)`);
         return { nodes: globalGraph.nodes.length, edges: globalGraph.edges.length };
     }
 

--- a/src/import-iwiki.ts
+++ b/src/import-iwiki.ts
@@ -92,7 +92,7 @@ async function downloadDocuments(
       if (result.status === 'fulfilled') {
         documents.push(result.value);
       } else {
-        log.warn(`下载文档失败，已跳过: ${String(result.reason)}`);
+        log.warn(`download failed, skipped: ${String(result.reason)}`);
       }
     }
   }
@@ -156,7 +156,7 @@ export async function importFromIWiki(opts: {
   }
 
   if (pages.length === 0) {
-    log.warn('未找到任何页面，导入终止');
+    log.warn('no pages found, import aborted');
     return;
   }
 
@@ -172,7 +172,7 @@ export async function importFromIWiki(opts: {
   }
 
   if (documents.length === 0) {
-    log.warn('所有文档下载失败，导入终止');
+    log.warn('all document downloads failed, import aborted');
     return;
   }
 
@@ -183,7 +183,7 @@ export async function importFromIWiki(opts: {
   const classified = await classifyWithAI(candidates);
 
   if (classified.length === 0) {
-    log.warn('AI 分类后无有效条目，导入终止');
+    log.warn('no valid entries after AI classification, import aborted');
     return;
   }
 
@@ -205,10 +205,10 @@ export async function importFromIWiki(opts: {
       if (mapsToEdges.length > 0) {
         log.success(`建立 ${mapsToEdges.length} 条 iWiki↔代码 MAPS_TO 关系`);
       } else {
-        log.info('[reconcile] 未发现 iWiki 文档与代码知识的匹配关系（文档内容可能与代码无关）');
+        log.info('[reconcile] no matches found between iWiki docs and code knowledge');
       }
     } catch (err) {
-      log.debug(`[reconcile] iWiki↔代码关系建立失败（非阻塞）: ${err instanceof Error ? err.message : err}`);
+      log.debug(`[reconcile] iWiki↔code relation failed (non-blocking): ${err instanceof Error ? err.message : err}`);
     }
   }
 

--- a/src/import-local.ts
+++ b/src/import-local.ts
@@ -126,7 +126,7 @@ function parseClassifyOutput(
     };
   } catch (parseErr: unknown) {
     // 解析失败 → 保守策略：标记为个人（不导入团队库），confidence=0
-    log.warn(`AI 分类结果解析失败，使用保守默认值（isPersonal=true）：${String(parseErr)}`);
+    log.warn(`AI classification parse failed, using conservative default (isPersonal=true): ${String(parseErr)}`);
     return {
       sourcePath,
       rawContent,
@@ -188,7 +188,7 @@ async function persistSession(session: ImportSession, sessionPath: string): Prom
   try {
     await writeFile(sessionPath, JSON.stringify(session, null, 2) + '\n');
   } catch (err: unknown) {
-    log.error(`会话持久化失败 [${sessionPath}]: ${String(err)}`);
+    log.error(`session persist failed [${sessionPath}]: ${String(err)}`);
   }
 }
 
@@ -233,7 +233,7 @@ export async function scanCandidates(opts: {
         const stat = fs.statSync(absPath);
         if (stat.size > MAX_FILE_SIZE_BYTES) continue;
       } catch (statErr: unknown) {
-        log.warn(`无法读取文件信息，跳过: ${absPath}（${String(statErr)}）`);
+        log.warn(`cannot stat file, skipped: ${absPath} (${String(statErr)})`);
         continue;
       }
       const raw = await readFileSafe(absPath);
@@ -257,7 +257,7 @@ export async function scanCandidates(opts: {
           const stat = fs.statSync(absPath);
           if (stat.size > MAX_FILE_SIZE_BYTES) continue;
         } catch (statErr: unknown) {
-          log.warn(`无法读取文件信息，跳过: ${absPath}（${String(statErr)}）`);
+          log.warn(`cannot stat file, skipped: ${absPath} (${String(statErr)})`);
           continue;
         }
         const raw = await readFileSafe(absPath);
@@ -295,7 +295,7 @@ export async function classifyWithAI(
     classified = await callClaudeParallel(tasks, AI_CONCURRENCY);
   } catch (err: unknown) {
     // AggregateError：部分失败，已在 parse 阶段尝试降级处理；此处全量 fallback 保守处理
-    log.error(`AI 分类部分失败，对所有条目使用保守策略: ${String(err)}`);
+    log.error(`AI classification partially failed, using conservative strategy for all entries: ${String(err)}`);
     classified = candidates.map((c) => ({
       sourcePath: c.path,
       rawContent: c.rawContent,
@@ -347,7 +347,7 @@ export async function interactiveReview(
       session = JSON.parse(raw) as ImportSession;
     } catch (loadErr: unknown) {
       // 文件不存在或解析失败 → 新建会话
-      log.warn(`加载会话文件失败，将新建会话: ${String(loadErr)}`);
+      log.warn(`failed to load session file, creating new session: ${String(loadErr)}`);
     }
   }
 
@@ -398,7 +398,7 @@ export async function interactiveReview(
   const total = session.items.length;
 
   if (pendingItems.length === 0) {
-    log.info('所有条目已处理完毕，无需继续交互。');
+    log.info('all entries processed, no further interaction needed.');
     return session;
   }
 
@@ -517,7 +517,7 @@ export async function pushAccepted(
       try {
         assertSafePath(destDir, defaultAllowedRoots());
       } catch (err: unknown) {
-        log.error(`拒绝写出到目录 [${destDir}]: ${String(err)}`);
+        log.error(`refused to write to directory [${destDir}]: ${String(err)}`);
         skipped++;
         continue;
       }
@@ -534,7 +534,7 @@ export async function pushAccepted(
     const destPath = path.join(destDir, filename);
 
     if (opts.dryRun) {
-      log.info(`[dry-run] 将写入: ${destPath}`);
+      log.info(`[dry-run] would write: ${destPath}`);
       pushed++;
       continue;
     }

--- a/src/import-repo-list.ts
+++ b/src/import-repo-list.ts
@@ -90,7 +90,7 @@ export async function importFromRepoList(
     const singleEntries: ReturnType<typeof sortByPriority> = [];
     for (const item of repoListFile.repos) {
         if (isOrgEntry(item)) {
-            log.warn(`org entry 暂不支持，已跳过：${item.org}（将在 P5.4 实现）`);
+            log.warn(`org entry not yet supported, skipped: ${item.org}`);
             skipped.push({ url: item.org, reason: 'org entry 暂不支持（P5.4 实现）' });
         } else {
             singleEntries.push(item);
@@ -124,7 +124,7 @@ export async function importFromRepoList(
             succeeded.push(1);
         } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
-            log.warn(`导入失败：${entry.url} — ${message}`);
+            log.warn(`import failed: ${entry.url} — ${message}`);
             failed.push({ url: entry.url, error: message });
         }
     }
@@ -161,7 +161,7 @@ export async function importFromRepoList(
             const { aggregateGlobalGraph } = await import('./graph-aggregate.js');
             await aggregateGlobalGraph(teamwikiRoot);
         } catch (e) {
-            log.warn(`[graph] 全局图谱聚合失败（不中断流程）：${(e as Error).message}`);
+            log.warn(`[graph] global aggregation failed (non-blocking): ${(e as Error).message}`);
         }
     }
 
@@ -184,10 +184,10 @@ export async function importFromRepoList(
             const domains = await loadDomains(domainsBase);
             await regenerateAggregate({ paths, domains });
             aggregateGenerated = true;
-            log.info(`聚合文件已生成：${paths.index}`);
+            log.info(`aggregated files generated: ${paths.index}`);
         } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
-            log.warn(`聚合文件生成失败（不中断流程）：${message}`);
+            log.warn(`aggregation file generation failed (non-blocking): ${message}`);
         }
     }
 
@@ -200,7 +200,7 @@ export async function importFromRepoList(
             await autoPushTeamRepo(lc.repo.localPath, '[teamai] Batch import: graph + aggregate');
             log.success(`已推送到团队知识仓库 (${lc.repo.remote})`);
         } catch (e) {
-            log.warn(`[git] 批量推送失败（不中断流程）：${(e as Error).message}`);
+            log.warn(`[git] batch push failed (non-blocking): ${(e as Error).message}`);
         }
     }
 

--- a/src/import-repo-list.ts
+++ b/src/import-repo-list.ts
@@ -191,14 +191,24 @@ export async function importFromRepoList(
         }
     }
 
-    // 6. 统一推送（graph + aggregate 一次性提交）
+    // 6. 统一推送（graph + aggregate 通过 MR 提交）
     if (!dryRun && succeeded.length > 0) {
         try {
             const { autoDetectInit } = await import('./config.js');
-            const { localConfig: lc } = await autoDetectInit();
-            const { autoPushTeamRepo } = await import('./utils/git.js');
-            await autoPushTeamRepo(lc.repo.localPath, '[teamai] Batch import: graph + aggregate');
-            log.success(`已推送到团队知识仓库 (${lc.repo.remote})`);
+            const { localConfig: lc, teamConfig: tc } = await autoDetectInit();
+            const { autoPushViaMR } = await import('./utils/git.js');
+            const prUrl = await autoPushViaMR(
+                lc.repo.localPath,
+                '[teamai] Batch import: graph + aggregate',
+                ['.'],
+                { repo: tc.repo, provider: tc.provider, reviewers: tc.reviewers },
+                { repo: lc.repo, username: lc.username },
+            );
+            if (prUrl) {
+                log.success(`已创建 MR: ${prUrl}`);
+            } else {
+                log.success(`已推送分支到团队知识仓库 (${lc.repo.remote})`);
+            }
         } catch (e) {
             log.warn(`[git] batch push failed (non-blocking): ${(e as Error).message}`);
         }

--- a/src/import-repo.ts
+++ b/src/import-repo.ts
@@ -390,7 +390,7 @@ async function interactiveConfirmDomain(
 
     if (lower === 'o') {
         const existingDomains = domains.domains.map((d, idx) => `  ${idx + 1}. ${d.name}`);
-        console.log('已有域列表：');
+        console.log('existing domains:');
         console.log(existingDomains.join('\n'));
         const numStr = await askQuestion('请输入编号：', '');
         const num = parseInt(numStr, 10);
@@ -479,7 +479,7 @@ export async function detectDomainDrift(args: {
         });
 
         log.warn(
-            `[drift] 仓库 ${url} 可能需要重新分类` +
+            `[drift] repo ${url} may need reclassification` +
             `（推荐域 ${recommendResult.domain}，confidence ${recommendResult.confidence.toFixed(2)}），` +
             `已记入 history。请人工 review，自动归属未变。`,
         );
@@ -580,7 +580,7 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
 
     if (useIncremental) {
         oldSha = lastSync.sha;
-        log.info(`[incremental] 缓存命中 ${cacheDir}，从 ${oldSha.slice(0, 8)} 增量同步`);
+        log.info(`[incremental] cache hit ${cacheDir}, syncing from ${oldSha.slice(0, 8)}`);
         try {
             const fetchResult = await shallowFetch(cacheDir);
             cloneSha = fetchResult.sha;
@@ -588,7 +588,7 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
             log.info(`[incremental] Fetch 完成: SHA=${cloneSha.slice(0, 8)}`);
         } catch (fetchErr) {
             log.warn(
-                `[incremental] fetch 失败，fallback 到全量 clone：` +
+                `[incremental] fetch failed, falling back to full clone: ` +
                 `${fetchErr instanceof Error ? fetchErr.message : String(fetchErr)}`,
             );
             try {
@@ -620,12 +620,12 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
 
     // 2.5 SHA 未变化时跳过 AI 扫描（增量模式快速路径）
     if (useIncremental && oldSha && cloneSha === oldSha) {
-        log.info(`[incremental] SHA 未变化 (${cloneSha.slice(0, 8)})，跳过 AI 扫描`);
+        log.info(`[incremental] SHA unchanged (${cloneSha.slice(0, 8)}), skipping AI scan`);
         await writeLastSync(cacheDir, cloneSha);
         try {
             await touchCacheEntry({ provider: providerName, owner, repo: repoName, lastSyncedSha: cloneSha });
         } catch {}
-        log.info(chalk.green(`✓ 仓库 ${owner}/${repoName} 无变化，跳过`));
+        log.info(chalk.green(`✓ repo ${owner}/${repoName} unchanged, skipped`));
         return;
     }
 
@@ -674,7 +674,7 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
             merged = mergeWithAnchors(oldFile, codebaseMd, { source: sourceTag, syncedAt });
             toWrite = merged.mergedMd;
         } catch (err) {
-            log.warn(`[section-merge] ${err instanceof Error ? err.message : err}；fallback 到全量重写`);
+            log.warn(`[section-merge] ${err instanceof Error ? err.message : err}; falling back to full rewrite`);
             if (oldFile !== null && !dryRun) {
                 const bakPath = `${repoMdPath}.bak`;
                 try { await fs.writeFile(bakPath, oldFile, 'utf8'); } catch {}
@@ -822,7 +822,7 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
             const { reconcileKnowledge } = await import('./wiki-engine/adapters/index.js');
             const result = await reconcileKnowledge({ wikiRoot: teamwikiRoot, dryRun: false });
             if (result.mappings > 0 || result.gaps.length > 0) {
-                log.info(`  对账: ${result.mappings} 映射, ${result.gaps.length} 缺口, ${result.graphEdges.length} MAPS_TO 边`);
+                log.info(`  reconcile: ${result.mappings} mappings, ${result.gaps.length} gaps, ${result.graphEdges.length} MAPS_TO edges`);
             }
         } catch (e) {
             log.debug(`reconcile skipped: ${(e as Error).message}`);

--- a/src/import-repo.ts
+++ b/src/import-repo.ts
@@ -645,11 +645,15 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
     // Resolve team-repo directory (needed for both docs/team-codebase and teamwiki)
     let teamRepoDir: string;
     let teamRepoRemote = '';
+    let mrTeamConfig: { repo: string; provider?: string; reviewers?: string[] } | null = null;
+    let mrLocalConfig: { repo: { remote: string; localPath: string }; username: string } | null = null;
     try {
         const { autoDetectInit } = await import('./config.js');
-        const { localConfig: lc } = await autoDetectInit();
+        const { localConfig: lc, teamConfig: tc } = await autoDetectInit();
         teamRepoDir = lc.repo.localPath;
         teamRepoRemote = lc.repo.remote;
+        mrTeamConfig = { repo: tc.repo, provider: tc.provider, reviewers: tc.reviewers };
+        mrLocalConfig = { repo: lc.repo, username: lc.username };
     } catch {
         teamRepoDir = path.join(process.cwd(), '.teamai', 'team-repo');
     }
@@ -829,7 +833,7 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
         }
     }
 
-    // 5. 聚合全局图谱 + 自动推送（单仓模式；batch 模式由 import-repo-list 统一处理）
+    // 5. 聚合全局图谱 + 创建 MR（单仓模式；batch 模式由 import-repo-list 统一处理）
     if (!dryRun && !skipAutoPush) {
         if (teamwikiRoot) {
             try {
@@ -839,10 +843,20 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
                 log.debug(`[graph] 单仓聚合跳过: ${(e as Error).message}`);
             }
         }
-        if (await fs.pathExists(teamRepoDir)) {
-            const { autoPushTeamRepo } = await import('./utils/git.js');
-            await autoPushTeamRepo(teamRepoDir, `[teamai] Import codebase knowledge from ${owner}/${repoName}`);
-            log.success(`已推送到团队知识仓库${teamRepoRemote ? ` (${teamRepoRemote})` : ''}`);
+        if (await fs.pathExists(teamRepoDir) && mrTeamConfig && mrLocalConfig) {
+            const { autoPushViaMR } = await import('./utils/git.js');
+            const prUrl = await autoPushViaMR(
+                teamRepoDir,
+                `[teamai] Import codebase knowledge from ${owner}/${repoName}`,
+                ['.'],
+                mrTeamConfig,
+                mrLocalConfig,
+            );
+            if (prUrl) {
+                log.success(`已创建 MR: ${prUrl}`);
+            } else {
+                log.success(`已推送分支到团队知识仓库${teamRepoRemote ? ` (${teamRepoRemote})` : ''}`);
+            }
         }
     }
 
@@ -856,10 +870,13 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
                 try {
                     const { deepEnrich } = await import('./deep-enrich.js');
                     await deepEnrich({ project: slug, evidenceDir, wikiRoot: teamwikiRoot, cacheDir });
-                    if (!skipAutoPush) {
-                        const { autoPushTeamRepo } = await import('./utils/git.js');
+                    if (!skipAutoPush && mrTeamConfig && mrLocalConfig) {
+                        const { autoPushViaMR } = await import('./utils/git.js');
                         if (await fs.pathExists(teamRepoDir)) {
-                            await autoPushTeamRepo(teamRepoDir, `[teamai] Deep enrich: ${slug}`);
+                            await autoPushViaMR(
+                                teamRepoDir, `[teamai] Deep enrich: ${slug}`,
+                                ['.'], mrTeamConfig, mrLocalConfig,
+                            );
                         }
                     }
                     log.info(chalk.green(`✓ 深度生成完成: ${slug}`));

--- a/src/import.ts
+++ b/src/import.ts
@@ -120,7 +120,7 @@ export async function importCmd(opts: ImportOptions): Promise<void> {
         incremental: opts.incremental ?? false,
         skipEnrich: opts.skipEnrich ?? false,
       });
-      log.info(`完成：成功 ${result.succeeded}，失败 ${result.failed.length}，跳过 ${result.skipped.length}`);
+      log.info(`done: ${result.succeeded} succeeded, ${result.failed.length} failed, ${result.skipped.length} skipped`);
       if (result.failed.length > 0) process.exitCode = 1;
       return;
     } else if (opts.fromIwiki) {
@@ -196,7 +196,7 @@ export async function importCmd(opts: ImportOptions): Promise<void> {
       log.info(`扫描本地目录: ${dirPath} (project: ${slug})`);
 
       if (opts.dryRun) {
-        log.info(`[dry-run] 跳过代码提取，不执行实际操作`);
+        log.info(`[dry-run] skipping code extraction, no action taken`);
         log.success(`本地目录 ${slug} 导入完成 (dry-run)`);
         return;
       }
@@ -258,7 +258,7 @@ export async function importCmd(opts: ImportOptions): Promise<void> {
       // 分支 3b：--from-claude，扫描规则文件并交互式导入
       const candidates = await scanCandidates({ fromClaude: true });
       if (candidates.length === 0) {
-        log.info('未发现可导入的文件');
+        log.info('no importable files found');
         return;
       }
       const classified = await classifyWithAI(candidates);

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -1069,7 +1069,7 @@ export async function pull(options: GlobalOptions): Promise<void> {
   // 2. User scope — only when NOT in project mode.
   let userConfig: LocalConfig | null = null;
   if (projectMode) {
-    log.info('检测到 project scope，已跳过 user scope');
+    log.info('project scope detected, skipped user scope');
   } else {
     try {
       userConfig = await loadLocalConfigForScope('user');

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -317,7 +317,7 @@ export async function recall(
       });
     }
   } catch {
-    log.warn('recall: 代码图谱检索不可用，可运行 teamai codebase --lint 诊断');
+    log.warn('recall: code graph retrieval unavailable, run teamai codebase --lint to diagnose');
   }
 
   // Re-sort merged results by score descending, then date descending

--- a/src/review-cmd.ts
+++ b/src/review-cmd.ts
@@ -61,8 +61,8 @@ function renderList(items: PendingReviewItem[]): void {
     for (const item of items) counts[item.risk]++;
 
     console.log(
-        chalk.bold(`[review] 共 ${items.length} 项`) +
-        `（high: ${counts.high}, medium: ${counts.medium}, low: ${counts.low}）`,
+        chalk.bold(`[review] ${items.length} items`) +
+        ` (high: ${counts.high}, medium: ${counts.medium}, low: ${counts.low})`,
     );
 
     if (items.length === 0) return;
@@ -199,13 +199,13 @@ export async function reviewCmd(opts: ReviewCmdOptions): Promise<void> {
 
         const succeeded = results.filter((r) => r.ok);
         const failed = results.filter((r) => !r.ok);
-        const summary = `[review] --all-apply 完成：成功 ${succeeded.length}，失败 ${failed.length}，跳过 ${skipped.length}`;
+        const summary = `[review] --all-apply done: ${succeeded.length} succeeded, ${failed.length} failed, ${skipped.length} skipped`;
         console.log(chalk.bold(summary));
         for (const fail of failed) {
             console.log(chalk.red(`  ✗ ${fail.id}: ${fail.reason}`));
         }
         for (const skip of skipped) {
-            console.log(chalk.dim(`  ○ 跳过 ${skip.id}（kind=${skip.kind}, risk=${skip.risk}）`));
+            console.log(chalk.dim(`  ○ skipped ${skip.id} (kind=${skip.kind}, risk=${skip.risk})`));
         }
         return;
     }
@@ -229,9 +229,9 @@ export async function reviewCmd(opts: ReviewCmdOptions): Promise<void> {
     const item = items.find((i) => i.id === idArg);
 
     if (!item) {
-        log.warn(`[review] 未找到 id="${idArg}"`);
+        log.warn(`[review] not found: id="${idArg}"`);
         if (jsonMode) {
-            console.log(JSON.stringify({ ok: false, reason: `未找到 id="${idArg}"` }));
+            console.log(JSON.stringify({ ok: false, reason: `not found: id="${idArg}"` }));
         }
         return;
     }
@@ -274,7 +274,7 @@ export async function reviewCmd(opts: ReviewCmdOptions): Promise<void> {
         }
 
         if (result.ok) {
-            console.log(chalk.green(`[review] 已应用：${idArg} → ${item.target.file}`));
+            console.log(chalk.green(`[review] applied: ${idArg} → ${item.target.file}`));
         } else {
             console.log(chalk.red(`[review] 应用失败：${idArg} — ${result.reason}`));
         }

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -145,12 +145,47 @@ export async function pushRepoDirectly(localPath: string, message: string, files
 /**
  * Best-effort push all changes in a team repo clone.
  * Logs success/failure without throwing.
+ * @deprecated Use autoPushViaMR instead for import flows.
  */
 export async function autoPushTeamRepo(repoPath: string, message: string): Promise<void> {
   try {
     await pushRepoDirectly(repoPath, message, ['.']);
   } catch (err) {
     log.warn(`[git] autoPush failed (non-blocking): ${(err as Error).message}`);
+  }
+}
+
+/**
+ * Push changes via branch + MR/PR instead of direct push to main.
+ * Creates a branch, commits, pushes, creates MR, then returns to default branch.
+ * Non-blocking: logs warnings on failure without throwing.
+ */
+export async function autoPushViaMR(
+  repoPath: string,
+  message: string,
+  files: string[],
+  teamConfig: { repo: string; provider?: string; reviewers?: string[] },
+  localConfig: { repo: { remote: string; localPath: string }; username: string },
+): Promise<string | null> {
+  try {
+    const branchName = generateBranchName(localConfig.username);
+    const pushed = await pushRepoBranch(repoPath, message, files, branchName);
+    if (!pushed) {
+      log.debug('[git] autoPushViaMR: nothing to commit');
+      return null;
+    }
+
+    const { createPrWithFallback } = await import('../push.js');
+    const prUrl = await createPrWithFallback(
+      teamConfig, localConfig, branchName, message, message,
+    );
+
+    await checkoutMaster(repoPath);
+    return prUrl;
+  } catch (err) {
+    log.warn(`[git] autoPushViaMR failed (non-blocking): ${(err as Error).message}`);
+    try { await checkoutMaster(repoPath); } catch { /* best effort */ }
+    return null;
   }
 }
 

--- a/src/utils/search-index.ts
+++ b/src/utils/search-index.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import matter from 'gray-matter';
 import { readFileSafe, readJson, writeJson, listFiles, listFilesRecursive, listDirs, pathExists } from './fs.js';
-import { tokenize } from './tokenizer.js';
+import { tokenize, MAX_TOKENIZE_CHARS } from './tokenizer.js';
 import { log } from './logger.js';
 import {
   SEARCH_INDEX_VERSION,
@@ -203,8 +203,8 @@ export function inferDomain(
   return 'neutral';
 }
 
-// Re-export for external callers that previously imported tokenize from this module
-export { tokenize };
+// Re-export tokenizer for external callers
+export { tokenize, MAX_TOKENIZE_CHARS };
 
 /**
  * Parse a learning document's frontmatter and body.
@@ -507,8 +507,8 @@ export async function buildIndex(
   // Guard: don't overwrite a healthy index with a significantly smaller one
   const targetPath = opts.indexPath ?? getSearchIndexPath();
   const existingIndex = await loadIndex(targetPath);
-  if (existingIndex && existingIndex.entries.length > 0 && entries.length === 0) {
-    log.warn(`Index rebuild skipped: refusing to overwrite ${existingIndex.entries.length} entries with empty index`);
+  if (existingIndex && existingIndex.entries.length > 5 && entries.length < existingIndex.entries.length * 0.2) {
+    log.warn(`Index rebuild skipped: new index (${entries.length}) is <20% of existing (${existingIndex.entries.length}), likely partial failure`);
     return elapsed;
   }
 

--- a/src/utils/tokenizer.ts
+++ b/src/utils/tokenizer.ts
@@ -9,14 +9,13 @@
  * - 全小写
  * - 去重
  */
-const MAX_TOKENIZE_CHARS = 100_000;
+export const MAX_TOKENIZE_CHARS = 50_000;
 
 export function tokenize(text: string): string[] {
   if (!text) return [];
 
   const input = text.length > MAX_TOKENIZE_CHARS ? text.slice(0, MAX_TOKENIZE_CHARS) : text;
   const segmenter = new Intl.Segmenter('zh-CN', { granularity: 'word' });
-  const segments = [...segmenter.segment(input)];
   const tokens: string[] = [];
 
   // Collect CJK characters in runs for bigram generation
@@ -31,7 +30,7 @@ export function tokenize(text: string): string[] {
     cjkRun = [];
   };
 
-  for (const seg of segments) {
+  for (const seg of segmenter.segment(input)) {
     if (!seg.isWordLike) {
       flushCjkRun();
       continue;
@@ -68,4 +67,16 @@ export function tokenize(text: string): string[] {
   flushCjkRun();
 
   return [...new Set(tokens)];
+}
+
+/** Non-deduplicated word-like token count (for BM25 document length). */
+export function tokenCount(text: string): number {
+  if (!text) return 0;
+  const input = text.length > MAX_TOKENIZE_CHARS ? text.slice(0, MAX_TOKENIZE_CHARS) : text;
+  const segmenter = new Intl.Segmenter('zh-CN', { granularity: 'word' });
+  let count = 0;
+  for (const seg of segmenter.segment(input)) {
+    if (seg.isWordLike) count++;
+  }
+  return count;
 }

--- a/src/wiki-engine/core/graph-index.schema.ts
+++ b/src/wiki-engine/core/graph-index.schema.ts
@@ -352,7 +352,11 @@ export async function loadGraphIndex(wikiRoot: string): Promise<GraphIndex | nul
   const graphPath = path.join(wikiRoot, ".indices", "graph-index.json");
   try {
     const raw = await readFile(graphPath, "utf8");
-    return JSON.parse(raw) as GraphIndex;
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed?.nodes) || !Array.isArray(parsed?.edges)) {
+      return null;
+    }
+    return parsed as GraphIndex;
   } catch {
     return null;
   }

--- a/src/wiki-engine/knowledge-reconciler.ts
+++ b/src/wiki-engine/knowledge-reconciler.ts
@@ -334,7 +334,6 @@ export async function reconcileKnowledge(options: ReconcileOptions): Promise<Rec
 
   // Phase 9 — Stale detection
   const MS_PER_DAY = 86_400_000;
-  const now = Date.now();
   for (const edge of graphEdges) {
     const fromPage = productPages.find(
       p => toPageSlug(path.relative(wikiRoot, p.path)) === edge.from
@@ -345,7 +344,7 @@ export async function reconcileKnowledge(options: ReconcileOptions): Promise<Rec
     if (!fromPage?.updated || !toPage?.updated) continue;
     const fromMs = new Date(fromPage.updated).getTime();
     const toMs = new Date(toPage.updated).getTime();
-    const daysDrift = Math.abs(now - Math.max(fromMs, toMs)) / MS_PER_DAY;
+    const daysDrift = Math.abs(fromMs - toMs) / MS_PER_DAY;
     if (daysDrift > 30) {
       staleWarnings.push({
         mappingFrom: edge.from,

--- a/src/wiki-engine/reconciler-v2-types.ts
+++ b/src/wiki-engine/reconciler-v2-types.ts
@@ -21,12 +21,11 @@ export function labelFromScore(score: number): WikiConfidence {
   return "AMBIGUOUS";
 }
 
-/** Build a NumericConfidence from factors (max of weights) */
+/** Build a NumericConfidence from factors (cumulative evidence, capped at 1.0) */
 export function buildConfidence(factors: ConfidenceFactor[]): NumericConfidence {
   if (factors.length === 0) return { score: 0, label: "AMBIGUOUS", factors: [] };
-  const score = Math.max(...factors.map(f => f.weight));
-  const clamped = Math.min(1, Math.max(0, score));
-  return { score: clamped, label: labelFromScore(clamped), factors };
+  const score = Math.min(1, factors.reduce((sum, f) => sum + f.weight, 0));
+  return { score, label: labelFromScore(score), factors };
 }
 
 // ─── API↔Interface Matching ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the remaining bugs reported in issues #82, #84, and #94 that were not fully resolved by PR #91.

### Issue #82 — knowledge-reconciler
- **Bug1**: `buildConfidence` → cumulative sum `Math.min(1, sum)`, corroborating evidence now increases confidence
- **Bug2**: Stale detection → `Math.abs(fromMs - toMs)` measures drift between two sides

### Issue #84 — codebase graph retrieval
- **Bug1**: `loadWikiPages` recursive traversal (modules/*.md now indexed)
- **Bug2**: Removed broken `rawTokenCount`; uses `tokenizer.ts` with correct camelCase/PascalCase split
- **Bug3**: `extractCodebase` load-merge-save prevents overwriting other repos
- **Bug4**: Unified tokenizer — single `tokenizer.ts` for both paths
- **Bug5**: `loadGraphIndex` schema validation + null fallback

### Issue #94 — PR #91 follow-ups
- **Issue1**: BM25 dl/tf truncation unified (countOccurrences truncates to MAX_TOKENIZE_CHARS)
- **Issue2**: Shrink-guard restored to 20% soft threshold
- **Issue3**: Same as #82 Bug1
- **Issue4**: Single exported `MAX_TOKENIZE_CHARS` (50k) + iterative Segmenter (no OOM)

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 131 files, 1691 tests pass
- [x] 15 new regression tests

Closes #82, closes #84, closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)