### PR TITLE
fix(ci): route scope-isolation issue85 test to e2e suite

### DIFF
--- a/src/__tests__/e2e/scope-isolation-issue85.test.ts
+++ b/src/__tests__/e2e/scope-isolation-issue85.test.ts
@@ -23,7 +23,7 @@ import { fileURLToPath } from 'node:url';
 //      silently degrading to the user's home.
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const ROOT = path.resolve(__dirname, '..', '..');
+const ROOT = path.resolve(__dirname, '..', '..', '..');
 const CLI = path.join(ROOT, 'dist', 'index.js');
 
 interface RunResult {


### PR DESCRIPTION
## Summary

- `main` CI 一直在 **Unit tests with coverage** 这步失败,报错 `CLI binary not found at .../dist/index.js`。
- 根因:#97 新增的 `src/__tests__/scope-isolation-e2e-issue85.test.ts` 是个 e2e 测试(会 spawn 真实 CLI 二进制),但文件名结尾是 `-e2e-issue85.test.ts`,**不匹配** e2e 配置的 `*-e2e.test.ts` glob,于是被单元测试阶段捡走执行。而单元测试跑在 `build` 之前,`dist/index.js` 尚不存在,测试直接中止。
- 本 PR 把该文件移动到 `src/__tests__/e2e/`(该目录被 `vitest.e2e.config.ts` include、被 `vitest.config.ts` exclude),并修正因目录加深导致的 `ROOT` 相对路径(`..` 增加一层)。

## Test plan

- [x] `npx vitest list --config vitest.config.ts` 不再包含该测试(已从单元集中移除)
- [x] `npx vitest list --config vitest.e2e.config.ts` 正确收录该测试(7 个用例)
- [x] `npm run build` 后运行该 e2e 测试:7 passed

Made with [Cursor](https://cursor.com)