### PR TITLE
feat(init): 初始化 scope 选择改用数字 1/2

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -247,10 +247,12 @@ export async function init(options: GlobalOptions & { repo?: string; scope?: str
   } else {
     const userPath = getTeamaiHome('user');
     const projectPath = getTeamaiHome('project', process.cwd());
-    log.info(`  user    → ${userPath}/`);
-    log.info(`  project → ${projectPath}/`);
-    const scopeAnswer = await askQuestion('Scope [user/project] (default: user): ', 'user');
-    if (scopeAnswer.toLowerCase() === 'project') {
+    log.info('Select scope:');
+    log.info(`  1. user    → ${userPath}/`);
+    log.info(`  2. project → ${projectPath}/`);
+    const scopeAnswer = await askQuestion('Scope [1/2] (default: 1): ', '1');
+    const normalizedScope = scopeAnswer.trim().toLowerCase();
+    if (normalizedScope === '2' || normalizedScope === 'project') {
       scope = 'project';
     }
   }


### PR DESCRIPTION
## 背景

`teamai init` 交互式选择 scope 时使用的是文本输入 `Scope [user/project] (default: user)`，而紧随其后的角色选择流程用的是数字编号（`1. ...` / `2. ...`）。两者风格不一致，容易让用户困惑。

## 改动

将 scope 提示改为与后续角色选择一致的数字编号：

```
Select scope:
  1. user    → ~/.teamai/
  2. project → <cwd>/.teamai/
Scope [1/2] (default: 1):
```

- 默认值 `1`（user），直接回车行为不变。
- 输入 `2` 选择 project。
- 兼容旧的 `user` / `project` 文本输入。

仅改动 `src/init.ts` 的交互式分支；`--scope` flag 与 HTTP 初始化流程不受影响。

## 测试

- `npx tsc --noEmit` 通过。
- `npx vitest run`：1660 passed。3 个失败位于 `import-repo-merge.test.ts`，经 `git stash` 在 base 上复现，属改动前既有失败，与本次无关。

Made with [Cursor](https://cursor.com)