### PR TITLE
feat(recall): implement progressive retrieval with G-document routing

### DIFF
--- a/agents/teamai-recall.md
+++ b/agents/teamai-recall.md
@@ -20,23 +20,29 @@ upstream API"). Treat this as your query.
 
 ## What you must do — step by step
 
-### Step 1 — Read codebase context (optional but preferred)
+### Step 1 — Classify question type and choose retrieval depth
 
-Check for the team's code knowledge graph in this order:
+Determine if the query matches a G-document category:
 
-1. `teamwiki/router.md` — if exists, read it to understand available repos
-2. `teamwiki/index.md` — global navigation with domain links
+| 问题关键词 | 类型 | 直接读取 |
+|-----------|------|---------|
+| 依赖/上游/下游/谁调用 | G1 | `teamwiki/evidence/code/<project>/docs/graph-g1-relations.md` |
+| 调用链/数据流/请求路径 | G2 | `teamwiki/evidence/code/<project>/docs/graph-g2-dataflow.md` |
+| 流程/场景/完整流程 | G5 | `teamwiki/evidence/code/<project>/docs/graph-g5-scenarios.md` |
+| 传递依赖/爆炸半径/影响 | G6 | `teamwiki/evidence/code/<project>/docs/graph-g6-multihop.md` |
 
-If `teamwiki/` exists, the team has a structured knowledge graph. After
-Step 3 returns codebase hits, you can **drill into** module summaries:
-- `teamwiki/evidence/code/<project>/modules/<dir>.md` — module-level overview with dependency direction and top components
-- `teamwiki/evidence/code/<project>/overview.md` — AI-generated architecture context (why/how, not just what)
+**If the query clearly matches a G-document type**: directly Read the
+corresponding file and extract relevant sections. Skip BM25 search.
 
-Fallback: if no `teamwiki/`, check `~/.teamai/docs/codebase.md` or
-`docs/team-codebase/index.md`. If none exists, silently skip.
+**Otherwise**: proceed to Step 2–3 for BM25 keyword search.
 
-> `teamai recall` automatically searches both flat knowledge (learnings/
-> skills/docs/rules) and codebase graph (teamwiki/) with BM25 + graph-boost.
+> `teamai recall` supports three depth levels:
+> - `--depth context` (default): searches overview + modules + docs (best for most queries)
+> - `--depth lookup`: searches ALL evidence pages including raw symbol lists (for precise file:line lookups)
+> - `--depth route`: returns the router table only (use when you need to discover what projects exist)
+
+Fallback: if no `teamwiki/`, check `~/.teamai/docs/codebase.md`. If
+none exists, silently skip.
 
 ### Step 2 — Extract keywords from the task description
 
@@ -45,14 +51,22 @@ Pick 3–6 high-signal keywords from the user query. Strip filler words
 
 ### Step 3 — Run the teamai recall command
 
-Execute:
+Execute with the appropriate depth:
 
 ```bash
+# Default: searches overview, modules, and docs (context layer)
 teamai recall "<keyword1> <keyword2> ..."
+
+# For precise symbol/line-number lookups, use lookup depth:
+teamai recall --depth lookup "<keyword1> <keyword2> ..."
 ```
 
 This searches all four knowledge categories (`skills`, `learnings`,
-`docs`, `rules`) via the local search index. Capture the full output.
+`docs`, `rules`) via the local search index, plus the codebase graph
+in `teamwiki/` with BM25 + graph-boost. Capture the full output.
+
+If the first call returns insufficient results, you may retry once with
+`--depth lookup` to broaden the search to raw symbol pages.
 
 If the command fails, knowledge base is empty, or returns zero hits,
 emit a single line `No relevant team knowledge found for: <query>` and

--- a/src/__tests__/import-repo-merge.test.ts
+++ b/src/__tests__/import-repo-merge.test.ts
@@ -31,18 +31,40 @@ vi.mock('../codebase.js', () => ({
     ),
 }));
 
+vi.mock('../codebase-extract.js', () => ({
+    extractCodebase: vi.fn(),
+}));
+
 // ─── Imports (after mocks) ──────────────────────────────
 
 import { importFromRepo } from '../import-repo.js';
 import { shallowClone } from '../clone.js';
 import { generateCodebaseMd } from '../codebase.js';
+import { extractCodebase } from '../codebase-extract.js';
 
 // ─── Constants ──────────────────────────────────────────
 
 const CLONE_SHA = 'deadbeef1234567890abcdef1234567890abcdef';
+const SLUG = 'github__owner__mergetest';
 
-const FIXED_CODEBASE_MD =
-    '---\ntitle: Test Repo\nlastUpdated: 2024-01-01T00:00:00.000Z\n---\n\n## 项目概述\n固定的项目概述内容，不会改变。\n\n## 技术栈\nTypeScript + vitest';
+const DETERMINISTIC_OVERVIEW = [
+    '---',
+    'title: github__owner__mergetest overview',
+    'domain: code-knowledge',
+    '---',
+    '',
+    '# github__owner__mergetest',
+    '',
+    '**5 facts** extracted from 3 files.',
+    'Graph: 4 nodes, 2 edges.',
+    '',
+    '## Module Structure',
+    '',
+    '| Module | Facts | Components | Interfaces |',
+    '|--------|-------|------------|------------|',
+    '| src | 3 | 2 | 1 |',
+    '',
+].join('\n');
 
 // ─── Helpers ────────────────────────────────────────────
 
@@ -52,13 +74,9 @@ async function makeWorkdir(): Promise<string> {
     return tmpDir;
 }
 
-async function sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 // ─── Tests ──────────────────────────────────────────────
 
-describe('importFromRepo — section merge', () => {
+describe('importFromRepo — AI narrative appended to overview.md', () => {
     let workdir: string;
     const TEST_URL = 'https://github.com/owner/mergetest';
 
@@ -72,7 +90,19 @@ describe('importFromRepo — section merge', () => {
             return { sha: CLONE_SHA, branch: 'main', cloneMethod: 'https-token' as const };
         });
 
-        vi.mocked(generateCodebaseMd).mockResolvedValue(FIXED_CODEBASE_MD);
+        // Mock extractCodebase to simulate writing teamwiki evidence files
+        vi.mocked(extractCodebase).mockImplementation(async (opts: { path: string; project?: string }) => {
+            const cacheDir = opts.path;
+            const project = opts.project || 'test';
+            const wikiRoot = path.join(cacheDir, 'teamwiki');
+            const evidenceDir = path.join(wikiRoot, 'evidence', 'code', project);
+            const indicesDir = path.join(wikiRoot, '.indices');
+
+            await fs.ensureDir(evidenceDir);
+            await fs.ensureDir(indicesDir);
+            await fs.writeFile(path.join(evidenceDir, 'overview.md'), DETERMINISTIC_OVERVIEW, 'utf8');
+            await fs.writeFile(path.join(indicesDir, 'graph-index.json'), JSON.stringify({ nodes: [], edges: [] }), 'utf8');
+        });
     });
 
     afterEach(async () => {
@@ -81,95 +111,56 @@ describe('importFromRepo — section merge', () => {
         await fs.remove(workdir);
     });
 
-    it('第一次跑 import → 文件被创建、含锚点', async () => {
+    it('AI 叙事追加到 teamwiki evidence overview.md 末尾', async () => {
         await importFromRepo({
             url: TEST_URL,
             interactive: false,
         });
 
-        const repoMdPath = path.join(workdir, '.teamai', 'team-repo', 'docs', 'team-codebase', 'repos', 'github__owner__mergetest.md');
-        const exists = await fs.pathExists(repoMdPath);
+        const overviewPath = path.join(
+            workdir, '.teamai', 'team-repo', 'teamwiki', 'evidence', 'code',
+            SLUG, 'overview.md',
+        );
+        const exists = await fs.pathExists(overviewPath);
         expect(exists).toBe(true);
 
-        const content = await fs.readFile(repoMdPath, 'utf8');
-        expect(content).toContain('<!-- managed-by: import --from-repo');
-        expect(content).toContain('<!-- /managed-by:');
-        expect(content).toContain('项目概述');
+        const content = await fs.readFile(overviewPath, 'utf8');
+        // 确定性内容（模块表格）在前
+        expect(content).toContain('## Module Structure');
+        // AI 叙事在后
+        expect(content).toContain('## AI 架构叙事');
+        expect(content).toContain('固定的项目概述内容，不会改变。');
         expect(content).toContain('技术栈');
     });
 
-    it('第二次跑同样输入 → 文件 mtime 不改变（真正跳过写入）', async () => {
-        // 第一次运行
+    it('docs/team-codebase/repos/ 不再被创建', async () => {
         await importFromRepo({
             url: TEST_URL,
             interactive: false,
         });
 
-        const repoMdPath = path.join(workdir, '.teamai', 'team-repo', 'docs', 'team-codebase', 'repos', 'github__owner__mergetest.md');
-        const stat1 = await fs.stat(repoMdPath);
-        const mtime1 = stat1.mtimeMs;
-
-        // 等待足够时间确保 mtime 可区分
-        await sleep(20);
-
-        // 第二次运行，相同输入（仓库已在 domains 中，走增量路径返回）
-        // 需要先让仓库不在 domains 中，重新走 import 流程
-        // 或者直接验证文件内容未变（字节级等同）
-        const content1 = await fs.readFile(repoMdPath, 'utf8');
-
-        // 模拟：手动调用 mergeWithAnchors 验证第二次不写盘
-        // 实际测试方式：删除 domains 记录，让第二次也能跑 import 全流程
-        // 清空 domains 并再次导入
-        await fs.remove(path.join(workdir, '.teamai', 'domains.yaml'));
-
-        await sleep(20);
-        await importFromRepo({
-            url: TEST_URL,
-            interactive: false,
-        });
-
-        const stat2 = await fs.stat(repoMdPath);
-        const mtime2 = stat2.mtimeMs;
-
-        // 关键断言：mtime 没有改变（跳过了写入）
-        expect(mtime2).toBe(mtime1);
-
-        // 文件内容也应字节级相同
-        const content2 = await fs.readFile(repoMdPath, 'utf8');
-        expect(content2).toBe(content1);
+        const oldPath = path.join(
+            workdir, '.teamai', 'team-repo', 'docs', 'team-codebase', 'repos',
+            `${SLUG}.md`,
+        );
+        const exists = await fs.pathExists(oldPath);
+        expect(exists).toBe(false);
     });
 
-    it('旧文件含未闭合锚点 → fallback 时备份旧文件、产物使用新 codebase', async () => {
-        const repoMdPath = path.join(workdir, '.teamai', 'team-repo', 'docs', 'team-codebase', 'repos', 'github__owner__mergetest.md');
-        await fs.ensureDir(path.dirname(repoMdPath));
-
-        // 准备含未闭合锚点的旧文件
-        const unclosedOldFile = [
-            '# Old Content',
-            '',
-            '<!-- managed-by: import --from-repo, section: 项目概述, source: old@aabbccdd, syncedAt: 2024-01-01T00:00:00Z -->',
-            '## 项目概述',
-            '旧内容，这是旧内容。',
-            // 故意缺少 <!-- /managed-by: 项目概述 --> 闭锚
-        ].join('\n');
-
-        await fs.writeFile(repoMdPath, unclosedOldFile, 'utf8');
-
-        // 执行 importFromRepo，此时 parseSections 会因未闭合锚点抛错 → fallback
+    it('skipEnrich 时不追加 AI 叙事', async () => {
         await importFromRepo({
             url: TEST_URL,
             interactive: false,
+            skipEnrich: true,
         });
 
-        // 1. 验证备份文件存在且内容等于旧文件
-        const bakPath = `${repoMdPath}.bak`;
-        expect(await fs.pathExists(bakPath)).toBe(true);
-        const bakContent = await fs.readFile(bakPath, 'utf8');
-        expect(bakContent).toBe(unclosedOldFile);
-
-        // 2. 验证产物文件包含新 codebase 内容（fallback 全量重写）
-        const newContent = await fs.readFile(repoMdPath, 'utf8');
-        expect(newContent).toContain('项目概述');
-        expect(newContent).toContain('固定的项目概述内容');
+        const overviewPath = path.join(
+            workdir, '.teamai', 'team-repo', 'teamwiki', 'evidence', 'code',
+            SLUG, 'overview.md',
+        );
+        if (await fs.pathExists(overviewPath)) {
+            const content = await fs.readFile(overviewPath, 'utf8');
+            expect(content).not.toContain('## AI 架构叙事');
+        }
     });
 });

--- a/src/__tests__/import-repo-merge.test.ts
+++ b/src/__tests__/import-repo-merge.test.ts
@@ -101,7 +101,8 @@ describe('importFromRepo — AI narrative appended to overview.md', () => {
             await fs.ensureDir(evidenceDir);
             await fs.ensureDir(indicesDir);
             await fs.writeFile(path.join(evidenceDir, 'overview.md'), DETERMINISTIC_OVERVIEW, 'utf8');
-            await fs.writeFile(path.join(indicesDir, 'graph-index.json'), JSON.stringify({ nodes: [], edges: [] }), 'utf8');
+            const emptyGraph = JSON.stringify({ nodes: [], edges: [] });
+            await fs.writeFile(path.join(indicesDir, 'graph-index.json'), emptyGraph, 'utf8');
         });
     });
 

--- a/src/__tests__/import-repo-merge.test.ts
+++ b/src/__tests__/import-repo-merge.test.ts
@@ -91,8 +91,8 @@ describe('importFromRepo — AI narrative appended to overview.md', () => {
         });
 
         // Mock extractCodebase to simulate writing teamwiki evidence files
-        vi.mocked(extractCodebase).mockImplementation(async (opts: { path: string; project?: string }) => {
-            const cacheDir = opts.path;
+        vi.mocked(extractCodebase).mockImplementation(async (opts) => {
+            const cacheDir = opts.path ?? '.';
             const project = opts.project || 'test';
             const wikiRoot = path.join(cacheDir, 'teamwiki');
             const evidenceDir = path.join(wikiRoot, 'evidence', 'code', project);

--- a/src/__tests__/issue-82-84-94-regression.test.ts
+++ b/src/__tests__/issue-82-84-94-regression.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Regression tests for issues #82, #84, #94 bug fixes.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildConfidence, labelFromScore } from '../wiki-engine/reconciler-v2-types.js';
+
+describe('buildConfidence (issue #82 bug1 + #94 issue3)', () => {
+  it('single factor preserves its weight as score', () => {
+    const result = buildConfidence([{ name: 'direct_match', weight: 0.9 }]);
+    expect(result.score).toBe(0.9);
+    expect(result.label).toBe('EXTRACTED');
+  });
+
+  it('adding positive evidence increases (not decreases) the score', () => {
+    const single = buildConfidence([{ name: 'direct_match', weight: 0.9 }]);
+    const multi = buildConfidence([
+      { name: 'direct_match', weight: 0.9 },
+      { name: 'title_proximity', weight: 0.1 },
+    ]);
+    expect(multi.score).toBeGreaterThanOrEqual(single.score);
+  });
+
+  it('cumulative weights are capped at 1.0', () => {
+    const result = buildConfidence([
+      { name: 'a', weight: 0.7 },
+      { name: 'b', weight: 0.5 },
+    ]);
+    expect(result.score).toBe(1.0);
+    expect(result.label).toBe('EXTRACTED');
+  });
+
+  it('empty factors returns score 0 with AMBIGUOUS label', () => {
+    const result = buildConfidence([]);
+    expect(result.score).toBe(0);
+    expect(result.label).toBe('AMBIGUOUS');
+  });
+
+  it('path_match + method_match yields higher score than path_match alone', () => {
+    const pathOnly = buildConfidence([{ name: 'path_match', weight: 0.7 }]);
+    const combined = buildConfidence([
+      { name: 'path_match', weight: 0.7 },
+      { name: 'method_match', weight: 0.3 },
+    ]);
+    expect(combined.score).toBeGreaterThan(pathOnly.score);
+  });
+});
+
+describe('labelFromScore thresholds', () => {
+  it('score >= 0.8 → EXTRACTED', () => {
+    expect(labelFromScore(0.8)).toBe('EXTRACTED');
+    expect(labelFromScore(1.0)).toBe('EXTRACTED');
+  });
+
+  it('score >= 0.5 and < 0.8 → INFERRED', () => {
+    expect(labelFromScore(0.5)).toBe('INFERRED');
+    expect(labelFromScore(0.79)).toBe('INFERRED');
+  });
+
+  it('score < 0.5 → AMBIGUOUS', () => {
+    expect(labelFromScore(0.49)).toBe('AMBIGUOUS');
+    expect(labelFromScore(0)).toBe('AMBIGUOUS');
+  });
+});
+
+describe('camelCase tokenize (issue #84 bug2)', () => {
+  it('splits camelCase identifiers into separate sub-tokens', async () => {
+    const { tokenize } = await import('../utils/tokenizer.js');
+    const tokens = tokenize('getUserName');
+    // Should contain both the whole word and sub-tokens
+    expect(tokens).toContain('getusername');
+    expect(tokens).toContain('get');
+    expect(tokens).toContain('user');
+    expect(tokens).toContain('name');
+  });
+
+  it('splits PascalCase identifiers (e.g. ModuleNotFoundError)', async () => {
+    const { tokenize } = await import('../utils/tokenizer.js');
+    const tokens = tokenize('ModuleNotFoundError');
+    expect(tokens).toContain('module');
+    expect(tokens).toContain('not');
+    expect(tokens).toContain('found');
+    expect(tokens).toContain('error');
+  });
+
+  it('does NOT split when text is already lowercased', async () => {
+    const { tokenize } = await import('../utils/tokenizer.js');
+    const tokens = tokenize('getusername');
+    // All-lowercase has no uppercase transitions to split on
+    expect(tokens).not.toContain('get');
+    expect(tokens).toContain('getusername');
+  });
+});
+
+describe('stale detection (issue #82 bug2)', () => {
+  it('measures drift between two sides, not age from today', () => {
+    // The fix changes: Math.abs(now - max(from, to)) → Math.abs(fromMs - toMs)
+    // Simulate the calculation
+    const fromMs = new Date('2025-01-01').getTime();
+    const toMs = new Date('2025-03-15').getTime();
+    const MS_PER_DAY = 86_400_000;
+
+    // New logic: drift between sides
+    const daysDrift = Math.abs(fromMs - toMs) / MS_PER_DAY;
+    expect(daysDrift).toBeCloseTo(73, 0); // ~73 days apart
+
+    // Old logic would have used: Math.abs(now - Math.max(fromMs, toMs))
+    // which gives hundreds of days (age) — completely different semantics
+    const now = Date.now();
+    const oldDrift = Math.abs(now - Math.max(fromMs, toMs)) / MS_PER_DAY;
+    expect(oldDrift).toBeGreaterThan(400); // way off from the actual drift
+  });
+
+  it('simultaneously updated pages have zero drift', () => {
+    const sameTime = new Date('2025-06-01').getTime();
+    const MS_PER_DAY = 86_400_000;
+    const daysDrift = Math.abs(sameTime - sameTime) / MS_PER_DAY;
+    expect(daysDrift).toBe(0);
+  });
+});
+
+describe('loadGraphIndex schema validation (issue #84 bug5)', () => {
+  it('returns null for non-existent directory', async () => {
+    const { loadGraphIndex } = await import('../wiki-engine/core/graph-index.schema.js');
+    const result = await loadGraphIndex('/tmp/nonexistent-wiki-root-' + Date.now());
+    expect(result).toBeNull();
+  });
+
+  it('returns null when file exists but nodes/edges are not arrays', async () => {
+    const { writeFile, mkdir, rm } = await import('node:fs/promises');
+    const { join } = await import('node:path');
+    const { loadGraphIndex } = await import('../wiki-engine/core/graph-index.schema.js');
+
+    const tmpRoot = `/tmp/graph-schema-test-${Date.now()}`;
+    const indicesDir = join(tmpRoot, '.indices');
+    await mkdir(indicesDir, { recursive: true });
+
+    // Write a JSON file with wrong structure (nodes is not an array)
+    await writeFile(join(indicesDir, 'graph-index.json'), JSON.stringify({ nodes: 'invalid', edges: [] }));
+    const result1 = await loadGraphIndex(tmpRoot);
+    expect(result1).toBeNull();
+
+    // Write a JSON file with missing edges field
+    await writeFile(join(indicesDir, 'graph-index.json'), JSON.stringify({ nodes: [] }));
+    const result2 = await loadGraphIndex(tmpRoot);
+    expect(result2).toBeNull();
+
+    // Write a valid graph — should return it
+    await writeFile(join(indicesDir, 'graph-index.json'), JSON.stringify({ nodes: [], edges: [] }));
+    const result3 = await loadGraphIndex(tmpRoot);
+    expect(result3).not.toBeNull();
+    expect(result3!.nodes).toEqual([]);
+    expect(result3!.edges).toEqual([]);
+
+    await rm(tmpRoot, { recursive: true });
+  });
+});

--- a/src/__tests__/pull-scope-isolation.test.ts
+++ b/src/__tests__/pull-scope-isolation.test.ts
@@ -70,7 +70,7 @@ import { pullSources } from '../source.js';
 import { log } from '../utils/logger.js';
 import type { TeamaiConfig, LocalConfig } from '../types.js';
 
-const SKIP_MSG = '检测到 project scope，已跳过 user scope';
+const SKIP_MSG = 'project scope detected, skipped user scope';
 
 describe('pull scope isolation (issue #73)', () => {
   let tmpDir: string;

--- a/src/__tests__/recall-progressive.test.ts
+++ b/src/__tests__/recall-progressive.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Tests for three-tier progressive retrieval (route / context / lookup)
+ * of queryCodeKnowledge.
+ *
+ * Verifies:
+ *   1. depth=route returns only the router file content
+ *   2. depth=context searches overview/modules/docs but excludes navigation files
+ *      and leaf component files
+ *   3. depth=lookup searches all files including component.md
+ *   4. graph-boost is applied in context mode when a valid graph-index.json exists
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs-extra';
+import path from 'node:path';
+import os from 'node:os';
+
+import { queryCodeKnowledge } from '../code-knowledge-recall.js';
+
+// ---------------------------------------------------------------------------
+// Fixture content constants
+// ---------------------------------------------------------------------------
+
+const ROUTER_CONTENT = `search-anchor: 路由, 索引
+title: Question Router
+
+## 问题路由表
+
+| 关键词 | 指向文件 |
+|--------|----------|
+| 依赖关系 | evidence/code/test-project/overview.md |
+| 模块 | evidence/code/test-project/modules/src.md |
+`;
+
+const INDEX_CONTENT = `# Team Wiki Index
+
+This file lists all top-level topics.
+`;
+
+const HOT_CONTENT = `# Hot Context
+
+Recently accessed pages are listed here.
+`;
+
+const OVERVIEW_CONTENT = `title: test-project overview
+
+## Module Structure
+
+This project is structured as follows:
+- src: main source module
+- docs: documentation
+`;
+
+const COMPONENT_CONTENT = `title: components
+
+## Component Registry
+
+- ButtonComponent: importFromRepo('ui-kit', 'Button')
+- InputComponent: importFromRepo('ui-kit', 'Input')
+- ModalComponent: importFromRepo('ui-kit', 'Modal')
+- TableComponent: importFromRepo('ui-kit', 'Table')
+
+Each component uses importFromRepo to pull from the shared library.
+`;
+
+const SRC_MODULE_CONTENT = `title: src module
+
+## Source Module
+
+The src module handles all business logic.
+It uses importFromRepo to pull shared utilities.
+
+## recall
+
+This module participates in knowledge recall workflows.
+`;
+
+const README_CONTENT = `title: G-Document 路由
+
+## Overview
+
+G-Document routes requests to the correct handler.
+See graph-g1-relations for the full dependency graph.
+`;
+
+const ARCHITECTURE_CONTENT = `title: architecture
+
+## 项目概述
+
+This document describes the overall architecture.
+`;
+
+// ---------------------------------------------------------------------------
+// Helper: build the full wiki tree under a tmpdir
+// ---------------------------------------------------------------------------
+
+async function buildWikiTree(tmpDir: string): Promise<void> {
+  const evidenceCodeProject = path.join(tmpDir, 'evidence', 'code', 'test-project');
+  const modulesDir = path.join(evidenceCodeProject, 'modules');
+  const docsDir = path.join(evidenceCodeProject, 'docs');
+
+  await fs.ensureDir(modulesDir);
+  await fs.ensureDir(docsDir);
+
+  // Top-level navigation files
+  await fs.writeFile(path.join(tmpDir, 'router.md'), ROUTER_CONTENT, 'utf-8');
+  await fs.writeFile(path.join(tmpDir, 'index.md'), INDEX_CONTENT, 'utf-8');
+  await fs.writeFile(path.join(tmpDir, 'hot.md'), HOT_CONTENT, 'utf-8');
+
+  // Project files
+  await fs.writeFile(path.join(evidenceCodeProject, 'overview.md'), OVERVIEW_CONTENT, 'utf-8');
+  await fs.writeFile(path.join(evidenceCodeProject, 'component.md'), COMPONENT_CONTENT, 'utf-8');
+  await fs.writeFile(path.join(modulesDir, 'src.md'), SRC_MODULE_CONTENT, 'utf-8');
+  await fs.writeFile(path.join(docsDir, 'README.md'), README_CONTENT, 'utf-8');
+  await fs.writeFile(path.join(docsDir, 'architecture.md'), ARCHITECTURE_CONTENT, 'utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('queryCodeKnowledge — progressive depth retrieval', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'teamai-recall-progressive-'));
+    await buildWikiTree(tmpDir);
+  });
+
+  afterEach(async () => {
+    await fs.remove(tmpDir);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 1: route mode returns only router file
+  // -------------------------------------------------------------------------
+  it('depth=route 时只返回路由文件内容', async () => {
+    const results = await queryCodeKnowledge('依赖关系', {
+      wikiRoot: tmpDir,
+      depth: 'route',
+      limit: 10,
+    });
+
+    expect(results.length).toBe(1);
+    expect(results[0].title).toBe('Question Router');
+    expect(results[0].snippet).toContain('问题路由表');
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 2: context mode searches overview/modules/docs but excludes nav files
+  //         and component.md (not matched by CONTEXT_ALLOWED_PATTERNS)
+  // -------------------------------------------------------------------------
+  it('depth=context 时搜索 overview/modules/docs 但排除 router/index/hot/component', async () => {
+    const results = await queryCodeKnowledge('importFromRepo', {
+      wikiRoot: tmpDir,
+      depth: 'context',
+      limit: 10,
+    });
+
+    // At least one result must be present (from modules/src.md)
+    expect(results.length).toBeGreaterThan(0);
+
+    const paths = results.map(r => r.page);
+
+    // modules/src.md or overview.md must appear (both contain the keyword or are eligible)
+    const hasEligibleHit = paths.some(
+      p => p.includes('modules/src.md') || p.includes('overview.md'),
+    );
+    expect(hasEligibleHit).toBe(true);
+
+    // Navigation / excluded files must NOT appear
+    for (const p of paths) {
+      expect(p).not.toMatch(/router\.md$/);
+      expect(p).not.toMatch(/index\.md$/);
+      expect(p).not.toMatch(/hot\.md$/);
+      expect(p).not.toMatch(/component\.md$/);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 3: lookup mode searches all files including component.md
+  // -------------------------------------------------------------------------
+  it('depth=lookup 时搜索全部文件包括 component.md', async () => {
+    const results = await queryCodeKnowledge('importFromRepo', {
+      wikiRoot: tmpDir,
+      depth: 'lookup',
+      limit: 10,
+    });
+
+    const paths = results.map(r => r.page);
+    const hasComponent = paths.some(p => p.includes('component.md'));
+    expect(hasComponent).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 4: graph-boost applies in context mode when graph-index.json exists
+  // -------------------------------------------------------------------------
+  it('context 模式的 graph-boost 仍然生效', async () => {
+    // graph-index.json is read from wikiRoot/.indices/ by loadGraphIndex
+    const indicesDir = path.join(tmpDir, '.indices');
+    await fs.ensureDir(indicesDir);
+
+    const graphIndex = {
+      schemaVersion: 'team-wiki.graph-index.v1',
+      generatedAt: new Date().toISOString(),
+      nodes: [
+        {
+          slug: 'recall',
+          type: 'module',
+          confidence: 'EXTRACTED',
+          title: 'recall',
+        },
+        {
+          slug: 'src-module',
+          type: 'module',
+          confidence: 'EXTRACTED',
+          title: 'src module',
+        },
+      ],
+      edges: [
+        {
+          from: 'recall',
+          to: 'src-module',
+          relation: 'REFERENCES',
+        },
+      ],
+    };
+
+    await fs.writeFile(
+      path.join(indicesDir, 'graph-index.json'),
+      JSON.stringify(graphIndex, null, 2),
+      'utf-8',
+    );
+
+    const results = await queryCodeKnowledge('recall', {
+      wikiRoot: tmpDir,
+      depth: 'context',
+      limit: 10,
+    });
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].score).toBeGreaterThan(0);
+  });
+});

--- a/src/__tests__/review-cmd.test.ts
+++ b/src/__tests__/review-cmd.test.ts
@@ -195,7 +195,7 @@ describe('review-cmd', () => {
         expect(removePendingReview).not.toHaveBeenCalledWith(expect.stringContaining('teamai-review-cmd-test-'), 'highriskitem1');
 
         const output = consoleSpy.mock.calls.map((c) => c.join(' ')).join('\n');
-        expect(output).toContain('跳过');
+        expect(output).toContain('skipped');
     });
 
     it('--json 输出有效 JSON（apply 模式）', async () => {

--- a/src/code-knowledge-recall.ts
+++ b/src/code-knowledge-recall.ts
@@ -9,7 +9,7 @@ import { readFile, readdir } from 'node:fs/promises';
 import path from 'node:path';
 
 import type { GraphIndex } from './wiki-engine/core/graph-index.schema.js';
-import { tokenize } from './utils/tokenizer.js';
+import { tokenize, tokenCount, MAX_TOKENIZE_CHARS } from './utils/tokenizer.js';
 
 export interface CodeKnowledgeResult {
   page: string;
@@ -29,7 +29,7 @@ interface PageDoc {
   path: string;
   title: string;
   content: string;
-  uniqueTokens: Set<string>;
+  tokens: string[];
   tokenCount: number; // B10: raw (non-deduplicated) token count for BM25 dl
 }
 
@@ -39,19 +39,10 @@ const TITLE_BOOST = 3.0;
 const RELATION_WEIGHT: Record<string, number> = { DEPENDS_ON: 3, REFERENCES: 2, MAPS_TO: 2, CONTAINS: 1 };
 const ENTRY_NODE_BOOST = 8;
 
-/** Raw (non-deduplicated) token count for BM25 dl (B10 fix) */
-function rawTokenCount(text: string): number {
-  const safe = text.length > MAX_INDEX_CHARS ? text.slice(0, MAX_INDEX_CHARS) : text;
-  const camelSplit = safe.replace(/([a-z])([A-Z])/g, '$1_$2').toLowerCase();
-  return camelSplit.split(/[^a-z0-9一-鿿]+/).filter((w) => w.length >= 2).length;
-}
-
-const MAX_INDEX_CHARS = 100_000;
-
 function countOccurrences(text: string, token: string): number {
   let count = 0;
   let idx = 0;
-  const lower = text.toLowerCase();
+  const lower = (text.length > MAX_TOKENIZE_CHARS ? text.slice(0, MAX_TOKENIZE_CHARS) : text).toLowerCase();
   while (true) {
     idx = lower.indexOf(token, idx);
     if (idx === -1) break;
@@ -67,8 +58,12 @@ function buildCorpusStats(pages: PageDoc[]): CorpusStats {
 
   for (const page of pages) {
     totalLength += page.tokenCount;
-    for (const token of page.uniqueTokens) {
-      df.set(token, (df.get(token) ?? 0) + 1);
+    const seen = new Set<string>();
+    for (const token of page.tokens) {
+      if (!seen.has(token)) {
+        seen.add(token);
+        df.set(token, (df.get(token) ?? 0) + 1);
+      }
     }
   }
 
@@ -183,50 +178,49 @@ function extractSnippet(content: string, queryTokens: string[], maxLen: number =
   return snippet;
 }
 
-async function collectMdFiles(dir: string): Promise<string[]> {
-  const results: string[] = [];
-  let entries;
-  try {
-    entries = await readdir(dir, { withFileTypes: true });
-  } catch {
-    return results;
-  }
-  for (const entry of entries) {
-    const fullPath = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      results.push(...await collectMdFiles(fullPath));
-    } else if (entry.name.endsWith('.md')) {
-      results.push(fullPath);
-    }
-  }
-  return results;
-}
-
 async function loadWikiPages(wikiRoot: string): Promise<PageDoc[]> {
   const evidenceDir = path.join(wikiRoot, 'evidence', 'code');
   const pages: PageDoc[] = [];
 
-  const allMdFiles = await collectMdFiles(evidenceDir);
-  for (const mdPath of allMdFiles) {
-    try {
-      const content = await readFile(mdPath, 'utf-8');
-      const titleMatch = content.match(/^title:\s*(.+)$/m);
-      const fileName = path.basename(mdPath, '.md');
-      const title = titleMatch ? titleMatch[1].trim() : fileName;
-      const relativePath = path.relative(path.join(wikiRoot, 'evidence', 'code'), mdPath);
-      pages.push({
-        path: `evidence/code/${relativePath}`,
-        title,
-        content,
-        uniqueTokens: new Set(tokenize(content)),
-        tokenCount: rawTokenCount(content),
-      });
-    } catch {
-      continue;
-    }
+  let projectDirs: string[];
+  try {
+    const entries = await readdir(evidenceDir, { withFileTypes: true });
+    projectDirs = entries.filter(e => e.isDirectory()).map(e => e.name);
+  } catch {
+    return pages;
+  }
+
+  for (const project of projectDirs) {
+    const projectDir = path.join(evidenceDir, project);
+    await loadPagesRecursive(projectDir, `evidence/code/${project}`, pages);
   }
 
   return pages;
+}
+
+async function loadPagesRecursive(dir: string, relativePath: string, pages: PageDoc[]): Promise<void> {
+  const entries = await readdir(dir, { withFileTypes: true }).catch(() => [] as import('node:fs').Dirent[]);
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await loadPagesRecursive(fullPath, `${relativePath}/${entry.name}`, pages);
+    } else if (entry.name.endsWith('.md')) {
+      try {
+        const content = await readFile(fullPath, 'utf-8');
+        const titleMatch = content.match(/^title:\s*(.+)$/m);
+        const title = titleMatch ? titleMatch[1].trim() : entry.name.replace('.md', '');
+        pages.push({
+          path: `${relativePath}/${entry.name}`,
+          title,
+          content,
+          tokens: tokenize(content),
+          tokenCount: tokenCount(content),
+        });
+      } catch {
+        continue;
+      }
+    }
+  }
 }
 
 // B7: Use protocol loadGraphIndex instead of local implementation

--- a/src/code-knowledge-recall.ts
+++ b/src/code-knowledge-recall.ts
@@ -39,6 +39,16 @@ const TITLE_BOOST = 3.0;
 const RELATION_WEIGHT: Record<string, number> = { DEPENDS_ON: 3, REFERENCES: 2, MAPS_TO: 2, CONTAINS: 1 };
 const ENTRY_NODE_BOOST = 8;
 
+/** 导航文件：在 context 模式下排除，避免模板文案干扰 BM25 */
+const NAVIGATION_FILES = new Set(['router.md', 'index.md', 'hot.md']);
+
+/** context 模式允许搜索的文件模式 */
+const CONTEXT_ALLOWED_PATTERNS = [
+  /overview\.md$/,
+  /modules\/.+\.md$/,
+  /docs\/.+\.md$/,
+];
+
 function countOccurrences(text: string, token: string): number {
   let count = 0;
   let idx = 0;
@@ -109,11 +119,40 @@ function findEntryNodes(queryTokens: string[], graph: GraphIndex): Set<string> {
   return entries;
 }
 
+interface AdjEntry {
+  neighbor: string;
+  relation: string;
+}
+
+function buildAdjacencyMap(graph: GraphIndex): Map<string, AdjEntry[]> {
+  const adj = new Map<string, AdjEntry[]>();
+  for (const edge of graph.edges) {
+    const fromList = adj.get(edge.from);
+    if (fromList) {
+      fromList.push({ neighbor: edge.to, relation: edge.relation });
+    } else {
+      adj.set(edge.from, [{ neighbor: edge.to, relation: edge.relation }]);
+    }
+    const toList = adj.get(edge.to);
+    if (toList) {
+      toList.push({ neighbor: edge.from, relation: edge.relation });
+    } else {
+      adj.set(edge.to, [{ neighbor: edge.from, relation: edge.relation }]);
+    }
+  }
+  return adj;
+}
+
 /**
  * B8 fix: Match page paths to graph node slugs via title/filename matching.
  * B24 fix: Use 2-hop neighbors (halved weight for second hop).
  */
-function computeGraphBoost(page: PageDoc, entryNodes: Set<string>, graph: GraphIndex): number {
+function computeGraphBoost(
+  page: PageDoc,
+  entryNodes: Set<string>,
+  graph: GraphIndex,
+  adj: Map<string, AdjEntry[]>,
+): number {
   // Match page to graph nodes by title
   const pageTitle = page.title.toLowerCase();
   const pageFile = page.path.replace(/^evidence\/code\/[^/]+\//, '').replace('.md', '');
@@ -127,33 +166,33 @@ function computeGraphBoost(page: PageDoc, entryNodes: Set<string>, graph: GraphI
     }
   }
 
-  // Check 1-hop and 2-hop neighbors
+  // Check 1-hop and 2-hop neighbors using adjacency map
   let maxBoost = 0;
-  for (const edge of graph.edges) {
-    const isFrom = entryNodes.has(edge.from);
-    const isTo = entryNodes.has(edge.to);
-    if (!isFrom && !isTo) continue;
+  for (const entrySlug of entryNodes) {
+    const neighbors = adj.get(entrySlug);
+    if (!neighbors) continue;
 
-    const neighborSlug = isFrom ? edge.to : edge.from;
-    const neighborParts = neighborSlug.split('/');
-    const neighborName = (neighborParts.pop() ?? '').toLowerCase();
+    for (const { neighbor: neighborSlug, relation } of neighbors) {
+      const neighborParts = neighborSlug.split('/');
+      const neighborName = (neighborParts.pop() ?? '').toLowerCase();
 
-    if (neighborName && (pageTitle.includes(neighborName) || pageFile.includes(neighborName))) {
-      const relWeight = RELATION_WEIGHT[edge.relation] ?? 1;
-      const boost = relWeight * 0.8; // 1-hop
-      if (boost > maxBoost) maxBoost = boost;
-    }
-
-    // 2-hop: check neighbors of this neighbor (B24)
-    for (const edge2 of graph.edges) {
-      if (edge2.from !== neighborSlug && edge2.to !== neighborSlug) continue;
-      const hop2Slug = edge2.from === neighborSlug ? edge2.to : edge2.from;
-      const hop2Parts = hop2Slug.split('/');
-      const hop2Name = (hop2Parts.pop() ?? '').toLowerCase();
-      if (hop2Name && (pageTitle.includes(hop2Name) || pageFile.includes(hop2Name))) {
-        const relWeight = RELATION_WEIGHT[edge2.relation] ?? 1;
-        const boost = relWeight * 0.4; // 2-hop: half weight
+      if (neighborName && (pageTitle.includes(neighborName) || pageFile.includes(neighborName))) {
+        const relWeight = RELATION_WEIGHT[relation] ?? 1;
+        const boost = relWeight * 0.8; // 1-hop
         if (boost > maxBoost) maxBoost = boost;
+      }
+
+      // 2-hop: check neighbors of this neighbor
+      const hop2Neighbors = adj.get(neighborSlug);
+      if (!hop2Neighbors) continue;
+      for (const { neighbor: hop2Slug, relation: rel2 } of hop2Neighbors) {
+        const hop2Parts = hop2Slug.split('/');
+        const hop2Name = (hop2Parts.pop() ?? '').toLowerCase();
+        if (hop2Name && (pageTitle.includes(hop2Name) || pageFile.includes(hop2Name))) {
+          const relWeight = RELATION_WEIGHT[rel2] ?? 1;
+          const boost = relWeight * 0.4; // 2-hop: half weight
+          if (boost > maxBoost) maxBoost = boost;
+        }
       }
     }
   }
@@ -178,10 +217,56 @@ function extractSnippet(content: string, queryTokens: string[], maxLen: number =
   return snippet;
 }
 
-async function loadWikiPages(wikiRoot: string): Promise<PageDoc[]> {
-  const evidenceDir = path.join(wikiRoot, 'evidence', 'code');
+async function loadWikiPages(wikiRoot: string, depth: 'route' | 'context' | 'lookup'): Promise<PageDoc[]> {
   const pages: PageDoc[] = [];
 
+  if (depth === 'route') {
+    // route 模式：只加载 router.md 和各项目的 docs/README.md
+    const routerPath = path.join(wikiRoot, 'router.md');
+    try {
+      const content = await readFile(routerPath, 'utf-8');
+      const titleMatch = content.match(/^title:\s*(.+)$/m);
+      const title = titleMatch ? titleMatch[1].trim() : 'router';
+      pages.push({
+        path: 'router.md',
+        title,
+        content,
+        tokens: tokenize(content),
+        tokenCount: tokenCount(content),
+      });
+    } catch {
+      // router.md 不存在则跳过
+    }
+
+    const evidenceDir = path.join(wikiRoot, 'evidence', 'code');
+    let projectDirs: string[];
+    try {
+      const entries = await readdir(evidenceDir, { withFileTypes: true });
+      projectDirs = entries.filter(e => e.isDirectory()).map(e => e.name);
+    } catch {
+      return pages;
+    }
+    for (const project of projectDirs) {
+      const readmePath = path.join(evidenceDir, project, 'docs', 'README.md');
+      try {
+        const content = await readFile(readmePath, 'utf-8');
+        const titleMatch = content.match(/^title:\s*(.+)$/m);
+        const title = titleMatch ? titleMatch[1].trim() : project;
+        pages.push({
+          path: `evidence/code/${project}/docs/README.md`,
+          title,
+          content,
+          tokens: tokenize(content),
+          tokenCount: tokenCount(content),
+        });
+      } catch {
+        continue;
+      }
+    }
+    return pages;
+  }
+
+  const evidenceDir = path.join(wikiRoot, 'evidence', 'code');
   let projectDirs: string[];
   try {
     const entries = await readdir(evidenceDir, { withFileTypes: true });
@@ -192,25 +277,38 @@ async function loadWikiPages(wikiRoot: string): Promise<PageDoc[]> {
 
   for (const project of projectDirs) {
     const projectDir = path.join(evidenceDir, project);
-    await loadPagesRecursive(projectDir, `evidence/code/${project}`, pages);
+    await loadPagesRecursive(projectDir, `evidence/code/${project}`, pages, depth);
   }
 
   return pages;
 }
 
-async function loadPagesRecursive(dir: string, relativePath: string, pages: PageDoc[]): Promise<void> {
+async function loadPagesRecursive(
+  dir: string,
+  relativePath: string,
+  pages: PageDoc[],
+  depth: 'route' | 'context' | 'lookup',
+): Promise<void> {
   const entries = await readdir(dir, { withFileTypes: true }).catch(() => [] as import('node:fs').Dirent[]);
   for (const entry of entries) {
     const fullPath = path.join(dir, entry.name);
     if (entry.isDirectory()) {
-      await loadPagesRecursive(fullPath, `${relativePath}/${entry.name}`, pages);
+      await loadPagesRecursive(fullPath, `${relativePath}/${entry.name}`, pages, depth);
     } else if (entry.name.endsWith('.md')) {
+      const relFilePath = `${relativePath}/${entry.name}`;
+      // depth=context 模式下，排除导航文件并限制搜索范围
+      if (depth === 'context') {
+        if (NAVIGATION_FILES.has(entry.name)) continue;
+        if (!CONTEXT_ALLOWED_PATTERNS.some(p => p.test(relFilePath))) continue;
+      }
+      // depth=route 不走 recursive 加载，由 loadWikiPages 单独处理
+      // depth=lookup 不做任何过滤
       try {
         const content = await readFile(fullPath, 'utf-8');
         const titleMatch = content.match(/^title:\s*(.+)$/m);
         const title = titleMatch ? titleMatch[1].trim() : entry.name.replace('.md', '');
         pages.push({
-          path: `${relativePath}/${entry.name}`,
+          path: relFilePath,
           title,
           content,
           tokens: tokenize(content),
@@ -232,6 +330,7 @@ async function loadGraph(wikiRoot: string): Promise<GraphIndex | null> {
 export interface QueryCodeKnowledgeOptions {
   wikiRoot: string;
   limit?: number;
+  /** route: 只返回路由建议；context: 搜索 overview+modules+docs；lookup: 全量搜索 */
   depth?: 'route' | 'context' | 'lookup';
 }
 
@@ -241,8 +340,22 @@ export async function queryCodeKnowledge(
 ): Promise<CodeKnowledgeResult[]> {
   const { wikiRoot, limit = 5, depth = 'context' } = options;
 
-  const pages = await loadWikiPages(wikiRoot);
+  const pages = await loadWikiPages(wikiRoot, depth);
   if (pages.length === 0) return [];
+
+  if (depth === 'route') {
+    // route 模式：返回路由建议而非 BM25 搜索结果
+    if (pages.length > 0) {
+      return [{
+        page: pages[0].path,
+        title: 'Question Router',
+        score: 10,
+        snippet: pages[0].content.slice(0, 800),
+        kind: 'codebase',
+      }];
+    }
+    return [];
+  }
 
   const graph = await loadGraph(wikiRoot);
   const queryTokens = tokenize(query);
@@ -250,12 +363,13 @@ export async function queryCodeKnowledge(
 
   const stats = buildCorpusStats(pages);
   const entryNodes = graph ? findEntryNodes(queryTokens, graph) : new Set<string>();
+  const adj = graph ? buildAdjacencyMap(graph) : new Map<string, AdjEntry[]>();
 
   const scored: Array<{ page: PageDoc; score: number }> = [];
   for (const page of pages) {
     let score = scoreBM25(page, queryTokens, stats);
     if (graph) {
-      score += computeGraphBoost(page, entryNodes, graph);
+      score += computeGraphBoost(page, entryNodes, graph, adj);
     }
     if (score > 0) {
       scored.push({ page, score });
@@ -264,7 +378,7 @@ export async function queryCodeKnowledge(
 
   scored.sort((a, b) => b.score - a.score);
 
-  const TOKEN_BUDGET: Record<string, number> = { route: 1500, context: 5000, lookup: 20000 };
+  const TOKEN_BUDGET: Record<string, number> = { route: 2000, context: 5000, lookup: 20000 };
   const budget = TOKEN_BUDGET[depth] ?? 5000;
   const estimateTokens = (text: string) => Math.ceil(text.length / 3.5);
 
@@ -275,9 +389,7 @@ export async function queryCodeKnowledge(
     if (results.length >= limit) break;
 
     let snippet: string;
-    if (depth === 'route') {
-      snippet = `${page.title} (${page.path})`;
-    } else if (depth === 'lookup') {
+    if (depth === 'lookup') {
       const maxChars = Math.floor(budget * 3.5 * 0.7 / Math.max(limit, 1));
       snippet = page.content.slice(0, maxChars);
     } else {

--- a/src/code-knowledge-recall.ts
+++ b/src/code-knowledge-recall.ts
@@ -283,30 +283,38 @@ async function loadWikiPages(wikiRoot: string, depth: 'route' | 'context' | 'loo
   return pages;
 }
 
+const MAX_RECURSION_DEPTH = 10;
+
 async function loadPagesRecursive(
   dir: string,
   relativePath: string,
   pages: PageDoc[],
   depth: 'route' | 'context' | 'lookup',
+  currentDepth: number = 0,
 ): Promise<void> {
-  const entries = await readdir(dir, { withFileTypes: true }).catch(() => [] as import('node:fs').Dirent[]);
+  if (currentDepth >= MAX_RECURSION_DEPTH) return;
+  const entries = await readdir(dir, { withFileTypes: true })
+    .catch(() => [] as import('node:fs').Dirent[]);
   for (const entry of entries) {
     const fullPath = path.join(dir, entry.name);
     if (entry.isDirectory()) {
-      await loadPagesRecursive(fullPath, `${relativePath}/${entry.name}`, pages, depth);
+      await loadPagesRecursive(
+        fullPath, `${relativePath}/${entry.name}`,
+        pages, depth, currentDepth + 1,
+      );
     } else if (entry.name.endsWith('.md')) {
       const relFilePath = `${relativePath}/${entry.name}`;
-      // depth=context 模式下，排除导航文件并限制搜索范围
       if (depth === 'context') {
+        // 排除项目内部的导航/索引文件（如 index.md）和原始 facts 页面
         if (NAVIGATION_FILES.has(entry.name)) continue;
         if (!CONTEXT_ALLOWED_PATTERNS.some(p => p.test(relFilePath))) continue;
       }
-      // depth=route 不走 recursive 加载，由 loadWikiPages 单独处理
-      // depth=lookup 不做任何过滤
       try {
         const content = await readFile(fullPath, 'utf-8');
         const titleMatch = content.match(/^title:\s*(.+)$/m);
-        const title = titleMatch ? titleMatch[1].trim() : entry.name.replace('.md', '');
+        const title = titleMatch
+          ? titleMatch[1].trim()
+          : entry.name.replace('.md', '');
         pages.push({
           path: relFilePath,
           title,
@@ -344,17 +352,13 @@ export async function queryCodeKnowledge(
   if (pages.length === 0) return [];
 
   if (depth === 'route') {
-    // route 模式：返回路由建议而非 BM25 搜索结果
-    if (pages.length > 0) {
-      return [{
-        page: pages[0].path,
-        title: 'Question Router',
-        score: 10,
-        snippet: pages[0].content.slice(0, 800),
-        kind: 'codebase',
-      }];
-    }
-    return [];
+    return [{
+      page: pages[0].path,
+      title: 'Question Router',
+      score: 10,
+      snippet: pages[0].content.slice(0, 800),
+      kind: 'codebase',
+    }];
   }
 
   const graph = await loadGraph(wikiRoot);

--- a/src/codebase-extract.ts
+++ b/src/codebase-extract.ts
@@ -22,6 +22,7 @@ import {
   mergeGraphs,
   createGraphIndex,
   saveGraphIndex,
+  loadGraphIndex,
 } from './wiki-engine/adapters/index.js';
 import type { CodeFact, InterfaceInventory, CallChain } from './wiki-engine/adapters/index.js';
 import type { GraphIndex } from './wiki-engine/core/graph-index.schema.js';
@@ -527,17 +528,17 @@ export async function extractCodebase(opts: ExtractCodebaseOptions): Promise<voi
         if (opts.json) {
           console.log(JSON.stringify({ status: 'up-to-date', project }));
         } else {
-          console.log(chalk.green(`[extract] ${project}: 无变更，跳过。`));
+          console.log(chalk.green(`[extract] ${project}: no changes, skipped.`));
         }
         return;
       }
       changedFiles = [...changes.added, ...changes.changed];
       if (!opts.json) {
-        console.log(chalk.dim(`[extract] 增量模式：${changedFiles.length} 文件变更`));
+        console.log(chalk.dim(`[extract] incremental: ${changedFiles.length} files changed`));
       }
     } catch {
       if (!opts.json) {
-        console.log(chalk.dim('[extract] 无历史 manifest，执行全量提取'));
+        console.log(chalk.dim('[extract] no manifest history, running full extraction'));
       }
     }
   }
@@ -547,7 +548,7 @@ export async function extractCodebase(opts: ExtractCodebaseOptions): Promise<voi
     if (opts.json) {
       console.log(JSON.stringify({ status: 'no-files', project }));
     } else {
-      console.log(chalk.yellow(`[extract] ${project}: 未发现可提取的源代码文件。`));
+      console.log(chalk.yellow(`[extract] ${project}: no extractable source files found.`));
     }
     return;
   }
@@ -573,8 +574,12 @@ export async function extractCodebase(opts: ExtractCodebaseOptions): Promise<voi
   const pageSlugs = [...pages.keys()].map(p => `evidence/code/${project}/${p.replace('.md', '')}`);
   const overlay = buildIndexHubOverlay(project, 'evidence/code', pageSlugs);
 
-  // Merge overlay into the unified GraphIndex
-  const mergedGraph = mergeGraphs(graph, overlay);
+  // Merge overlay into the per-repo graph
+  const repoGraph = mergeGraphs(graph, overlay);
+
+  // Load existing global graph and merge to avoid overwriting other repos' data
+  const existingGraph = await loadGraphIndex(wikiRoot) ?? createGraphIndex();
+  const mergedGraph = mergeGraphs(existingGraph, repoGraph);
 
   // Write graph-index.json using protocol function (B5)
   await saveGraphIndex(wikiRoot, mergedGraph);
@@ -582,7 +587,7 @@ export async function extractCodebase(opts: ExtractCodebaseOptions): Promise<voi
   // AI enrichment (optional, non-blocking; skipped with --skip-enrich)
   let aiDomains: DomainGroup[] = [];
   if (opts.skipEnrich) {
-    if (!opts.json) console.log(chalk.dim('  [AI 增强: 已跳过 (--skip-enrich)]'));
+    if (!opts.json) console.log(chalk.dim('  [AI enrich: skipped (--skip-enrich)]'));
   } else try {
     const { enrichWithAI, writeManifest } = await import('./enrich-with-ai.js');
     const modules = new Map<string, CodeFact[]>();
@@ -608,12 +613,12 @@ export async function extractCodebase(opts: ExtractCodebaseOptions): Promise<voi
       await writeFile(path.join(evidenceDir, '_domains.json'), JSON.stringify(domainMeta, null, 2), 'utf-8');
       if (!opts.json) {
         const domainLabel = domainMeta.domain || '未分类';
-        console.log(`  AI 增强: ${enrichResult.manifest.components.length} 模块, 域=${domainLabel}`);
+        console.log(`  AI enrich: ${enrichResult.manifest.components.length} modules, domain=${domainLabel}`);
       }
     }
   } catch (e) {
     if (!opts.json) {
-      console.log(chalk.dim(`  [AI 增强跳过: ${(e as Error).message}]`));
+      console.log(chalk.dim(`  [AI enrich skipped: ${(e as Error).message}]`));
     }
   }
 

--- a/src/codebase-extract.ts
+++ b/src/codebase-extract.ts
@@ -20,9 +20,7 @@ import {
   traceCallChains,
   buildIndexHubOverlay,
   mergeGraphs,
-  createGraphIndex,
   saveGraphIndex,
-  loadGraphIndex,
 } from './wiki-engine/adapters/index.js';
 import type { CodeFact, InterfaceInventory, CallChain } from './wiki-engine/adapters/index.js';
 import type { GraphIndex } from './wiki-engine/core/graph-index.schema.js';
@@ -577,12 +575,9 @@ export async function extractCodebase(opts: ExtractCodebaseOptions): Promise<voi
   // Merge overlay into the per-repo graph
   const repoGraph = mergeGraphs(graph, overlay);
 
-  // Load existing global graph and merge to avoid overwriting other repos' data
-  const existingGraph = await loadGraphIndex(wikiRoot) ?? createGraphIndex();
-  const mergedGraph = mergeGraphs(existingGraph, repoGraph);
-
-  // Write graph-index.json using protocol function (B5)
-  await saveGraphIndex(wikiRoot, mergedGraph);
+  // Write per-repo graph only; global aggregation is done by aggregateGlobalGraph()
+  // in import-repo.ts after all per-repo graphs are in place (avoids write races).
+  await saveGraphIndex(wikiRoot, repoGraph);
 
   // AI enrichment (optional, non-blocking; skipped with --skip-enrich)
   let aiDomains: DomainGroup[] = [];
@@ -633,7 +628,7 @@ export async function extractCodebase(opts: ExtractCodebaseOptions): Promise<voi
   }
 
   // 生成 overview.md — 确定性架构概览 (B16)
-  const overview = buildOverview(facts, mergedGraph, project, interfaceInventory, callChains);
+  const overview = buildOverview(facts, repoGraph, project, interfaceInventory, callChains);
   await writeFile(path.join(evidenceDir, 'overview.md'), overview, 'utf-8');
 
   // 生成 team-wiki 标准入口文件
@@ -644,8 +639,8 @@ export async function extractCodebase(opts: ExtractCodebaseOptions): Promise<voi
   }
   const indexStats: IndexStats = {
     totalFacts: facts.length,
-    totalNodes: mergedGraph.nodes.length,
-    totalEdges: mergedGraph.edges.length,
+    totalNodes: repoGraph.nodes.length,
+    totalEdges: repoGraph.edges.length,
     interfaces: Object.keys(ifByType).length > 0 ? ifByType : undefined,
     callChains: callChains.length > 0 ? callChains.length : undefined,
   };
@@ -700,7 +695,7 @@ export async function extractCodebase(opts: ExtractCodebaseOptions): Promise<voi
     project,
     filesScanned: files.length,
     facts: { total: facts.length, byKind },
-    graph: { nodes: mergedGraph.nodes.length, edges: mergedGraph.edges.length },
+    graph: { nodes: repoGraph.nodes.length, edges: repoGraph.edges.length },
     incremental: !!opts.incremental && !!changedFiles,
     outputDir: wikiRoot,
   };

--- a/src/codebase-upgrade-wiki.ts
+++ b/src/codebase-upgrade-wiki.ts
@@ -27,7 +27,7 @@ export async function upgradeCodebaseWiki(opts: UpgradeCodebaseWikiOptions): Pro
     if (opts.json) {
       console.log(JSON.stringify({ status: 'nothing-to-migrate', reason: 'docs/team-codebase/repos/ not found' }));
     } else {
-      log.info('未发现 docs/team-codebase/repos/ 目录，无需迁移。');
+      log.info('no docs/team-codebase/repos/ directory found, no migration needed.');
     }
     return;
   }
@@ -39,13 +39,13 @@ export async function upgradeCodebaseWiki(opts: UpgradeCodebaseWikiOptions): Pro
     if (opts.json) {
       console.log(JSON.stringify({ status: 'nothing-to-migrate', reason: 'no .md files in repos/' }));
     } else {
-      log.info('repos/ 下无 .md 文件，无需迁移。');
+      log.info('no .md files under repos/, no migration needed.');
     }
     return;
   }
 
   if (!opts.json) {
-    log.info(`发现 ${mdFiles.length} 个旧格式仓库文档，开始迁移到 teamwiki/ 图谱格式...`);
+    log.info(`found ${mdFiles.length} legacy repo docs, starting migration to teamwiki/ graph format...`);
   }
 
   const result: MigrationResult = { migrated: [], skipped: [], errors: [] };
@@ -95,13 +95,13 @@ export async function upgradeCodebaseWiki(opts: UpgradeCodebaseWikiOptions): Pro
       }
     }
     if (result.skipped.length > 0) {
-      console.log(chalk.yellow(`跳过 ${result.skipped.length} 个：`));
+      console.log(chalk.yellow(`skipped ${result.skipped.length}:`));
       for (const s of result.skipped) {
         console.log(chalk.yellow(`  - ${s}`));
       }
     }
     if (result.errors.length > 0) {
-      console.log(chalk.red(`失败 ${result.errors.length} 个：`));
+      console.log(chalk.red(`failed ${result.errors.length}:`));
       for (const e of result.errors) {
         console.log(chalk.red(`  ✗ ${e}`));
       }
@@ -109,8 +109,8 @@ export async function upgradeCodebaseWiki(opts: UpgradeCodebaseWikiOptions): Pro
 
     if (!opts.dryRun && result.migrated.length > 0) {
       log.info('');
-      log.info('迁移完成。旧的 docs/team-codebase/ 目录已保留（未删除）。');
-      log.info('确认新图谱工作正常后，可手动删除 docs/team-codebase/ 目录。');
+      log.info('migration complete. old docs/team-codebase/ directory preserved (not deleted).');
+      log.info('after confirming the new graph works, you can manually delete docs/team-codebase/.');
     }
   }
 }

--- a/src/deep-enrich.ts
+++ b/src/deep-enrich.ts
@@ -70,7 +70,7 @@ async function loadContext(evidenceDir: string): Promise<EnrichContext> {
 
   const [indexMd, callChains, overview] = await Promise.all([
     readFileSafe(path.join(evidenceDir, 'index.md')),
-    readFileSafe(path.join(evidenceDir, 'call-chains.md')),
+    readFileSafe(path.join(evidenceDir, 'dependency-paths.md')),
     readFileSafe(path.join(evidenceDir, 'overview.md')),
   ]);
 
@@ -230,7 +230,7 @@ ${interfaceSummary}
 function buildG1RelationsDoc(manifest: Manifest): string {
   const edges = manifest.edges ?? [];
   if (edges.length === 0) {
-    return '# 组件关系矩阵\n\n（暂无依赖边数据）\n';
+    return '# 组件关系矩阵\n\n（暂无依赖边数据）\n\n> 可能原因：AI enrich 未执行（skipEnrich=true）或未检测到组件间依赖关系。\n> 尝试：重新运行 `teamai import --from-repo <url>`（不带 --skip-enrich）。\n';
   }
   const rows = edges.map(e => `| ${e.from} | ${e.to} | ${e.relation ?? 'DEPENDS_ON'} |`).join('\n');
   return `# 组件关系矩阵\n\n| 来源组件 | 目标组件 | 关系类型 |\n|----------|----------|----------|\n${rows}\n`;
@@ -238,7 +238,7 @@ function buildG1RelationsDoc(manifest: Manifest): string {
 
 function buildG2DataflowDoc(callChains: string): string {
   if (!callChains.trim()) {
-    return '# 数据流图\n\n（暂无调用链数据）\n';
+    return '# 数据流图\n\n（暂无调用链数据）\n\n> 可能原因：代码中未检测到入口→服务→数据层的多层调用链。\n> 常见于纯库项目或单层架构项目。\n';
   }
   // 提取 entry→data 路径行（以 → 或 -> 连接的行）
   const lines = callChains.split('\n').filter(l => /→|->/.test(l));
@@ -251,7 +251,7 @@ function buildG2DataflowDoc(callChains: string): string {
 
 function buildG3InterfacesDoc(interfacesMd: string): string {
   if (!interfacesMd.trim()) {
-    return '# 接口映射表\n\n（暂无接口数据）\n';
+    return '# 接口映射表\n\n（暂无接口数据）\n\n> 可能原因：未检测到 HTTP/gRPC/MQ 等对外接口定义。\n> 仅当代码中存在路由注册、Proto 定义或消息队列声明时才会提取接口。\n';
   }
   return `# 接口映射表\n\n${interfacesMd}\n`;
 }

--- a/src/deep-enrich.ts
+++ b/src/deep-enrich.ts
@@ -104,7 +104,10 @@ function progressPath(evidenceDir: string): string {
   return path.join(evidenceDir, PROGRESS_PATH_SUBDIR, PROGRESS_FILENAME);
 }
 
-const VALID_PHASES = new Set<string>(['pending', 'components', 'architecture', 'graph', 'ai-graph', 'index-enhance', 'done']);
+const VALID_PHASES = new Set<string>([
+  'pending', 'components', 'architecture', 'graph',
+  'ai-graph', 'index-enhance', 'done',
+]);
 
 function isValidProgressState(v: unknown, project: string): v is ProgressState {
   if (typeof v !== 'object' || v === null) return false;
@@ -230,7 +233,13 @@ ${interfaceSummary}
 function buildG1RelationsDoc(manifest: Manifest): string {
   const edges = manifest.edges ?? [];
   if (edges.length === 0) {
-    return '# 组件关系矩阵\n\n（暂无依赖边数据）\n\n> 可能原因：AI enrich 未执行（skipEnrich=true）或未检测到组件间依赖关系。\n> 尝试：重新运行 `teamai import --from-repo <url>`（不带 --skip-enrich）。\n';
+    return [
+      '# 组件关系矩阵', '',
+      '（暂无依赖边数据）', '',
+      '> 可能原因：AI enrich 未执行（skipEnrich=true）或未检测到组件间依赖关系。',
+      '> 尝试：重新运行 `teamai import --from-repo <url>`（不带 --skip-enrich）。',
+      '',
+    ].join('\n');
   }
 
   const components = new Set<string>();
@@ -508,10 +517,11 @@ ${callChains.slice(0, 1500)}
 ${modules.slice(0, 1000)}
 
 要求：
-1. 识别 5 个最重要的业务场景（如用户请求处理、数据同步、错误恢复等）
+1. 识别项目中真实存在的核心业务场景（最多 5 个，如果项目较小则按实际数量输出，不要虚构）
 2. 每个场景生成一个 mermaid sequenceDiagram
 3. 每个图后附 2-3 句文字说明关键决策点
 4. 参与者使用实际模块名/组件名
+5. 如果可识别的真实场景少于 3 个，只输出实际存在的场景
 
 输出格式：
 # 核心业务场景序列图
@@ -537,8 +547,9 @@ function buildG6Content(project: string, manifest: Manifest): string {
   const adj = new Map<string, Set<string>>();
   const inDegree = new Map<string, number>();
   for (const e of edges) {
-    if (!adj.has(e.from)) adj.set(e.from, new Set());
-    adj.get(e.from)!.add(e.to);
+    const existing = adj.get(e.from) ?? new Set<string>();
+    existing.add(e.to);
+    adj.set(e.from, existing);
     inDegree.set(e.to, (inDegree.get(e.to) ?? 0) + 1);
     if (!inDegree.has(e.from)) inDegree.set(e.from, 0);
   }
@@ -588,7 +599,9 @@ function buildG6Content(project: string, manifest: Manifest): string {
     lines.push(`| 2-hop | ${hopResults[1].slice(0, 8).join(', ') || '—'} | ${hopResults[1].length} |`);
     lines.push(`| 3-hop | ${hopResults[2].slice(0, 8).join(', ') || '—'} | ${hopResults[2].length} |`);
     lines.push('');
-    lines.push(`**爆炸半径**: ${node} 变更可能影响 ${visited.size - 1} 个组件（${Math.round((visited.size - 1) / allNodes.length * 100)}% 覆盖率）`);
+    const affected = visited.size - 1;
+    const pct = Math.round(affected / allNodes.length * 100);
+    lines.push(`**爆炸半径**: ${node} 变更可能影响 ${affected} 个组件（${pct}% 覆盖率）`);
     lines.push('');
   }
 
@@ -610,7 +623,11 @@ async function runPhaseAiGraph(
   await writeFile(path.join(docsDir, 'graph-g6-multihop.md'), g6, 'utf-8');
   log.debug(`deep-enrich[${project}]: G6 多跳路径写入完成`);
 
-  // G5: AI 生成场景序列图
+  // G5: AI 生成场景序列图（需要足够的模块数据）
+  if (ctx.moduleDocs.size < 2) {
+    log.warn(`deep-enrich[${project}]: 模块数不足（${ctx.moduleDocs.size} < 2），跳过 G5`);
+    return;
+  }
   const architectureMd = await readFileSafe(path.join(docsDir, 'architecture.md'));
   if (!architectureMd.trim()) {
     log.warn(`deep-enrich[${project}]: 无架构文档，跳过 G5 场景序列图生成`);

--- a/src/deep-enrich.ts
+++ b/src/deep-enrich.ts
@@ -232,21 +232,100 @@ function buildG1RelationsDoc(manifest: Manifest): string {
   if (edges.length === 0) {
     return '# 组件关系矩阵\n\n（暂无依赖边数据）\n\n> 可能原因：AI enrich 未执行（skipEnrich=true）或未检测到组件间依赖关系。\n> 尝试：重新运行 `teamai import --from-repo <url>`（不带 --skip-enrich）。\n';
   }
-  const rows = edges.map(e => `| ${e.from} | ${e.to} | ${e.relation ?? 'DEPENDS_ON'} |`).join('\n');
-  return `# 组件关系矩阵\n\n| 来源组件 | 目标组件 | 关系类型 |\n|----------|----------|----------|\n${rows}\n`;
+
+  const components = new Set<string>();
+  const forwardDeps = new Map<string, string[]>();
+  const reverseDeps = new Map<string, string[]>();
+
+  for (const e of edges) {
+    components.add(e.from);
+    components.add(e.to);
+    const fwd = forwardDeps.get(e.from) ?? [];
+    fwd.push(`${e.to} (${e.relation ?? 'DEPENDS_ON'})`);
+    forwardDeps.set(e.from, fwd);
+    const rev = reverseDeps.get(e.to) ?? [];
+    rev.push(`${e.from} (${e.relation ?? 'DEPENDS_ON'})`);
+    reverseDeps.set(e.to, rev);
+  }
+
+  const lines = [
+    '# 组件关系矩阵',
+    '<!-- search-anchor: 依赖, 关系, 上游, 下游, DEPENDS_ON, imports, 模块关系 -->',
+    '',
+    `共 ${components.size} 个组件，${edges.length} 条边。`,
+    '',
+    '## 依赖表',
+    '',
+    '| 来源组件 | 目标组件 | 关系类型 |',
+    '|----------|----------|----------|',
+    ...edges.slice(0, 50).map(e => `| ${e.from} | ${e.to} | ${e.relation ?? 'DEPENDS_ON'} |`),
+    '',
+    '## 正向依赖索引（X 依赖→）',
+    '',
+  ];
+
+  for (const [mod, deps] of [...forwardDeps.entries()].sort((a, b) => b[1].length - a[1].length).slice(0, 20)) {
+    lines.push(`- **${mod}** → ${deps.join(', ')}`);
+  }
+
+  lines.push('', '## 反向依赖索引（→X 被谁依赖）', '');
+
+  for (const [mod, deps] of [...reverseDeps.entries()].sort((a, b) => b[1].length - a[1].length).slice(0, 20)) {
+    lines.push(`- **${mod}** ← ${deps.join(', ')}`);
+  }
+
+  lines.push('');
+  return lines.join('\n');
 }
 
 function buildG2DataflowDoc(callChains: string): string {
   if (!callChains.trim()) {
     return '# 数据流图\n\n（暂无调用链数据）\n\n> 可能原因：代码中未检测到入口→服务→数据层的多层调用链。\n> 常见于纯库项目或单层架构项目。\n';
   }
-  // 提取 entry→data 路径行（以 → 或 -> 连接的行）
-  const lines = callChains.split('\n').filter(l => /→|->/.test(l));
-  if (lines.length === 0) {
-    return `# 数据流图\n\n\`\`\`\n${callChains.slice(0, 2000)}\n\`\`\`\n`;
+
+  const lines = [
+    '# 数据流图',
+    '<!-- search-anchor: 调用链, 数据流, 请求路径, entry, flow, 入口, 链路 -->',
+    '',
+  ];
+
+  const rawLines = callChains.split('\n');
+  const chainBlocks: Array<{ entry: string; steps: string[] }> = [];
+  let currentBlock: { entry: string; steps: string[] } | null = null;
+
+  for (const line of rawLines) {
+    const entryMatch = line.match(/^##?\s+(.+)/);
+    if (entryMatch) {
+      if (currentBlock) chainBlocks.push(currentBlock);
+      currentBlock = { entry: entryMatch[1], steps: [] };
+    } else if (currentBlock && line.trim()) {
+      currentBlock.steps.push(line.trim());
+    }
   }
-  const flowRows = lines.slice(0, 30).map(l => `| ${l.trim()} |`).join('\n');
-  return `# 数据流图\n\n| 调用链路径 |\n|------------|\n${flowRows}\n`;
+  if (currentBlock) chainBlocks.push(currentBlock);
+
+  if (chainBlocks.length > 0) {
+    for (const block of chainBlocks.slice(0, 15)) {
+      lines.push(`## ${block.entry}`, '');
+      for (const step of block.steps.slice(0, 10)) {
+        lines.push(`  ${step}`);
+      }
+      lines.push('');
+    }
+  } else {
+    const flowLines = rawLines.filter(l => /→|->/.test(l));
+    if (flowLines.length > 0) {
+      lines.push('| 调用链路径 |', '|------------|');
+      for (const l of flowLines.slice(0, 30)) {
+        lines.push(`| ${l.trim()} |`);
+      }
+    } else {
+      lines.push('```', callChains.slice(0, 2000), '```');
+    }
+  }
+
+  lines.push('');
+  return lines.join('\n');
 }
 
 function buildG3InterfacesDoc(interfacesMd: string): string {

--- a/src/deep-enrich.ts
+++ b/src/deep-enrich.ts
@@ -15,7 +15,7 @@ export interface DeepEnrichOptions {
 
 interface ProgressState {
   project: string;
-  phase: 'pending' | 'components' | 'architecture' | 'graph' | 'done';
+  phase: 'pending' | 'components' | 'architecture' | 'graph' | 'ai-graph' | 'index-enhance' | 'done';
   componentsDone: string[];
   componentsPending: string[];
   startedAt: string;
@@ -104,7 +104,7 @@ function progressPath(evidenceDir: string): string {
   return path.join(evidenceDir, PROGRESS_PATH_SUBDIR, PROGRESS_FILENAME);
 }
 
-const VALID_PHASES = new Set<string>(['pending', 'components', 'architecture', 'graph', 'done']);
+const VALID_PHASES = new Set<string>(['pending', 'components', 'architecture', 'graph', 'ai-graph', 'index-enhance', 'done']);
 
 function isValidProgressState(v: unknown, project: string): v is ProgressState {
   if (typeof v !== 'object' || v === null) return false;
@@ -491,15 +491,179 @@ async function runPhaseGraph(
   log.debug(`deep-enrich[${project}]: 图谱文档写入 ${docsDir}`);
 }
 
+// ─── Phase 4: AI 图谱（G5 场景序列图 + G6 多跳路径）──────────
+
+function buildG5Prompt(project: string, architecture: string, callChains: string, modules: string): string {
+  return `你是一个高级架构师。基于以下项目信息，为 Top-5 核心业务场景生成 mermaid sequenceDiagram。
+
+项目：${project}
+
+架构文档摘要（前2000字）：
+${architecture.slice(0, 2000)}
+
+调用链数据：
+${callChains.slice(0, 1500)}
+
+模块列表：
+${modules.slice(0, 1000)}
+
+要求：
+1. 识别 5 个最重要的业务场景（如用户请求处理、数据同步、错误恢复等）
+2. 每个场景生成一个 mermaid sequenceDiagram
+3. 每个图后附 2-3 句文字说明关键决策点
+4. 参与者使用实际模块名/组件名
+
+输出格式：
+# 核心业务场景序列图
+<!-- search-anchor: 流程, 场景, 序列图, sequence, 业务流, 完整流程 -->
+
+## 场景 1: <名称>
+\`\`\`mermaid
+sequenceDiagram
+...
+\`\`\`
+<说明>
+
+## 场景 2: ...
+`;
+}
+
+function buildG6Content(project: string, manifest: Manifest): string {
+  const edges = manifest.edges ?? [];
+  if (edges.length === 0) {
+    return '# 多跳传递依赖分析\n<!-- search-anchor: 传递依赖, 爆炸半径, 影响范围, blast radius, transitive -->\n\n（暂无依赖边数据，无法计算传递依赖）\n';
+  }
+
+  const adj = new Map<string, Set<string>>();
+  const inDegree = new Map<string, number>();
+  for (const e of edges) {
+    if (!adj.has(e.from)) adj.set(e.from, new Set());
+    adj.get(e.from)!.add(e.to);
+    inDegree.set(e.to, (inDegree.get(e.to) ?? 0) + 1);
+    if (!inDegree.has(e.from)) inDegree.set(e.from, 0);
+  }
+
+  const allNodes = [...new Set([...adj.keys(), ...inDegree.keys()])];
+  const degree = allNodes.map(n => ({
+    node: n,
+    total: (adj.get(n)?.size ?? 0) + (inDegree.get(n) ?? 0),
+  })).sort((a, b) => b.total - a.total);
+
+  const topNodes = degree.slice(0, 5);
+
+  const lines = [
+    `# ${project} — 多跳传递依赖分析`,
+    '<!-- search-anchor: 传递依赖, 爆炸半径, 影响范围, blast radius, transitive, 级联 -->',
+    '',
+    `基于 ${edges.length} 条边、${allNodes.length} 个节点的 3-hop BFS 分析。`,
+    '',
+  ];
+
+  for (const { node, total } of topNodes) {
+    lines.push(`## ${node}（degree: ${total}）`, '');
+
+    // 3-hop BFS forward
+    const visited = new Set<string>([node]);
+    let frontier = [node];
+    const hopResults: string[][] = [[], [], []];
+    for (let hop = 0; hop < 3; hop++) {
+      const nextFrontier: string[] = [];
+      for (const curr of frontier) {
+        const neighbors = adj.get(curr);
+        if (!neighbors) continue;
+        for (const next of neighbors) {
+          if (!visited.has(next)) {
+            visited.add(next);
+            nextFrontier.push(next);
+            hopResults[hop].push(next);
+          }
+        }
+      }
+      frontier = nextFrontier;
+    }
+
+    lines.push('| Hop | 可达组件 | 数量 |');
+    lines.push('|-----|---------|------|');
+    lines.push(`| 1-hop | ${hopResults[0].slice(0, 8).join(', ') || '—'} | ${hopResults[0].length} |`);
+    lines.push(`| 2-hop | ${hopResults[1].slice(0, 8).join(', ') || '—'} | ${hopResults[1].length} |`);
+    lines.push(`| 3-hop | ${hopResults[2].slice(0, 8).join(', ') || '—'} | ${hopResults[2].length} |`);
+    lines.push('');
+    lines.push(`**爆炸半径**: ${node} 变更可能影响 ${visited.size - 1} 个组件（${Math.round((visited.size - 1) / allNodes.length * 100)}% 覆盖率）`);
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+async function runPhaseAiGraph(
+  opts: DeepEnrichOptions,
+  ctx: EnrichContext,
+  docsDir: string,
+): Promise<void> {
+  const { project, evidenceDir } = opts;
+  log.info(`deep-enrich[${project}]: Phase 4 — 生成 AI 图谱文档（G5/G6）`);
+
+  await mkdir(docsDir, { recursive: true });
+
+  // G6: 确定性 BFS（不需要 AI）
+  const g6 = buildG6Content(project, ctx.manifest);
+  await writeFile(path.join(docsDir, 'graph-g6-multihop.md'), g6, 'utf-8');
+  log.debug(`deep-enrich[${project}]: G6 多跳路径写入完成`);
+
+  // G5: AI 生成场景序列图
+  const architectureMd = await readFileSafe(path.join(docsDir, 'architecture.md'));
+  if (!architectureMd.trim()) {
+    log.warn(`deep-enrich[${project}]: 无架构文档，跳过 G5 场景序列图生成`);
+    return;
+  }
+
+  const moduleList = [...ctx.moduleDocs.entries()]
+    .map(([name, content]) => `${name}: ${content.slice(0, 200)}`)
+    .join('\n');
+
+  const prompt = buildG5Prompt(project, architectureMd, ctx.callChains, moduleList);
+
+  try {
+    const g5Content = await callClaude(prompt);
+    if (g5Content.trim()) {
+      await writeFile(path.join(docsDir, 'graph-g5-scenarios.md'), g5Content, 'utf-8');
+      log.debug(`deep-enrich[${project}]: G5 场景序列图写入完成`);
+    }
+  } catch (e) {
+    log.warn(`deep-enrich[${project}]: G5 场景序列图生成失败，跳过: ${(e as Error).message}`);
+  }
+}
+
+// ─── Phase 5: 索引增强（router.md + per-project index.md 重写）──
+
+async function runPhaseIndexEnhance(
+  opts: DeepEnrichOptions,
+  ctx: EnrichContext,
+  docsDir: string,
+): Promise<void> {
+  const { project, evidenceDir } = opts;
+  log.info(`deep-enrich[${project}]: Phase 5 — 索引增强`);
+
+  const { graphReadmeTemplate } = await import('./wiki-engine/adapters/templates.js');
+
+  // 写入 graph/README.md 路由分发表
+  await mkdir(docsDir, { recursive: true });
+  const graphReadme = graphReadmeTemplate(project);
+  await writeFile(path.join(docsDir, 'README.md'), graphReadme, 'utf-8');
+  log.debug(`deep-enrich[${project}]: graph/README.md 路由表写入完成`);
+}
+
 // ─── 主函数 ─────────────────────────────────────────────────
 
 /**
  * 对已导入仓库执行深度 AI 知识生成。
  *
- * 读取 evidenceDir 中已有的确定性提取结果，并发调用 AI 生成：
- * - Phase 1: 每个组件的设计文档（concurrency=2）
- * - Phase 2: 整体架构总览文档（单次调用）
- * - Phase 3: 确定性图谱文档（无需 AI，直接渲染）
+ * 读取 evidenceDir 中已有的确定性提取结果，分阶段生成：
+ * - Phase 1: 每个组件的设计文档（AI，concurrency=2）
+ * - Phase 2: 整体架构总览文档（AI，单次调用）
+ * - Phase 3: 确定性图谱文档（G1/G2/G3，无需 AI）
+ * - Phase 4: AI 图谱文档（G5 场景序列图 + G6 多跳路径）
+ * - Phase 5: 索引增强（graph/README.md 路由分发表）
  *
  * 支持断点续传：通过 _review/progress.json 记录已完成组件。
  *
@@ -544,14 +708,28 @@ export async function deepEnrich(opts: DeepEnrichOptions): Promise<void> {
     await runPhaseArchitecture(opts, ctx, docsDir);
   }
 
-  // 5. Phase 3: 图谱文档
+  // 5. Phase 3: 确定性图谱文档
   if (progress.phase === 'architecture' || progress.phase === 'graph') {
     progress.phase = 'graph';
     await saveProgress(evidenceDir, progress);
     await runPhaseGraph(opts, ctx, docsDir);
   }
 
-  // 6. 完成
+  // 6. Phase 4: AI 图谱（G5 场景序列图 + G6 多跳路径）
+  if (progress.phase === 'graph' || progress.phase === 'ai-graph') {
+    progress.phase = 'ai-graph';
+    await saveProgress(evidenceDir, progress);
+    await runPhaseAiGraph(opts, ctx, docsDir);
+  }
+
+  // 7. Phase 5: 索引增强（graph/README.md 路由表）
+  if (progress.phase === 'ai-graph' || progress.phase === 'index-enhance') {
+    progress.phase = 'index-enhance';
+    await saveProgress(evidenceDir, progress);
+    await runPhaseIndexEnhance(opts, ctx, docsDir);
+  }
+
+  // 8. 完成
   progress.phase = 'done';
   await saveProgress(evidenceDir, progress);
   log.success(`deep-enrich[${project}]: 深度知识生成完成`);

--- a/src/drift-cmd.ts
+++ b/src/drift-cmd.ts
@@ -54,10 +54,10 @@ function truncate(str: string, maxLen: number): string {
 function renderDriftList(items: PendingReviewItem[]): void {
     const driftItems = items.filter((item) => item.kind === 'domain-drift');
     if (driftItems.length === 0) {
-        console.log(chalk.gray('[drift] 暂无待处理漂移项'));
+        console.log(chalk.gray('[drift] no pending drift items'));
         return;
     }
-    console.log(chalk.cyan(`[drift] 共 ${driftItems.length} 项`));
+    console.log(chalk.cyan(`[drift] ${driftItems.length} items`));
     const header = [
         '  ' + 'URL'.padEnd(40),
         '旧域'.padEnd(12),
@@ -252,7 +252,7 @@ export async function driftCmd(opts: DriftCmdOptions): Promise<void> {
             console.log(
                 chalk.cyan('[drift] apply-all 完成：') +
                 chalk.green(`${okCount} 成功`) + '  ' +
-                chalk.yellow(`${skippedCount} 跳过`) + '  ' +
+                chalk.yellow(`${skippedCount} skipped`) + '  ' +
                 chalk.red(`${failedCount} 失败`),
             );
         }
@@ -268,7 +268,7 @@ export async function driftCmd(opts: DriftCmdOptions): Promise<void> {
 
         if (apply) {
             if (driftItems.length === 0) {
-                log.error(`[drift] 未找到 ${repoUrlArg} 的漂移项`);
+                log.error(`[drift] no drift items found for ${repoUrlArg}`);
                 process.exitCode = 1;
                 return;
             }
@@ -296,7 +296,7 @@ export async function driftCmd(opts: DriftCmdOptions): Promise<void> {
 
         // show 单条
         if (driftItems.length === 0) {
-            console.log(chalk.gray(`[drift] 未找到 ${repoUrlArg} 的漂移项`));
+            console.log(chalk.gray(`[drift] no drift items found for ${repoUrlArg}`));
             return;
         }
         if (json) {

--- a/src/graph-aggregate.ts
+++ b/src/graph-aggregate.ts
@@ -46,7 +46,7 @@ export async function aggregateGlobalGraph(
                 globalGraph = overlay;
             }
         } catch (e) {
-            log.warn(`[graph] 跳过 ${dir.name} graph: ${(e as Error).message}`);
+            log.warn(`[graph] skipped ${dir.name} graph: ${(e as Error).message}`);
         }
     }
 
@@ -54,7 +54,7 @@ export async function aggregateGlobalGraph(
         const destPath = path.join(teamwikiRoot, '.indices', 'graph-index.json');
         await fs.ensureDir(path.dirname(destPath));
         await fs.writeFile(destPath, JSON.stringify(globalGraph, null, 2), 'utf8');
-        log.info(`全局 graph-index.json 已聚合（${globalGraph.nodes.length} nodes, ${globalGraph.edges.length} edges）`);
+        log.info(`global graph-index.json aggregated (${globalGraph.nodes.length} nodes, ${globalGraph.edges.length} edges)`);
         return { nodes: globalGraph.nodes.length, edges: globalGraph.edges.length };
     }
 

--- a/src/import-iwiki.ts
+++ b/src/import-iwiki.ts
@@ -92,7 +92,7 @@ async function downloadDocuments(
       if (result.status === 'fulfilled') {
         documents.push(result.value);
       } else {
-        log.warn(`下载文档失败，已跳过: ${String(result.reason)}`);
+        log.warn(`download failed, skipped: ${String(result.reason)}`);
       }
     }
   }
@@ -156,7 +156,7 @@ export async function importFromIWiki(opts: {
   }
 
   if (pages.length === 0) {
-    log.warn('未找到任何页面，导入终止');
+    log.warn('no pages found, import aborted');
     return;
   }
 
@@ -172,7 +172,7 @@ export async function importFromIWiki(opts: {
   }
 
   if (documents.length === 0) {
-    log.warn('所有文档下载失败，导入终止');
+    log.warn('all document downloads failed, import aborted');
     return;
   }
 
@@ -183,7 +183,7 @@ export async function importFromIWiki(opts: {
   const classified = await classifyWithAI(candidates);
 
   if (classified.length === 0) {
-    log.warn('AI 分类后无有效条目，导入终止');
+    log.warn('no valid entries after AI classification, import aborted');
     return;
   }
 
@@ -205,10 +205,10 @@ export async function importFromIWiki(opts: {
       if (mapsToEdges.length > 0) {
         log.success(`建立 ${mapsToEdges.length} 条 iWiki↔代码 MAPS_TO 关系`);
       } else {
-        log.info('[reconcile] 未发现 iWiki 文档与代码知识的匹配关系（文档内容可能与代码无关）');
+        log.info('[reconcile] no matches found between iWiki docs and code knowledge');
       }
     } catch (err) {
-      log.debug(`[reconcile] iWiki↔代码关系建立失败（非阻塞）: ${err instanceof Error ? err.message : err}`);
+      log.debug(`[reconcile] iWiki↔code relation failed (non-blocking): ${err instanceof Error ? err.message : err}`);
     }
   }
 

--- a/src/import-local.ts
+++ b/src/import-local.ts
@@ -126,7 +126,7 @@ function parseClassifyOutput(
     };
   } catch (parseErr: unknown) {
     // 解析失败 → 保守策略：标记为个人（不导入团队库），confidence=0
-    log.warn(`AI 分类结果解析失败，使用保守默认值（isPersonal=true）：${String(parseErr)}`);
+    log.warn(`AI classification parse failed, using conservative default (isPersonal=true): ${String(parseErr)}`);
     return {
       sourcePath,
       rawContent,
@@ -188,7 +188,7 @@ async function persistSession(session: ImportSession, sessionPath: string): Prom
   try {
     await writeFile(sessionPath, JSON.stringify(session, null, 2) + '\n');
   } catch (err: unknown) {
-    log.error(`会话持久化失败 [${sessionPath}]: ${String(err)}`);
+    log.error(`session persist failed [${sessionPath}]: ${String(err)}`);
   }
 }
 
@@ -233,7 +233,7 @@ export async function scanCandidates(opts: {
         const stat = fs.statSync(absPath);
         if (stat.size > MAX_FILE_SIZE_BYTES) continue;
       } catch (statErr: unknown) {
-        log.warn(`无法读取文件信息，跳过: ${absPath}（${String(statErr)}）`);
+        log.warn(`cannot stat file, skipped: ${absPath} (${String(statErr)})`);
         continue;
       }
       const raw = await readFileSafe(absPath);
@@ -257,7 +257,7 @@ export async function scanCandidates(opts: {
           const stat = fs.statSync(absPath);
           if (stat.size > MAX_FILE_SIZE_BYTES) continue;
         } catch (statErr: unknown) {
-          log.warn(`无法读取文件信息，跳过: ${absPath}（${String(statErr)}）`);
+          log.warn(`cannot stat file, skipped: ${absPath} (${String(statErr)})`);
           continue;
         }
         const raw = await readFileSafe(absPath);
@@ -295,7 +295,7 @@ export async function classifyWithAI(
     classified = await callClaudeParallel(tasks, AI_CONCURRENCY);
   } catch (err: unknown) {
     // AggregateError：部分失败，已在 parse 阶段尝试降级处理；此处全量 fallback 保守处理
-    log.error(`AI 分类部分失败，对所有条目使用保守策略: ${String(err)}`);
+    log.error(`AI classification partially failed, using conservative strategy for all entries: ${String(err)}`);
     classified = candidates.map((c) => ({
       sourcePath: c.path,
       rawContent: c.rawContent,
@@ -347,7 +347,7 @@ export async function interactiveReview(
       session = JSON.parse(raw) as ImportSession;
     } catch (loadErr: unknown) {
       // 文件不存在或解析失败 → 新建会话
-      log.warn(`加载会话文件失败，将新建会话: ${String(loadErr)}`);
+      log.warn(`failed to load session file, creating new session: ${String(loadErr)}`);
     }
   }
 
@@ -398,7 +398,7 @@ export async function interactiveReview(
   const total = session.items.length;
 
   if (pendingItems.length === 0) {
-    log.info('所有条目已处理完毕，无需继续交互。');
+    log.info('all entries processed, no further interaction needed.');
     return session;
   }
 
@@ -517,7 +517,7 @@ export async function pushAccepted(
       try {
         assertSafePath(destDir, defaultAllowedRoots());
       } catch (err: unknown) {
-        log.error(`拒绝写出到目录 [${destDir}]: ${String(err)}`);
+        log.error(`refused to write to directory [${destDir}]: ${String(err)}`);
         skipped++;
         continue;
       }
@@ -534,7 +534,7 @@ export async function pushAccepted(
     const destPath = path.join(destDir, filename);
 
     if (opts.dryRun) {
-      log.info(`[dry-run] 将写入: ${destPath}`);
+      log.info(`[dry-run] would write: ${destPath}`);
       pushed++;
       continue;
     }

--- a/src/import-repo-list.ts
+++ b/src/import-repo-list.ts
@@ -90,7 +90,7 @@ export async function importFromRepoList(
     const singleEntries: ReturnType<typeof sortByPriority> = [];
     for (const item of repoListFile.repos) {
         if (isOrgEntry(item)) {
-            log.warn(`org entry 暂不支持，已跳过：${item.org}（将在 P5.4 实现）`);
+            log.warn(`org entry not yet supported, skipped: ${item.org}`);
             skipped.push({ url: item.org, reason: 'org entry 暂不支持（P5.4 实现）' });
         } else {
             singleEntries.push(item);
@@ -124,7 +124,7 @@ export async function importFromRepoList(
             succeeded.push(1);
         } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
-            log.warn(`导入失败：${entry.url} — ${message}`);
+            log.warn(`import failed: ${entry.url} — ${message}`);
             failed.push({ url: entry.url, error: message });
         }
     }
@@ -161,7 +161,7 @@ export async function importFromRepoList(
             const { aggregateGlobalGraph } = await import('./graph-aggregate.js');
             await aggregateGlobalGraph(teamwikiRoot);
         } catch (e) {
-            log.warn(`[graph] 全局图谱聚合失败（不中断流程）：${(e as Error).message}`);
+            log.warn(`[graph] global aggregation failed (non-blocking): ${(e as Error).message}`);
         }
     }
 
@@ -184,10 +184,10 @@ export async function importFromRepoList(
             const domains = await loadDomains(domainsBase);
             await regenerateAggregate({ paths, domains });
             aggregateGenerated = true;
-            log.info(`聚合文件已生成：${paths.index}`);
+            log.info(`aggregated files generated: ${paths.index}`);
         } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
-            log.warn(`聚合文件生成失败（不中断流程）：${message}`);
+            log.warn(`aggregation file generation failed (non-blocking): ${message}`);
         }
     }
 
@@ -200,7 +200,7 @@ export async function importFromRepoList(
             await autoPushTeamRepo(lc.repo.localPath, '[teamai] Batch import: graph + aggregate');
             log.success(`已推送到团队知识仓库 (${lc.repo.remote})`);
         } catch (e) {
-            log.warn(`[git] 批量推送失败（不中断流程）：${(e as Error).message}`);
+            log.warn(`[git] batch push failed (non-blocking): ${(e as Error).message}`);
         }
     }
 

--- a/src/import-repo.ts
+++ b/src/import-repo.ts
@@ -390,7 +390,7 @@ async function interactiveConfirmDomain(
 
     if (lower === 'o') {
         const existingDomains = domains.domains.map((d, idx) => `  ${idx + 1}. ${d.name}`);
-        console.log('已有域列表：');
+        console.log('existing domains:');
         console.log(existingDomains.join('\n'));
         const numStr = await askQuestion('请输入编号：', '');
         const num = parseInt(numStr, 10);
@@ -479,7 +479,7 @@ export async function detectDomainDrift(args: {
         });
 
         log.warn(
-            `[drift] 仓库 ${url} 可能需要重新分类` +
+            `[drift] repo ${url} may need reclassification` +
             `（推荐域 ${recommendResult.domain}，confidence ${recommendResult.confidence.toFixed(2)}），` +
             `已记入 history。请人工 review，自动归属未变。`,
         );
@@ -580,7 +580,7 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
 
     if (useIncremental) {
         oldSha = lastSync.sha;
-        log.info(`[incremental] 缓存命中 ${cacheDir}，从 ${oldSha.slice(0, 8)} 增量同步`);
+        log.info(`[incremental] cache hit ${cacheDir}, syncing from ${oldSha.slice(0, 8)}`);
         try {
             const fetchResult = await shallowFetch(cacheDir);
             cloneSha = fetchResult.sha;
@@ -588,7 +588,7 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
             log.info(`[incremental] Fetch 完成: SHA=${cloneSha.slice(0, 8)}`);
         } catch (fetchErr) {
             log.warn(
-                `[incremental] fetch 失败，fallback 到全量 clone：` +
+                `[incremental] fetch failed, falling back to full clone: ` +
                 `${fetchErr instanceof Error ? fetchErr.message : String(fetchErr)}`,
             );
             try {
@@ -620,12 +620,12 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
 
     // 2.5 SHA 未变化时跳过 AI 扫描（增量模式快速路径）
     if (useIncremental && oldSha && cloneSha === oldSha) {
-        log.info(`[incremental] SHA 未变化 (${cloneSha.slice(0, 8)})，跳过 AI 扫描`);
+        log.info(`[incremental] SHA unchanged (${cloneSha.slice(0, 8)}), skipping AI scan`);
         await writeLastSync(cacheDir, cloneSha);
         try {
             await touchCacheEntry({ provider: providerName, owner, repo: repoName, lastSyncedSha: cloneSha });
         } catch {}
-        log.info(chalk.green(`✓ 仓库 ${owner}/${repoName} 无变化，跳过`));
+        log.info(chalk.green(`✓ repo ${owner}/${repoName} unchanged, skipped`));
         return;
     }
 
@@ -674,7 +674,7 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
             merged = mergeWithAnchors(oldFile, codebaseMd, { source: sourceTag, syncedAt });
             toWrite = merged.mergedMd;
         } catch (err) {
-            log.warn(`[section-merge] ${err instanceof Error ? err.message : err}；fallback 到全量重写`);
+            log.warn(`[section-merge] ${err instanceof Error ? err.message : err}; falling back to full rewrite`);
             if (oldFile !== null && !dryRun) {
                 const bakPath = `${repoMdPath}.bak`;
                 try { await fs.writeFile(bakPath, oldFile, 'utf8'); } catch {}
@@ -822,7 +822,7 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
             const { reconcileKnowledge } = await import('./wiki-engine/adapters/index.js');
             const result = await reconcileKnowledge({ wikiRoot: teamwikiRoot, dryRun: false });
             if (result.mappings > 0 || result.gaps.length > 0) {
-                log.info(`  对账: ${result.mappings} 映射, ${result.gaps.length} 缺口, ${result.graphEdges.length} MAPS_TO 边`);
+                log.info(`  reconcile: ${result.mappings} mappings, ${result.gaps.length} gaps, ${result.graphEdges.length} MAPS_TO edges`);
             }
         } catch (e) {
             log.debug(`reconcile skipped: ${(e as Error).message}`);

--- a/src/import-repo.ts
+++ b/src/import-repo.ts
@@ -667,12 +667,15 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
                 const evidenceDest = path.join(teamwikiRoot, 'evidence', 'code', slug);
                 await fs.ensureDir(evidenceDest);
                 await fs.copy(evidenceSrc, evidenceDest, { overwrite: true });
-                // 将 AI 叙事追加到确定性 overview.md 末尾（buildOverview 生成表格在前，AI 叙事在后）
+                // 将 AI 叙事写入 overview.md（幂等：已有则替换，无则追加）
                 if (codebaseMd) {
                     const overviewPath = path.join(evidenceDest, 'overview.md');
                     const existing = await fs.readFile(overviewPath, 'utf8').catch(() => '');
                     const aiNarrative = codebaseMd.replace(/^---[\s\S]*?---\n*/m, '');
-                    const combined = existing.trimEnd() + '\n\n---\n\n## AI 架构叙事\n\n' + aiNarrative;
+                    const marker = '## AI 架构叙事';
+                    const markerIdx = existing.indexOf(marker);
+                    const base = markerIdx >= 0 ? existing.slice(0, markerIdx).trimEnd() : existing.trimEnd();
+                    const combined = base + '\n\n---\n\n' + marker + '\n\n' + aiNarrative;
                     await fs.writeFile(overviewPath, combined, 'utf8');
                 }
                 // Per-repo graph: copy to evidence/<slug>/.indices/ (no global merge here — done in batch)
@@ -699,7 +702,7 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
             const { routerTemplate, indexTemplate, HOT_TEMPLATE } = await import('./wiki-engine/adapters/templates.js');
             const routerPath = path.join(teamwikiRoot, 'router.md');
             const indexPath = path.join(teamwikiRoot, 'index.md');
-            const projectLink = `[[code/${slug}/index]]`;
+            const projectLink = `[[evidence/code/${slug}/index]]`;
             if (await fs.pathExists(routerPath)) {
                 const router = await fs.readFile(routerPath, 'utf8');
                 if (!router.includes(projectLink)) {
@@ -766,7 +769,7 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
     log.info(chalk.green(`✓ 仓库 ${owner}/${repoName} 导入完成`));
 
     // 5b. 后台深度生成（不阻塞；batch 模式下跳过 push 由调用方统一处理）
-    if (!dryRun && teamwikiRoot) {
+    if (!dryRun && !skipEnrich && teamwikiRoot) {
         const evidenceDir = path.join(teamwikiRoot, 'evidence', 'code', slug);
         if (await fs.pathExists(path.join(evidenceDir, '_manifest.json'))) {
             setImmediate(async () => {

--- a/src/import-repo.ts
+++ b/src/import-repo.ts
@@ -4,7 +4,6 @@ import chalk from 'chalk';
 
 import { generateCodebaseMd } from './codebase.js';
 import { extractCodebase } from './codebase-extract.js';
-import { mergeWithAnchors } from './section-patcher.js';
 import { detectProvider } from './providers/registry.js';
 import { shallowClone, shallowFetch } from './clone.js';
 import { appendPendingReview, loadPendingReview, removePendingReview } from './review-store.js';
@@ -27,7 +26,6 @@ import {
 } from './domains/index.js';
 import { askQuestion } from './utils/prompt.js';
 import { log } from './utils/logger.js';
-import { assertSafePath } from './utils/path-safety.js';
 
 // ─── Types ──────────────────────────────────────────────
 
@@ -44,7 +42,7 @@ export interface ImportFromRepoOptions {
     explicitDomain?: string;
     /** Dry-run 模式：跳过写盘但执行 clone+扫描 */
     dryRun?: boolean;
-    /** 自定义产物根目录；默认 .teamai/team-repo/docs/team-codebase */
+    /** 自定义产物根目录；默认 .teamai/team-repo/teamwiki */
     output?: string;
     /**
      * 是否启用交互式确认。
@@ -526,11 +524,12 @@ export async function detectDomainDrift(args: {
  * 流程：
  *  1. 解析 url → provider + RepoInfo（owner/repo）
  *  2. shallow clone（或增量 fetch+reset）到 ~/.teamai/cache/repos/<provider>/<owner>/<repo>
- *  3. generateCodebaseMd({ repoPath: cacheDir })
- *  4. 写出到 <outputRoot>/repos/<slug>.md（默认 outputRoot=.teamai/team-repo/docs/team-codebase）
- *  5. 推荐业务域（或使用 --domain 显式指定）
- *  6. 写入 .teamai/domains.yaml + appendHistory
- *  7. 写 LAST_SYNC
+ *  3. generateCodebaseMd({ repoPath: cacheDir }) → AI 叙事
+ *  4. extractCodebase → teamwiki evidence 产物（确定性 overview + graph）
+ *  5. AI 叙事追加到 teamwiki/evidence/code/<slug>/overview.md
+ *  6. 推荐业务域（或使用 --domain 显式指定）
+ *  7. 写入 .teamai/domains.yaml + appendHistory
+ *  8. 写 LAST_SYNC
  *
  * @throws 克隆失败、扫描失败、IO 失败时抛 Error
  */
@@ -642,7 +641,7 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
         }
     }
 
-    // Resolve team-repo directory (needed for both docs/team-codebase and teamwiki)
+    // Resolve team-repo directory (needed for teamwiki evidence output)
     let teamRepoDir: string;
     let teamRepoRemote = '';
     try {
@@ -654,84 +653,7 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
         teamRepoDir = path.join(process.cwd(), '.teamai', 'team-repo');
     }
 
-    // 4. 写入 docs/team-codebase 叙事文档（AI 扫描成功时）
-    const outputRoot = output ?? path.join(teamRepoDir, 'docs', 'team-codebase');
-    let repoMdPath = path.join(outputRoot, 'repos', `${slug}.md`);
-
-    if (codebaseMd) {
-        assertSafePath(repoMdPath, [path.join(outputRoot, 'repos')]);
-        const sourceTag = `${url}@${cloneSha.slice(0, 8)}`;
-        const syncedAt = new Date().toISOString();
-
-        let oldFile: string | null = null;
-        if (await fs.pathExists(repoMdPath)) {
-            try { oldFile = await fs.readFile(repoMdPath, 'utf8'); } catch { oldFile = null; }
-        }
-
-        let merged: ReturnType<typeof mergeWithAnchors>;
-        let toWrite: string;
-        try {
-            merged = mergeWithAnchors(oldFile, codebaseMd, { source: sourceTag, syncedAt });
-            toWrite = merged.mergedMd;
-        } catch (err) {
-            log.warn(`[section-merge] ${err instanceof Error ? err.message : err}; falling back to full rewrite`);
-            if (oldFile !== null && !dryRun) {
-                const bakPath = `${repoMdPath}.bak`;
-                try { await fs.writeFile(bakPath, oldFile, 'utf8'); } catch {}
-            }
-            merged = mergeWithAnchors(null, codebaseMd, { source: sourceTag, syncedAt });
-            toWrite = merged.mergedMd;
-        }
-
-    // 注入 repo_url 到 frontmatter，供 aggregate 映射 domain
-    if (toWrite.startsWith('---\n') && !toWrite.includes('\nrepo_url:')) {
-        const fmEnd = toWrite.indexOf('\n---\n', 4);
-        if (fmEnd !== -1) {
-            toWrite = toWrite.slice(0, fmEnd) + `\nrepo_url: ${url}` + toWrite.slice(fmEnd);
-        }
-    }
-
-    if (dryRun) {
-        console.log(chalk.yellow(`[dry-run] 产物路径: ${repoMdPath}`));
-        console.log(chalk.yellow('[dry-run] 产物预览（前 50 行）：'));
-        const preview = toWrite.split('\n').slice(0, 50).join('\n');
-        console.log(preview);
-        if (merged.changedSlugs.length > 0) {
-            console.log(chalk.yellow(`[dry-run] 变化章节: ${merged.changedSlugs.join(', ')}`));
-        }
-        if (merged.addedSlugs.length > 0) {
-            console.log(chalk.yellow(`[dry-run] 新增章节: ${merged.addedSlugs.join(', ')}`));
-        }
-        if (merged.removedSlugs.length > 0) {
-            console.log(chalk.yellow(`[dry-run] 移除章节: ${merged.removedSlugs.join(', ')}`));
-        }
-    } else {
-        await fs.ensureDir(path.dirname(repoMdPath));
-        const noChange =
-            merged.changedSlugs.length === 0 &&
-            merged.addedSlugs.length === 0 &&
-            merged.removedSlugs.length === 0 &&
-            oldFile !== null &&
-            oldFile === toWrite;
-        if (noChange) {
-            log.info(`[section-merge] 仓库 ${repoName} 无章节变化，跳过写入`);
-        } else {
-            await fs.writeFile(repoMdPath, toWrite, 'utf8');
-            log.info(`产物已写入: ${repoMdPath}`);
-            if (merged.changedSlugs.length > 0) {
-                log.debug(`[section-merge] 变化章节: ${merged.changedSlugs.join(', ')}`);
-            }
-            if (merged.addedSlugs.length > 0) {
-                log.debug(`[section-merge] 新增章节: ${merged.addedSlugs.join(', ')}`);
-            }
-            if (merged.removedSlugs.length > 0) {
-                log.debug(`[section-merge] 移除章节: ${merged.removedSlugs.join(', ')}`);
-            }
-        }
-    }
-    } // end if (codebaseMd)
-
-    // 4b. 生成 teamwiki/ 知识图谱产物（写入 team-repo 以便自动 push）
+    // 4. 生成 teamwiki/ 知识图谱产物 + AI 叙事追加到 overview.md
     const teamwikiRoot = output
         ? path.resolve(output, '..', 'teamwiki')
         : path.join(teamRepoDir, 'teamwiki');
@@ -745,18 +667,13 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
                 const evidenceDest = path.join(teamwikiRoot, 'evidence', 'code', slug);
                 await fs.ensureDir(evidenceDest);
                 await fs.copy(evidenceSrc, evidenceDest, { overwrite: true });
-                // 如果 AI 扫描成功，将架构概述写入 overview.md
+                // 将 AI 叙事追加到确定性 overview.md 末尾（buildOverview 生成表格在前，AI 叙事在后）
                 if (codebaseMd) {
-                    const overviewContent = [
-                        '---',
-                        `title: ${slug} overview`,
-                        'domain: code-knowledge',
-                        `source: [${url}]`,
-                        '---',
-                        '',
-                        codebaseMd.replace(/^---[\s\S]*?---\n*/m, ''),
-                    ].join('\n');
-                    await fs.writeFile(path.join(evidenceDest, 'overview.md'), overviewContent, 'utf8');
+                    const overviewPath = path.join(evidenceDest, 'overview.md');
+                    const existing = await fs.readFile(overviewPath, 'utf8').catch(() => '');
+                    const aiNarrative = codebaseMd.replace(/^---[\s\S]*?---\n*/m, '');
+                    const combined = existing.trimEnd() + '\n\n---\n\n## AI 架构叙事\n\n' + aiNarrative;
+                    await fs.writeFile(overviewPath, combined, 'utf8');
                 }
                 // Per-repo graph: copy to evidence/<slug>/.indices/ (no global merge here — done in batch)
                 const srcGraph = path.join(cacheWiki, '.indices', 'graph-index.json');

--- a/src/import.ts
+++ b/src/import.ts
@@ -120,7 +120,7 @@ export async function importCmd(opts: ImportOptions): Promise<void> {
         incremental: opts.incremental ?? false,
         skipEnrich: opts.skipEnrich ?? false,
       });
-      log.info(`完成：成功 ${result.succeeded}，失败 ${result.failed.length}，跳过 ${result.skipped.length}`);
+      log.info(`done: ${result.succeeded} succeeded, ${result.failed.length} failed, ${result.skipped.length} skipped`);
       if (result.failed.length > 0) process.exitCode = 1;
       return;
     } else if (opts.fromIwiki) {
@@ -196,7 +196,7 @@ export async function importCmd(opts: ImportOptions): Promise<void> {
       log.info(`扫描本地目录: ${dirPath} (project: ${slug})`);
 
       if (opts.dryRun) {
-        log.info(`[dry-run] 跳过代码提取，不执行实际操作`);
+        log.info(`[dry-run] skipping code extraction, no action taken`);
         log.success(`本地目录 ${slug} 导入完成 (dry-run)`);
         return;
       }
@@ -258,7 +258,7 @@ export async function importCmd(opts: ImportOptions): Promise<void> {
       // 分支 3b：--from-claude，扫描规则文件并交互式导入
       const candidates = await scanCandidates({ fromClaude: true });
       if (candidates.length === 0) {
-        log.info('未发现可导入的文件');
+        log.info('no importable files found');
         return;
       }
       const classified = await classifyWithAI(candidates);

--- a/src/index.ts
+++ b/src/index.ts
@@ -654,7 +654,7 @@ program
   .addOption(new Option('--stale-days <n>', 'Threshold for sync-stale check').default('60').hideHelp())
   .addOption(new Option('--pending-review-threshold <n>', 'Threshold for pending-review backlog').default('10').hideHelp())
   .option('--json', 'Output report as JSON (suitable for CI)')
-  .addOption(new Option('--output <path>', 'Custom team-codebase root (mirrors --from-repo)').hideHelp())
+  .addOption(new Option('--output <path>', 'Custom teamwiki output root directory').hideHelp())
   .action(async (cmdOpts) => {
     const globalOpts = program.opts() as GlobalOptions;
     const { codebaseCmd } = await import('./codebase-cmd.js');
@@ -685,7 +685,7 @@ program
     .option('--apply-all', 'Apply all drift items above confidence threshold')
     .option('--threshold <n>', 'Confidence threshold for --apply-all (default 0.8)', '0.8')
     .option('--lock', 'Lock the repo against future drift signals')
-    .option('--output <path>', 'Custom team-codebase root (mirrors --from-repo)')
+    .option('--output <path>', 'Custom teamwiki output root directory')
     .option('--skip-aggregate', 'Skip regenerateAggregate after apply')
     .option('--json', 'Machine-readable output')
     .action(async (subcommand, repoUrlArg, cmdOpts) => {

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -1069,7 +1069,7 @@ export async function pull(options: GlobalOptions): Promise<void> {
   // 2. User scope — only when NOT in project mode.
   let userConfig: LocalConfig | null = null;
   if (projectMode) {
-    log.info('检测到 project scope，已跳过 user scope');
+    log.info('project scope detected, skipped user scope');
   } else {
     try {
       userConfig = await loadLocalConfigForScope('user');

--- a/src/rebuild-wiki-index.ts
+++ b/src/rebuild-wiki-index.ts
@@ -96,7 +96,7 @@ export async function rebuildWikiIndex(teamwikiRoot: string): Promise<void> {
     }
 
     // Read call-chains count
-    const chainsPath = path.join(dirPath, 'call-chains.md');
+    const chainsPath = path.join(dirPath, 'dependency-paths.md');
     if (await pathExists(chainsPath)) {
       const content = await readFile(chainsPath, 'utf-8');
       const chainMatch = content.match(/(\d+)\s*call chain/);
@@ -156,7 +156,7 @@ export async function rebuildWikiIndex(teamwikiRoot: string): Promise<void> {
   routerLines.push('1. **按组件名匹配** → 路由关键词列对应域');
   routerLines.push('2. **跨仓库依赖问题** → 查 graph-index.json 的 DEPENDS_ON 边');
   routerLines.push('3. **接口/API 问题** → 优先匹配有 interfaces.md 的仓库');
-  routerLines.push('4. **调用链/排障** → 查对应仓库的 call-chains.md');
+  routerLines.push('4. **调用链/排障** → 查对应仓库的 dependency-paths.md');
   routerLines.push('5. **模块职责概述** → 查 overview.md 或 modules/*.md');
   routerLines.push('');
   await writeFile(path.join(teamwikiRoot, 'router.md'), routerLines.join('\n'), 'utf-8');

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -317,7 +317,7 @@ export async function recall(
       });
     }
   } catch {
-    log.warn('recall: 代码图谱检索不可用，可运行 teamai codebase --lint 诊断');
+    log.warn('recall: code graph retrieval unavailable, run teamai codebase --lint to diagnose');
   }
 
   // Re-sort merged results by score descending, then date descending

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -230,6 +230,12 @@ export async function recall(
     return;
   }
 
+  const VALID_DEPTHS = new Set(['route', 'context', 'lookup']);
+  if (options.depth && !VALID_DEPTHS.has(options.depth)) {
+    log.warn(`Invalid --depth "${options.depth}", falling back to "context". Valid: route, context, lookup`);
+    options.depth = 'context';
+  }
+
   // Scope isolation (issue #73): when a project-scope install is detected in
   // cwd, recall queries the project index ONLY. Otherwise it falls back to the
   // user scope. The two scopes are never merged anymore.

--- a/src/review-cmd.ts
+++ b/src/review-cmd.ts
@@ -61,8 +61,8 @@ function renderList(items: PendingReviewItem[]): void {
     for (const item of items) counts[item.risk]++;
 
     console.log(
-        chalk.bold(`[review] 共 ${items.length} 项`) +
-        `（high: ${counts.high}, medium: ${counts.medium}, low: ${counts.low}）`,
+        chalk.bold(`[review] ${items.length} items`) +
+        ` (high: ${counts.high}, medium: ${counts.medium}, low: ${counts.low})`,
     );
 
     if (items.length === 0) return;
@@ -199,13 +199,13 @@ export async function reviewCmd(opts: ReviewCmdOptions): Promise<void> {
 
         const succeeded = results.filter((r) => r.ok);
         const failed = results.filter((r) => !r.ok);
-        const summary = `[review] --all-apply 完成：成功 ${succeeded.length}，失败 ${failed.length}，跳过 ${skipped.length}`;
+        const summary = `[review] --all-apply done: ${succeeded.length} succeeded, ${failed.length} failed, ${skipped.length} skipped`;
         console.log(chalk.bold(summary));
         for (const fail of failed) {
             console.log(chalk.red(`  ✗ ${fail.id}: ${fail.reason}`));
         }
         for (const skip of skipped) {
-            console.log(chalk.dim(`  ○ 跳过 ${skip.id}（kind=${skip.kind}, risk=${skip.risk}）`));
+            console.log(chalk.dim(`  ○ skipped ${skip.id} (kind=${skip.kind}, risk=${skip.risk})`));
         }
         return;
     }
@@ -229,9 +229,9 @@ export async function reviewCmd(opts: ReviewCmdOptions): Promise<void> {
     const item = items.find((i) => i.id === idArg);
 
     if (!item) {
-        log.warn(`[review] 未找到 id="${idArg}"`);
+        log.warn(`[review] not found: id="${idArg}"`);
         if (jsonMode) {
-            console.log(JSON.stringify({ ok: false, reason: `未找到 id="${idArg}"` }));
+            console.log(JSON.stringify({ ok: false, reason: `not found: id="${idArg}"` }));
         }
         return;
     }
@@ -274,7 +274,7 @@ export async function reviewCmd(opts: ReviewCmdOptions): Promise<void> {
         }
 
         if (result.ok) {
-            console.log(chalk.green(`[review] 已应用：${idArg} → ${item.target.file}`));
+            console.log(chalk.green(`[review] applied: ${idArg} → ${item.target.file}`));
         } else {
             console.log(chalk.red(`[review] 应用失败：${idArg} — ${result.reason}`));
         }

--- a/src/utils/search-index.ts
+++ b/src/utils/search-index.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import matter from 'gray-matter';
 import { readFileSafe, readJson, writeJson, listFiles, listFilesRecursive, listDirs, pathExists } from './fs.js';
-import { tokenize } from './tokenizer.js';
+import { tokenize, MAX_TOKENIZE_CHARS } from './tokenizer.js';
 import { log } from './logger.js';
 import {
   SEARCH_INDEX_VERSION,
@@ -203,8 +203,8 @@ export function inferDomain(
   return 'neutral';
 }
 
-// Re-export for external callers that previously imported tokenize from this module
-export { tokenize };
+// Re-export tokenizer for external callers
+export { tokenize, MAX_TOKENIZE_CHARS };
 
 /**
  * Parse a learning document's frontmatter and body.
@@ -507,8 +507,8 @@ export async function buildIndex(
   // Guard: don't overwrite a healthy index with a significantly smaller one
   const targetPath = opts.indexPath ?? getSearchIndexPath();
   const existingIndex = await loadIndex(targetPath);
-  if (existingIndex && existingIndex.entries.length > 0 && entries.length === 0) {
-    log.warn(`Index rebuild skipped: refusing to overwrite ${existingIndex.entries.length} entries with empty index`);
+  if (existingIndex && existingIndex.entries.length > 5 && entries.length < existingIndex.entries.length * 0.2) {
+    log.warn(`Index rebuild skipped: new index (${entries.length}) is <20% of existing (${existingIndex.entries.length}), likely partial failure`);
     return elapsed;
   }
 

--- a/src/utils/tokenizer.ts
+++ b/src/utils/tokenizer.ts
@@ -11,11 +11,13 @@
  */
 export const MAX_TOKENIZE_CHARS = 50_000;
 
+const sharedSegmenter = new Intl.Segmenter('zh-CN', { granularity: 'word' });
+
 export function tokenize(text: string): string[] {
   if (!text) return [];
 
   const input = text.length > MAX_TOKENIZE_CHARS ? text.slice(0, MAX_TOKENIZE_CHARS) : text;
-  const segmenter = new Intl.Segmenter('zh-CN', { granularity: 'word' });
+  const segmenter = sharedSegmenter;
   const tokens: string[] = [];
 
   // Collect CJK characters in runs for bigram generation
@@ -72,10 +74,10 @@ export function tokenize(text: string): string[] {
 /** Non-deduplicated word-like token count (for BM25 document length). */
 export function tokenCount(text: string): number {
   if (!text) return 0;
-  const input = text.length > MAX_TOKENIZE_CHARS ? text.slice(0, MAX_TOKENIZE_CHARS) : text;
-  const segmenter = new Intl.Segmenter('zh-CN', { granularity: 'word' });
+  const input = text.length > MAX_TOKENIZE_CHARS
+    ? text.slice(0, MAX_TOKENIZE_CHARS) : text;
   let count = 0;
-  for (const seg of segmenter.segment(input)) {
+  for (const seg of sharedSegmenter.segment(input)) {
     if (seg.isWordLike) count++;
   }
   return count;

--- a/src/utils/tokenizer.ts
+++ b/src/utils/tokenizer.ts
@@ -9,14 +9,13 @@
  * - 全小写
  * - 去重
  */
-const MAX_TOKENIZE_CHARS = 100_000;
+export const MAX_TOKENIZE_CHARS = 50_000;
 
 export function tokenize(text: string): string[] {
   if (!text) return [];
 
   const input = text.length > MAX_TOKENIZE_CHARS ? text.slice(0, MAX_TOKENIZE_CHARS) : text;
   const segmenter = new Intl.Segmenter('zh-CN', { granularity: 'word' });
-  const segments = [...segmenter.segment(input)];
   const tokens: string[] = [];
 
   // Collect CJK characters in runs for bigram generation
@@ -31,7 +30,7 @@ export function tokenize(text: string): string[] {
     cjkRun = [];
   };
 
-  for (const seg of segments) {
+  for (const seg of segmenter.segment(input)) {
     if (!seg.isWordLike) {
       flushCjkRun();
       continue;
@@ -68,4 +67,16 @@ export function tokenize(text: string): string[] {
   flushCjkRun();
 
   return [...new Set(tokens)];
+}
+
+/** Non-deduplicated word-like token count (for BM25 document length). */
+export function tokenCount(text: string): number {
+  if (!text) return 0;
+  const input = text.length > MAX_TOKENIZE_CHARS ? text.slice(0, MAX_TOKENIZE_CHARS) : text;
+  const segmenter = new Intl.Segmenter('zh-CN', { granularity: 'word' });
+  let count = 0;
+  for (const seg of segmenter.segment(input)) {
+    if (seg.isWordLike) count++;
+  }
+  return count;
 }

--- a/src/wiki-engine/adapters/templates.ts
+++ b/src/wiki-engine/adapters/templates.ts
@@ -26,7 +26,8 @@ export function routerTemplate(
   for (const p of projects) {
     if (p.keywords) p.keywords.forEach(k => allKeywords.add(k));
   }
-  const anchorTerms = ['路由', '索引', '入口', '知识库', '代码知识', 'architecture', 'module', 'dependency', ...allKeywords].slice(0, 20);
+  const baseTerms = ['路由', '索引', '入口', '知识库', '代码知识', 'architecture', 'module', 'dependency'];
+  const anchorTerms = [...baseTerms, ...allKeywords].slice(0, 20);
 
   const lines = [
     '# Team Wiki Router',

--- a/src/wiki-engine/adapters/templates.ts
+++ b/src/wiki-engine/adapters/templates.ts
@@ -4,20 +4,61 @@ export interface DomainGroup {
   apiCount?: number;
 }
 
+export interface ProjectEntry {
+  slug: string;
+  label: string;
+  description?: string;
+  keywords?: string[];
+}
+
+export interface ModuleEntry {
+  slug: string;
+  responsibilities?: string[];
+  category?: string;
+  topComponents?: string[];
+}
+
 export function routerTemplate(
-  projects: Array<{ slug: string; label: string }>,
+  projects: ProjectEntry[],
   domains?: DomainGroup[],
 ): string {
-  const lines = ['# Team Wiki Router', '', 'Route broad questions to the relevant domain entrypoint.', ''];
+  const allKeywords = new Set<string>();
+  for (const p of projects) {
+    if (p.keywords) p.keywords.forEach(k => allKeywords.add(k));
+  }
+  const anchorTerms = ['路由', '索引', '入口', '知识库', '代码知识', 'architecture', 'module', 'dependency', ...allKeywords].slice(0, 20);
+
+  const lines = [
+    '# Team Wiki Router',
+    `<!-- search-anchor: ${anchorTerms.join(', ')} -->`,
+    '',
+    'Route broad questions to the relevant domain entrypoint.',
+    '',
+    '## 问题路由表',
+    '',
+    '| 问题类型 | 目标文档 | 示例问题 |',
+    '|----------|----------|---------|',
+    '| 谁依赖谁 / 模块关系 | G1 组件关系矩阵 | "X 模块的上下游是什么" |',
+    '| 调用链 / 数据流 | G2 数据流图 | "请求从入口到数据库经过哪些模块" |',
+    '| 完整业务流程 | G5 场景序列图 | "用户登录的完整流程是什么" |',
+    '| 传递依赖 / 爆炸半径 | G6 多跳路径 | "如果 X 挂了会影响什么" |',
+    '| 架构概览 / 技术栈 | overview.md | "项目整体架构是什么" |',
+    '| 某模块职责 / 依赖 | modules/<dir>.md | "recall 模块做什么" |',
+    '',
+    '## 项目域入口',
+    '',
+  ];
 
   if (domains && domains.length > 0) {
     for (const domain of domains) {
-      lines.push(`## ${domain.name}${domain.apiCount ? ` (${domain.apiCount} APIs)` : ''}`);
+      lines.push(`### ${domain.name}${domain.apiCount ? ` (${domain.apiCount} APIs)` : ''}`);
       lines.push('');
       for (const comp of domain.components) {
         const proj = projects.find(p => p.slug === comp || p.label === comp);
         if (proj) {
-          lines.push(`- [[evidence/code/${proj.slug}/index]] — ${proj.label}`);
+          const desc = proj.description ? ` — ${proj.description}` : '';
+          const kw = proj.keywords?.length ? ` [${proj.keywords.slice(0, 5).join(', ')}]` : '';
+          lines.push(`- [[evidence/code/${proj.slug}/index]]${desc}${kw}`);
         } else {
           lines.push(`- ${comp}`);
         }
@@ -27,16 +68,19 @@ export function routerTemplate(
     const grouped = new Set(domains.flatMap(d => d.components));
     const ungrouped = projects.filter(p => !grouped.has(p.slug) && !grouped.has(p.label));
     if (ungrouped.length > 0) {
-      lines.push('## Other');
+      lines.push('### Other');
       lines.push('');
       for (const p of ungrouped) {
-        lines.push(`- [[evidence/code/${p.slug}/index]] — ${p.label} 代码知识`);
+        const desc = p.description ? ` — ${p.description}` : ' — 代码知识';
+        lines.push(`- [[evidence/code/${p.slug}/index]]${desc}`);
       }
       lines.push('');
     }
   } else {
     for (const p of projects) {
-      lines.push(`- [[code/${p.slug}/index]] — ${p.label} 代码知识`);
+      const desc = p.description ? ` — ${p.description}` : ' — 代码知识';
+      const kw = p.keywords?.length ? ` [${p.keywords.slice(0, 5).join(', ')}]` : '';
+      lines.push(`- [[evidence/code/${p.slug}/index]]${desc}${kw}`);
     }
     lines.push('');
   }
@@ -53,15 +97,18 @@ export interface IndexStats {
 }
 
 export function indexTemplate(
-  projects: Array<{ slug: string; label: string; description?: string }>,
+  projects: ProjectEntry[],
   stats?: IndexStats,
+  modules?: ModuleEntry[],
 ): string {
-  const domainLinks = projects
-    .map(p => `- [${p.slug}](./evidence/code/${p.slug}/index.md) — ${p.description ?? p.label}`)
-    .join('\n');
+  const allKeywords = projects.flatMap(p => p.keywords ?? []).slice(0, 15);
+  const searchAnchor = allKeywords.length > 0
+    ? `\n<!-- search-anchor: ${allKeywords.join(', ')} -->`
+    : '';
 
   const sections = [
     '# Team Wiki Index',
+    searchAnchor,
     '',
     `Last updated: ${new Date().toISOString()}`,
     '',
@@ -80,8 +127,31 @@ export function indexTemplate(
     sections.push('');
   }
 
-  sections.push('## Domains', '', domainLinks, '');
-  sections.push('## Navigation', '', '- [router.md](./router.md) — 领域路由入口', '- [hot.md](./hot.md) — 活跃工作记忆', '');
+  if (modules && modules.length > 0) {
+    sections.push('## 模块速查', '');
+    sections.push('| 模块 | 职责 | 关键组件 | 层级 |');
+    sections.push('|------|------|---------|------|');
+    for (const mod of modules.slice(0, 20)) {
+      const resp = mod.responsibilities?.slice(0, 2).join('; ') ?? '—';
+      const comps = mod.topComponents?.slice(0, 3).join(', ') ?? '—';
+      const cat = mod.category ?? '—';
+      sections.push(`| ${mod.slug} | ${resp} | ${comps} | ${cat} |`);
+    }
+    sections.push('');
+  }
+
+  sections.push('## 文档导航', '');
+  for (const p of projects) {
+    const desc = p.description ?? p.label;
+    sections.push(`### ${p.slug}`, '');
+    sections.push(`- [overview.md](./evidence/code/${p.slug}/overview.md) — 架构概览`);
+    sections.push(`- [modules/](./evidence/code/${p.slug}/modules/) — 模块级摘要（推荐首选）`);
+    sections.push(`- [docs/](./evidence/code/${p.slug}/docs/) — 深度设计文档 + G-document`);
+    sections.push(`- [component.md](./evidence/code/${p.slug}/component.md) — 原始符号清单`);
+    sections.push('');
+  }
+
+  sections.push('## Navigation', '', '- [router.md](./router.md) — 问题路由入口', '- [hot.md](./hot.md) — 活跃工作记忆', '');
 
   return sections.join('\n');
 }
@@ -93,3 +163,20 @@ export const HOT_TEMPLATE = [
   'Move durable conclusions into domain pages.',
   '',
 ].join('\n');
+
+export function graphReadmeTemplate(project: string): string {
+  return [
+    `# ${project} — G-Document 路由`,
+    '<!-- search-anchor: 图谱, graph, G1, G2, G5, G6, 依赖, 调用链, 流程, 爆炸半径 -->',
+    '',
+    '根据问题类型选择对应文档：',
+    '',
+    '| 关键词 | 文档 | 说明 |',
+    '|--------|------|------|',
+    '| 依赖/上游/下游/imports | [graph-g1-relations.md](./graph-g1-relations.md) | N×N 组件依赖矩阵 |',
+    '| 调用链/数据流/请求路径 | [graph-g2-dataflow.md](./graph-g2-dataflow.md) | 入口→数据层调用链 |',
+    '| 流程/场景/sequence | [graph-g5-scenarios.md](./graph-g5-scenarios.md) | 核心业务场景序列图 |',
+    '| 传递依赖/影响范围/blast | [graph-g6-multihop.md](./graph-g6-multihop.md) | 多跳传递依赖分析 |',
+    '',
+  ].join('\n');
+}

--- a/src/wiki-engine/adapters/templates.ts
+++ b/src/wiki-engine/adapters/templates.ts
@@ -106,13 +106,9 @@ export function indexTemplate(
     ? `\n<!-- search-anchor: ${allKeywords.join(', ')} -->`
     : '';
 
-  const sections = [
-    '# Team Wiki Index',
-    searchAnchor,
-    '',
-    `Last updated: ${new Date().toISOString()}`,
-    '',
-  ];
+  const sections = ['# Team Wiki Index'];
+  if (searchAnchor) sections.push(searchAnchor);
+  sections.push('', `Last updated: ${new Date().toISOString()}`, '');
 
   if (stats) {
     sections.push('## Stats', '');

--- a/src/wiki-engine/core/graph-index.schema.ts
+++ b/src/wiki-engine/core/graph-index.schema.ts
@@ -352,7 +352,11 @@ export async function loadGraphIndex(wikiRoot: string): Promise<GraphIndex | nul
   const graphPath = path.join(wikiRoot, ".indices", "graph-index.json");
   try {
     const raw = await readFile(graphPath, "utf8");
-    return JSON.parse(raw) as GraphIndex;
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed?.nodes) || !Array.isArray(parsed?.edges)) {
+      return null;
+    }
+    return parsed as GraphIndex;
   } catch {
     return null;
   }

--- a/src/wiki-engine/knowledge-reconciler.ts
+++ b/src/wiki-engine/knowledge-reconciler.ts
@@ -334,7 +334,6 @@ export async function reconcileKnowledge(options: ReconcileOptions): Promise<Rec
 
   // Phase 9 — Stale detection
   const MS_PER_DAY = 86_400_000;
-  const now = Date.now();
   for (const edge of graphEdges) {
     const fromPage = productPages.find(
       p => toPageSlug(path.relative(wikiRoot, p.path)) === edge.from
@@ -345,7 +344,7 @@ export async function reconcileKnowledge(options: ReconcileOptions): Promise<Rec
     if (!fromPage?.updated || !toPage?.updated) continue;
     const fromMs = new Date(fromPage.updated).getTime();
     const toMs = new Date(toPage.updated).getTime();
-    const daysDrift = Math.abs(now - Math.max(fromMs, toMs)) / MS_PER_DAY;
+    const daysDrift = Math.abs(fromMs - toMs) / MS_PER_DAY;
     if (daysDrift > 30) {
       staleWarnings.push({
         mappingFrom: edge.from,

--- a/src/wiki-engine/reconciler-v2-types.ts
+++ b/src/wiki-engine/reconciler-v2-types.ts
@@ -21,12 +21,11 @@ export function labelFromScore(score: number): WikiConfidence {
   return "AMBIGUOUS";
 }
 
-/** Build a NumericConfidence from factors (max of weights) */
+/** Build a NumericConfidence from factors (cumulative evidence, capped at 1.0) */
 export function buildConfidence(factors: ConfidenceFactor[]): NumericConfidence {
   if (factors.length === 0) return { score: 0, label: "AMBIGUOUS", factors: [] };
-  const score = Math.max(...factors.map(f => f.weight));
-  const clamped = Math.min(1, Math.max(0, score));
-  return { score: clamped, label: labelFromScore(clamped), factors };
+  const score = Math.min(1, factors.reduce((sum, f) => sum + f.weight, 0));
+  return { score, label: labelFromScore(score), factors };
 }
 
 // ─── API↔Interface Matching ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Implement three-layer progressive retrieval system (route → context → lookup) replacing flat BM25 search
- Add G5 (scenario sequence diagrams) and G6 (multi-hop transitive dependency analysis) graph documents
- Upgrade router.md/index.md with search-anchor and question routing table
- Optimize graph-boost with pre-computed adjacency map (O(E²) → O(degree²))
- Fix multiple knowledge repository generation bugs (overview duplication, g2 filename mismatch, non-idempotent writes)

### Key changes

**Production side (import-time generation):**
- `router.md`: search-anchor + question type → G-document routing table
- `index.md`: module quick-reference table + structured navigation
- G1/G2: upgraded to N×N matrix with forward/reverse dependency indexes
- G5 (new): AI-generated mermaid sequenceDiagram for core business scenarios
- G6 (new): deterministic 3-hop BFS transitive dependency + blast radius analysis
- `graph/README.md`: G-document dispatch routing table

**Consumption side (recall-time retrieval):**
- `depth=route`: returns routing suggestions only (no BM25)
- `depth=context` (default): searches overview + modules + docs, excludes navigation files
- `depth=lookup`: full search including raw symbol pages
- Graph-boost adjacency map optimization
- Invalid `--depth` values produce warning + fallback to context

**Bug fixes:**
- Remove `docs/team-codebase/repos/` duplication (teamwiki evidence as sole carrier)
- Fix `deep-enrich` reading `call-chains.md` → `dependency-paths.md`
- Fix `--skip-enrich` not blocking G5 AI calls
- Fix router.md append link missing `evidence/` prefix
- Make overview.md AI narrative append idempotent
- Eliminate graph-index write race condition in concurrent imports
- Fix `rebuild-wiki-index.ts` still referencing old filename
- Share Intl.Segmenter instance (module-level singleton)
- Add recursion depth limit to loadPagesRecursive

## Test plan

- [x] 130 test files, 1675 tests passing
- [x] TypeScript type check (tsc --noEmit) clean
- [x] New `recall-progressive.test.ts` verifying route/context/lookup behavior
- [x] E2E: init → pull → import (11 repos) → recall --depth → graph integrity
- [x] CSIG code review + code quality review + PR review all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)