### PR TITLE
feat(recall): progressive retrieval with G-document routing

### DIFF
--- a/agents/teamai-recall.md
+++ b/agents/teamai-recall.md
@@ -20,23 +20,29 @@ upstream API"). Treat this as your query.
 
 ## What you must do — step by step
 
-### Step 1 — Read codebase context (optional but preferred)
+### Step 1 — Classify question type and choose retrieval depth
 
-Check for the team's code knowledge graph in this order:
+Determine if the query matches a G-document category:
 
-1. `teamwiki/router.md` — if exists, read it to understand available repos
-2. `teamwiki/index.md` — global navigation with domain links
+| 问题关键词 | 类型 | 直接读取 |
+|-----------|------|---------|
+| 依赖/上游/下游/谁调用 | G1 | `teamwiki/evidence/code/<project>/docs/graph-g1-relations.md` |
+| 调用链/数据流/请求路径 | G2 | `teamwiki/evidence/code/<project>/docs/graph-g2-dataflow.md` |
+| 流程/场景/完整流程 | G5 | `teamwiki/evidence/code/<project>/docs/graph-g5-scenarios.md` |
+| 传递依赖/爆炸半径/影响 | G6 | `teamwiki/evidence/code/<project>/docs/graph-g6-multihop.md` |
 
-If `teamwiki/` exists, the team has a structured knowledge graph. After
-Step 3 returns codebase hits, you can **drill into** module summaries:
-- `teamwiki/evidence/code/<project>/modules/<dir>.md` — module-level overview with dependency direction and top components
-- `teamwiki/evidence/code/<project>/overview.md` — AI-generated architecture context (why/how, not just what)
+**If the query clearly matches a G-document type**: directly Read the
+corresponding file and extract relevant sections. Skip BM25 search.
 
-Fallback: if no `teamwiki/`, check `~/.teamai/docs/codebase.md` or
-`docs/team-codebase/index.md`. If none exists, silently skip.
+**Otherwise**: proceed to Step 2–3 for BM25 keyword search.
 
-> `teamai recall` automatically searches both flat knowledge (learnings/
-> skills/docs/rules) and codebase graph (teamwiki/) with BM25 + graph-boost.
+> `teamai recall` supports three depth levels:
+> - `--depth context` (default): searches overview + modules + docs (best for most queries)
+> - `--depth lookup`: searches ALL evidence pages including raw symbol lists (for precise file:line lookups)
+> - `--depth route`: returns the router table only (use when you need to discover what projects exist)
+
+Fallback: if no `teamwiki/`, check `~/.teamai/docs/codebase.md`. If
+none exists, silently skip.
 
 ### Step 2 — Extract keywords from the task description
 
@@ -45,14 +51,22 @@ Pick 3–6 high-signal keywords from the user query. Strip filler words
 
 ### Step 3 — Run the teamai recall command
 
-Execute:
+Execute with the appropriate depth:
 
 ```bash
+# Default: searches overview, modules, and docs (context layer)
 teamai recall "<keyword1> <keyword2> ..."
+
+# For precise symbol/line-number lookups, use lookup depth:
+teamai recall --depth lookup "<keyword1> <keyword2> ..."
 ```
 
 This searches all four knowledge categories (`skills`, `learnings`,
-`docs`, `rules`) via the local search index. Capture the full output.
+`docs`, `rules`) via the local search index, plus the codebase graph
+in `teamwiki/` with BM25 + graph-boost. Capture the full output.
+
+If the first call returns insufficient results, you may retry once with
+`--depth lookup` to broaden the search to raw symbol pages.
 
 If the command fails, knowledge base is empty, or returns zero hits,
 emit a single line `No relevant team knowledge found for: <query>` and

--- a/src/__tests__/import-repo-merge.test.ts
+++ b/src/__tests__/import-repo-merge.test.ts
@@ -31,18 +31,40 @@ vi.mock('../codebase.js', () => ({
     ),
 }));
 
+vi.mock('../codebase-extract.js', () => ({
+    extractCodebase: vi.fn(),
+}));
+
 // ─── Imports (after mocks) ──────────────────────────────
 
 import { importFromRepo } from '../import-repo.js';
 import { shallowClone } from '../clone.js';
 import { generateCodebaseMd } from '../codebase.js';
+import { extractCodebase } from '../codebase-extract.js';
 
 // ─── Constants ──────────────────────────────────────────
 
 const CLONE_SHA = 'deadbeef1234567890abcdef1234567890abcdef';
+const SLUG = 'github__owner__mergetest';
 
-const FIXED_CODEBASE_MD =
-    '---\ntitle: Test Repo\nlastUpdated: 2024-01-01T00:00:00.000Z\n---\n\n## 项目概述\n固定的项目概述内容，不会改变。\n\n## 技术栈\nTypeScript + vitest';
+const DETERMINISTIC_OVERVIEW = [
+    '---',
+    'title: github__owner__mergetest overview',
+    'domain: code-knowledge',
+    '---',
+    '',
+    '# github__owner__mergetest',
+    '',
+    '**5 facts** extracted from 3 files.',
+    'Graph: 4 nodes, 2 edges.',
+    '',
+    '## Module Structure',
+    '',
+    '| Module | Facts | Components | Interfaces |',
+    '|--------|-------|------------|------------|',
+    '| src | 3 | 2 | 1 |',
+    '',
+].join('\n');
 
 // ─── Helpers ────────────────────────────────────────────
 
@@ -52,13 +74,9 @@ async function makeWorkdir(): Promise<string> {
     return tmpDir;
 }
 
-async function sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 // ─── Tests ──────────────────────────────────────────────
 
-describe('importFromRepo — section merge', () => {
+describe('importFromRepo — AI narrative appended to overview.md', () => {
     let workdir: string;
     const TEST_URL = 'https://github.com/owner/mergetest';
 
@@ -72,7 +90,20 @@ describe('importFromRepo — section merge', () => {
             return { sha: CLONE_SHA, branch: 'main', cloneMethod: 'https-token' as const };
         });
 
-        vi.mocked(generateCodebaseMd).mockResolvedValue(FIXED_CODEBASE_MD);
+        // Mock extractCodebase to simulate writing teamwiki evidence files
+        vi.mocked(extractCodebase).mockImplementation(async (opts) => {
+            const cacheDir = opts.path ?? '.';
+            const project = opts.project || 'test';
+            const wikiRoot = path.join(cacheDir, 'teamwiki');
+            const evidenceDir = path.join(wikiRoot, 'evidence', 'code', project);
+            const indicesDir = path.join(wikiRoot, '.indices');
+
+            await fs.ensureDir(evidenceDir);
+            await fs.ensureDir(indicesDir);
+            await fs.writeFile(path.join(evidenceDir, 'overview.md'), DETERMINISTIC_OVERVIEW, 'utf8');
+            const emptyGraph = JSON.stringify({ nodes: [], edges: [] });
+            await fs.writeFile(path.join(indicesDir, 'graph-index.json'), emptyGraph, 'utf8');
+        });
     });
 
     afterEach(async () => {
@@ -81,95 +112,56 @@ describe('importFromRepo — section merge', () => {
         await fs.remove(workdir);
     });
 
-    it('第一次跑 import → 文件被创建、含锚点', async () => {
+    it('AI 叙事追加到 teamwiki evidence overview.md 末尾', async () => {
         await importFromRepo({
             url: TEST_URL,
             interactive: false,
         });
 
-        const repoMdPath = path.join(workdir, '.teamai', 'team-repo', 'docs', 'team-codebase', 'repos', 'github__owner__mergetest.md');
-        const exists = await fs.pathExists(repoMdPath);
+        const overviewPath = path.join(
+            workdir, '.teamai', 'team-repo', 'teamwiki', 'evidence', 'code',
+            SLUG, 'overview.md',
+        );
+        const exists = await fs.pathExists(overviewPath);
         expect(exists).toBe(true);
 
-        const content = await fs.readFile(repoMdPath, 'utf8');
-        expect(content).toContain('<!-- managed-by: import --from-repo');
-        expect(content).toContain('<!-- /managed-by:');
-        expect(content).toContain('项目概述');
+        const content = await fs.readFile(overviewPath, 'utf8');
+        // 确定性内容（模块表格）在前
+        expect(content).toContain('## Module Structure');
+        // AI 叙事在后
+        expect(content).toContain('## AI 架构叙事');
+        expect(content).toContain('固定的项目概述内容，不会改变。');
         expect(content).toContain('技术栈');
     });
 
-    it('第二次跑同样输入 → 文件 mtime 不改变（真正跳过写入）', async () => {
-        // 第一次运行
+    it('docs/team-codebase/repos/ 不再被创建', async () => {
         await importFromRepo({
             url: TEST_URL,
             interactive: false,
         });
 
-        const repoMdPath = path.join(workdir, '.teamai', 'team-repo', 'docs', 'team-codebase', 'repos', 'github__owner__mergetest.md');
-        const stat1 = await fs.stat(repoMdPath);
-        const mtime1 = stat1.mtimeMs;
-
-        // 等待足够时间确保 mtime 可区分
-        await sleep(20);
-
-        // 第二次运行，相同输入（仓库已在 domains 中，走增量路径返回）
-        // 需要先让仓库不在 domains 中，重新走 import 流程
-        // 或者直接验证文件内容未变（字节级等同）
-        const content1 = await fs.readFile(repoMdPath, 'utf8');
-
-        // 模拟：手动调用 mergeWithAnchors 验证第二次不写盘
-        // 实际测试方式：删除 domains 记录，让第二次也能跑 import 全流程
-        // 清空 domains 并再次导入
-        await fs.remove(path.join(workdir, '.teamai', 'domains.yaml'));
-
-        await sleep(20);
-        await importFromRepo({
-            url: TEST_URL,
-            interactive: false,
-        });
-
-        const stat2 = await fs.stat(repoMdPath);
-        const mtime2 = stat2.mtimeMs;
-
-        // 关键断言：mtime 没有改变（跳过了写入）
-        expect(mtime2).toBe(mtime1);
-
-        // 文件内容也应字节级相同
-        const content2 = await fs.readFile(repoMdPath, 'utf8');
-        expect(content2).toBe(content1);
+        const oldPath = path.join(
+            workdir, '.teamai', 'team-repo', 'docs', 'team-codebase', 'repos',
+            `${SLUG}.md`,
+        );
+        const exists = await fs.pathExists(oldPath);
+        expect(exists).toBe(false);
     });
 
-    it('旧文件含未闭合锚点 → fallback 时备份旧文件、产物使用新 codebase', async () => {
-        const repoMdPath = path.join(workdir, '.teamai', 'team-repo', 'docs', 'team-codebase', 'repos', 'github__owner__mergetest.md');
-        await fs.ensureDir(path.dirname(repoMdPath));
-
-        // 准备含未闭合锚点的旧文件
-        const unclosedOldFile = [
-            '# Old Content',
-            '',
-            '<!-- managed-by: import --from-repo, section: 项目概述, source: old@aabbccdd, syncedAt: 2024-01-01T00:00:00Z -->',
-            '## 项目概述',
-            '旧内容，这是旧内容。',
-            // 故意缺少 <!-- /managed-by: 项目概述 --> 闭锚
-        ].join('\n');
-
-        await fs.writeFile(repoMdPath, unclosedOldFile, 'utf8');
-
-        // 执行 importFromRepo，此时 parseSections 会因未闭合锚点抛错 → fallback
+    it('skipEnrich 时不追加 AI 叙事', async () => {
         await importFromRepo({
             url: TEST_URL,
             interactive: false,
+            skipEnrich: true,
         });
 
-        // 1. 验证备份文件存在且内容等于旧文件
-        const bakPath = `${repoMdPath}.bak`;
-        expect(await fs.pathExists(bakPath)).toBe(true);
-        const bakContent = await fs.readFile(bakPath, 'utf8');
-        expect(bakContent).toBe(unclosedOldFile);
-
-        // 2. 验证产物文件包含新 codebase 内容（fallback 全量重写）
-        const newContent = await fs.readFile(repoMdPath, 'utf8');
-        expect(newContent).toContain('项目概述');
-        expect(newContent).toContain('固定的项目概述内容');
+        const overviewPath = path.join(
+            workdir, '.teamai', 'team-repo', 'teamwiki', 'evidence', 'code',
+            SLUG, 'overview.md',
+        );
+        if (await fs.pathExists(overviewPath)) {
+            const content = await fs.readFile(overviewPath, 'utf8');
+            expect(content).not.toContain('## AI 架构叙事');
+        }
     });
 });

--- a/src/__tests__/recall-progressive.test.ts
+++ b/src/__tests__/recall-progressive.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Tests for three-tier progressive retrieval (route / context / lookup)
+ * of queryCodeKnowledge.
+ *
+ * Verifies:
+ *   1. depth=route returns only the router file content
+ *   2. depth=context searches overview/modules/docs but excludes navigation files
+ *      and leaf component files
+ *   3. depth=lookup searches all files including component.md
+ *   4. graph-boost is applied in context mode when a valid graph-index.json exists
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs-extra';
+import path from 'node:path';
+import os from 'node:os';
+
+import { queryCodeKnowledge } from '../code-knowledge-recall.js';
+
+// ---------------------------------------------------------------------------
+// Fixture content constants
+// ---------------------------------------------------------------------------
+
+const ROUTER_CONTENT = `search-anchor: 路由, 索引
+title: Question Router
+
+## 问题路由表
+
+| 关键词 | 指向文件 |
+|--------|----------|
+| 依赖关系 | evidence/code/test-project/overview.md |
+| 模块 | evidence/code/test-project/modules/src.md |
+`;
+
+const INDEX_CONTENT = `# Team Wiki Index
+
+This file lists all top-level topics.
+`;
+
+const HOT_CONTENT = `# Hot Context
+
+Recently accessed pages are listed here.
+`;
+
+const OVERVIEW_CONTENT = `title: test-project overview
+
+## Module Structure
+
+This project is structured as follows:
+- src: main source module
+- docs: documentation
+`;
+
+const COMPONENT_CONTENT = `title: components
+
+## Component Registry
+
+- ButtonComponent: importFromRepo('ui-kit', 'Button')
+- InputComponent: importFromRepo('ui-kit', 'Input')
+- ModalComponent: importFromRepo('ui-kit', 'Modal')
+- TableComponent: importFromRepo('ui-kit', 'Table')
+
+Each component uses importFromRepo to pull from the shared library.
+`;
+
+const SRC_MODULE_CONTENT = `title: src module
+
+## Source Module
+
+The src module handles all business logic.
+It uses importFromRepo to pull shared utilities.
+
+## recall
+
+This module participates in knowledge recall workflows.
+`;
+
+const README_CONTENT = `title: G-Document 路由
+
+## Overview
+
+G-Document routes requests to the correct handler.
+See graph-g1-relations for the full dependency graph.
+`;
+
+const ARCHITECTURE_CONTENT = `title: architecture
+
+## 项目概述
+
+This document describes the overall architecture.
+`;
+
+// ---------------------------------------------------------------------------
+// Helper: build the full wiki tree under a tmpdir
+// ---------------------------------------------------------------------------
+
+async function buildWikiTree(tmpDir: string): Promise<void> {
+  const evidenceCodeProject = path.join(tmpDir, 'evidence', 'code', 'test-project');
+  const modulesDir = path.join(evidenceCodeProject, 'modules');
+  const docsDir = path.join(evidenceCodeProject, 'docs');
+
+  await fs.ensureDir(modulesDir);
+  await fs.ensureDir(docsDir);
+
+  // Top-level navigation files
+  await fs.writeFile(path.join(tmpDir, 'router.md'), ROUTER_CONTENT, 'utf-8');
+  await fs.writeFile(path.join(tmpDir, 'index.md'), INDEX_CONTENT, 'utf-8');
+  await fs.writeFile(path.join(tmpDir, 'hot.md'), HOT_CONTENT, 'utf-8');
+
+  // Project files
+  await fs.writeFile(path.join(evidenceCodeProject, 'overview.md'), OVERVIEW_CONTENT, 'utf-8');
+  await fs.writeFile(path.join(evidenceCodeProject, 'component.md'), COMPONENT_CONTENT, 'utf-8');
+  await fs.writeFile(path.join(modulesDir, 'src.md'), SRC_MODULE_CONTENT, 'utf-8');
+  await fs.writeFile(path.join(docsDir, 'README.md'), README_CONTENT, 'utf-8');
+  await fs.writeFile(path.join(docsDir, 'architecture.md'), ARCHITECTURE_CONTENT, 'utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('queryCodeKnowledge — progressive depth retrieval', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'teamai-recall-progressive-'));
+    await buildWikiTree(tmpDir);
+  });
+
+  afterEach(async () => {
+    await fs.remove(tmpDir);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 1: route mode returns only router file
+  // -------------------------------------------------------------------------
+  it('depth=route 时只返回路由文件内容', async () => {
+    const results = await queryCodeKnowledge('依赖关系', {
+      wikiRoot: tmpDir,
+      depth: 'route',
+      limit: 10,
+    });
+
+    expect(results.length).toBe(1);
+    expect(results[0].title).toBe('Question Router');
+    expect(results[0].snippet).toContain('问题路由表');
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 2: context mode searches overview/modules/docs but excludes nav files
+  //         and component.md (not matched by CONTEXT_ALLOWED_PATTERNS)
+  // -------------------------------------------------------------------------
+  it('depth=context 时搜索 overview/modules/docs 但排除 router/index/hot/component', async () => {
+    const results = await queryCodeKnowledge('importFromRepo', {
+      wikiRoot: tmpDir,
+      depth: 'context',
+      limit: 10,
+    });
+
+    // At least one result must be present (from modules/src.md)
+    expect(results.length).toBeGreaterThan(0);
+
+    const paths = results.map(r => r.page);
+
+    // modules/src.md or overview.md must appear (both contain the keyword or are eligible)
+    const hasEligibleHit = paths.some(
+      p => p.includes('modules/src.md') || p.includes('overview.md'),
+    );
+    expect(hasEligibleHit).toBe(true);
+
+    // Navigation / excluded files must NOT appear
+    for (const p of paths) {
+      expect(p).not.toMatch(/router\.md$/);
+      expect(p).not.toMatch(/index\.md$/);
+      expect(p).not.toMatch(/hot\.md$/);
+      expect(p).not.toMatch(/component\.md$/);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 3: lookup mode searches all files including component.md
+  // -------------------------------------------------------------------------
+  it('depth=lookup 时搜索全部文件包括 component.md', async () => {
+    const results = await queryCodeKnowledge('importFromRepo', {
+      wikiRoot: tmpDir,
+      depth: 'lookup',
+      limit: 10,
+    });
+
+    const paths = results.map(r => r.page);
+    const hasComponent = paths.some(p => p.includes('component.md'));
+    expect(hasComponent).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 4: graph-boost applies in context mode when graph-index.json exists
+  // -------------------------------------------------------------------------
+  it('context 模式的 graph-boost 仍然生效', async () => {
+    // graph-index.json is read from wikiRoot/.indices/ by loadGraphIndex
+    const indicesDir = path.join(tmpDir, '.indices');
+    await fs.ensureDir(indicesDir);
+
+    const graphIndex = {
+      schemaVersion: 'team-wiki.graph-index.v1',
+      generatedAt: new Date().toISOString(),
+      nodes: [
+        {
+          slug: 'recall',
+          type: 'module',
+          confidence: 'EXTRACTED',
+          title: 'recall',
+        },
+        {
+          slug: 'src-module',
+          type: 'module',
+          confidence: 'EXTRACTED',
+          title: 'src module',
+        },
+      ],
+      edges: [
+        {
+          from: 'recall',
+          to: 'src-module',
+          relation: 'REFERENCES',
+        },
+      ],
+    };
+
+    await fs.writeFile(
+      path.join(indicesDir, 'graph-index.json'),
+      JSON.stringify(graphIndex, null, 2),
+      'utf-8',
+    );
+
+    const results = await queryCodeKnowledge('recall', {
+      wikiRoot: tmpDir,
+      depth: 'context',
+      limit: 10,
+    });
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].score).toBeGreaterThan(0);
+  });
+});

--- a/src/ci/extract-mr.ts
+++ b/src/ci/extract-mr.ts
@@ -370,8 +370,17 @@ export async function ciExtractMr(opts: CiExtractMrOptions): Promise<void> {
           const srcWiki = path.join(businessRepo, 'teamwiki');
           const teamWikiRoot = path.join(path.resolve(opts.teamRepo!), 'teamwiki');
           if (await fse.pathExists(srcWiki)) {
-            await fse.copy(srcWiki, teamWikiRoot, { overwrite: true });
+            // Copy per-repo evidence only (not global .indices/) to avoid overwriting aggregated graph
+            const evidenceSrc = path.join(srcWiki, 'evidence', 'code', projectName);
+            const evidenceDest = path.join(teamWikiRoot, 'evidence', 'code', projectName);
+            if (await fse.pathExists(evidenceSrc)) {
+              await fse.ensureDir(evidenceDest);
+              await fse.copy(evidenceSrc, evidenceDest, { overwrite: true });
+            }
             await fse.remove(srcWiki).catch(() => {});
+            // Re-aggregate global graph from all per-repo graphs
+            const { aggregateGlobalGraph } = await import('../graph-aggregate.js');
+            await aggregateGlobalGraph(teamWikiRoot);
             graphWritten = true;
             log.success(`teamwiki/ 图谱已更新到团队仓库`);
           }

--- a/src/code-knowledge-recall.ts
+++ b/src/code-knowledge-recall.ts
@@ -42,7 +42,7 @@ const ENTRY_NODE_BOOST = 8;
 /** 导航文件：在 context 模式下排除，避免模板文案干扰 BM25 */
 const NAVIGATION_FILES = new Set(['router.md', 'index.md', 'hot.md']);
 
-/** context 模式允许搜索的文件模式 */
+/** context 模式允许搜索的文件模式（白名单，覆盖 overview + modules + docs 含 G1-G6） */
 const CONTEXT_ALLOWED_PATTERNS = [
   /overview\.md$/,
   /modules\/.+\.md$/,
@@ -221,12 +221,12 @@ async function loadWikiPages(wikiRoot: string, depth: 'route' | 'context' | 'loo
   const pages: PageDoc[] = [];
 
   if (depth === 'route') {
-    // route 模式：只加载 router.md 和各项目的 docs/README.md
+    // route 模式：只加载 router.md（路由入口）
     const routerPath = path.join(wikiRoot, 'router.md');
     try {
       const content = await readFile(routerPath, 'utf-8');
       const titleMatch = content.match(/^title:\s*(.+)$/m);
-      const title = titleMatch ? titleMatch[1].trim() : 'router';
+      const title = titleMatch ? titleMatch[1].trim() : 'Team Wiki Router';
       pages.push({
         path: 'router.md',
         title,
@@ -236,32 +236,6 @@ async function loadWikiPages(wikiRoot: string, depth: 'route' | 'context' | 'loo
       });
     } catch {
       // router.md 不存在则跳过
-    }
-
-    const evidenceDir = path.join(wikiRoot, 'evidence', 'code');
-    let projectDirs: string[];
-    try {
-      const entries = await readdir(evidenceDir, { withFileTypes: true });
-      projectDirs = entries.filter(e => e.isDirectory()).map(e => e.name);
-    } catch {
-      return pages;
-    }
-    for (const project of projectDirs) {
-      const readmePath = path.join(evidenceDir, project, 'docs', 'README.md');
-      try {
-        const content = await readFile(readmePath, 'utf-8');
-        const titleMatch = content.match(/^title:\s*(.+)$/m);
-        const title = titleMatch ? titleMatch[1].trim() : project;
-        pages.push({
-          path: `evidence/code/${project}/docs/README.md`,
-          title,
-          content,
-          tokens: tokenize(content),
-          tokenCount: tokenCount(content),
-        });
-      } catch {
-        continue;
-      }
     }
     return pages;
   }
@@ -305,9 +279,12 @@ async function loadPagesRecursive(
     } else if (entry.name.endsWith('.md')) {
       const relFilePath = `${relativePath}/${entry.name}`;
       if (depth === 'context') {
-        // 排除项目内部的导航/索引文件（如 index.md）和原始 facts 页面
-        if (NAVIGATION_FILES.has(entry.name)) continue;
+        // 先检查白名单模式（overview/modules/docs 下的文件）
         if (!CONTEXT_ALLOWED_PATTERNS.some(p => p.test(relFilePath))) continue;
+        // 仅排除项目根层级的导航文件（不影响 docs/index.md 等嵌套文件）
+        const relSegments = relFilePath.split('/');
+        const depthFromProject = relSegments.length - 3; // evidence/code/<project>/ = 3 segments
+        if (depthFromProject <= 1 && NAVIGATION_FILES.has(entry.name)) continue;
       }
       try {
         const content = await readFile(fullPath, 'utf-8');
@@ -354,7 +331,7 @@ export async function queryCodeKnowledge(
   if (depth === 'route') {
     return [{
       page: pages[0].path,
-      title: 'Question Router',
+      title: pages[0].title,
       score: 10,
       snippet: pages[0].content.slice(0, 800),
       kind: 'codebase',

--- a/src/code-knowledge-recall.ts
+++ b/src/code-knowledge-recall.ts
@@ -39,6 +39,16 @@ const TITLE_BOOST = 3.0;
 const RELATION_WEIGHT: Record<string, number> = { DEPENDS_ON: 3, REFERENCES: 2, MAPS_TO: 2, CONTAINS: 1 };
 const ENTRY_NODE_BOOST = 8;
 
+/** 导航文件：在 context 模式下排除，避免模板文案干扰 BM25 */
+const NAVIGATION_FILES = new Set(['router.md', 'index.md', 'hot.md']);
+
+/** context 模式允许搜索的文件模式 */
+const CONTEXT_ALLOWED_PATTERNS = [
+  /overview\.md$/,
+  /modules\/.+\.md$/,
+  /docs\/.+\.md$/,
+];
+
 function countOccurrences(text: string, token: string): number {
   let count = 0;
   let idx = 0;
@@ -109,11 +119,40 @@ function findEntryNodes(queryTokens: string[], graph: GraphIndex): Set<string> {
   return entries;
 }
 
+interface AdjEntry {
+  neighbor: string;
+  relation: string;
+}
+
+function buildAdjacencyMap(graph: GraphIndex): Map<string, AdjEntry[]> {
+  const adj = new Map<string, AdjEntry[]>();
+  for (const edge of graph.edges) {
+    const fromList = adj.get(edge.from);
+    if (fromList) {
+      fromList.push({ neighbor: edge.to, relation: edge.relation });
+    } else {
+      adj.set(edge.from, [{ neighbor: edge.to, relation: edge.relation }]);
+    }
+    const toList = adj.get(edge.to);
+    if (toList) {
+      toList.push({ neighbor: edge.from, relation: edge.relation });
+    } else {
+      adj.set(edge.to, [{ neighbor: edge.from, relation: edge.relation }]);
+    }
+  }
+  return adj;
+}
+
 /**
  * B8 fix: Match page paths to graph node slugs via title/filename matching.
  * B24 fix: Use 2-hop neighbors (halved weight for second hop).
  */
-function computeGraphBoost(page: PageDoc, entryNodes: Set<string>, graph: GraphIndex): number {
+function computeGraphBoost(
+  page: PageDoc,
+  entryNodes: Set<string>,
+  graph: GraphIndex,
+  adj: Map<string, AdjEntry[]>,
+): number {
   // Match page to graph nodes by title
   const pageTitle = page.title.toLowerCase();
   const pageFile = page.path.replace(/^evidence\/code\/[^/]+\//, '').replace('.md', '');
@@ -127,33 +166,33 @@ function computeGraphBoost(page: PageDoc, entryNodes: Set<string>, graph: GraphI
     }
   }
 
-  // Check 1-hop and 2-hop neighbors
+  // Check 1-hop and 2-hop neighbors using adjacency map
   let maxBoost = 0;
-  for (const edge of graph.edges) {
-    const isFrom = entryNodes.has(edge.from);
-    const isTo = entryNodes.has(edge.to);
-    if (!isFrom && !isTo) continue;
+  for (const entrySlug of entryNodes) {
+    const neighbors = adj.get(entrySlug);
+    if (!neighbors) continue;
 
-    const neighborSlug = isFrom ? edge.to : edge.from;
-    const neighborParts = neighborSlug.split('/');
-    const neighborName = (neighborParts.pop() ?? '').toLowerCase();
+    for (const { neighbor: neighborSlug, relation } of neighbors) {
+      const neighborParts = neighborSlug.split('/');
+      const neighborName = (neighborParts.pop() ?? '').toLowerCase();
 
-    if (neighborName && (pageTitle.includes(neighborName) || pageFile.includes(neighborName))) {
-      const relWeight = RELATION_WEIGHT[edge.relation] ?? 1;
-      const boost = relWeight * 0.8; // 1-hop
-      if (boost > maxBoost) maxBoost = boost;
-    }
-
-    // 2-hop: check neighbors of this neighbor (B24)
-    for (const edge2 of graph.edges) {
-      if (edge2.from !== neighborSlug && edge2.to !== neighborSlug) continue;
-      const hop2Slug = edge2.from === neighborSlug ? edge2.to : edge2.from;
-      const hop2Parts = hop2Slug.split('/');
-      const hop2Name = (hop2Parts.pop() ?? '').toLowerCase();
-      if (hop2Name && (pageTitle.includes(hop2Name) || pageFile.includes(hop2Name))) {
-        const relWeight = RELATION_WEIGHT[edge2.relation] ?? 1;
-        const boost = relWeight * 0.4; // 2-hop: half weight
+      if (neighborName && (pageTitle.includes(neighborName) || pageFile.includes(neighborName))) {
+        const relWeight = RELATION_WEIGHT[relation] ?? 1;
+        const boost = relWeight * 0.8; // 1-hop
         if (boost > maxBoost) maxBoost = boost;
+      }
+
+      // 2-hop: check neighbors of this neighbor
+      const hop2Neighbors = adj.get(neighborSlug);
+      if (!hop2Neighbors) continue;
+      for (const { neighbor: hop2Slug, relation: rel2 } of hop2Neighbors) {
+        const hop2Parts = hop2Slug.split('/');
+        const hop2Name = (hop2Parts.pop() ?? '').toLowerCase();
+        if (hop2Name && (pageTitle.includes(hop2Name) || pageFile.includes(hop2Name))) {
+          const relWeight = RELATION_WEIGHT[rel2] ?? 1;
+          const boost = relWeight * 0.4; // 2-hop: half weight
+          if (boost > maxBoost) maxBoost = boost;
+        }
       }
     }
   }
@@ -178,10 +217,56 @@ function extractSnippet(content: string, queryTokens: string[], maxLen: number =
   return snippet;
 }
 
-async function loadWikiPages(wikiRoot: string): Promise<PageDoc[]> {
-  const evidenceDir = path.join(wikiRoot, 'evidence', 'code');
+async function loadWikiPages(wikiRoot: string, depth: 'route' | 'context' | 'lookup'): Promise<PageDoc[]> {
   const pages: PageDoc[] = [];
 
+  if (depth === 'route') {
+    // route 模式：只加载 router.md 和各项目的 docs/README.md
+    const routerPath = path.join(wikiRoot, 'router.md');
+    try {
+      const content = await readFile(routerPath, 'utf-8');
+      const titleMatch = content.match(/^title:\s*(.+)$/m);
+      const title = titleMatch ? titleMatch[1].trim() : 'router';
+      pages.push({
+        path: 'router.md',
+        title,
+        content,
+        tokens: tokenize(content),
+        tokenCount: tokenCount(content),
+      });
+    } catch {
+      // router.md 不存在则跳过
+    }
+
+    const evidenceDir = path.join(wikiRoot, 'evidence', 'code');
+    let projectDirs: string[];
+    try {
+      const entries = await readdir(evidenceDir, { withFileTypes: true });
+      projectDirs = entries.filter(e => e.isDirectory()).map(e => e.name);
+    } catch {
+      return pages;
+    }
+    for (const project of projectDirs) {
+      const readmePath = path.join(evidenceDir, project, 'docs', 'README.md');
+      try {
+        const content = await readFile(readmePath, 'utf-8');
+        const titleMatch = content.match(/^title:\s*(.+)$/m);
+        const title = titleMatch ? titleMatch[1].trim() : project;
+        pages.push({
+          path: `evidence/code/${project}/docs/README.md`,
+          title,
+          content,
+          tokens: tokenize(content),
+          tokenCount: tokenCount(content),
+        });
+      } catch {
+        continue;
+      }
+    }
+    return pages;
+  }
+
+  const evidenceDir = path.join(wikiRoot, 'evidence', 'code');
   let projectDirs: string[];
   try {
     const entries = await readdir(evidenceDir, { withFileTypes: true });
@@ -192,25 +277,46 @@ async function loadWikiPages(wikiRoot: string): Promise<PageDoc[]> {
 
   for (const project of projectDirs) {
     const projectDir = path.join(evidenceDir, project);
-    await loadPagesRecursive(projectDir, `evidence/code/${project}`, pages);
+    await loadPagesRecursive(projectDir, `evidence/code/${project}`, pages, depth);
   }
 
   return pages;
 }
 
-async function loadPagesRecursive(dir: string, relativePath: string, pages: PageDoc[]): Promise<void> {
-  const entries = await readdir(dir, { withFileTypes: true }).catch(() => [] as import('node:fs').Dirent[]);
+const MAX_RECURSION_DEPTH = 10;
+
+async function loadPagesRecursive(
+  dir: string,
+  relativePath: string,
+  pages: PageDoc[],
+  depth: 'route' | 'context' | 'lookup',
+  currentDepth: number = 0,
+): Promise<void> {
+  if (currentDepth >= MAX_RECURSION_DEPTH) return;
+  const entries = await readdir(dir, { withFileTypes: true })
+    .catch(() => [] as import('node:fs').Dirent[]);
   for (const entry of entries) {
     const fullPath = path.join(dir, entry.name);
     if (entry.isDirectory()) {
-      await loadPagesRecursive(fullPath, `${relativePath}/${entry.name}`, pages);
+      await loadPagesRecursive(
+        fullPath, `${relativePath}/${entry.name}`,
+        pages, depth, currentDepth + 1,
+      );
     } else if (entry.name.endsWith('.md')) {
+      const relFilePath = `${relativePath}/${entry.name}`;
+      if (depth === 'context') {
+        // 排除项目内部的导航/索引文件（如 index.md）和原始 facts 页面
+        if (NAVIGATION_FILES.has(entry.name)) continue;
+        if (!CONTEXT_ALLOWED_PATTERNS.some(p => p.test(relFilePath))) continue;
+      }
       try {
         const content = await readFile(fullPath, 'utf-8');
         const titleMatch = content.match(/^title:\s*(.+)$/m);
-        const title = titleMatch ? titleMatch[1].trim() : entry.name.replace('.md', '');
+        const title = titleMatch
+          ? titleMatch[1].trim()
+          : entry.name.replace('.md', '');
         pages.push({
-          path: `${relativePath}/${entry.name}`,
+          path: relFilePath,
           title,
           content,
           tokens: tokenize(content),
@@ -232,6 +338,7 @@ async function loadGraph(wikiRoot: string): Promise<GraphIndex | null> {
 export interface QueryCodeKnowledgeOptions {
   wikiRoot: string;
   limit?: number;
+  /** route: 只返回路由建议；context: 搜索 overview+modules+docs；lookup: 全量搜索 */
   depth?: 'route' | 'context' | 'lookup';
 }
 
@@ -241,8 +348,18 @@ export async function queryCodeKnowledge(
 ): Promise<CodeKnowledgeResult[]> {
   const { wikiRoot, limit = 5, depth = 'context' } = options;
 
-  const pages = await loadWikiPages(wikiRoot);
+  const pages = await loadWikiPages(wikiRoot, depth);
   if (pages.length === 0) return [];
+
+  if (depth === 'route') {
+    return [{
+      page: pages[0].path,
+      title: 'Question Router',
+      score: 10,
+      snippet: pages[0].content.slice(0, 800),
+      kind: 'codebase',
+    }];
+  }
 
   const graph = await loadGraph(wikiRoot);
   const queryTokens = tokenize(query);
@@ -250,12 +367,13 @@ export async function queryCodeKnowledge(
 
   const stats = buildCorpusStats(pages);
   const entryNodes = graph ? findEntryNodes(queryTokens, graph) : new Set<string>();
+  const adj = graph ? buildAdjacencyMap(graph) : new Map<string, AdjEntry[]>();
 
   const scored: Array<{ page: PageDoc; score: number }> = [];
   for (const page of pages) {
     let score = scoreBM25(page, queryTokens, stats);
     if (graph) {
-      score += computeGraphBoost(page, entryNodes, graph);
+      score += computeGraphBoost(page, entryNodes, graph, adj);
     }
     if (score > 0) {
       scored.push({ page, score });
@@ -264,7 +382,7 @@ export async function queryCodeKnowledge(
 
   scored.sort((a, b) => b.score - a.score);
 
-  const TOKEN_BUDGET: Record<string, number> = { route: 1500, context: 5000, lookup: 20000 };
+  const TOKEN_BUDGET: Record<string, number> = { route: 2000, context: 5000, lookup: 20000 };
   const budget = TOKEN_BUDGET[depth] ?? 5000;
   const estimateTokens = (text: string) => Math.ceil(text.length / 3.5);
 
@@ -275,9 +393,7 @@ export async function queryCodeKnowledge(
     if (results.length >= limit) break;
 
     let snippet: string;
-    if (depth === 'route') {
-      snippet = `${page.title} (${page.path})`;
-    } else if (depth === 'lookup') {
+    if (depth === 'lookup') {
       const maxChars = Math.floor(budget * 3.5 * 0.7 / Math.max(limit, 1));
       snippet = page.content.slice(0, maxChars);
     } else {

--- a/src/codebase-extract.ts
+++ b/src/codebase-extract.ts
@@ -20,9 +20,7 @@ import {
   traceCallChains,
   buildIndexHubOverlay,
   mergeGraphs,
-  createGraphIndex,
   saveGraphIndex,
-  loadGraphIndex,
 } from './wiki-engine/adapters/index.js';
 import type { CodeFact, InterfaceInventory, CallChain } from './wiki-engine/adapters/index.js';
 import type { GraphIndex } from './wiki-engine/core/graph-index.schema.js';
@@ -577,12 +575,9 @@ export async function extractCodebase(opts: ExtractCodebaseOptions): Promise<voi
   // Merge overlay into the per-repo graph
   const repoGraph = mergeGraphs(graph, overlay);
 
-  // Load existing global graph and merge to avoid overwriting other repos' data
-  const existingGraph = await loadGraphIndex(wikiRoot) ?? createGraphIndex();
-  const mergedGraph = mergeGraphs(existingGraph, repoGraph);
-
-  // Write graph-index.json using protocol function (B5)
-  await saveGraphIndex(wikiRoot, mergedGraph);
+  // Write per-repo graph only; global aggregation is done by aggregateGlobalGraph()
+  // in import-repo.ts after all per-repo graphs are in place (avoids write races).
+  await saveGraphIndex(wikiRoot, repoGraph);
 
   // AI enrichment (optional, non-blocking; skipped with --skip-enrich)
   let aiDomains: DomainGroup[] = [];
@@ -633,7 +628,7 @@ export async function extractCodebase(opts: ExtractCodebaseOptions): Promise<voi
   }
 
   // 生成 overview.md — 确定性架构概览 (B16)
-  const overview = buildOverview(facts, mergedGraph, project, interfaceInventory, callChains);
+  const overview = buildOverview(facts, repoGraph, project, interfaceInventory, callChains);
   await writeFile(path.join(evidenceDir, 'overview.md'), overview, 'utf-8');
 
   // 生成 team-wiki 标准入口文件
@@ -644,8 +639,8 @@ export async function extractCodebase(opts: ExtractCodebaseOptions): Promise<voi
   }
   const indexStats: IndexStats = {
     totalFacts: facts.length,
-    totalNodes: mergedGraph.nodes.length,
-    totalEdges: mergedGraph.edges.length,
+    totalNodes: repoGraph.nodes.length,
+    totalEdges: repoGraph.edges.length,
     interfaces: Object.keys(ifByType).length > 0 ? ifByType : undefined,
     callChains: callChains.length > 0 ? callChains.length : undefined,
   };
@@ -700,7 +695,7 @@ export async function extractCodebase(opts: ExtractCodebaseOptions): Promise<voi
     project,
     filesScanned: files.length,
     facts: { total: facts.length, byKind },
-    graph: { nodes: mergedGraph.nodes.length, edges: mergedGraph.edges.length },
+    graph: { nodes: repoGraph.nodes.length, edges: repoGraph.edges.length },
     incremental: !!opts.incremental && !!changedFiles,
     outputDir: wikiRoot,
   };

--- a/src/deep-enrich.ts
+++ b/src/deep-enrich.ts
@@ -544,20 +544,22 @@ function buildG6Content(project: string, manifest: Manifest): string {
     return '# 多跳传递依赖分析\n<!-- search-anchor: 传递依赖, 爆炸半径, 影响范围, blast radius, transitive -->\n\n（暂无依赖边数据，无法计算传递依赖）\n';
   }
 
+  // 正向邻接表（from→to）和反向邻接表（to→from，用于爆炸半径 BFS）
   const adj = new Map<string, Set<string>>();
-  const inDegree = new Map<string, number>();
+  const revAdj = new Map<string, Set<string>>();
   for (const e of edges) {
-    const existing = adj.get(e.from) ?? new Set<string>();
-    existing.add(e.to);
-    adj.set(e.from, existing);
-    inDegree.set(e.to, (inDegree.get(e.to) ?? 0) + 1);
-    if (!inDegree.has(e.from)) inDegree.set(e.from, 0);
+    const fwd = adj.get(e.from) ?? new Set<string>();
+    fwd.add(e.to);
+    adj.set(e.from, fwd);
+    const rev = revAdj.get(e.to) ?? new Set<string>();
+    rev.add(e.from);
+    revAdj.set(e.to, rev);
   }
 
-  const allNodes = [...new Set([...adj.keys(), ...inDegree.keys()])];
+  const allNodes = [...new Set([...adj.keys(), ...revAdj.keys()])];
   const degree = allNodes.map(n => ({
     node: n,
-    total: (adj.get(n)?.size ?? 0) + (inDegree.get(n) ?? 0),
+    total: (adj.get(n)?.size ?? 0) + (revAdj.get(n)?.size ?? 0),
   })).sort((a, b) => b.total - a.total);
 
   const topNodes = degree.slice(0, 5);
@@ -573,16 +575,16 @@ function buildG6Content(project: string, manifest: Manifest): string {
   for (const { node, total } of topNodes) {
     lines.push(`## ${node}（degree: ${total}）`, '');
 
-    // 3-hop BFS forward
+    // 3-hop BFS on reverse edges: find who transitively depends on this node
     const visited = new Set<string>([node]);
     let frontier = [node];
     const hopResults: string[][] = [[], [], []];
     for (let hop = 0; hop < 3; hop++) {
       const nextFrontier: string[] = [];
       for (const curr of frontier) {
-        const neighbors = adj.get(curr);
-        if (!neighbors) continue;
-        for (const next of neighbors) {
+        const dependents = revAdj.get(curr);
+        if (!dependents) continue;
+        for (const next of dependents) {
           if (!visited.has(next)) {
             visited.add(next);
             nextFrontier.push(next);
@@ -612,26 +614,28 @@ async function runPhaseAiGraph(
   opts: DeepEnrichOptions,
   ctx: EnrichContext,
   docsDir: string,
-): Promise<void> {
+): Promise<{ g5Generated: boolean; g6Generated: boolean }> {
   const { project, evidenceDir } = opts;
   log.info(`deep-enrich[${project}]: Phase 4 — 生成 AI 图谱文档（G5/G6）`);
 
   await mkdir(docsDir, { recursive: true });
 
   // G6: 确定性 BFS（不需要 AI）
+  const g6HasEdges = (ctx.manifest.edges ?? []).length > 0;
   const g6 = buildG6Content(project, ctx.manifest);
   await writeFile(path.join(docsDir, 'graph-g6-multihop.md'), g6, 'utf-8');
   log.debug(`deep-enrich[${project}]: G6 多跳路径写入完成`);
 
   // G5: AI 生成场景序列图（需要足够的模块数据）
+  let g5Generated = false;
   if (ctx.moduleDocs.size < 2) {
     log.warn(`deep-enrich[${project}]: 模块数不足（${ctx.moduleDocs.size} < 2），跳过 G5`);
-    return;
+    return { g5Generated, g6Generated: g6HasEdges };
   }
   const architectureMd = await readFileSafe(path.join(docsDir, 'architecture.md'));
   if (!architectureMd.trim()) {
     log.warn(`deep-enrich[${project}]: 无架构文档，跳过 G5 场景序列图生成`);
-    return;
+    return { g5Generated, g6Generated: g6HasEdges };
   }
 
   const moduleList = [...ctx.moduleDocs.entries()]
@@ -645,10 +649,12 @@ async function runPhaseAiGraph(
     if (g5Content.trim()) {
       await writeFile(path.join(docsDir, 'graph-g5-scenarios.md'), g5Content, 'utf-8');
       log.debug(`deep-enrich[${project}]: G5 场景序列图写入完成`);
+      g5Generated = true;
     }
   } catch (e) {
     log.warn(`deep-enrich[${project}]: G5 场景序列图生成失败，跳过: ${(e as Error).message}`);
   }
+  return { g5Generated, g6Generated: g6HasEdges };
 }
 
 // ─── Phase 5: 索引增强（router.md + per-project index.md 重写）──
@@ -657,15 +663,19 @@ async function runPhaseIndexEnhance(
   opts: DeepEnrichOptions,
   ctx: EnrichContext,
   docsDir: string,
+  graphFlags?: { g5Generated: boolean; g6Generated: boolean },
 ): Promise<void> {
   const { project, evidenceDir } = opts;
   log.info(`deep-enrich[${project}]: Phase 5 — 索引增强`);
 
   const { graphReadmeTemplate } = await import('./wiki-engine/adapters/templates.js');
 
-  // 写入 graph/README.md 路由分发表
+  // 写入 graph/README.md 路由分发表（按实际生成情况动态渲染）
   await mkdir(docsDir, { recursive: true });
-  const graphReadme = graphReadmeTemplate(project);
+  const graphReadme = graphReadmeTemplate(project, {
+    hasG5: graphFlags?.g5Generated ?? false,
+    hasG6: graphFlags?.g6Generated ?? true,
+  });
   await writeFile(path.join(docsDir, 'README.md'), graphReadme, 'utf-8');
   log.debug(`deep-enrich[${project}]: graph/README.md 路由表写入完成`);
 }
@@ -733,17 +743,18 @@ export async function deepEnrich(opts: DeepEnrichOptions): Promise<void> {
   }
 
   // 6. Phase 4: AI 图谱（G5 场景序列图 + G6 多跳路径）
+  let graphFlags = { g5Generated: false, g6Generated: true };
   if (progress.phase === 'graph' || progress.phase === 'ai-graph') {
     progress.phase = 'ai-graph';
     await saveProgress(evidenceDir, progress);
-    await runPhaseAiGraph(opts, ctx, docsDir);
+    graphFlags = await runPhaseAiGraph(opts, ctx, docsDir);
   }
 
   // 7. Phase 5: 索引增强（graph/README.md 路由表）
   if (progress.phase === 'ai-graph' || progress.phase === 'index-enhance') {
     progress.phase = 'index-enhance';
     await saveProgress(evidenceDir, progress);
-    await runPhaseIndexEnhance(opts, ctx, docsDir);
+    await runPhaseIndexEnhance(opts, ctx, docsDir, graphFlags);
   }
 
   // 8. 完成

--- a/src/deep-enrich.ts
+++ b/src/deep-enrich.ts
@@ -15,7 +15,7 @@ export interface DeepEnrichOptions {
 
 interface ProgressState {
   project: string;
-  phase: 'pending' | 'components' | 'architecture' | 'graph' | 'done';
+  phase: 'pending' | 'components' | 'architecture' | 'graph' | 'ai-graph' | 'index-enhance' | 'done';
   componentsDone: string[];
   componentsPending: string[];
   startedAt: string;
@@ -70,7 +70,7 @@ async function loadContext(evidenceDir: string): Promise<EnrichContext> {
 
   const [indexMd, callChains, overview] = await Promise.all([
     readFileSafe(path.join(evidenceDir, 'index.md')),
-    readFileSafe(path.join(evidenceDir, 'call-chains.md')),
+    readFileSafe(path.join(evidenceDir, 'dependency-paths.md')),
     readFileSafe(path.join(evidenceDir, 'overview.md')),
   ]);
 
@@ -104,7 +104,10 @@ function progressPath(evidenceDir: string): string {
   return path.join(evidenceDir, PROGRESS_PATH_SUBDIR, PROGRESS_FILENAME);
 }
 
-const VALID_PHASES = new Set<string>(['pending', 'components', 'architecture', 'graph', 'done']);
+const VALID_PHASES = new Set<string>([
+  'pending', 'components', 'architecture', 'graph',
+  'ai-graph', 'index-enhance', 'done',
+]);
 
 function isValidProgressState(v: unknown, project: string): v is ProgressState {
   if (typeof v !== 'object' || v === null) return false;
@@ -230,28 +233,113 @@ ${interfaceSummary}
 function buildG1RelationsDoc(manifest: Manifest): string {
   const edges = manifest.edges ?? [];
   if (edges.length === 0) {
-    return '# 组件关系矩阵\n\n（暂无依赖边数据）\n';
+    return [
+      '# 组件关系矩阵', '',
+      '（暂无依赖边数据）', '',
+      '> 可能原因：AI enrich 未执行（skipEnrich=true）或未检测到组件间依赖关系。',
+      '> 尝试：重新运行 `teamai import --from-repo <url>`（不带 --skip-enrich）。',
+      '',
+    ].join('\n');
   }
-  const rows = edges.map(e => `| ${e.from} | ${e.to} | ${e.relation ?? 'DEPENDS_ON'} |`).join('\n');
-  return `# 组件关系矩阵\n\n| 来源组件 | 目标组件 | 关系类型 |\n|----------|----------|----------|\n${rows}\n`;
+
+  const components = new Set<string>();
+  const forwardDeps = new Map<string, string[]>();
+  const reverseDeps = new Map<string, string[]>();
+
+  for (const e of edges) {
+    components.add(e.from);
+    components.add(e.to);
+    const fwd = forwardDeps.get(e.from) ?? [];
+    fwd.push(`${e.to} (${e.relation ?? 'DEPENDS_ON'})`);
+    forwardDeps.set(e.from, fwd);
+    const rev = reverseDeps.get(e.to) ?? [];
+    rev.push(`${e.from} (${e.relation ?? 'DEPENDS_ON'})`);
+    reverseDeps.set(e.to, rev);
+  }
+
+  const lines = [
+    '# 组件关系矩阵',
+    '<!-- search-anchor: 依赖, 关系, 上游, 下游, DEPENDS_ON, imports, 模块关系 -->',
+    '',
+    `共 ${components.size} 个组件，${edges.length} 条边。`,
+    '',
+    '## 依赖表',
+    '',
+    '| 来源组件 | 目标组件 | 关系类型 |',
+    '|----------|----------|----------|',
+    ...edges.slice(0, 50).map(e => `| ${e.from} | ${e.to} | ${e.relation ?? 'DEPENDS_ON'} |`),
+    '',
+    '## 正向依赖索引（X 依赖→）',
+    '',
+  ];
+
+  for (const [mod, deps] of [...forwardDeps.entries()].sort((a, b) => b[1].length - a[1].length).slice(0, 20)) {
+    lines.push(`- **${mod}** → ${deps.join(', ')}`);
+  }
+
+  lines.push('', '## 反向依赖索引（→X 被谁依赖）', '');
+
+  for (const [mod, deps] of [...reverseDeps.entries()].sort((a, b) => b[1].length - a[1].length).slice(0, 20)) {
+    lines.push(`- **${mod}** ← ${deps.join(', ')}`);
+  }
+
+  lines.push('');
+  return lines.join('\n');
 }
 
 function buildG2DataflowDoc(callChains: string): string {
   if (!callChains.trim()) {
-    return '# 数据流图\n\n（暂无调用链数据）\n';
+    return '# 数据流图\n\n（暂无调用链数据）\n\n> 可能原因：代码中未检测到入口→服务→数据层的多层调用链。\n> 常见于纯库项目或单层架构项目。\n';
   }
-  // 提取 entry→data 路径行（以 → 或 -> 连接的行）
-  const lines = callChains.split('\n').filter(l => /→|->/.test(l));
-  if (lines.length === 0) {
-    return `# 数据流图\n\n\`\`\`\n${callChains.slice(0, 2000)}\n\`\`\`\n`;
+
+  const lines = [
+    '# 数据流图',
+    '<!-- search-anchor: 调用链, 数据流, 请求路径, entry, flow, 入口, 链路 -->',
+    '',
+  ];
+
+  const rawLines = callChains.split('\n');
+  const chainBlocks: Array<{ entry: string; steps: string[] }> = [];
+  let currentBlock: { entry: string; steps: string[] } | null = null;
+
+  for (const line of rawLines) {
+    const entryMatch = line.match(/^##?\s+(.+)/);
+    if (entryMatch) {
+      if (currentBlock) chainBlocks.push(currentBlock);
+      currentBlock = { entry: entryMatch[1], steps: [] };
+    } else if (currentBlock && line.trim()) {
+      currentBlock.steps.push(line.trim());
+    }
   }
-  const flowRows = lines.slice(0, 30).map(l => `| ${l.trim()} |`).join('\n');
-  return `# 数据流图\n\n| 调用链路径 |\n|------------|\n${flowRows}\n`;
+  if (currentBlock) chainBlocks.push(currentBlock);
+
+  if (chainBlocks.length > 0) {
+    for (const block of chainBlocks.slice(0, 15)) {
+      lines.push(`## ${block.entry}`, '');
+      for (const step of block.steps.slice(0, 10)) {
+        lines.push(`  ${step}`);
+      }
+      lines.push('');
+    }
+  } else {
+    const flowLines = rawLines.filter(l => /→|->/.test(l));
+    if (flowLines.length > 0) {
+      lines.push('| 调用链路径 |', '|------------|');
+      for (const l of flowLines.slice(0, 30)) {
+        lines.push(`| ${l.trim()} |`);
+      }
+    } else {
+      lines.push('```', callChains.slice(0, 2000), '```');
+    }
+  }
+
+  lines.push('');
+  return lines.join('\n');
 }
 
 function buildG3InterfacesDoc(interfacesMd: string): string {
   if (!interfacesMd.trim()) {
-    return '# 接口映射表\n\n（暂无接口数据）\n';
+    return '# 接口映射表\n\n（暂无接口数据）\n\n> 可能原因：未检测到 HTTP/gRPC/MQ 等对外接口定义。\n> 仅当代码中存在路由注册、Proto 定义或消息队列声明时才会提取接口。\n';
   }
   return `# 接口映射表\n\n${interfacesMd}\n`;
 }
@@ -412,15 +500,187 @@ async function runPhaseGraph(
   log.debug(`deep-enrich[${project}]: 图谱文档写入 ${docsDir}`);
 }
 
+// ─── Phase 4: AI 图谱（G5 场景序列图 + G6 多跳路径）──────────
+
+function buildG5Prompt(project: string, architecture: string, callChains: string, modules: string): string {
+  return `你是一个高级架构师。基于以下项目信息，为 Top-5 核心业务场景生成 mermaid sequenceDiagram。
+
+项目：${project}
+
+架构文档摘要（前2000字）：
+${architecture.slice(0, 2000)}
+
+调用链数据：
+${callChains.slice(0, 1500)}
+
+模块列表：
+${modules.slice(0, 1000)}
+
+要求：
+1. 识别项目中真实存在的核心业务场景（最多 5 个，如果项目较小则按实际数量输出，不要虚构）
+2. 每个场景生成一个 mermaid sequenceDiagram
+3. 每个图后附 2-3 句文字说明关键决策点
+4. 参与者使用实际模块名/组件名
+5. 如果可识别的真实场景少于 3 个，只输出实际存在的场景
+
+输出格式：
+# 核心业务场景序列图
+<!-- search-anchor: 流程, 场景, 序列图, sequence, 业务流, 完整流程 -->
+
+## 场景 1: <名称>
+\`\`\`mermaid
+sequenceDiagram
+...
+\`\`\`
+<说明>
+
+## 场景 2: ...
+`;
+}
+
+function buildG6Content(project: string, manifest: Manifest): string {
+  const edges = manifest.edges ?? [];
+  if (edges.length === 0) {
+    return '# 多跳传递依赖分析\n<!-- search-anchor: 传递依赖, 爆炸半径, 影响范围, blast radius, transitive -->\n\n（暂无依赖边数据，无法计算传递依赖）\n';
+  }
+
+  const adj = new Map<string, Set<string>>();
+  const inDegree = new Map<string, number>();
+  for (const e of edges) {
+    const existing = adj.get(e.from) ?? new Set<string>();
+    existing.add(e.to);
+    adj.set(e.from, existing);
+    inDegree.set(e.to, (inDegree.get(e.to) ?? 0) + 1);
+    if (!inDegree.has(e.from)) inDegree.set(e.from, 0);
+  }
+
+  const allNodes = [...new Set([...adj.keys(), ...inDegree.keys()])];
+  const degree = allNodes.map(n => ({
+    node: n,
+    total: (adj.get(n)?.size ?? 0) + (inDegree.get(n) ?? 0),
+  })).sort((a, b) => b.total - a.total);
+
+  const topNodes = degree.slice(0, 5);
+
+  const lines = [
+    `# ${project} — 多跳传递依赖分析`,
+    '<!-- search-anchor: 传递依赖, 爆炸半径, 影响范围, blast radius, transitive, 级联 -->',
+    '',
+    `基于 ${edges.length} 条边、${allNodes.length} 个节点的 3-hop BFS 分析。`,
+    '',
+  ];
+
+  for (const { node, total } of topNodes) {
+    lines.push(`## ${node}（degree: ${total}）`, '');
+
+    // 3-hop BFS forward
+    const visited = new Set<string>([node]);
+    let frontier = [node];
+    const hopResults: string[][] = [[], [], []];
+    for (let hop = 0; hop < 3; hop++) {
+      const nextFrontier: string[] = [];
+      for (const curr of frontier) {
+        const neighbors = adj.get(curr);
+        if (!neighbors) continue;
+        for (const next of neighbors) {
+          if (!visited.has(next)) {
+            visited.add(next);
+            nextFrontier.push(next);
+            hopResults[hop].push(next);
+          }
+        }
+      }
+      frontier = nextFrontier;
+    }
+
+    lines.push('| Hop | 可达组件 | 数量 |');
+    lines.push('|-----|---------|------|');
+    lines.push(`| 1-hop | ${hopResults[0].slice(0, 8).join(', ') || '—'} | ${hopResults[0].length} |`);
+    lines.push(`| 2-hop | ${hopResults[1].slice(0, 8).join(', ') || '—'} | ${hopResults[1].length} |`);
+    lines.push(`| 3-hop | ${hopResults[2].slice(0, 8).join(', ') || '—'} | ${hopResults[2].length} |`);
+    lines.push('');
+    const affected = visited.size - 1;
+    const pct = Math.round(affected / allNodes.length * 100);
+    lines.push(`**爆炸半径**: ${node} 变更可能影响 ${affected} 个组件（${pct}% 覆盖率）`);
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+async function runPhaseAiGraph(
+  opts: DeepEnrichOptions,
+  ctx: EnrichContext,
+  docsDir: string,
+): Promise<void> {
+  const { project, evidenceDir } = opts;
+  log.info(`deep-enrich[${project}]: Phase 4 — 生成 AI 图谱文档（G5/G6）`);
+
+  await mkdir(docsDir, { recursive: true });
+
+  // G6: 确定性 BFS（不需要 AI）
+  const g6 = buildG6Content(project, ctx.manifest);
+  await writeFile(path.join(docsDir, 'graph-g6-multihop.md'), g6, 'utf-8');
+  log.debug(`deep-enrich[${project}]: G6 多跳路径写入完成`);
+
+  // G5: AI 生成场景序列图（需要足够的模块数据）
+  if (ctx.moduleDocs.size < 2) {
+    log.warn(`deep-enrich[${project}]: 模块数不足（${ctx.moduleDocs.size} < 2），跳过 G5`);
+    return;
+  }
+  const architectureMd = await readFileSafe(path.join(docsDir, 'architecture.md'));
+  if (!architectureMd.trim()) {
+    log.warn(`deep-enrich[${project}]: 无架构文档，跳过 G5 场景序列图生成`);
+    return;
+  }
+
+  const moduleList = [...ctx.moduleDocs.entries()]
+    .map(([name, content]) => `${name}: ${content.slice(0, 200)}`)
+    .join('\n');
+
+  const prompt = buildG5Prompt(project, architectureMd, ctx.callChains, moduleList);
+
+  try {
+    const g5Content = await callClaude(prompt);
+    if (g5Content.trim()) {
+      await writeFile(path.join(docsDir, 'graph-g5-scenarios.md'), g5Content, 'utf-8');
+      log.debug(`deep-enrich[${project}]: G5 场景序列图写入完成`);
+    }
+  } catch (e) {
+    log.warn(`deep-enrich[${project}]: G5 场景序列图生成失败，跳过: ${(e as Error).message}`);
+  }
+}
+
+// ─── Phase 5: 索引增强（router.md + per-project index.md 重写）──
+
+async function runPhaseIndexEnhance(
+  opts: DeepEnrichOptions,
+  ctx: EnrichContext,
+  docsDir: string,
+): Promise<void> {
+  const { project, evidenceDir } = opts;
+  log.info(`deep-enrich[${project}]: Phase 5 — 索引增强`);
+
+  const { graphReadmeTemplate } = await import('./wiki-engine/adapters/templates.js');
+
+  // 写入 graph/README.md 路由分发表
+  await mkdir(docsDir, { recursive: true });
+  const graphReadme = graphReadmeTemplate(project);
+  await writeFile(path.join(docsDir, 'README.md'), graphReadme, 'utf-8');
+  log.debug(`deep-enrich[${project}]: graph/README.md 路由表写入完成`);
+}
+
 // ─── 主函数 ─────────────────────────────────────────────────
 
 /**
  * 对已导入仓库执行深度 AI 知识生成。
  *
- * 读取 evidenceDir 中已有的确定性提取结果，并发调用 AI 生成：
- * - Phase 1: 每个组件的设计文档（concurrency=2）
- * - Phase 2: 整体架构总览文档（单次调用）
- * - Phase 3: 确定性图谱文档（无需 AI，直接渲染）
+ * 读取 evidenceDir 中已有的确定性提取结果，分阶段生成：
+ * - Phase 1: 每个组件的设计文档（AI，concurrency=2）
+ * - Phase 2: 整体架构总览文档（AI，单次调用）
+ * - Phase 3: 确定性图谱文档（G1/G2/G3，无需 AI）
+ * - Phase 4: AI 图谱文档（G5 场景序列图 + G6 多跳路径）
+ * - Phase 5: 索引增强（graph/README.md 路由分发表）
  *
  * 支持断点续传：通过 _review/progress.json 记录已完成组件。
  *
@@ -465,14 +725,28 @@ export async function deepEnrich(opts: DeepEnrichOptions): Promise<void> {
     await runPhaseArchitecture(opts, ctx, docsDir);
   }
 
-  // 5. Phase 3: 图谱文档
+  // 5. Phase 3: 确定性图谱文档
   if (progress.phase === 'architecture' || progress.phase === 'graph') {
     progress.phase = 'graph';
     await saveProgress(evidenceDir, progress);
     await runPhaseGraph(opts, ctx, docsDir);
   }
 
-  // 6. 完成
+  // 6. Phase 4: AI 图谱（G5 场景序列图 + G6 多跳路径）
+  if (progress.phase === 'graph' || progress.phase === 'ai-graph') {
+    progress.phase = 'ai-graph';
+    await saveProgress(evidenceDir, progress);
+    await runPhaseAiGraph(opts, ctx, docsDir);
+  }
+
+  // 7. Phase 5: 索引增强（graph/README.md 路由表）
+  if (progress.phase === 'ai-graph' || progress.phase === 'index-enhance') {
+    progress.phase = 'index-enhance';
+    await saveProgress(evidenceDir, progress);
+    await runPhaseIndexEnhance(opts, ctx, docsDir);
+  }
+
+  // 8. 完成
   progress.phase = 'done';
   await saveProgress(evidenceDir, progress);
   log.success(`deep-enrich[${project}]: 深度知识生成完成`);

--- a/src/import-repo.ts
+++ b/src/import-repo.ts
@@ -679,14 +679,23 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
                     const marker = '## AI 架构叙事';
                     const markerIdx = existing.indexOf(marker);
                     const base = markerIdx >= 0 ? existing.slice(0, markerIdx).trimEnd() : existing.trimEnd();
-                    const combined = base + '\n\n---\n\n' + marker + '\n\n' + aiNarrative;
+                    let combined: string;
+                    if (!base || !base.startsWith('---')) {
+                        combined = `---\ntitle: ${slug} overview\ndomain: code-knowledge\n---\n\n${marker}\n\n${aiNarrative}`;
+                    } else {
+                        combined = base + '\n\n---\n\n' + marker + '\n\n' + aiNarrative;
+                    }
                     await fs.writeFile(overviewPath, combined, 'utf8');
                 }
                 // Per-repo graph: copy to evidence/<slug>/.indices/ (no global merge here — done in batch)
                 const srcGraph = path.join(cacheWiki, '.indices', 'graph-index.json');
-                const evidenceGraphDir = path.join(teamwikiRoot, 'evidence', 'code', slug, '.indices');
-                await fs.ensureDir(evidenceGraphDir);
-                await fs.copy(srcGraph, path.join(evidenceGraphDir, 'graph-index.json'));
+                if (await fs.pathExists(srcGraph)) {
+                    const evidenceGraphDir = path.join(teamwikiRoot, 'evidence', 'code', slug, '.indices');
+                    await fs.ensureDir(evidenceGraphDir);
+                    await fs.copy(srcGraph, path.join(evidenceGraphDir, 'graph-index.json'));
+                } else {
+                    log.debug(`[graph] per-repo graph-index.json not found, skipping copy`);
+                }
                 await fs.remove(cacheWiki);
             }
             // 白名单显式 domain 覆盖 AI 推断

--- a/src/import-repo.ts
+++ b/src/import-repo.ts
@@ -4,7 +4,6 @@ import chalk from 'chalk';
 
 import { generateCodebaseMd } from './codebase.js';
 import { extractCodebase } from './codebase-extract.js';
-import { mergeWithAnchors } from './section-patcher.js';
 import { detectProvider } from './providers/registry.js';
 import { shallowClone, shallowFetch } from './clone.js';
 import { appendPendingReview, loadPendingReview, removePendingReview } from './review-store.js';
@@ -27,7 +26,6 @@ import {
 } from './domains/index.js';
 import { askQuestion } from './utils/prompt.js';
 import { log } from './utils/logger.js';
-import { assertSafePath } from './utils/path-safety.js';
 
 // ─── Types ──────────────────────────────────────────────
 
@@ -44,7 +42,7 @@ export interface ImportFromRepoOptions {
     explicitDomain?: string;
     /** Dry-run 模式：跳过写盘但执行 clone+扫描 */
     dryRun?: boolean;
-    /** 自定义产物根目录；默认 .teamai/team-repo/docs/team-codebase */
+    /** 自定义产物根目录；默认 .teamai/team-repo/teamwiki */
     output?: string;
     /**
      * 是否启用交互式确认。
@@ -526,11 +524,12 @@ export async function detectDomainDrift(args: {
  * 流程：
  *  1. 解析 url → provider + RepoInfo（owner/repo）
  *  2. shallow clone（或增量 fetch+reset）到 ~/.teamai/cache/repos/<provider>/<owner>/<repo>
- *  3. generateCodebaseMd({ repoPath: cacheDir })
- *  4. 写出到 <outputRoot>/repos/<slug>.md（默认 outputRoot=.teamai/team-repo/docs/team-codebase）
- *  5. 推荐业务域（或使用 --domain 显式指定）
- *  6. 写入 .teamai/domains.yaml + appendHistory
- *  7. 写 LAST_SYNC
+ *  3. generateCodebaseMd({ repoPath: cacheDir }) → AI 叙事
+ *  4. extractCodebase → teamwiki evidence 产物（确定性 overview + graph）
+ *  5. AI 叙事追加到 teamwiki/evidence/code/<slug>/overview.md
+ *  6. 推荐业务域（或使用 --domain 显式指定）
+ *  7. 写入 .teamai/domains.yaml + appendHistory
+ *  8. 写 LAST_SYNC
  *
  * @throws 克隆失败、扫描失败、IO 失败时抛 Error
  */
@@ -642,7 +641,7 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
         }
     }
 
-    // Resolve team-repo directory (needed for both docs/team-codebase and teamwiki)
+    // Resolve team-repo directory (needed for teamwiki evidence output)
     let teamRepoDir: string;
     let teamRepoRemote = '';
     let mrTeamConfig: { repo: string; provider?: string; reviewers?: string[] } | null = null;
@@ -658,84 +657,7 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
         teamRepoDir = path.join(process.cwd(), '.teamai', 'team-repo');
     }
 
-    // 4. 写入 docs/team-codebase 叙事文档（AI 扫描成功时）
-    const outputRoot = output ?? path.join(teamRepoDir, 'docs', 'team-codebase');
-    let repoMdPath = path.join(outputRoot, 'repos', `${slug}.md`);
-
-    if (codebaseMd) {
-        assertSafePath(repoMdPath, [path.join(outputRoot, 'repos')]);
-        const sourceTag = `${url}@${cloneSha.slice(0, 8)}`;
-        const syncedAt = new Date().toISOString();
-
-        let oldFile: string | null = null;
-        if (await fs.pathExists(repoMdPath)) {
-            try { oldFile = await fs.readFile(repoMdPath, 'utf8'); } catch { oldFile = null; }
-        }
-
-        let merged: ReturnType<typeof mergeWithAnchors>;
-        let toWrite: string;
-        try {
-            merged = mergeWithAnchors(oldFile, codebaseMd, { source: sourceTag, syncedAt });
-            toWrite = merged.mergedMd;
-        } catch (err) {
-            log.warn(`[section-merge] ${err instanceof Error ? err.message : err}; falling back to full rewrite`);
-            if (oldFile !== null && !dryRun) {
-                const bakPath = `${repoMdPath}.bak`;
-                try { await fs.writeFile(bakPath, oldFile, 'utf8'); } catch {}
-            }
-            merged = mergeWithAnchors(null, codebaseMd, { source: sourceTag, syncedAt });
-            toWrite = merged.mergedMd;
-        }
-
-    // 注入 repo_url 到 frontmatter，供 aggregate 映射 domain
-    if (toWrite.startsWith('---\n') && !toWrite.includes('\nrepo_url:')) {
-        const fmEnd = toWrite.indexOf('\n---\n', 4);
-        if (fmEnd !== -1) {
-            toWrite = toWrite.slice(0, fmEnd) + `\nrepo_url: ${url}` + toWrite.slice(fmEnd);
-        }
-    }
-
-    if (dryRun) {
-        console.log(chalk.yellow(`[dry-run] 产物路径: ${repoMdPath}`));
-        console.log(chalk.yellow('[dry-run] 产物预览（前 50 行）：'));
-        const preview = toWrite.split('\n').slice(0, 50).join('\n');
-        console.log(preview);
-        if (merged.changedSlugs.length > 0) {
-            console.log(chalk.yellow(`[dry-run] 变化章节: ${merged.changedSlugs.join(', ')}`));
-        }
-        if (merged.addedSlugs.length > 0) {
-            console.log(chalk.yellow(`[dry-run] 新增章节: ${merged.addedSlugs.join(', ')}`));
-        }
-        if (merged.removedSlugs.length > 0) {
-            console.log(chalk.yellow(`[dry-run] 移除章节: ${merged.removedSlugs.join(', ')}`));
-        }
-    } else {
-        await fs.ensureDir(path.dirname(repoMdPath));
-        const noChange =
-            merged.changedSlugs.length === 0 &&
-            merged.addedSlugs.length === 0 &&
-            merged.removedSlugs.length === 0 &&
-            oldFile !== null &&
-            oldFile === toWrite;
-        if (noChange) {
-            log.info(`[section-merge] 仓库 ${repoName} 无章节变化，跳过写入`);
-        } else {
-            await fs.writeFile(repoMdPath, toWrite, 'utf8');
-            log.info(`产物已写入: ${repoMdPath}`);
-            if (merged.changedSlugs.length > 0) {
-                log.debug(`[section-merge] 变化章节: ${merged.changedSlugs.join(', ')}`);
-            }
-            if (merged.addedSlugs.length > 0) {
-                log.debug(`[section-merge] 新增章节: ${merged.addedSlugs.join(', ')}`);
-            }
-            if (merged.removedSlugs.length > 0) {
-                log.debug(`[section-merge] 移除章节: ${merged.removedSlugs.join(', ')}`);
-            }
-        }
-    }
-    } // end if (codebaseMd)
-
-    // 4b. 生成 teamwiki/ 知识图谱产物（写入 team-repo 以便自动 push）
+    // 4. 生成 teamwiki/ 知识图谱产物 + AI 叙事追加到 overview.md
     const teamwikiRoot = output
         ? path.resolve(output, '..', 'teamwiki')
         : path.join(teamRepoDir, 'teamwiki');
@@ -749,18 +671,16 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
                 const evidenceDest = path.join(teamwikiRoot, 'evidence', 'code', slug);
                 await fs.ensureDir(evidenceDest);
                 await fs.copy(evidenceSrc, evidenceDest, { overwrite: true });
-                // 如果 AI 扫描成功，将架构概述写入 overview.md
+                // 将 AI 叙事写入 overview.md（幂等：已有则替换，无则追加）
                 if (codebaseMd) {
-                    const overviewContent = [
-                        '---',
-                        `title: ${slug} overview`,
-                        'domain: code-knowledge',
-                        `source: [${url}]`,
-                        '---',
-                        '',
-                        codebaseMd.replace(/^---[\s\S]*?---\n*/m, ''),
-                    ].join('\n');
-                    await fs.writeFile(path.join(evidenceDest, 'overview.md'), overviewContent, 'utf8');
+                    const overviewPath = path.join(evidenceDest, 'overview.md');
+                    const existing = await fs.readFile(overviewPath, 'utf8').catch(() => '');
+                    const aiNarrative = codebaseMd.replace(/^---[\s\S]*?---\n*/m, '');
+                    const marker = '## AI 架构叙事';
+                    const markerIdx = existing.indexOf(marker);
+                    const base = markerIdx >= 0 ? existing.slice(0, markerIdx).trimEnd() : existing.trimEnd();
+                    const combined = base + '\n\n---\n\n' + marker + '\n\n' + aiNarrative;
+                    await fs.writeFile(overviewPath, combined, 'utf8');
                 }
                 // Per-repo graph: copy to evidence/<slug>/.indices/ (no global merge here — done in batch)
                 const srcGraph = path.join(cacheWiki, '.indices', 'graph-index.json');
@@ -786,7 +706,7 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
             const { routerTemplate, indexTemplate, HOT_TEMPLATE } = await import('./wiki-engine/adapters/templates.js');
             const routerPath = path.join(teamwikiRoot, 'router.md');
             const indexPath = path.join(teamwikiRoot, 'index.md');
-            const projectLink = `[[code/${slug}/index]]`;
+            const projectLink = `[[evidence/code/${slug}/index]]`;
             if (await fs.pathExists(routerPath)) {
                 const router = await fs.readFile(routerPath, 'utf8');
                 if (!router.includes(projectLink)) {
@@ -863,7 +783,7 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
     log.info(chalk.green(`✓ 仓库 ${owner}/${repoName} 导入完成`));
 
     // 5b. 后台深度生成（不阻塞；batch 模式下跳过 push 由调用方统一处理）
-    if (!dryRun && teamwikiRoot) {
+    if (!dryRun && !skipEnrich && teamwikiRoot) {
         const evidenceDir = path.join(teamwikiRoot, 'evidence', 'code', slug);
         if (await fs.pathExists(path.join(evidenceDir, '_manifest.json'))) {
             setImmediate(async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -654,7 +654,7 @@ program
   .addOption(new Option('--stale-days <n>', 'Threshold for sync-stale check').default('60').hideHelp())
   .addOption(new Option('--pending-review-threshold <n>', 'Threshold for pending-review backlog').default('10').hideHelp())
   .option('--json', 'Output report as JSON (suitable for CI)')
-  .addOption(new Option('--output <path>', 'Custom team-codebase root (mirrors --from-repo)').hideHelp())
+  .addOption(new Option('--output <path>', 'Custom teamwiki output root directory').hideHelp())
   .action(async (cmdOpts) => {
     const globalOpts = program.opts() as GlobalOptions;
     const { codebaseCmd } = await import('./codebase-cmd.js');
@@ -685,7 +685,7 @@ program
     .option('--apply-all', 'Apply all drift items above confidence threshold')
     .option('--threshold <n>', 'Confidence threshold for --apply-all (default 0.8)', '0.8')
     .option('--lock', 'Lock the repo against future drift signals')
-    .option('--output <path>', 'Custom team-codebase root (mirrors --from-repo)')
+    .option('--output <path>', 'Custom teamwiki output root directory')
     .option('--skip-aggregate', 'Skip regenerateAggregate after apply')
     .option('--json', 'Machine-readable output')
     .action(async (subcommand, repoUrlArg, cmdOpts) => {

--- a/src/rebuild-wiki-index.ts
+++ b/src/rebuild-wiki-index.ts
@@ -96,7 +96,7 @@ export async function rebuildWikiIndex(teamwikiRoot: string): Promise<void> {
     }
 
     // Read call-chains count
-    const chainsPath = path.join(dirPath, 'call-chains.md');
+    const chainsPath = path.join(dirPath, 'dependency-paths.md');
     if (await pathExists(chainsPath)) {
       const content = await readFile(chainsPath, 'utf-8');
       const chainMatch = content.match(/(\d+)\s*call chain/);
@@ -156,7 +156,7 @@ export async function rebuildWikiIndex(teamwikiRoot: string): Promise<void> {
   routerLines.push('1. **按组件名匹配** → 路由关键词列对应域');
   routerLines.push('2. **跨仓库依赖问题** → 查 graph-index.json 的 DEPENDS_ON 边');
   routerLines.push('3. **接口/API 问题** → 优先匹配有 interfaces.md 的仓库');
-  routerLines.push('4. **调用链/排障** → 查对应仓库的 call-chains.md');
+  routerLines.push('4. **调用链/排障** → 查对应仓库的 dependency-paths.md');
   routerLines.push('5. **模块职责概述** → 查 overview.md 或 modules/*.md');
   routerLines.push('');
   await writeFile(path.join(teamwikiRoot, 'router.md'), routerLines.join('\n'), 'utf-8');

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -230,6 +230,12 @@ export async function recall(
     return;
   }
 
+  const VALID_DEPTHS = new Set(['route', 'context', 'lookup']);
+  if (options.depth && !VALID_DEPTHS.has(options.depth)) {
+    log.warn(`Invalid --depth "${options.depth}", falling back to "context". Valid: route, context, lookup`);
+    options.depth = 'context';
+  }
+
   // Scope isolation (issue #73): when a project-scope install is detected in
   // cwd, recall queries the project index ONLY. Otherwise it falls back to the
   // user scope. The two scopes are never merged anymore.

--- a/src/utils/tokenizer.ts
+++ b/src/utils/tokenizer.ts
@@ -11,11 +11,13 @@
  */
 export const MAX_TOKENIZE_CHARS = 50_000;
 
+const sharedSegmenter = new Intl.Segmenter('zh-CN', { granularity: 'word' });
+
 export function tokenize(text: string): string[] {
   if (!text) return [];
 
   const input = text.length > MAX_TOKENIZE_CHARS ? text.slice(0, MAX_TOKENIZE_CHARS) : text;
-  const segmenter = new Intl.Segmenter('zh-CN', { granularity: 'word' });
+  const segmenter = sharedSegmenter;
   const tokens: string[] = [];
 
   // Collect CJK characters in runs for bigram generation
@@ -72,10 +74,10 @@ export function tokenize(text: string): string[] {
 /** Non-deduplicated word-like token count (for BM25 document length). */
 export function tokenCount(text: string): number {
   if (!text) return 0;
-  const input = text.length > MAX_TOKENIZE_CHARS ? text.slice(0, MAX_TOKENIZE_CHARS) : text;
-  const segmenter = new Intl.Segmenter('zh-CN', { granularity: 'word' });
+  const input = text.length > MAX_TOKENIZE_CHARS
+    ? text.slice(0, MAX_TOKENIZE_CHARS) : text;
   let count = 0;
-  for (const seg of segmenter.segment(input)) {
+  for (const seg of sharedSegmenter.segment(input)) {
     if (seg.isWordLike) count++;
   }
   return count;

--- a/src/wiki-engine/adapters/templates.ts
+++ b/src/wiki-engine/adapters/templates.ts
@@ -161,8 +161,14 @@ export const HOT_TEMPLATE = [
   '',
 ].join('\n');
 
-export function graphReadmeTemplate(project: string): string {
-  return [
+export interface GraphReadmeOptions {
+  hasG5?: boolean;
+  hasG6?: boolean;
+}
+
+export function graphReadmeTemplate(project: string, opts?: GraphReadmeOptions): string {
+  const { hasG5 = true, hasG6 = true } = opts ?? {};
+  const lines = [
     `# ${project} — G-Document 路由`,
     '<!-- search-anchor: 图谱, graph, G1, G2, G5, G6, 依赖, 调用链, 流程, 爆炸半径 -->',
     '',
@@ -172,8 +178,13 @@ export function graphReadmeTemplate(project: string): string {
     '|--------|------|------|',
     '| 依赖/上游/下游/imports | [graph-g1-relations.md](./graph-g1-relations.md) | N×N 组件依赖矩阵 |',
     '| 调用链/数据流/请求路径 | [graph-g2-dataflow.md](./graph-g2-dataflow.md) | 入口→数据层调用链 |',
-    '| 流程/场景/sequence | [graph-g5-scenarios.md](./graph-g5-scenarios.md) | 核心业务场景序列图 |',
-    '| 传递依赖/影响范围/blast | [graph-g6-multihop.md](./graph-g6-multihop.md) | 多跳传递依赖分析 |',
-    '',
-  ].join('\n');
+  ];
+  if (hasG5) {
+    lines.push('| 流程/场景/sequence | [graph-g5-scenarios.md](./graph-g5-scenarios.md) | 核心业务场景序列图 |');
+  }
+  if (hasG6) {
+    lines.push('| 传递依赖/影响范围/blast | [graph-g6-multihop.md](./graph-g6-multihop.md) | 多跳传递依赖分析 |');
+  }
+  lines.push('');
+  return lines.join('\n');
 }

--- a/src/wiki-engine/adapters/templates.ts
+++ b/src/wiki-engine/adapters/templates.ts
@@ -4,20 +4,62 @@ export interface DomainGroup {
   apiCount?: number;
 }
 
+export interface ProjectEntry {
+  slug: string;
+  label: string;
+  description?: string;
+  keywords?: string[];
+}
+
+export interface ModuleEntry {
+  slug: string;
+  responsibilities?: string[];
+  category?: string;
+  topComponents?: string[];
+}
+
 export function routerTemplate(
-  projects: Array<{ slug: string; label: string }>,
+  projects: ProjectEntry[],
   domains?: DomainGroup[],
 ): string {
-  const lines = ['# Team Wiki Router', '', 'Route broad questions to the relevant domain entrypoint.', ''];
+  const allKeywords = new Set<string>();
+  for (const p of projects) {
+    if (p.keywords) p.keywords.forEach(k => allKeywords.add(k));
+  }
+  const baseTerms = ['路由', '索引', '入口', '知识库', '代码知识', 'architecture', 'module', 'dependency'];
+  const anchorTerms = [...baseTerms, ...allKeywords].slice(0, 20);
+
+  const lines = [
+    '# Team Wiki Router',
+    `<!-- search-anchor: ${anchorTerms.join(', ')} -->`,
+    '',
+    'Route broad questions to the relevant domain entrypoint.',
+    '',
+    '## 问题路由表',
+    '',
+    '| 问题类型 | 目标文档 | 示例问题 |',
+    '|----------|----------|---------|',
+    '| 谁依赖谁 / 模块关系 | G1 组件关系矩阵 | "X 模块的上下游是什么" |',
+    '| 调用链 / 数据流 | G2 数据流图 | "请求从入口到数据库经过哪些模块" |',
+    '| 完整业务流程 | G5 场景序列图 | "用户登录的完整流程是什么" |',
+    '| 传递依赖 / 爆炸半径 | G6 多跳路径 | "如果 X 挂了会影响什么" |',
+    '| 架构概览 / 技术栈 | overview.md | "项目整体架构是什么" |',
+    '| 某模块职责 / 依赖 | modules/<dir>.md | "recall 模块做什么" |',
+    '',
+    '## 项目域入口',
+    '',
+  ];
 
   if (domains && domains.length > 0) {
     for (const domain of domains) {
-      lines.push(`## ${domain.name}${domain.apiCount ? ` (${domain.apiCount} APIs)` : ''}`);
+      lines.push(`### ${domain.name}${domain.apiCount ? ` (${domain.apiCount} APIs)` : ''}`);
       lines.push('');
       for (const comp of domain.components) {
         const proj = projects.find(p => p.slug === comp || p.label === comp);
         if (proj) {
-          lines.push(`- [[evidence/code/${proj.slug}/index]] — ${proj.label}`);
+          const desc = proj.description ? ` — ${proj.description}` : '';
+          const kw = proj.keywords?.length ? ` [${proj.keywords.slice(0, 5).join(', ')}]` : '';
+          lines.push(`- [[evidence/code/${proj.slug}/index]]${desc}${kw}`);
         } else {
           lines.push(`- ${comp}`);
         }
@@ -27,16 +69,19 @@ export function routerTemplate(
     const grouped = new Set(domains.flatMap(d => d.components));
     const ungrouped = projects.filter(p => !grouped.has(p.slug) && !grouped.has(p.label));
     if (ungrouped.length > 0) {
-      lines.push('## Other');
+      lines.push('### Other');
       lines.push('');
       for (const p of ungrouped) {
-        lines.push(`- [[evidence/code/${p.slug}/index]] — ${p.label} 代码知识`);
+        const desc = p.description ? ` — ${p.description}` : ' — 代码知识';
+        lines.push(`- [[evidence/code/${p.slug}/index]]${desc}`);
       }
       lines.push('');
     }
   } else {
     for (const p of projects) {
-      lines.push(`- [[code/${p.slug}/index]] — ${p.label} 代码知识`);
+      const desc = p.description ? ` — ${p.description}` : ' — 代码知识';
+      const kw = p.keywords?.length ? ` [${p.keywords.slice(0, 5).join(', ')}]` : '';
+      lines.push(`- [[evidence/code/${p.slug}/index]]${desc}${kw}`);
     }
     lines.push('');
   }
@@ -53,19 +98,18 @@ export interface IndexStats {
 }
 
 export function indexTemplate(
-  projects: Array<{ slug: string; label: string; description?: string }>,
+  projects: ProjectEntry[],
   stats?: IndexStats,
+  modules?: ModuleEntry[],
 ): string {
-  const domainLinks = projects
-    .map(p => `- [${p.slug}](./evidence/code/${p.slug}/index.md) — ${p.description ?? p.label}`)
-    .join('\n');
+  const allKeywords = projects.flatMap(p => p.keywords ?? []).slice(0, 15);
+  const searchAnchor = allKeywords.length > 0
+    ? `\n<!-- search-anchor: ${allKeywords.join(', ')} -->`
+    : '';
 
-  const sections = [
-    '# Team Wiki Index',
-    '',
-    `Last updated: ${new Date().toISOString()}`,
-    '',
-  ];
+  const sections = ['# Team Wiki Index'];
+  if (searchAnchor) sections.push(searchAnchor);
+  sections.push('', `Last updated: ${new Date().toISOString()}`, '');
 
   if (stats) {
     sections.push('## Stats', '');
@@ -80,8 +124,31 @@ export function indexTemplate(
     sections.push('');
   }
 
-  sections.push('## Domains', '', domainLinks, '');
-  sections.push('## Navigation', '', '- [router.md](./router.md) — 领域路由入口', '- [hot.md](./hot.md) — 活跃工作记忆', '');
+  if (modules && modules.length > 0) {
+    sections.push('## 模块速查', '');
+    sections.push('| 模块 | 职责 | 关键组件 | 层级 |');
+    sections.push('|------|------|---------|------|');
+    for (const mod of modules.slice(0, 20)) {
+      const resp = mod.responsibilities?.slice(0, 2).join('; ') ?? '—';
+      const comps = mod.topComponents?.slice(0, 3).join(', ') ?? '—';
+      const cat = mod.category ?? '—';
+      sections.push(`| ${mod.slug} | ${resp} | ${comps} | ${cat} |`);
+    }
+    sections.push('');
+  }
+
+  sections.push('## 文档导航', '');
+  for (const p of projects) {
+    const desc = p.description ?? p.label;
+    sections.push(`### ${p.slug}`, '');
+    sections.push(`- [overview.md](./evidence/code/${p.slug}/overview.md) — 架构概览`);
+    sections.push(`- [modules/](./evidence/code/${p.slug}/modules/) — 模块级摘要（推荐首选）`);
+    sections.push(`- [docs/](./evidence/code/${p.slug}/docs/) — 深度设计文档 + G-document`);
+    sections.push(`- [component.md](./evidence/code/${p.slug}/component.md) — 原始符号清单`);
+    sections.push('');
+  }
+
+  sections.push('## Navigation', '', '- [router.md](./router.md) — 问题路由入口', '- [hot.md](./hot.md) — 活跃工作记忆', '');
 
   return sections.join('\n');
 }
@@ -93,3 +160,20 @@ export const HOT_TEMPLATE = [
   'Move durable conclusions into domain pages.',
   '',
 ].join('\n');
+
+export function graphReadmeTemplate(project: string): string {
+  return [
+    `# ${project} — G-Document 路由`,
+    '<!-- search-anchor: 图谱, graph, G1, G2, G5, G6, 依赖, 调用链, 流程, 爆炸半径 -->',
+    '',
+    '根据问题类型选择对应文档：',
+    '',
+    '| 关键词 | 文档 | 说明 |',
+    '|--------|------|------|',
+    '| 依赖/上游/下游/imports | [graph-g1-relations.md](./graph-g1-relations.md) | N×N 组件依赖矩阵 |',
+    '| 调用链/数据流/请求路径 | [graph-g2-dataflow.md](./graph-g2-dataflow.md) | 入口→数据层调用链 |',
+    '| 流程/场景/sequence | [graph-g5-scenarios.md](./graph-g5-scenarios.md) | 核心业务场景序列图 |',
+    '| 传递依赖/影响范围/blast | [graph-g6-multihop.md](./graph-g6-multihop.md) | 多跳传递依赖分析 |',
+    '',
+  ].join('\n');
+}


### PR DESCRIPTION
## Summary

- Implement three-layer progressive retrieval (route → context → lookup) replacing flat BM25 search
- Add G5 scenario sequence diagrams and G6 multi-hop transitive dependency analysis
- Upgrade router.md/index.md with search-anchor and question routing table
- Optimize graph-boost with pre-computed adjacency map (O(E²) → O(degree²))
- Fix multiple knowledge repo generation bugs (overview duplication, g2 filename, race condition, idempotency)

### Progressive retrieval layers

| depth | Behavior | Use case |
|-------|----------|----------|
| `route` | Returns routing table only, no BM25 | Discover available projects/G-docs |
| `context` (default) | Searches overview + modules + docs | Most queries |
| `lookup` | Full search including raw symbol pages | Precise file:line lookups |

### G-document routing

| Question type | Document | Example |
|---------------|----------|---------|
| Dependencies | G1 relations matrix | "What depends on X?" |
| Call chains | G2 dataflow | "Request path from entry to DB?" |
| Business flows | G5 scenarios | "Full login flow?" |
| Blast radius | G6 multi-hop | "If X fails, what breaks?" |

## Test plan

- [x] 130 test files, 1675 tests passing
- [x] TypeScript type check clean
- [x] New `recall-progressive.test.ts` verifying route/context/lookup behavior
- [x] CSIG + code quality + PR review findings all addressed

Depends on: #98 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)