### PR TITLE
fix(dashboard): exclude task-notification from human prompt count

### DIFF
--- a/src/__tests__/conversation-token-metrics.test.ts
+++ b/src/__tests__/conversation-token-metrics.test.ts
@@ -120,6 +120,18 @@ describe('scanTranscriptStop — prompt counting', () => {
     expect(prompts).toBe(3);
     expect(interrupt).toBe(1);
   });
+
+  it('excludes <task-notification> system messages from prompt count', async () => {
+    const taskNotif = '<task-notification>\n<task-id>abc123</task-id>\n<tool-use-id>toolu_01X</tool-use-id>\n<output-file>/tmp/out</output-file>\n</task-notification>';
+    const p = writeTranscript([
+      userText('real prompt from user'),
+      userString(taskNotif),       // system-injected, not human
+      userText(taskNotif),         // also system-injected in array form
+      userText('another real prompt'),
+    ]);
+    const { prompts } = await scanTranscriptStop(p);
+    expect(prompts).toBe(2);
+  });
 });
 
 // ─── aggregateSessionMetrics: prompts + tokens ──────────

--- a/src/dashboard-collector.ts
+++ b/src/dashboard-collector.ts
@@ -17,6 +17,7 @@ import {
   CORRECTION_KEYWORDS,
   INTERVENTION_SCAN_MAX_BYTES,
   TRANSCRIPT_INTERRUPT_PREFIX,
+  TRANSCRIPT_SYSTEM_PREFIXES,
   TRANSCRIPT_REJECT_MARKERS,
   emptyTokenUsage,
   addTokenUsage,
@@ -207,7 +208,13 @@ export async function scanTranscriptStop(
 
       // Plain-string user content = a genuine human prompt (older transcript shape).
       if (typeof content === 'string') {
-        if (!isMeta && content.trim() && !content.startsWith(TRANSCRIPT_INTERRUPT_PREFIX)) {
+        const trimContent = content.trim();
+        if (
+          !isMeta &&
+          trimContent &&
+          !trimContent.startsWith(TRANSCRIPT_INTERRUPT_PREFIX) &&
+          !TRANSCRIPT_SYSTEM_PREFIXES.some((p) => trimContent.startsWith(p))
+        ) {
           prompts++;
         }
         continue;
@@ -217,9 +224,10 @@ export async function scanTranscriptStop(
       let hasHumanText = false;
       for (const item of content as Array<Record<string, unknown>>) {
         if (item?.type === 'text' && typeof item.text === 'string') {
+          const txt = item.text.trim();
           if (item.text.startsWith(TRANSCRIPT_INTERRUPT_PREFIX)) {
             interrupt++;
-          } else if (item.text.trim()) {
+          } else if (txt && !TRANSCRIPT_SYSTEM_PREFIXES.some((p) => txt.startsWith(p))) {
             hasHumanText = true;
           }
         } else if (item?.type === 'tool_result' && item.is_error === true) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -559,6 +559,10 @@ export const CORRECTION_KEYWORDS = [
 export const INTERVENTION_SCAN_MAX_BYTES = 50 * 1024 * 1024;
 /** Marker that prefixes a user-interrupt entry in the Claude Code transcript. */
 export const TRANSCRIPT_INTERRUPT_PREFIX = '[Request interrupted by user';
+/** Prefixes of system-injected user messages that are NOT genuine human prompts. */
+export const TRANSCRIPT_SYSTEM_PREFIXES = [
+  '<task-notification>',
+];
 /** Substrings that mark a tool_result as a user rejection (permission deny). */
 export const TRANSCRIPT_REJECT_MARKERS = [
   'The tool use was rejected',


### PR DESCRIPTION
## Summary
- `<task-notification>` messages (background task completion notifications) were being miscounted as genuine human conversation turns because their `isMeta` field is `null` instead of `true`
- Added `TRANSCRIPT_SYSTEM_PREFIXES` constant to filter out system-injected messages in both string and array content branches of `scanTranscriptStop`
- Added regression test covering this scenario

## Root cause
Claude Code injects `<task-notification>` entries as `type:"user"` with `isMeta: null` when background tasks complete. The existing code only checked `isMeta === true` to exclude non-human entries, so these notifications slipped through and inflated the prompt count.

## Test plan
- [x] New test: `excludes <task-notification> system messages from prompt count`
- [x] All existing prompt-counting tests still pass
- [x] TypeScript type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)