### PR TITLE
fix(dashboard): parse CodeBuddy index.json for token usage

### DIFF
--- a/src/__tests__/conversation-token-metrics.test.ts
+++ b/src/__tests__/conversation-token-metrics.test.ts
@@ -83,6 +83,29 @@ describe('scanTranscriptStop — token usage', () => {
     expect(tokens).toEqual({ input: 0, output: 7, cacheRead: 0, cacheCreation: 0 });
   });
 
+  it('parses CodeBuddy index.json (requests[].usage + user messages)', async () => {
+    // CodeBuddy persists a single index.json, not Claude JSONL. Tokens live in
+    // requests[].usage.{inputTokens,outputTokens}; prompts = user messages.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-cb-'));
+    const p = path.join(dir, 'index.json');
+    fs.writeFileSync(p, JSON.stringify({
+      messages: [
+        { id: 'a', role: 'user' },
+        { id: 'b', role: 'assistant' },
+        { id: 'c', role: 'tool' },
+        { id: 'd', role: 'user' },
+      ],
+      requests: [
+        { usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 } },
+        { usage: { inputTokens: 215609, outputTokens: 2967, totalTokens: 218576 } },
+      ],
+    }));
+    const { tokens, prompts } = await scanTranscriptStop(p);
+    expect(tokens).toEqual({ input: 215609, output: 2967, cacheRead: 0, cacheCreation: 0 });
+    expect(prompts).toBe(2);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it('falls back to requestId for dedup when message.id is missing', async () => {
     const line = (extra: object) => JSON.stringify({
       type: 'assistant',

--- a/src/dashboard-collector.ts
+++ b/src/dashboard-collector.ts
@@ -152,6 +152,15 @@ export async function scanTranscriptStop(
   // the same usage). Prefer message.id; fall back to the top-level requestId.
   const countedUsageKeys = new Set<string>();
 
+  // CodeBuddy persists its transcript as a single `index.json` document (a JSON
+  // object with `requests[].usage` + `messages[]`), NOT the Claude Code JSONL
+  // schema the streaming scanner below expects. Detect and parse that shape
+  // separately — otherwise every line fails JSON.parse and tokens stay 0.
+  if (path.basename(transcriptPath) === 'index.json') {
+    const cb = await scanCodebuddyIndex(transcriptPath);
+    if (cb) return cb;
+  }
+
   try {
     const stat = await fs.promises.stat(transcriptPath);
     if (stat.size === 0) return { interrupt, toolReject, tokens, prompts };
@@ -250,6 +259,58 @@ export async function scanTranscriptStop(
   }
 
   return { interrupt, toolReject, tokens, prompts };
+}
+
+/**
+ * Scan a CodeBuddy `index.json` transcript for a cumulative, idempotent token +
+ * prompt snapshot. CodeBuddy's schema differs from Claude Code:
+ *
+ *   {
+ *     "messages": [{ "role": "user" | "assistant" | "tool", ... }],
+ *     "requests": [{ "usage": { "inputTokens", "outputTokens", "totalTokens" } }]
+ *   }
+ *
+ * - tokens:  summed across `requests[].usage` (same per-turn accumulation model as
+ *            the Claude scan, so re-sent context is counted each request). CodeBuddy
+ *            reports no cache-read/creation split at the request level, so those map
+ *            to 0 and `input + output` matches CodeBuddy's own `totalTokens`.
+ * - prompts: count of `messages[]` entries with role === 'user' (human turns).
+ *
+ * Returns null when the file is missing, too large, unparseable, or not a CodeBuddy
+ * index document — the caller then falls back to the Claude JSONL scanner.
+ */
+async function scanCodebuddyIndex(
+  transcriptPath: string,
+): Promise<TranscriptScanResult | null> {
+  try {
+    const stat = await fs.promises.stat(transcriptPath);
+    if (stat.size === 0 || stat.size > INTERVENTION_SCAN_MAX_BYTES) return null;
+
+    const content = await fs.promises.readFile(transcriptPath, 'utf-8');
+    const data = JSON.parse(content) as {
+      messages?: Array<{ role?: unknown }>;
+      requests?: Array<{ usage?: Record<string, unknown> }>;
+    };
+    if (!data || !Array.isArray(data.requests)) return null;
+
+    const tokens = emptyTokenUsage();
+    for (const req of data.requests) {
+      const usage = req?.usage;
+      if (!usage) continue;
+      tokens.input += toNum(usage.inputTokens);
+      tokens.output += toNum(usage.outputTokens);
+    }
+
+    const prompts = Array.isArray(data.messages)
+      ? data.messages.filter((m) => m?.role === 'user').length
+      : 0;
+
+    // CodeBuddy transcripts don't expose interrupt / tool-reject markers.
+    return { interrupt: 0, toolReject: 0, tokens, prompts };
+  } catch (e) {
+    log.warn(`dashboard: failed to scan CodeBuddy index: ${(e as Error).message}`);
+    return null;
+  }
 }
 
 /** Coerce an unknown usage field to a non-negative finite number (0 otherwise). */


### PR DESCRIPTION
## Problem

Token/prompt usage statistics never populated for **CodeBuddy** sessions (always 0), while Claude sessions worked.

Root cause: token stats have a single source — `scanTranscriptStop()` scanning the `transcript_path` at Stop time. That scanner is hard-bound to the **Claude Code JSONL schema** (line-by-line `JSON.parse` of `{type:"assistant", message.usage.*_tokens}`). CodeBuddy's Stop hook *does* fire and *does* pass a `transcript_path`, but it points to a single pretty-printed `index.json` document (CodeBuddy's own format), so every line fails `JSON.parse` and tokens stay 0.

CodeBuddy's `index.json` actually contains authoritative usage:
```json
{
  "messages": [{ "role": "user" | "assistant" | "tool" }],
  "requests": [{ "usage": { "inputTokens", "outputTokens", "totalTokens" } }]
}
```

## Fix

Add `scanCodebuddyIndex()`:
- **tokens**: sum `requests[].usage.{inputTokens,outputTokens}` (same per-turn accumulation model as the Claude scan; `input + output` matches CodeBuddy's own `totalTokens`). CodeBuddy exposes no cache-read/creation split at the request level, so those map to 0.
- **prompts**: count `messages[]` with `role === "user"`.

Dispatched from `scanTranscriptStop()` when the transcript basename is `index.json`, with a safe fallback to the existing Claude JSONL scanner (returns `null` on any parse failure). No change to the Claude path.

## Verification

Tested end-to-end against a **real local CodeBuddy transcript**:
- `scanTranscriptStop(index.json)` → `{input: 215609, output: 2967}`, `prompts: 2` (total 218576 matches the file's `totalTokens`)
- Full `parseHookEvent(Stop payload, "codebuddy")` path attaches `tokens` + `prompts`
- Compiled artifact via the real hook CLI command `dashboard-report --stdin --tool codebuddy` writes the tokens into `events.jsonl`

Added a regression test; `vitest` (dashboard-collector + conversation-token-metrics, 83 tests) and `tsc --noEmit` pass.