### PR TITLE
fix(dashboard): retry CodeBuddy index.json read until token usage is flushed

### DIFF
--- a/src/__tests__/conversation-token-metrics.test.ts
+++ b/src/__tests__/conversation-token-metrics.test.ts
@@ -106,6 +106,27 @@ describe('scanTranscriptStop — token usage', () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it('retries CodeBuddy index.json until usage is flushed after Stop', async () => {
+    // CodeBuddy writes requests[].usage a moment AFTER firing the Stop hook, so the
+    // first read sees zero usage. The scanner must retry until usage appears —
+    // otherwise single-turn sessions would record 0 tokens permanently.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-cb-race-'));
+    const p = path.join(dir, 'index.json');
+    const messages = [{ id: 'a', role: 'user' }];
+    // Initial snapshot: message present, usage not yet flushed (all zero).
+    fs.writeFileSync(p, JSON.stringify({ messages, requests: [{ usage: { inputTokens: 0, outputTokens: 0 } }] }));
+    // Flush real usage shortly after the scan starts (mimics CodeBuddy's late write).
+    const timer = setTimeout(() => {
+      fs.writeFileSync(p, JSON.stringify({ messages, requests: [{ usage: { inputTokens: 1200, outputTokens: 88 } }] }));
+    }, 300);
+
+    const { tokens, prompts } = await scanTranscriptStop(p);
+    clearTimeout(timer);
+    expect(tokens).toEqual({ input: 1200, output: 88, cacheRead: 0, cacheCreation: 0 });
+    expect(prompts).toBe(1);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it('falls back to requestId for dedup when message.id is missing', async () => {
     const line = (extra: object) => JSON.stringify({
       type: 'assistant',

--- a/src/dashboard-collector.ts
+++ b/src/dashboard-collector.ts
@@ -262,8 +262,8 @@ export async function scanTranscriptStop(
 }
 
 /**
- * Scan a CodeBuddy `index.json` transcript for a cumulative, idempotent token +
- * prompt snapshot. CodeBuddy's schema differs from Claude Code:
+ * Read a CodeBuddy `index.json` transcript once. CodeBuddy's schema differs from
+ * Claude Code:
  *
  *   {
  *     "messages": [{ "role": "user" | "assistant" | "tool", ... }],
@@ -276,10 +276,10 @@ export async function scanTranscriptStop(
  *            to 0 and `input + output` matches CodeBuddy's own `totalTokens`.
  * - prompts: count of `messages[]` entries with role === 'user' (human turns).
  *
- * Returns null when the file is missing, too large, unparseable, or not a CodeBuddy
- * index document — the caller then falls back to the Claude JSONL scanner.
+ * Returns null when the file is missing, too large, unparseable (e.g. read mid-write),
+ * or not a CodeBuddy index document.
  */
-async function scanCodebuddyIndex(
+async function readCodebuddyIndexOnce(
   transcriptPath: string,
 ): Promise<TranscriptScanResult | null> {
   try {
@@ -311,6 +311,48 @@ async function scanCodebuddyIndex(
     log.warn(`dashboard: failed to scan CodeBuddy index: ${(e as Error).message}`);
     return null;
   }
+}
+
+/** Total token count across all four buckets. */
+function totalTokenCount(t: TokenUsage): number {
+  return t.input + t.output + t.cacheRead + t.cacheCreation;
+}
+
+/** Retry budget for waiting on CodeBuddy's post-Stop token-usage flush. */
+const CODEBUDDY_USAGE_MAX_ATTEMPTS = 8;
+const CODEBUDDY_USAGE_RETRY_MS = 250;
+
+/**
+ * Scan a CodeBuddy `index.json` for a cumulative, idempotent token + prompt
+ * snapshot, with a bounded retry.
+ *
+ * CodeBuddy flushes per-request token usage into `index.json` *shortly after* it
+ * fires the Stop hook, so the first read frequently sees the human `messages`
+ * already written (prompts are captured) but `requests[].usage` still zero. Without
+ * a retry, single-turn / last-turn sessions would permanently record 0 tokens. We
+ * re-read (up to ~1.75s, well within the 60s hook timeout) until usage appears.
+ *
+ * Returns null only when the file never parses as a CodeBuddy index — the caller
+ * then falls back to the Claude JSONL scanner.
+ */
+async function scanCodebuddyIndex(
+  transcriptPath: string,
+): Promise<TranscriptScanResult | null> {
+  let last: TranscriptScanResult | null = null;
+  for (let attempt = 0; attempt < CODEBUDDY_USAGE_MAX_ATTEMPTS; attempt++) {
+    const result = await readCodebuddyIndexOnce(transcriptPath);
+    if (result) {
+      last = result;
+      // Usage has been flushed — the snapshot is complete, stop waiting.
+      if (totalTokenCount(result.tokens) > 0) return result;
+    }
+    if (attempt < CODEBUDDY_USAGE_MAX_ATTEMPTS - 1) {
+      await new Promise((resolve) => setTimeout(resolve, CODEBUDDY_USAGE_RETRY_MS));
+    }
+  }
+  // Never observed non-zero usage: return the best (zero-token) snapshot we have,
+  // or null so the caller falls back to the Claude JSONL scanner.
+  return last;
 }
 
 /** Coerce an unknown usage field to a non-negative finite number (0 otherwise). */


### PR DESCRIPTION
## Problem

Follow-up to #107. Even after CodeBuddy `index.json` parsing landed, the dashboard still shows **0 tokens** for most CodeBuddy sessions.

Root cause (reproduced against a live local CodeBuddy session): CodeBuddy writes per-request token usage into `index.json` **shortly after** it fires the Stop hook. At scan time the human `messages` are already written (so `prompts` is captured), but `requests[].usage` is still zero. A recorded Stop event looked like:

```json
{"type":"stop","tool":"codebuddy","transcriptPath":".../index.json","prompts":1}
```

— note `prompts:1` but **no `tokens`**, while the same `index.json` moments later held `{inputTokens:22627, outputTokens:183}`. Under the "latest Stop snapshot wins" model, single-turn (and every session's last-turn) tokens were therefore lost permanently.

## Fix

Split the parse into `readCodebuddyIndexOnce()` and wrap it in `scanCodebuddyIndex()` with a **bounded retry**: re-read until `requests[].usage` sums to a non-zero total, up to ~1.75s (8 × 250ms) — comfortably within the 60s per-hook timeout. Falls back to the best zero-token snapshot / Claude JSONL scanner if usage never appears.

No change to the Claude JSONL path.

## Verification

- New regression test writes a zero-usage `index.json`, flushes real usage after 300ms, and asserts the scan waits and returns `{input:1200, output:88}` + `prompts:1`.
- `vitest` (dashboard-collector + conversation-token-metrics, 84 tests) and `tsc --noEmit` pass.