### PR TITLE
[codex] clarify dashboard prompt counts and dedupe hook dispatch

### DIFF
--- a/src/__tests__/hook-dispatch.test.ts
+++ b/src/__tests__/hook-dispatch.test.ts
@@ -76,7 +76,7 @@ describe('hook-dispatch', () => {
       expect(skillHandler.execute).not.toHaveBeenCalled();
     });
 
-    it('wildcard matcher handlers also fire when a specific matcher is dispatched', async () => {
+    it('wildcard matcher handlers do not fire during a specific matcher dispatch', async () => {
       const wildcardHandler = createHandler('dashboard');
       const bashHandler = createHandler('auto-recall');
 
@@ -89,7 +89,7 @@ describe('hook-dispatch', () => {
 
       await dispatcher.dispatch('post-tool-use', 'Bash', {}, 'claude');
 
-      expect(wildcardHandler.execute).toHaveBeenCalledOnce();
+      expect(wildcardHandler.execute).not.toHaveBeenCalled();
       expect(bashHandler.execute).toHaveBeenCalledOnce();
     });
   });

--- a/src/dashboard-html.ts
+++ b/src/dashboard-html.ts
@@ -613,7 +613,7 @@ export function getDashboardHtml(port: number): string {
       if (isExpanded) {
         let promptsHtml = '';
         if (s.prompts && s.prompts.length > 0) {
-          promptsHtml = '<div class="detail-label">Prompts (' + s.prompts.length + ')</div>' +
+          promptsHtml = '<div class="detail-label">User Prompts (' + s.prompts.length + ')</div>' +
             s.prompts.map(p => '<div class="prompt-item">' + escapeHtml(p) + '</div>').join('');
         }
         let outputHtml = '';
@@ -637,7 +637,7 @@ export function getDashboardHtml(port: number): string {
       // 2. First question
       const firstQuestionSection = s.promptSummary
         ? '<div class="card-section">' +
-            '<div class="card-section-label">First Question</div>' +
+            '<div class="card-section-label">First User Prompt</div>' +
             '<div class="prompt-summary">' + escapeHtml(s.promptSummary) + '</div>' +
           '</div>'
         : '';
@@ -646,7 +646,7 @@ export function getDashboardHtml(port: number): string {
       const lastPrompt = s.prompts && s.prompts.length > 1 ? s.prompts[s.prompts.length - 1] : '';
       const lastQuestionSection = lastPrompt
         ? '<div class="card-section">' +
-            '<div class="card-section-label">Last Question</div>' +
+            '<div class="card-section-label">Latest User Prompt</div>' +
             '<div class="prompt-summary">' + escapeHtml(lastPrompt) + '</div>' +
           '</div>'
         : '';

--- a/src/hook-dispatch.ts
+++ b/src/hook-dispatch.ts
@@ -70,8 +70,9 @@ function withTimeout<T>(promise: Promise<T>, ms: number, handlerName: string): P
  * Create a dispatcher with the given handler registrations.
  *
  * Routing rules:
- *   - A handler matches if its event matches AND (its matcher === dispatched matcher OR its matcher === '*')
- *   - Wildcard ('*') matchers fire for any dispatched matcher on that event
+ *   - A handler matches if its event and matcher both match the dispatched hook.
+ *   - The injected wildcard hook dispatches matcher='*' separately, so wildcard
+ *     handlers must not also run during a specific matcher dispatch.
  */
 export function createDispatcher(config: DispatcherConfig): Dispatcher {
   return {
@@ -79,8 +80,7 @@ export function createDispatcher(config: DispatcherConfig): Dispatcher {
       // Find all handlers that should fire for this event+matcher
       const matched = config.handlers.filter((reg) => {
         if (reg.event !== event) return false;
-        // Wildcard handlers always fire; specific matchers must match exactly
-        return reg.matcher === '*' || reg.matcher === matcher;
+        return reg.matcher === matcher;
       });
 
       // Execute all matched handlers concurrently with isolation + per-handler timeout


### PR DESCRIPTION
## What changed

- Clarify dashboard prompt labels so `prompts.length` is presented as user prompt count, not human intervention count.
- Change hook dispatch routing to match the dispatched matcher exactly. The wildcard hook is injected as its own hook, so it no longer also runs during specific matcher dispatches like `Bash`.
- Update the hook dispatcher regression test for the dedupe behavior.

## Why

While checking Codex usage and human-input metrics, the dashboard wording made total user prompts easy to confuse with correction/intervention counts. Separately, `PostToolUse` had both wildcard and specific matcher hooks, and the dispatcher was running wildcard handlers again for specific matcher dispatches, which could duplicate dashboard tool-use events.

## Validation

- `npm test -- --run src/__tests__/hook-dispatch.test.ts`
- `npm run typecheck`
- `npx vitest run --config vitest.e2e.config.ts src/__tests__/hooks-e2e.test.ts src/__tests__/intervention-e2e.test.ts src/__tests__/conversation-token-e2e.test.ts`

Full `npm run test:e2e` was also run before opening the PR and is not green on current base due to existing failures outside this change:

- `src/__tests__/auto-recall-e2e.test.ts`: expected hook stdout is empty in 4 cases.
- `src/__tests__/scope-isolation-e2e.test.ts`: skip notice assertion expects Chinese text, actual output is English.