### PR TITLE
fix(digest): enable usage reporting for project scope

### DIFF
--- a/src/pull.ts
+++ b/src/pull.ts
@@ -780,20 +780,12 @@ async function pullForScope(
     }
   }
 
-  // Step 5: Auto-report usage data (user scope only). This pushes usage back to
-  // the team git repo, so it only applies to git-backed repos — HTTP consumers
-  // have no local git checkout and are read-only, so skip it entirely.
-  if (!options.dryRun && localConfig.scope === 'user' && localConfig.repo.kind !== 'http') {
-    try {
-      const { reportUsageToTeam } = await import('./team-push.js');
-      await reportUsageToTeam(localConfig.repo.localPath, localConfig.username);
-    } catch (e) {
-      log.error(`Auto-report skipped: ${(e as Error).message}`);
-    }
-  }
+  // Step 5: Auto-report usage data — handled centrally in pull() to avoid
+  // double-truncation when both user and project scopes share events.
+  // (no-op here; see pull() for the unified reporting logic)
 
-  // Step 6: Show skill recommendations (user scope only)
-  if (!options.silent && !options.dryRun && localConfig.scope === 'user') {
+  // Step 6: Show skill recommendations
+  if (!options.silent && !options.dryRun) {
     try {
       const YAML = (await import('yaml')).default;
       const { listFiles, readFileSafe } = await import('./utils/fs.js');
@@ -1098,7 +1090,34 @@ export async function pull(options: GlobalOptions): Promise<void> {
   // session start. In project mode user is null, so user hooks are left alone.
   await reconcileHooksAllScopes(projectMode ? null : userConfig, projectConfig, options);
 
-  // 4. Pull cross-team source skills (always — even in project mode), against
+  // 4. Auto-report usage data to all active scopes. Events live in a single
+  //    shared file (~/.teamai/usage.jsonl), so we report to each repo with
+  //    skipTruncate=true first, then truncate once at the end.
+  if (!options.dryRun) {
+    try {
+      const { reportUsageToTeam } = await import('./team-push.js');
+      const { truncateUsageAfterReport, readUsageEvents } = await import('./usage-tracker.js');
+      const targets: Array<{ repoPath: string; username: string }> = [];
+      if (projectConfig) targets.push({ repoPath: projectConfig.repo.localPath, username: projectConfig.username });
+      if (userConfig && userConfig.repo.kind !== 'http') targets.push({ repoPath: userConfig.repo.localPath, username: userConfig.username });
+
+      const eventCount = (await readUsageEvents()).length;
+      for (const t of targets) {
+        try {
+          await reportUsageToTeam(t.repoPath, t.username, { skipTruncate: true });
+        } catch (e) {
+          log.error(`Auto-report to ${t.repoPath} skipped: ${(e as Error).message}`);
+        }
+      }
+      if (eventCount > 0 && targets.length > 0) {
+        await truncateUsageAfterReport(eventCount);
+      }
+    } catch (e) {
+      log.debug(`Auto-report skipped: ${(e as Error).message}`);
+    }
+  }
+
+  // 5. Pull cross-team source skills (always — even in project mode), against
   //    the active scope so deploys land in the right base dir.
   const sourceConfig = projectConfig ?? userConfig;
   if (sourceConfig) {

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -2,7 +2,7 @@ import YAML from 'yaml';
 import path from 'node:path';
 import { readUsageEvents } from './usage-tracker.js';
 import { readFileSafe } from './utils/fs.js';
-import { loadLocalConfig } from './config.js';
+import { loadLocalConfig, detectProjectConfig } from './config.js';
 import type { UsageEvent, UserStats } from './types.js';
 
 interface SkillStats {
@@ -45,7 +45,7 @@ export function aggregateUsage(events: UsageEvent[]): SkillStats[] {
  */
 async function loadReportedStats(): Promise<UserStats | null> {
   try {
-    const config = await loadLocalConfig();
+    const config = await detectProjectConfig() ?? await loadLocalConfig();
     if (!config) return null;
     const statsPath = path.join(config.repo.localPath, 'stats', `${config.username}.yaml`);
     const content = await readFileSafe(statsPath);

--- a/src/team-push.ts
+++ b/src/team-push.ts
@@ -271,6 +271,7 @@ function hasPromptTokenDelta(d: PromptTokenDelta): boolean {
 export async function reportUsageToTeam(
   repoPath: string,
   username: string,
+  options?: { skipTruncate?: boolean },
 ): Promise<void> {
   try {
     const events = await readUsageEvents();
@@ -370,10 +371,12 @@ export async function reportUsageToTeam(
 
     await Promise.race([pushPromise, timeoutPromise]);
 
-    // Success — truncate reported usage events (only if we had any)
-    if (hasUsage) {
+    // Success — truncate reported usage events (only if caller allows it)
+    if (hasUsage && !options?.skipTruncate) {
       await truncateUsageAfterReport(events.length);
       log.debug(`Reported ${events.length} usage events to team repo`);
+    } else if (hasUsage) {
+      log.debug(`Reported ${events.length} usage events to team repo (kept local copy)`);
     }
     // Success — advance the reported snapshots so we don't re-count.
     if (hasInterventions) {


### PR DESCRIPTION
## Summary

- Project scope 下 `teamai digest` 始终显示 "No team usage data available"，因为 usage 数据只上报到 user scope 的 team repo
- 将 usage 上报从 `pullForScope()` 提升到 `pull()` 主函数，统一向所有 active scope 的 repo 上报
- 添加 `skipTruncate` 选项避免共享的 usage.jsonl 被提前截断
- 修复 `teamai stats` 在 project scope 下无法读取已上报数据
- 让 skill recommendations 对 project scope 也生效

## Test plan

- [x] `npx tsc --noEmit` 通过
- [x] `npx vitest run` 通过（2 个预先存在的 import-repo 失败无关）
- [ ] 在有 project scope 配置的目录执行 `teamai pull`，确认 stats 上报到 project team repo
- [ ] 执行 `teamai digest`，确认不再显示 "No team usage data available"
- [ ] 执行 `teamai stats`，确认能读取 project repo 的已上报统计

🤖 Generated with [Claude Code](https://claude.com/claude-code)