### PR TITLE
docs: update CLAUDE.md with git conventions and output language rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,16 @@ git push origin main --tags
 
 CI stages: validate (lint + test) -> build -> e2e -> publish (tag builds only).
 
+## Git Conventions
+
+- **Default branch**: `main` (not `master`). All worktrees and PRs should be based on `origin/main`.
+- **PR target**: Always submit PRs to `Tencent/teamai-cli` (the upstream). Never push PRs to personal forks (`hsuchifeng`, `jeff-r2026`, etc.) unless explicitly told.
+- **Clean PRs**: Before pushing, verify commit scope with `git log origin/main..HEAD`. If unrelated commits appear, rebase or cherry-pick onto a fresh branch from `origin/main`.
+
+## Output Language
+
+All CLI user-facing output must be in **English**. No Chinese strings in production code. Test assertions should match English output.
+
 ## Workflow Rules
 
 - **必须使用 Worktree**：每次需要修改代码前，必须先通过 `EnterWorktree` 进入一个隔离的 git worktree 进行开发，禁止直接在主工作目录修改代码。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ npm version minor      # new feature, backward compatible
 npm version major      # breaking change
 
 # 2. Push code and tag together — CI auto-publishes both packages
-git push origin master --tags
+git push origin main --tags
 ```
 
 CI stages: validate (lint + test) -> build -> e2e -> publish (tag builds only).


### PR DESCRIPTION
## Summary
- Update default branch reference from `master` to `main`
- Add Git Conventions section (PR target, branch base, clean PR checks)
- Add Output Language rule (CLI output must be English)

Derived from recurring issues in recent sessions.

## Test plan
- [x] Doc-only change, no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)