### PR TITLE
fix(init): auto-select role when only one is available

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -54,6 +54,17 @@ async function promptForRoleProfile(
     };
   }
 
+  // Auto-select when only one role is available
+  if (manifest.roles.length === 1) {
+    const only = manifest.roles[0];
+    log.info(`Role: ${roleLabels[0]} (auto-selected)`);
+    return {
+      primaryRole: only.id,
+      additionalRoles: [],
+      resourceProfileVersion: manifest.version,
+    };
+  }
+
   log.info('Available roles:');
   roleLabels.forEach((label, index) => {
     log.info(`  ${index + 1}. ${label}`);


### PR DESCRIPTION
## Summary
- When `teamai init` detects only one role in the team repo's roles manifest, it now auto-selects that role instead of prompting the user to pick from a list of one.
- Displays the selected role with an `(auto-selected)` suffix so the user knows what happened.

## Test plan
- [x] Existing `init.test.ts` passes (9 tests)
- [x] Type check passes
- [ ] Manual test: run `teamai init` against a team repo with a single role — should skip the number prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)