### PR TITLE
docs: mark auto-recall proposal as superseded (#106)

### DIFF
--- a/docs/designs/git-native-memory.md
+++ b/docs/designs/git-native-memory.md
@@ -92,11 +92,11 @@
 
 | # | Proposal | Effort | Decision | Reasoning |
 |---|----------|--------|----------|-----------|
-| 1 | Auto-Recall on SessionStart | M | DEFERRED | 等基线 recall 跑起来再加自动触发 |
+| 1 | Auto-Recall on SessionStart | M | SUPERSEDED | 已被 `teamai-recall` subagent + builtin-rules 主动检索替代 |
 | 2 | Recall 自动投票 (Upvote) | S | **ACCEPTED** | 零冲突，飞轮反馈机制的关键一环 |
 | 3 | Frontmatter 标准化 | S | **ACCEPTED** | 提升搜索质量，向后兼容 |
 | 4 | Reflect 层 | L | DEFERRED | 知识库冷启动阶段，数据不足 |
 
 ## Deferred to TODOS.md
-- **Auto-Recall on SessionStart (P2)** — SessionStart hook 自动运行 recall，零摩擦知识注入
+- ~~**Auto-Recall on SessionStart (P2)**~~ — 已被 `teamai-recall` subagent + builtin-rules 主动检索替代（#106）
 - **Reflect 层 (P3)** — LLM 分析 learnings 生成 meta-insights，需知识库积累到 20+ 篇


### PR DESCRIPTION
## Summary
- `docs/designs/git-native-memory.md` 中 Auto-Recall on SessionStart 提案状态从 DEFERRED 更新为 SUPERSEDED
- 该功能已被 `teamai-recall` subagent + builtin-rules 主动检索方案替代（#106）

另外，本地 `~/.claude/rules/teamai-recall.md` 中残留的"自动错误检索"段落已手动删除。该文件由 `builtin-rules.ts` 管理，下次 `teamai pull` 会自动部署正确版本。

## Test plan
- [x] 确认 `builtin-rules.ts` 中 rule 内容已无 auto-recall 描述
- [x] 确认 README 中 TodoWrite hook 描述仍准确（代码中 hook 存在）
- [x] CHANGELOG 为历史记录，不修改

🤖 Generated with [Claude Code](https://claude.com/claude-code)