### PR TITLE
fix(import): address review findings for progress bar PR

### DIFF
--- a/src/import-repo.ts
+++ b/src/import-repo.ts
@@ -701,7 +701,9 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
                     const existing = await fs.readFile(overviewPath, 'utf8').catch(() => '');
                     const aiNarrative = codebaseMd.replace(/^---[\s\S]*?---\n*/m, '');
                     const marker = '## AI Architecture Narrative';
-                    const markerIdx = existing.indexOf(marker);
+                    const oldMarker = '## AI 架构叙事';
+                    let markerIdx = existing.indexOf(marker);
+                    if (markerIdx < 0) markerIdx = existing.indexOf(oldMarker);
                     const base = markerIdx >= 0 ? existing.slice(0, markerIdx).trimEnd() : existing.trimEnd();
                     let combined: string;
                     if (!base || !base.startsWith('---')) {

--- a/src/import.ts
+++ b/src/import.ts
@@ -10,9 +10,9 @@ import { importFromRepo } from './import-repo.js';
 import { importFromRepoList } from './import-repo-list.js';
 import { importFromOrg } from './import-org.js';
 import { importFromIWikiDual } from './iwiki-dual.js';
-import { GlobalOptions } from './types.js';
+import type { GlobalOptions, LearningDraft } from './types.js';
 import { Listr, PRESET_TIMER } from 'listr2';
-import { log } from './utils/logger.js';
+import { log, setSilent } from './utils/logger.js';
 import { autoPushTeamRepo } from './utils/git.js';
 
 /**
@@ -235,7 +235,7 @@ export async function importCmd(opts: ImportOptions): Promise<void> {
                 task.skip('No existing evidence for this repo');
               }
             } catch (e) {
-              task.output = `Failed (non-blocking): ${(e as Error).message}`;
+              task.title = `Incremental update skipped: ${(e as Error).message}`;
             }
           },
           rendererOptions: { persistentOutput: true },
@@ -256,10 +256,11 @@ export async function importCmd(opts: ImportOptions): Promise<void> {
         },
       ], {
         rendererOptions: { timer: PRESET_TIMER, collapseErrors: false },
-        exitOnError: false,
-        ctx: { learning: undefined as unknown, repoUrl: '' as string, didUpdate: false as boolean },
+        exitOnError: true,
+        ctx: { learning: undefined as LearningDraft | undefined, repoUrl: '', didUpdate: false },
       });
-      await tasks.run();
+      setSilent(true);
+      try { await tasks.run(); } finally { setSilent(false); }
     } else if (opts.dir) {
       // 分支 3：--dir <path>，代码知识提取（等同于 --from-repo 但跳过 clone）
       const dirPath = path.resolve(opts.dir);


### PR DESCRIPTION
## Summary

Follow-up fixes for PR #117 (progress bar) that was merged before review fixes landed.

| Priority | Fix |
|----------|-----|
| P0 | `exitOnError: false` → `true` in --from-mr listr2 config (errors were silently swallowed) |
| P1 | Backward compat for old Chinese marker `## AI 架构叙事` in overview.md |
| P1 | `setSilent(true)` around listr2 to prevent ora/listr2 TTY conflict |
| P2 | Explicit `LearningDraft \| undefined` type for ctx.learning |
| P2 | `task.title` instead of `task.output` for failure message |

## Test plan

- [x] tsc --noEmit clean
- [x] 1582 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)