### PR TITLE
fix(deep-enrich): reset stale progress when manifest is newer than last run

### DIFF
--- a/src/deep-enrich.ts
+++ b/src/deep-enrich.ts
@@ -37,6 +37,7 @@ interface ManifestEdge {
 
 interface Manifest {
   project?: string;
+  generatedAt?: string;
   components?: ManifestComponent[];
   edges?: ManifestEdge[];
 }
@@ -767,6 +768,27 @@ export async function deepEnrich(opts: DeepEnrichOptions): Promise<void> {
   // 2. 初始化 progress（断点续传）
   const allSlugs = components.map(c => c.slug);
   const progress = await loadProgress(evidenceDir, project, allSlugs);
+
+  // 2b. Stale progress guard: reset when progress is outdated relative to the manifest.
+  // This happens when import writes a fresh _manifest.json but an old progress.json
+  // (from a prior run) survives on the git branch that deep-enrich executes against.
+  if (progress.phase === 'done') {
+    const manifestTime = ctx.manifest.generatedAt;
+    const progressStale = manifestTime && progress.startedAt < manifestTime;
+    let docsEmpty = true;
+    if (await pathExists(docsDir)) {
+      const entries = await readdir(docsDir).catch(() => [] as string[]);
+      docsEmpty = entries.filter(e => e.endsWith('.md')).length === 0;
+    }
+    if (docsEmpty || progressStale) {
+      log.info(`deep-enrich[${project}]: stale progress detected (phase=done, docs_empty=${docsEmpty}, progress_stale=${Boolean(progressStale)}), resetting`);
+      progress.phase = 'pending';
+      progress.componentsDone = [];
+      progress.componentsPending = [...allSlugs];
+      progress.startedAt = new Date().toISOString();
+      await saveProgress(evidenceDir, progress);
+    }
+  }
 
   // 3. Phase 1: 组件设计文档
   if (progress.phase === 'pending' || progress.phase === 'components') {

--- a/src/import-repo.ts
+++ b/src/import-repo.ts
@@ -802,7 +802,21 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
         }
     }
 
-    // 5. Aggregate global graph + create MR (single-repo mode; batch mode handled by import-repo-list)
+    // 5. Deep enrich (synchronous, before push — so all content goes into one MR)
+    if (!dryRun && !skipEnrich && teamwikiRoot) {
+        const evidenceDir = path.join(teamwikiRoot, 'evidence', 'code', slug);
+        if (await fs.pathExists(path.join(evidenceDir, '_manifest.json'))) {
+            try {
+                const { deepEnrich } = await import('./deep-enrich.js');
+                await deepEnrich({ project: slug, evidenceDir, wikiRoot: teamwikiRoot, cacheDir });
+                log.info(chalk.green(`✓ Deep enrich complete: ${slug}`));
+            } catch (e) {
+                log.debug(`deep-enrich failed for ${slug} (non-blocking): ${(e as Error).message}`);
+            }
+        }
+    }
+
+    // 6. Aggregate global graph + create MR (single-repo mode; batch mode handled by import-repo-list)
     if (!dryRun && !skipAutoPush) {
         if (teamwikiRoot) {
             try {
@@ -831,33 +845,8 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
 
     log.info(chalk.green(`✓ Repo ${owner}/${repoName} import complete`));
 
-    // 5b. Background deep enrichment (non-blocking; in batch mode caller handles push)
-    if (!dryRun && !skipEnrich && teamwikiRoot) {
-        const evidenceDir = path.join(teamwikiRoot, 'evidence', 'code', slug);
-        if (await fs.pathExists(path.join(evidenceDir, '_manifest.json'))) {
-            setImmediate(async () => {
-                try {
-                    const { deepEnrich } = await import('./deep-enrich.js');
-                    await deepEnrich({ project: slug, evidenceDir, wikiRoot: teamwikiRoot, cacheDir });
-                    if (!skipAutoPush && mrTeamConfig && mrLocalConfig) {
-                        const { autoPushViaMR } = await import('./utils/git.js');
-                        if (await fs.pathExists(teamRepoDir)) {
-                            await autoPushViaMR(
-                                teamRepoDir, `[teamai] Deep enrich: ${slug}`,
-                                ['.'], mrTeamConfig, mrLocalConfig,
-                            );
-                        }
-                    }
-                    log.info(chalk.green(`✓ Deep enrich complete: ${slug}`));
-                } catch (e) {
-                    log.debug(`deep-enrich background failed for ${slug}: ${(e as Error).message}`);
-                }
-            });
-        }
-    }
 
-
-    // 6. Write LAST_SYNC
+    // 7. Write LAST_SYNC
     if (!dryRun) {
         await writeLastSync(cacheDir, cloneSha);
         try {


### PR DESCRIPTION
## Summary

Fixes deep-enrich producing empty MRs (only progress.json timestamp update) when running after `teamai import --from-repo`.

**Root cause:** `autoPushViaMR` calls `checkoutMaster()` after committing the import branch. The subsequent `setImmediate`-scheduled deep-enrich then runs against the master working tree, where:
1. Old `progress.json` (phase="done") causes all generation phases to be skipped
2. Evidence files reflect the old master state, not the freshly extracted data

**Fix (two commits):**

1. **`deep-enrich.ts`** — Add stale progress guard: reset to "pending" when phase=done but either docs/ is empty or `_manifest.json` is newer than the progress timestamp. Defense-in-depth.

2. **`import-repo.ts`** — Move deep-enrich from async `setImmediate` (after push) to synchronous execution (before push). This ensures:
   - Deep-enrich reads the freshly written evidence on disk
   - All content (extract + enrich) goes into a **single MR** instead of two
   - No branch/timing confusion between import and enrich phases

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 1590 tests pass
- [ ] Manual: `teamai import --from-repo <url>` produces a single MR with both evidence and deep-enrich docs
- [ ] Manual: re-running import on an already-enriched repo with stale progress.json correctly resets and regenerates