### PR TITLE
fix(init): remove additional roles prompt

### DIFF
--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -262,8 +262,8 @@ describe('init', () => {
         cloneDone = true;
       });
 
-      // Answers: create repo confirm (Y), configure reviewers (n), primary role (1), no additional roles
-      questionAnswers = ['Y', 'n', '1', ''];
+      // Answers: create repo confirm (Y), configure reviewers (n), primary role (1)
+      questionAnswers = ['Y', 'n', '1'];
 
       await init({ repo: 'https://git.woa.com/HyperAI/new-repo.git', scope: 'user' });
 
@@ -325,7 +325,7 @@ describe('init', () => {
   });
 
   describe('role persistence', () => {
-    it('writes primaryRole, additionalRoles, and resourceProfileVersion when roles are selected', async () => {
+    it('writes primaryRole and resourceProfileVersion when role is selected', async () => {
       let cloneDone = false;
       pathExistsFn = (p: string) => {
         if (p === localPath) return cloneDone;
@@ -366,13 +366,13 @@ describe('init', () => {
           toolPaths: {},
         } as never);
 
-      questionAnswers = ['n', '1', '1'];
+      questionAnswers = ['n', '1'];
 
       await init({ repo: 'https://git.woa.com/HyperAI/teamai-test.git', scope: 'user' });
 
       expect(saveLocalConfig).toHaveBeenCalledWith(expect.objectContaining({
         primaryRole: 'hai',
-        additionalRoles: ['pm'],
+        additionalRoles: [],
         resourceProfileVersion: 1,
       }));
     });
@@ -390,8 +390,8 @@ describe('init', () => {
         cloneDone = true;
       });
 
-      // Answers: scope (user via default), configure reviewers (n), primary role (1), no additional
-      questionAnswers = ['user', 'n', '1', ''];
+      // Answers: scope (user via default), configure reviewers (n), primary role (1)
+      questionAnswers = ['user', 'n', '1'];
 
       const { log } = await import('../utils/logger.js');
 
@@ -414,8 +414,8 @@ describe('init', () => {
         cloneDone = true;
       });
 
-      // Answers: configure reviewers (n), primary role (1), no additional
-      questionAnswers = ['n', '1', ''];
+      // Answers: configure reviewers (n), primary role (1)
+      questionAnswers = ['n', '1'];
 
       const { log } = await import('../utils/logger.js');
       vi.mocked(log.info).mockClear();

--- a/src/init.ts
+++ b/src/init.ts
@@ -77,27 +77,10 @@ async function promptForRoleProfile(
   }
 
   const primaryRole = manifest.roles[primaryIndex - 1];
-  const additionalCandidates = manifest.roles.filter((role) => role.id !== primaryRole.id);
-  let additionalRoles: string[] = [];
-
-  if (additionalCandidates.length > 0) {
-    log.info('Additional roles (optional):');
-    additionalCandidates.forEach((role, index) => {
-      const suffix = role.description ? `: ${role.description}` : '';
-      log.info(`  ${index + 1}. ${role.id}${suffix}`);
-    });
-
-    const additionalAnswer = await askQuestion(
-      'Additional roles (comma-separated numbers, blank to skip): ',
-      '',
-    );
-    const additionalIndexes = parseRoleSelection(additionalAnswer, additionalCandidates.length);
-    additionalRoles = additionalIndexes.map((selection) => additionalCandidates[selection - 1].id);
-  }
 
   return {
     primaryRole: primaryRole.id,
-    additionalRoles,
+    additionalRoles: [],
     resourceProfileVersion: manifest.version,
   };
 }


### PR DESCRIPTION
## Summary
- Remove the interactive "Additional roles" prompt from `teamai init` to simplify onboarding
- Users can still add additional roles later via `teamai roles set --add`
- The `additionalRoles` field and all downstream logic remain intact

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — all 971 tests pass
- [x] Manual: `teamai init` no longer shows the additional roles prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)