### PR TITLE
fix(init): skip hook injection for uninstalled tools

### DIFF
--- a/src/__tests__/hooks-e2e.test.ts
+++ b/src/__tests__/hooks-e2e.test.ts
@@ -253,6 +253,10 @@ describe('hooks E2E — real file I/O', () => {
       const originalHome = process.env.HOME;
       process.env.HOME = tmpDir;
 
+      // Pre-create tool root dirs so they are detected as installed
+      await fse.ensureDir(path.join(tmpDir, '.claude'));
+      await fse.ensureDir(path.join(tmpDir, '.cursor'));
+
       await injectHooksToAllTools({
         claude: { settings: '.claude/settings.json' },
         cursor: { settings: '.cursor/hooks.json' },
@@ -291,6 +295,8 @@ describe('hooks E2E — real file I/O', () => {
       const originalHome = process.env.HOME;
       process.env.HOME = tmpDir;
 
+      await fse.ensureDir(path.join(tmpDir, '.claude'));
+
       await injectHooksToAllTools({
         claude: { settings: '.claude/settings.json' },
         'codex-internal': {},
@@ -304,6 +310,27 @@ describe('hooks E2E — real file I/O', () => {
       // codex-internal has no settings → no hooks file created
       const codexInternalFile = path.join(tmpDir, '.codex-internal', 'settings.json');
       expect(await fse.pathExists(codexInternalFile)).toBe(false);
+    });
+
+    it('skips tools whose root directory does not exist (not installed)', async () => {
+      const originalHome = process.env.HOME;
+      process.env.HOME = tmpDir;
+
+      // Only create .claude dir — .tclaude is NOT created (simulating uninstalled tool)
+      await fse.ensureDir(path.join(tmpDir, '.claude'));
+
+      await injectHooksToAllTools({
+        claude: { settings: '.claude/settings.json' },
+        tclaude: { settings: '.tclaude/settings.json' },
+      });
+
+      process.env.HOME = originalHome;
+
+      const claudeFile = path.join(tmpDir, '.claude', 'settings.json');
+      const tclaudeFile = path.join(tmpDir, '.tclaude', 'settings.json');
+
+      expect(await fse.pathExists(claudeFile)).toBe(true);
+      expect(await fse.pathExists(tclaudeFile)).toBe(false);
     });
   });
 });

--- a/src/__tests__/hooks-reconcile-scope.test.ts
+++ b/src/__tests__/hooks-reconcile-scope.test.ts
@@ -51,6 +51,10 @@ function manifest(): Promise<Record<string, Array<{ id: string }>>> {
 beforeEach(async () => {
   project = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-recon-proj-'));
   repo = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-recon-repo-'));
+  // Pre-create tool root dirs so they are detected as installed
+  await fse.ensureDir(path.join(project, '.claude'));
+  await fse.ensureDir(path.join(project, '.cursor'));
+  await fse.ensureDir(path.join(project, '.codex'));
 });
 afterEach(async () => {
   await fse.remove(project);

--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -377,6 +377,29 @@ describe('hooks', () => {
         process.env.HOME = originalHome;
       }
     });
+
+    it('skips tools whose root directory does not exist', async () => {
+      const originalHome = process.env.HOME;
+      process.env.HOME = '/test-home';
+
+      const { pathExists: mockedPathExists } = await import('../utils/fs.js');
+      (mockedPathExists as ReturnType<typeof vi.fn>).mockImplementation(async (p: string) => {
+        return (p as string).includes('.claude');
+      });
+
+      try {
+        await injectHooksToAllTools({
+          claude: { settings: '.claude/settings.json' },
+          tclaude: { settings: '.tclaude/settings.json' },
+        });
+
+        expect(mockFiles[path.join('/test-home', '.claude/settings.json')]).toBeDefined();
+        expect(mockFiles[path.join('/test-home', '.tclaude/settings.json')]).toBeUndefined();
+      } finally {
+        (mockedPathExists as ReturnType<typeof vi.fn>).mockImplementation(async () => true);
+        process.env.HOME = originalHome;
+      }
+    });
   });
 
   describe('format alignment', () => {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -497,11 +497,17 @@ export async function getHookStatus(settingsPath: string, tool?: string): Promis
   return present ? 'installed' : 'missing';
 }
 
-/** Inject teamai built-in hooks into all AI tool settings. */
+/**
+ * Inject teamai built-in hooks into all AI tool settings.
+ * Only writes to tools whose root directory already exists on disk,
+ * preventing creation of config dirs for tools the user hasn't installed.
+ */
 export async function injectHooksToAllTools(toolPaths: Record<string, { settings?: string }>, baseDir?: string): Promise<void> {
   const resolvedBaseDir = baseDir ?? (process.env.HOME ?? '');
   for (const [tool, paths] of Object.entries(toolPaths)) {
     if (paths.settings) {
+      const toolRoot = path.join(resolvedBaseDir, paths.settings.split('/')[0]);
+      if (!await pathExists(toolRoot)) continue;
       const settingsPath = path.join(resolvedBaseDir, paths.settings);
       try {
         await injectHooks(settingsPath, tool);
@@ -536,6 +542,8 @@ export async function reconcileHooksToAllTools(
 ): Promise<void> {
   for (const [tool, paths] of Object.entries(toolPaths)) {
     if (!paths.settings) continue;
+    const toolRoot = path.join(baseDir, paths.settings.split('/')[0]);
+    if (!await pathExists(toolRoot)) continue;
     const settingsPath = path.join(baseDir, paths.settings);
     try {
       await reconcileHooks(settingsPath, tool, teamDefs, {


### PR DESCRIPTION
## Summary
- `injectHooksToAllTools` and `reconcileHooksToAllTools` now check whether the tool's root directory exists before writing hooks
- Prevents creating `.claude-internal`, `.tclaude`, `.tcodex`, `.codex-internal` etc. for tools the user hasn't installed
- Aligns hook injection behavior with `pull.ts` which already uses `isToolInstalled` checks for skills/rules/agents

## Test plan
- [x] Unit test: mock `pathExists` to return false → tool skipped
- [x] E2E test: only pre-created tool dirs receive hooks, others untouched
- [x] `hooks-reconcile-scope` tests updated and passing
- [x] Full test suite passes (1554 tests, excluding pre-existing `import-*` failures on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)