### PR TITLE
feat(recall): change default to enabled when team config is unset

### DIFF
--- a/src/recall-toggle.ts
+++ b/src/recall-toggle.ts
@@ -113,7 +113,7 @@ export async function recallStatus(_opts: GlobalOptions): Promise<void> {
   const { localConfig, teamConfig } = await autoDetectInit();
 
   const effective = isRecallEnabled(localConfig, teamConfig);
-  const teamSetting = teamConfig.sharing?.recall?.enabled ?? false;
+  const teamSetting = teamConfig.sharing?.recall?.enabled ?? true;
   const userOverride = localConfig.recallEnabled;
 
   console.log(`Recall: ${effective ? 'enabled' : 'disabled'}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,7 +42,7 @@ export const SharingConfigSchema = z.object({
     requireTeamScripts: z.boolean().default(false),
   }).optional(),
   recall: z.object({
-    enabled: z.boolean().default(false),
+    enabled: z.boolean().default(true),
   }).optional(),
 });
 
@@ -62,10 +62,10 @@ export function getHooksSharing(config: { sharing?: { hooks?: { autoApply?: bool
 export function getRecallSharing(config: { sharing?: { recall?: { enabled?: boolean } } }): {
   enabled: boolean;
 } {
-  return { enabled: config.sharing?.recall?.enabled ?? false };
+  return { enabled: config.sharing?.recall?.enabled ?? true };
 }
 
-/** Resolve whether recall is enabled: user override > team config > default (false). */
+/** Resolve whether recall is enabled: user override > team config > default (true). */
 export function isRecallEnabled(
   localConfig: { recallEnabled?: boolean },
   teamConfig: { sharing?: { recall?: { enabled?: boolean } } },


### PR DESCRIPTION
## Summary
- Flip the `sharing.recall.enabled` default from `false` to `true`
- Teams no longer need to explicitly opt in — recall is enabled out of the box
- Teams that want to disable can still set `sharing.recall.enabled: false` in teamai.yaml

## Test plan
- [x] Existing recall-related tests pass (`scope.test.ts`, `builtin-agents.test.ts`)
- [ ] Verify `teamai recall status` shows "enabled" for a team without explicit config

🤖 Generated with [Claude Code](https://claude.com/claude-code)