### PR TITLE
feat(votes): Phase 3 + Phase 4 — dual-counter votes and automatic maintenance

### DIFF
--- a/src/__tests__/confidence.test.ts
+++ b/src/__tests__/confidence.test.ts
@@ -1,0 +1,73 @@
+// -*- coding: utf-8 -*-
+import { describe, it, expect } from 'vitest';
+
+import { computeConfidence } from '../maintenance/confidence.js';
+
+describe('computeConfidence', () => {
+  it('returns 0 for brand new doc with no activity', () => {
+    const score = computeConfidence({
+      recalledCount: 0,
+      upvotedCount: 0,
+      lastRecalledAt: '',
+    });
+    expect(score).toBe(0);
+  });
+
+  it('returns moderate score for recently recalled doc', () => {
+    const now = new Date().toISOString();
+    const score = computeConfidence({
+      recalledCount: 5,
+      upvotedCount: 2,
+      lastRecalledAt: now,
+    });
+    // base = min(1, 5*0.1 + 2*0.3) = min(1, 1.1) = 1.0
+    // recency ≈ 1.0 (just now)
+    // ratio = 2/5 = 0.4
+    // confidence = 1.0*0.4 + 1.0*0.3 + 0.4*0.3 = 0.4 + 0.3 + 0.12 = 0.82
+    expect(score).toBeGreaterThanOrEqual(0.8);
+    expect(score).toBeLessThanOrEqual(0.85);
+  });
+
+  it('returns low score for old doc never upvoted', () => {
+    const oldDate = new Date(Date.now() - 200 * 24 * 60 * 60 * 1000).toISOString();
+    const score = computeConfidence({
+      recalledCount: 1,
+      upvotedCount: 0,
+      lastRecalledAt: oldDate,
+    });
+    // base = min(1, 1*0.1) = 0.1
+    // recency = max(0, 1 - 200/180) = 0
+    // ratio = 0/1 = 0
+    // confidence = 0.1*0.4 + 0*0.3 + 0*0.3 = 0.04
+    expect(score).toBeLessThan(0.1);
+  });
+
+  it('caps at reasonable maximum for heavily used docs', () => {
+    const now = new Date().toISOString();
+    const score = computeConfidence({
+      recalledCount: 100,
+      upvotedCount: 50,
+      lastRecalledAt: now,
+    });
+    // base = 1.0 (capped)
+    // recency = 1.0
+    // ratio = 50/100 = 0.5
+    // confidence = 1.0*0.4 + 1.0*0.3 + 0.5*0.3 = 0.85
+    expect(score).toBeGreaterThanOrEqual(0.8);
+    expect(score).toBeLessThanOrEqual(1.0);
+  });
+
+  it('returns value between 0 and 1', () => {
+    const cases = [
+      { recalledCount: 0, upvotedCount: 0, lastRecalledAt: '' },
+      { recalledCount: 1, upvotedCount: 0, lastRecalledAt: new Date().toISOString() },
+      { recalledCount: 10, upvotedCount: 10, lastRecalledAt: new Date().toISOString() },
+      { recalledCount: 3, upvotedCount: 1, lastRecalledAt: new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString() },
+    ];
+    for (const factors of cases) {
+      const score = computeConfidence(factors);
+      expect(score).toBeGreaterThanOrEqual(0);
+      expect(score).toBeLessThanOrEqual(1);
+    }
+  });
+});

--- a/src/__tests__/maintenance-promote.test.ts
+++ b/src/__tests__/maintenance-promote.test.ts
@@ -1,5 +1,5 @@
 // -*- coding: utf-8 -*-
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -8,6 +8,14 @@ import matter from 'gray-matter';
 
 import { findPromotionCandidates, executePromotion } from '../maintenance/promote.js';
 import type { UserVotesV2 } from '../types.js';
+
+// Mock AI client to avoid real CLI calls in tests
+vi.mock('../utils/ai-client.js', () => ({
+  callClaude: vi.fn(async (prompt: string) => {
+    if (prompt.includes('Classify')) return 'skills';
+    return '---\ntitle: promoted content\ntags: [test]\ndate: 2026-07-03\n---\nPromoted by AI.';
+  }),
+}));
 
 let tmpDir: string;
 

--- a/src/__tests__/maintenance-promote.test.ts
+++ b/src/__tests__/maintenance-promote.test.ts
@@ -1,0 +1,159 @@
+// -*- coding: utf-8 -*-
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import YAML from 'yaml';
+import matter from 'gray-matter';
+
+import { findPromotionCandidates, executePromotion } from '../maintenance/promote.js';
+import type { UserVotesV2 } from '../types.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-promote-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function makeLearning(dir: string, id: string, opts: { date?: string; title?: string } = {}): void {
+  const date = opts.date ?? new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+  const title = opts.title ?? id;
+  const content = matter.stringify('How to do something step-by-step.', { title, date, tags: ['workflow'] });
+  fs.writeFileSync(path.join(dir, `${id}.md`), content);
+}
+
+function makeHighVotes(votesDir: string, docId: string): void {
+  const recentDate = new Date().toISOString();
+  // Create votes from 3 users with high upvote ratio (meets MIN_USERS=2, MIN_UPVOTED=5)
+  // Need confidence >= 0.90: high base + high recency + high ratio
+  for (const user of ['alice', 'bob', 'carol']) {
+    const data: UserVotesV2 = {
+      version: 2,
+      votes: {
+        [docId]: { recalled_count: 5, upvoted_count: 4, last_recalled_at: recentDate, last_upvoted_at: recentDate },
+      },
+      deltas: {},
+    };
+    fs.writeFileSync(path.join(votesDir, `${user}.yaml`), YAML.stringify(data));
+  }
+}
+
+describe('findPromotionCandidates', () => {
+  it('returns empty when no learnings meet thresholds', async () => {
+    const learningsDir = path.join(tmpDir, 'learnings');
+    const votesDir = path.join(tmpDir, 'votes');
+    fs.mkdirSync(learningsDir, { recursive: true });
+    fs.mkdirSync(votesDir, { recursive: true });
+
+    makeLearning(learningsDir, 'low-conf');
+    // Only 1 user with low votes
+    const data: UserVotesV2 = {
+      version: 2,
+      votes: { 'low-conf': { recalled_count: 1, upvoted_count: 0, last_recalled_at: new Date().toISOString() } },
+      deltas: {},
+    };
+    fs.writeFileSync(path.join(votesDir, 'jeff.yaml'), YAML.stringify(data));
+
+    const candidates = await findPromotionCandidates(learningsDir, votesDir);
+    expect(candidates).toHaveLength(0);
+  });
+
+  it('identifies high-confidence learnings from multiple users', async () => {
+    const learningsDir = path.join(tmpDir, 'learnings');
+    const votesDir = path.join(tmpDir, 'votes');
+    fs.mkdirSync(learningsDir, { recursive: true });
+    fs.mkdirSync(votesDir, { recursive: true });
+
+    makeLearning(learningsDir, 'great-doc');
+    makeHighVotes(votesDir, 'great-doc');
+
+    const candidates = await findPromotionCandidates(learningsDir, votesDir);
+    expect(candidates.length).toBeGreaterThan(0);
+    expect(candidates[0].docId).toBe('great-doc');
+    expect(candidates[0].suggestedCategory).toBeDefined();
+  });
+
+  it('skips already-promoted learnings', async () => {
+    const learningsDir = path.join(tmpDir, 'learnings');
+    const votesDir = path.join(tmpDir, 'votes');
+    fs.mkdirSync(learningsDir, { recursive: true });
+    fs.mkdirSync(votesDir, { recursive: true });
+
+    // Create learning with promoted_to marker
+    const content = matter.stringify('Content', { title: 'promoted', date: '2026-01-01', promoted_to: 'skills/promoted.md' });
+    fs.writeFileSync(path.join(learningsDir, 'promoted.md'), content);
+    makeHighVotes(votesDir, 'promoted');
+
+    const candidates = await findPromotionCandidates(learningsDir, votesDir);
+    expect(candidates.find((c) => c.docId === 'promoted')).toBeUndefined();
+  });
+
+  it('skips learnings younger than 14 days', async () => {
+    const learningsDir = path.join(tmpDir, 'learnings');
+    const votesDir = path.join(tmpDir, 'votes');
+    fs.mkdirSync(learningsDir, { recursive: true });
+    fs.mkdirSync(votesDir, { recursive: true });
+
+    // Recent doc (3 days old)
+    const recentDate = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+    makeLearning(learningsDir, 'too-new', { date: recentDate });
+    makeHighVotes(votesDir, 'too-new');
+
+    const candidates = await findPromotionCandidates(learningsDir, votesDir);
+    expect(candidates.find((c) => c.docId === 'too-new')).toBeUndefined();
+  });
+});
+
+describe('executePromotion', () => {
+  it('dry-run does not create files', async () => {
+    const learningsDir = path.join(tmpDir, 'learnings');
+    fs.mkdirSync(learningsDir, { recursive: true });
+    makeLearning(learningsDir, 'candidate');
+
+    const candidate = {
+      docId: 'candidate',
+      filename: 'candidate.md',
+      path: path.join(learningsDir, 'candidate.md'),
+      confidence: 0.95,
+      upvotedCount: 10,
+      userCount: 3,
+      title: 'candidate',
+      suggestedCategory: 'skills' as const,
+    };
+
+    const targetPath = await executePromotion(candidate, tmpDir, { dryRun: true });
+    expect(targetPath).toContain('skills/candidate.md');
+    expect(fs.existsSync(path.join(tmpDir, 'skills', 'candidate.md'))).toBe(false);
+  });
+
+  it('copies file and marks original with promoted_to', async () => {
+    const learningsDir = path.join(tmpDir, 'learnings');
+    const skillsDir = path.join(tmpDir, 'skills');
+    fs.mkdirSync(learningsDir, { recursive: true });
+    makeLearning(learningsDir, 'ready');
+
+    const candidate = {
+      docId: 'ready',
+      filename: 'ready.md',
+      path: path.join(learningsDir, 'ready.md'),
+      confidence: 0.95,
+      upvotedCount: 10,
+      userCount: 3,
+      title: 'ready',
+      suggestedCategory: 'skills' as const,
+    };
+
+    await executePromotion(candidate, tmpDir, { category: 'skills' });
+
+    expect(fs.existsSync(path.join(skillsDir, 'ready.md'))).toBe(true);
+
+    // Original should have promoted_to in frontmatter
+    const original = fs.readFileSync(path.join(learningsDir, 'ready.md'), 'utf-8');
+    const { data } = matter(original);
+    expect(data.promoted_to).toBe('skills/ready.md');
+  });
+});

--- a/src/__tests__/maintenance-prune.test.ts
+++ b/src/__tests__/maintenance-prune.test.ts
@@ -1,0 +1,134 @@
+// -*- coding: utf-8 -*-
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import YAML from 'yaml';
+import matter from 'gray-matter';
+
+import { findPruneCandidates, executePrune } from '../maintenance/prune.js';
+import type { UserVotesV2 } from '../types.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-prune-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function makeLearning(dir: string, id: string, date: string): void {
+  const content = matter.stringify('Learning content here.', { title: id, date, tags: ['test'] });
+  fs.writeFileSync(path.join(dir, `${id}.md`), content);
+}
+
+function makeVotes(dir: string, username: string, votes: Record<string, { recalled_count: number; upvoted_count: number; last_recalled_at: string }>): void {
+  const data: UserVotesV2 = { version: 2, votes: {}, deltas: {} };
+  for (const [docId, entry] of Object.entries(votes)) {
+    data.votes[docId] = { ...entry };
+  }
+  fs.writeFileSync(path.join(dir, `${username}.yaml`), YAML.stringify(data));
+}
+
+describe('findPruneCandidates', () => {
+  it('returns empty for docs with no vote data', async () => {
+    const learningsDir = path.join(tmpDir, 'learnings');
+    const votesDir = path.join(tmpDir, 'votes');
+    fs.mkdirSync(learningsDir, { recursive: true });
+    fs.mkdirSync(votesDir, { recursive: true });
+
+    makeLearning(learningsDir, 'new-doc', '2026-06-01');
+
+    const candidates = await findPruneCandidates(learningsDir, votesDir);
+    expect(candidates).toHaveLength(0);
+  });
+
+  it('identifies low-confidence docs', async () => {
+    const learningsDir = path.join(tmpDir, 'learnings');
+    const votesDir = path.join(tmpDir, 'votes');
+    fs.mkdirSync(learningsDir, { recursive: true });
+    fs.mkdirSync(votesDir, { recursive: true });
+
+    // Create an old doc with minimal activity -> low confidence
+    const oldDate = new Date(Date.now() - 200 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+    makeLearning(learningsDir, 'stale-doc', oldDate);
+    makeVotes(votesDir, 'user1', {
+      'stale-doc': { recalled_count: 1, upvoted_count: 0, last_recalled_at: oldDate },
+    });
+
+    const candidates = await findPruneCandidates(learningsDir, votesDir);
+    expect(candidates.length).toBeGreaterThan(0);
+    expect(candidates[0].filename).toBe('stale-doc.md');
+  });
+
+  it('respects custom threshold', async () => {
+    const learningsDir = path.join(tmpDir, 'learnings');
+    const votesDir = path.join(tmpDir, 'votes');
+    fs.mkdirSync(learningsDir, { recursive: true });
+    fs.mkdirSync(votesDir, { recursive: true });
+
+    makeLearning(learningsDir, 'borderline', '2026-06-01');
+    makeVotes(votesDir, 'user1', {
+      'borderline': { recalled_count: 3, upvoted_count: 1, last_recalled_at: new Date().toISOString() },
+    });
+
+    // With very high threshold, should find it
+    const highThreshold = await findPruneCandidates(learningsDir, votesDir, { threshold: 0.99 });
+    expect(highThreshold.length).toBeGreaterThan(0);
+
+    // With very low threshold, should not find it
+    const lowThreshold = await findPruneCandidates(learningsDir, votesDir, { threshold: 0.01 });
+    expect(lowThreshold).toHaveLength(0);
+  });
+
+  it('handles missing date gracefully', async () => {
+    const learningsDir = path.join(tmpDir, 'learnings');
+    const votesDir = path.join(tmpDir, 'votes');
+    fs.mkdirSync(learningsDir, { recursive: true });
+    fs.mkdirSync(votesDir, { recursive: true });
+
+    // Doc without date
+    fs.writeFileSync(path.join(learningsDir, 'nodate.md'), '---\ntitle: no date\n---\nContent');
+    const oldDate = new Date(Date.now() - 200 * 24 * 60 * 60 * 1000).toISOString();
+    makeVotes(votesDir, 'user1', {
+      'nodate': { recalled_count: 1, upvoted_count: 0, last_recalled_at: oldDate },
+    });
+
+    const candidates = await findPruneCandidates(learningsDir, votesDir);
+    // Should work without crashing; doc may end up in confidence-too-low OR stale branch
+    const nodateCandidate = candidates.find((c) => c.filename === 'nodate.md');
+    expect(nodateCandidate).toBeDefined();
+    // If it hits the stale branch, reason should contain 'no-date'; otherwise 'confidence'
+    expect(nodateCandidate!.reason).toMatch(/confidence|no-date/);
+  });
+});
+
+describe('executePrune', () => {
+  it('dry-run does not delete files', async () => {
+    const learningsDir = path.join(tmpDir, 'learnings');
+    fs.mkdirSync(learningsDir, { recursive: true });
+    makeLearning(learningsDir, 'target', '2026-01-01');
+
+    const candidates = [{ filename: 'target.md', path: path.join(learningsDir, 'target.md'), confidence: 0.05, lastActivity: '', reason: 'test' }];
+    const result = await executePrune(tmpDir, candidates, { dryRun: true });
+
+    expect(result.archived).toBe(0);
+    expect(result.removed).toBe(0);
+    expect(fs.existsSync(path.join(learningsDir, 'target.md'))).toBe(true);
+  });
+
+  it('archive mode moves files to _archive/', async () => {
+    const learningsDir = path.join(tmpDir, 'learnings');
+    fs.mkdirSync(learningsDir, { recursive: true });
+    makeLearning(learningsDir, 'target', '2026-01-01');
+
+    const candidates = [{ filename: 'target.md', path: path.join(learningsDir, 'target.md'), confidence: 0.05, lastActivity: '', reason: 'test' }];
+    const result = await executePrune(tmpDir, candidates, { archive: true });
+
+    expect(result.archived).toBe(1);
+    expect(fs.existsSync(path.join(learningsDir, 'target.md'))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, 'learnings', '_archive', 'target.md'))).toBe(true);
+  });
+});

--- a/src/__tests__/recall.test.ts
+++ b/src/__tests__/recall.test.ts
@@ -6,7 +6,7 @@ import YAML from 'yaml';
 import { autoUpvote } from '../recall.js';
 import { buildIndex, loadIndex, search } from '../utils/search-index.js';
 import type { SearchResult } from '../utils/search-index.js';
-import type { SearchIndex, UserVotes } from '../types.js';
+import type { SearchIndex, UserVotesV2 } from '../types.js';
 
 // ─── Test helpers ──────────────────────────────────────────
 
@@ -73,7 +73,7 @@ describe('autoUpvote', () => {
     };
   }
 
-  it('T12: creates new vote entry on first upvote', async () => {
+  it('T12: creates new vote entry on first upvote (V2 format)', async () => {
     const results = [makeResult('api-timeout-2026-03-20-abc.md')];
     await autoUpvote(results, 'jeff', repoPath);
 
@@ -82,9 +82,11 @@ describe('autoUpvote', () => {
     expect(fs.existsSync(localPath)).toBe(true);
 
     const content = fs.readFileSync(localPath, 'utf-8');
-    const parsed = YAML.parse(content) as UserVotes;
+    const parsed = YAML.parse(content) as UserVotesV2;
+    expect(parsed.version).toBe(2);
     expect(parsed.votes['api-timeout-2026-03-20-abc']).toBeDefined();
-    expect(parsed.votes['api-timeout-2026-03-20-abc'].at).toBeTruthy();
+    expect(parsed.votes['api-timeout-2026-03-20-abc'].recalled_count).toBe(1);
+    expect(parsed.votes['api-timeout-2026-03-20-abc'].last_recalled_at).toBeTruthy();
 
     // Repo votes dir should NOT have the file — votes are only written
     // to the repo by reportUsageToTeam() during `teamai pull`.
@@ -92,23 +94,21 @@ describe('autoUpvote', () => {
     expect(fs.existsSync(repoVotePath)).toBe(false);
   });
 
-  it('T13: idempotent — duplicate vote does not change file', async () => {
+  it('T13: increments recalled_count on each call (V2 is cumulative)', async () => {
     const results = [makeResult('api-timeout-2026-03-20-abc.md')];
 
     // First vote
     await autoUpvote(results, 'jeff', repoPath);
     const localPath = path.join(tmpDir, '.teamai', 'votes', 'jeff.yaml');
     const firstContent = fs.readFileSync(localPath, 'utf-8');
-    const firstParsed = YAML.parse(firstContent) as UserVotes;
-    const firstTimestamp = firstParsed.votes['api-timeout-2026-03-20-abc'].at;
+    const firstParsed = YAML.parse(firstContent) as UserVotesV2;
+    expect(firstParsed.votes['api-timeout-2026-03-20-abc'].recalled_count).toBe(1);
 
-    // Second vote (same doc)
+    // Second vote (same doc) — should increment
     await autoUpvote(results, 'jeff', repoPath);
     const secondContent = fs.readFileSync(localPath, 'utf-8');
-    const secondParsed = YAML.parse(secondContent) as UserVotes;
-
-    // Timestamp should NOT have changed (idempotent)
-    expect(secondParsed.votes['api-timeout-2026-03-20-abc'].at).toBe(firstTimestamp);
+    const secondParsed = YAML.parse(secondContent) as UserVotesV2;
+    expect(secondParsed.votes['api-timeout-2026-03-20-abc'].recalled_count).toBe(2);
   });
 
   it('accumulates votes for different docs', async () => {
@@ -117,7 +117,7 @@ describe('autoUpvote', () => {
 
     const localPath = path.join(tmpDir, '.teamai', 'votes', 'jeff.yaml');
     const content = fs.readFileSync(localPath, 'utf-8');
-    const parsed = YAML.parse(content) as UserVotes;
+    const parsed = YAML.parse(content) as UserVotesV2;
     expect(Object.keys(parsed.votes)).toHaveLength(2);
     expect(parsed.votes['doc-a']).toBeDefined();
     expect(parsed.votes['doc-b']).toBeDefined();
@@ -138,8 +138,10 @@ describe('autoUpvote', () => {
     await autoUpvote(results, 'jeff', repoPath);
 
     const content = fs.readFileSync(path.join(localDir, 'jeff.yaml'), 'utf-8');
-    const parsed = YAML.parse(content) as UserVotes;
+    const parsed = YAML.parse(content) as UserVotesV2;
+    expect(parsed.version).toBe(2);
     expect(parsed.votes['new-doc']).toBeDefined();
+    expect(parsed.votes['new-doc'].recalled_count).toBe(1);
   });
 });
 

--- a/src/__tests__/search-domain-weighting.test.ts
+++ b/src/__tests__/search-domain-weighting.test.ts
@@ -197,7 +197,7 @@ describe('domain-weighted search scoring', () => {
     const index = await loadIndex(indexPath);
 
     expect(index).not.toBeNull();
-    expect(index!.version).toBe(5);
+    expect(index!.version).toBe(6);
 
     for (const entry of index!.entries) {
       expect(entry.domain).toBeDefined();

--- a/src/__tests__/transcript-parser.test.ts
+++ b/src/__tests__/transcript-parser.test.ts
@@ -1,0 +1,131 @@
+// -*- coding: utf-8 -*-
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { parseTranscriptForVotes } from '../transcript-parser.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-transcript-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeLine(filePath: string, entry: Record<string, unknown>): void {
+  fs.appendFileSync(filePath, JSON.stringify(entry) + '\n');
+}
+
+describe('parseTranscriptForVotes', () => {
+  it('returns empty for non-existent file', async () => {
+    const result = await parseTranscriptForVotes(path.join(tmpDir, 'nope.jsonl'));
+    expect(result.recalledDocIds).toEqual([]);
+    expect(result.referencedDocIds).toEqual([]);
+  });
+
+  it('returns empty for empty file', async () => {
+    const filePath = path.join(tmpDir, 'empty.jsonl');
+    fs.writeFileSync(filePath, '');
+    const result = await parseTranscriptForVotes(filePath);
+    expect(result.recalledDocIds).toEqual([]);
+    expect(result.referencedDocIds).toEqual([]);
+  });
+
+  it('extracts recalled doc IDs from recall markers', async () => {
+    const filePath = path.join(tmpDir, 'transcript.jsonl');
+    writeLine(filePath, {
+      type: 'assistant',
+      message: {
+        content: [{
+          type: 'text',
+          text: '--- [teamai:recall:start] ---\nFile: /path/to/learnings/api-fix.md\nFile: /path/to/docs/design-overview.md\n--- [teamai:recall:end] ---',
+        }],
+      },
+    });
+
+    const result = await parseTranscriptForVotes(filePath);
+    expect(result.recalledDocIds).toContain('api-fix');
+    expect(result.recalledDocIds).toContain('design-overview');
+    expect(result.recalledDocIds).toHaveLength(2);
+  });
+
+  it('extracts referenced doc IDs from HTML comment markers', async () => {
+    const filePath = path.join(tmpDir, 'transcript.jsonl');
+    writeLine(filePath, {
+      type: 'assistant',
+      message: {
+        content: [{
+          type: 'text',
+          text: 'Here is my answer.\n\n<!-- teamai:referenced-doc-ids: [api-fix, design-overview] -->',
+        }],
+      },
+    });
+
+    const result = await parseTranscriptForVotes(filePath);
+    expect(result.referencedDocIds).toContain('api-fix');
+    expect(result.referencedDocIds).toContain('design-overview');
+    expect(result.referencedDocIds).toHaveLength(2);
+  });
+
+  it('deduplicates across multiple messages', async () => {
+    const filePath = path.join(tmpDir, 'transcript.jsonl');
+    writeLine(filePath, {
+      type: 'assistant',
+      message: {
+        content: [{
+          type: 'text',
+          text: '--- [teamai:recall:start] ---\nFile: /path/api-fix.md\n--- [teamai:recall:end] ---',
+        }],
+      },
+    });
+    writeLine(filePath, {
+      type: 'assistant',
+      message: {
+        content: [{
+          type: 'text',
+          text: '--- [teamai:recall:start] ---\nFile: /path/api-fix.md\n--- [teamai:recall:end] ---',
+        }],
+      },
+    });
+
+    const result = await parseTranscriptForVotes(filePath);
+    expect(result.recalledDocIds).toHaveLength(1);
+  });
+
+  it('ignores non-assistant entries', async () => {
+    const filePath = path.join(tmpDir, 'transcript.jsonl');
+    writeLine(filePath, {
+      type: 'user',
+      message: {
+        content: [{
+          type: 'text',
+          text: '<!-- teamai:referenced-doc-ids: [fake-doc] -->',
+        }],
+      },
+    });
+
+    const result = await parseTranscriptForVotes(filePath);
+    expect(result.referencedDocIds).toEqual([]);
+  });
+
+  it('handles quoted doc IDs in referenced markers', async () => {
+    const filePath = path.join(tmpDir, 'transcript.jsonl');
+    writeLine(filePath, {
+      type: 'assistant',
+      message: {
+        content: [{
+          type: 'text',
+          text: '<!-- teamai:referenced-doc-ids: ["doc-a", \'doc-b\'] -->',
+        }],
+      },
+    });
+
+    const result = await parseTranscriptForVotes(filePath);
+    expect(result.referencedDocIds).toContain('doc-a');
+    expect(result.referencedDocIds).toContain('doc-b');
+  });
+});

--- a/src/__tests__/votes-e2e.test.ts
+++ b/src/__tests__/votes-e2e.test.ts
@@ -1,0 +1,186 @@
+// -*- coding: utf-8 -*-
+/**
+ * End-to-end data flow verification for the Phase 3 + Phase 4 pipeline.
+ *
+ * Simulates: recall → incrementRecalled → Stop hook transcript parse →
+ * incrementUpvoted → syncVotesToTeam → buildIndex (confidence + hotness) →
+ * search (cold penalty applied)
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import YAML from 'yaml';
+import matter from 'gray-matter';
+
+import { incrementRecalled, incrementUpvoted, syncVotesToTeam, loadUserVotes } from '../votes.js';
+import { parseTranscriptForVotes } from '../transcript-parser.js';
+import { buildIndex, loadIndex, search } from '../utils/search-index.js';
+import { computeAllConfidence, writeBackConfidence } from '../maintenance/confidence.js';
+import { annotateHotness, HOT_THRESHOLD } from '../maintenance/hot-cold.js';
+import { findPruneCandidates } from '../maintenance/prune.js';
+import type { UserVotesV2 } from '../types.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-e2e-votes-'));
+  process.env.HOME = tmpDir;
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('Phase 3+4 end-to-end data flow', () => {
+
+  it('full pipeline: recall → vote → sync → confidence → hotness → search ranking', async () => {
+    // ─── Setup: create learnings and team repo structure ───
+    const learningsDir = path.join(tmpDir, 'learnings');
+    const votesDir = path.join(tmpDir, 'votes');
+    const repoVotesDir = path.join(tmpDir, 'repo', 'votes');
+    fs.mkdirSync(learningsDir, { recursive: true });
+    fs.mkdirSync(votesDir, { recursive: true });
+    fs.mkdirSync(repoVotesDir, { recursive: true });
+
+    // Create two learnings: one active (will be recalled + upvoted), one stale
+    const activeLearning = matter.stringify(
+      'Use retry backoff with exponential delay for transient API errors.',
+      { title: 'API retry pattern', tags: ['api', 'timeout'], date: '2026-06-01' },
+    );
+    const staleLearning = matter.stringify(
+      'Some outdated advice that nobody finds useful anymore.',
+      { title: 'Outdated pattern', tags: ['api'], date: '2025-01-01' },
+    );
+    fs.writeFileSync(path.join(learningsDir, 'api-retry.md'), activeLearning);
+    fs.writeFileSync(path.join(learningsDir, 'outdated-pattern.md'), staleLearning);
+
+    // ─── Step 1: Simulate recall (autoUpvote → incrementRecalled) ───
+    const localVotePath = path.join(votesDir, 'jeff.yaml');
+    await incrementRecalled(localVotePath, ['api-retry', 'outdated-pattern']);
+    await incrementRecalled(localVotePath, ['api-retry']); // recalled again
+    await incrementRecalled(localVotePath, ['api-retry']); // and again
+
+    // Verify: api-retry recalled 3x, outdated-pattern 1x
+    const afterRecall = await loadUserVotes(localVotePath);
+    expect(afterRecall.votes['api-retry'].recalled_count).toBe(3);
+    expect(afterRecall.votes['outdated-pattern'].recalled_count).toBe(1);
+    expect(afterRecall.deltas['api-retry'].recalled_delta).toBe(3);
+
+    // ─── Step 2: Simulate Stop hook (transcript parse → incrementUpvoted) ───
+    // Create a fake transcript with referenced-doc-ids
+    const transcriptPath = path.join(tmpDir, 'transcript.jsonl');
+    const transcriptEntry = {
+      type: 'assistant',
+      message: {
+        content: [{
+          type: 'text',
+          text: 'Here is the solution.\n\n<!-- teamai:referenced-doc-ids: [api-retry] -->',
+        }],
+      },
+    };
+    fs.writeFileSync(transcriptPath, JSON.stringify(transcriptEntry) + '\n');
+
+    const voteData = await parseTranscriptForVotes(transcriptPath);
+    expect(voteData.referencedDocIds).toContain('api-retry');
+    expect(voteData.referencedDocIds).not.toContain('outdated-pattern');
+
+    await incrementUpvoted(localVotePath, voteData.referencedDocIds);
+
+    // Verify: api-retry now has upvoted_count=1
+    const afterUpvote = await loadUserVotes(localVotePath);
+    expect(afterUpvote.votes['api-retry'].upvoted_count).toBe(1);
+    expect(afterUpvote.votes['outdated-pattern'].upvoted_count).toBe(0);
+
+    // ─── Step 3: Sync to team repo ───
+    const synced = await syncVotesToTeam(path.join(tmpDir, 'repo'), 'jeff', votesDir);
+    expect(synced).toBe(true);
+
+    // Verify: repo has merged data, local deltas cleared
+    const repoVotes = await loadUserVotes(path.join(repoVotesDir, 'jeff.yaml'));
+    expect(repoVotes.votes['api-retry'].recalled_count).toBe(3);
+    expect(repoVotes.votes['api-retry'].upvoted_count).toBe(1);
+
+    const localAfterSync = await loadUserVotes(localVotePath);
+    expect(Object.keys(localAfterSync.deltas)).toHaveLength(0);
+
+    // ─── Step 4: Compute confidence ───
+    const confidenceMap = await computeAllConfidence(repoVotesDir);
+    const apiRetryConf = confidenceMap.get('api-retry')!;
+    const outdatedConf = confidenceMap.get('outdated-pattern')!;
+
+    // api-retry: recalled=3, upvoted=1, recent → higher confidence
+    // outdated-pattern: recalled=1, upvoted=0, old → lower confidence
+    expect(apiRetryConf).toBeGreaterThan(outdatedConf);
+    expect(apiRetryConf).toBeGreaterThan(0.3);
+
+    // ─── Step 5: Build index with hotness annotation ───
+    const indexPath = path.join(tmpDir, 'search-index.json');
+    await buildIndex({ learningsDir, votesDir: repoVotesDir, indexPath });
+
+    const index = await loadIndex(indexPath);
+    expect(index).not.toBeNull();
+    expect(index!.entries.length).toBe(2);
+
+    const apiEntry = index!.entries.find(e => e.filename === 'api-retry.md')!;
+    const outdatedEntry = index!.entries.find(e => e.filename === 'outdated-pattern.md')!;
+
+    // Confidence is annotated
+    expect(apiEntry.confidence).toBeDefined();
+    expect(outdatedEntry.confidence).toBeDefined();
+
+    // Hotness is annotated
+    expect(apiEntry.hotness).toBeDefined();
+    expect(outdatedEntry.hotness).toBeDefined();
+
+    // ─── Step 6: Search verifies cold penalty ───
+    const results = search('api', index!);
+    expect(results.length).toBe(2);
+
+    // api-retry should rank higher (more votes + higher hotness)
+    expect(results[0].entry.filename).toBe('api-retry.md');
+    expect(results[0].score).toBeGreaterThan(results[1].score);
+  });
+
+  it('confidence writeback updates frontmatter', async () => {
+    const learningsDir = path.join(tmpDir, 'learnings');
+    const votesDir = path.join(tmpDir, 'votes');
+    fs.mkdirSync(learningsDir, { recursive: true });
+    fs.mkdirSync(votesDir, { recursive: true });
+
+    const content = matter.stringify('Content here.', { title: 'test-doc', date: '2026-06-01', tags: ['test'] });
+    fs.writeFileSync(path.join(learningsDir, 'test-doc.md'), content);
+
+    // Add votes
+    const v2: UserVotesV2 = {
+      version: 2,
+      votes: { 'test-doc': { recalled_count: 5, upvoted_count: 3, last_recalled_at: new Date().toISOString(), last_upvoted_at: new Date().toISOString() } },
+      deltas: {},
+    };
+    fs.writeFileSync(path.join(votesDir, 'user1.yaml'), YAML.stringify(v2));
+
+    const map = await computeAllConfidence(votesDir);
+    const updated = await writeBackConfidence(learningsDir, map);
+    expect(updated).toBe(1);
+
+    // Verify frontmatter has confidence
+    const afterContent = fs.readFileSync(path.join(learningsDir, 'test-doc.md'), 'utf-8');
+    const { data } = matter(afterContent);
+    expect(data.confidence).toBeDefined();
+    expect(data.confidence).toBeGreaterThan(0);
+  });
+
+  it('prune skips docs with no vote data (new docs protected)', async () => {
+    const learningsDir = path.join(tmpDir, 'learnings');
+    const votesDir = path.join(tmpDir, 'votes');
+    fs.mkdirSync(learningsDir, { recursive: true });
+    fs.mkdirSync(votesDir, { recursive: true });
+
+    // New doc with no vote data
+    const content = matter.stringify('Brand new learning.', { title: 'new-doc', date: '2026-07-01', tags: ['test'] });
+    fs.writeFileSync(path.join(learningsDir, 'new-doc.md'), content);
+
+    const candidates = await findPruneCandidates(learningsDir, votesDir);
+    expect(candidates).toHaveLength(0);
+  });
+});

--- a/src/__tests__/votes.test.ts
+++ b/src/__tests__/votes.test.ts
@@ -1,0 +1,284 @@
+// -*- coding: utf-8 -*-
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import YAML from 'yaml';
+
+import {
+  migrateV1ToV2,
+  loadUserVotes,
+  saveUserVotes,
+  incrementRecalled,
+  incrementUpvoted,
+  mergeDeltas,
+  syncVotesToTeam,
+  recallFeedback,
+} from '../votes.js';
+import type { UserVotes, UserVotesV2 } from '../types.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-votes-test-'));
+  process.env.HOME = tmpDir;
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('migrateV1ToV2', () => {
+  it('converts v1 entries to v2 with recalled_count=1', () => {
+    const v1: UserVotes = {
+      votes: {
+        'doc-a': { at: '2026-06-01T00:00:00Z' },
+        'doc-b': { at: '2026-06-02T00:00:00Z' },
+      },
+    };
+    const v2 = migrateV1ToV2(v1);
+
+    expect(v2.version).toBe(2);
+    expect(v2.votes['doc-a'].recalled_count).toBe(1);
+    expect(v2.votes['doc-a'].upvoted_count).toBe(0);
+    expect(v2.votes['doc-a'].last_recalled_at).toBe('2026-06-01T00:00:00Z');
+    expect(v2.votes['doc-b'].recalled_count).toBe(1);
+    expect(v2.deltas).toEqual({});
+  });
+
+  it('handles empty v1', () => {
+    const v2 = migrateV1ToV2({ votes: {} });
+    expect(v2.version).toBe(2);
+    expect(Object.keys(v2.votes)).toHaveLength(0);
+  });
+});
+
+describe('loadUserVotes', () => {
+  it('returns empty v2 for non-existent file', async () => {
+    const result = await loadUserVotes(path.join(tmpDir, 'nonexistent.yaml'));
+    expect(result.version).toBe(2);
+    expect(Object.keys(result.votes)).toHaveLength(0);
+  });
+
+  it('auto-migrates v1 file on read', async () => {
+    const v1: UserVotes = { votes: { 'doc-x': { at: '2026-06-01T00:00:00Z' } } };
+    const filePath = path.join(tmpDir, 'user.yaml');
+    fs.writeFileSync(filePath, YAML.stringify(v1));
+
+    const result = await loadUserVotes(filePath);
+    expect(result.version).toBe(2);
+    expect(result.votes['doc-x'].recalled_count).toBe(1);
+
+    // Verify file was rewritten as v2
+    const onDisk = YAML.parse(fs.readFileSync(filePath, 'utf-8'));
+    expect(onDisk.version).toBe(2);
+  });
+
+  it('reads v2 file directly', async () => {
+    const v2: UserVotesV2 = {
+      version: 2,
+      votes: { 'doc-y': { recalled_count: 3, upvoted_count: 1, last_recalled_at: '2026-06-01T00:00:00Z' } },
+      deltas: { 'doc-y': { recalled_delta: 1, upvoted_delta: 0 } },
+    };
+    const filePath = path.join(tmpDir, 'user.yaml');
+    fs.writeFileSync(filePath, YAML.stringify(v2));
+
+    const result = await loadUserVotes(filePath);
+    expect(result.votes['doc-y'].recalled_count).toBe(3);
+    expect(result.deltas['doc-y'].recalled_delta).toBe(1);
+  });
+
+  it('recovers from corrupt YAML', async () => {
+    const filePath = path.join(tmpDir, 'user.yaml');
+    fs.writeFileSync(filePath, '{{{{ not yaml }}}}');
+
+    const result = await loadUserVotes(filePath);
+    expect(result.version).toBe(2);
+    expect(Object.keys(result.votes)).toHaveLength(0);
+  });
+});
+
+describe('incrementRecalled', () => {
+  it('creates new entry and records delta', async () => {
+    const filePath = path.join(tmpDir, 'user.yaml');
+    await incrementRecalled(filePath, ['doc-a', 'doc-b']);
+
+    const data = YAML.parse(fs.readFileSync(filePath, 'utf-8')) as UserVotesV2;
+    expect(data.votes['doc-a'].recalled_count).toBe(1);
+    expect(data.votes['doc-b'].recalled_count).toBe(1);
+    expect(data.deltas['doc-a'].recalled_delta).toBe(1);
+    expect(data.deltas['doc-b'].recalled_delta).toBe(1);
+  });
+
+  it('accumulates on repeated calls', async () => {
+    const filePath = path.join(tmpDir, 'user.yaml');
+    await incrementRecalled(filePath, ['doc-a']);
+    await incrementRecalled(filePath, ['doc-a']);
+    await incrementRecalled(filePath, ['doc-a']);
+
+    const data = YAML.parse(fs.readFileSync(filePath, 'utf-8')) as UserVotesV2;
+    expect(data.votes['doc-a'].recalled_count).toBe(3);
+    expect(data.deltas['doc-a'].recalled_delta).toBe(3);
+  });
+
+  it('does nothing for empty docIds', async () => {
+    const filePath = path.join(tmpDir, 'user.yaml');
+    await incrementRecalled(filePath, []);
+    expect(fs.existsSync(filePath)).toBe(false);
+  });
+});
+
+describe('incrementUpvoted', () => {
+  it('increments upvoted_count and records delta', async () => {
+    const filePath = path.join(tmpDir, 'user.yaml');
+    await incrementRecalled(filePath, ['doc-a']);
+    await incrementUpvoted(filePath, ['doc-a']);
+
+    const data = YAML.parse(fs.readFileSync(filePath, 'utf-8')) as UserVotesV2;
+    expect(data.votes['doc-a'].recalled_count).toBe(1);
+    expect(data.votes['doc-a'].upvoted_count).toBe(1);
+    expect(data.votes['doc-a'].last_upvoted_at).toBeTruthy();
+    expect(data.deltas['doc-a'].upvoted_delta).toBe(1);
+  });
+});
+
+describe('mergeDeltas', () => {
+  it('applies local deltas onto remote snapshot', () => {
+    const local: UserVotesV2 = {
+      version: 2,
+      votes: { 'doc-a': { recalled_count: 5, upvoted_count: 2, last_recalled_at: '2026-06-10T00:00:00Z' } },
+      deltas: { 'doc-a': { recalled_delta: 3, upvoted_delta: 1 } },
+    };
+    const remote: UserVotesV2 = {
+      version: 2,
+      votes: { 'doc-a': { recalled_count: 2, upvoted_count: 1, last_recalled_at: '2026-06-05T00:00:00Z' } },
+      deltas: {},
+    };
+
+    const merged = mergeDeltas(local, remote);
+    expect(merged.votes['doc-a'].recalled_count).toBe(5); // 2 + 3
+    expect(merged.votes['doc-a'].upvoted_count).toBe(2); // 1 + 1
+    expect(merged.votes['doc-a'].last_recalled_at).toBe('2026-06-10T00:00:00Z');
+    expect(merged.deltas).toEqual({});
+  });
+
+  it('handles new docs in local that are not in remote', () => {
+    const local: UserVotesV2 = {
+      version: 2,
+      votes: { 'new-doc': { recalled_count: 1, upvoted_count: 0, last_recalled_at: '2026-06-10T00:00:00Z' } },
+      deltas: { 'new-doc': { recalled_delta: 1, upvoted_delta: 0 } },
+    };
+    const remote: UserVotesV2 = { version: 2, votes: {}, deltas: {} };
+
+    const merged = mergeDeltas(local, remote);
+    expect(merged.votes['new-doc'].recalled_count).toBe(1);
+  });
+
+  it('floors negative deltas to zero (prevents negative counts)', () => {
+    const local: UserVotesV2 = {
+      version: 2,
+      votes: { 'doc-a': { recalled_count: 0, upvoted_count: 0, last_recalled_at: '2026-06-10T00:00:00Z' } },
+      deltas: { 'doc-a': { recalled_delta: 0, upvoted_delta: -1 } },
+    };
+    const remote: UserVotesV2 = {
+      version: 2,
+      votes: { 'doc-a': { recalled_count: 1, upvoted_count: 0, last_recalled_at: '2026-06-05T00:00:00Z' } },
+      deltas: {},
+    };
+
+    const merged = mergeDeltas(local, remote);
+    expect(merged.votes['doc-a'].upvoted_count).toBe(0);
+    expect(merged.votes['doc-a'].recalled_count).toBe(1);
+  });
+});
+
+describe('syncVotesToTeam', () => {
+  it('merges local deltas into remote and clears local deltas', async () => {
+    const localDir = path.join(tmpDir, 'local-votes');
+    const repoDir = path.join(tmpDir, 'repo');
+    fs.mkdirSync(localDir, { recursive: true });
+    fs.mkdirSync(path.join(repoDir, 'votes'), { recursive: true });
+
+    // Local has 2 recalled + 1 upvoted with deltas
+    const local: UserVotesV2 = {
+      version: 2,
+      votes: { 'doc-a': { recalled_count: 2, upvoted_count: 1, last_recalled_at: '2026-06-10T00:00:00Z', last_upvoted_at: '2026-06-10T00:00:00Z' } },
+      deltas: { 'doc-a': { recalled_delta: 2, upvoted_delta: 1 } },
+    };
+    fs.writeFileSync(path.join(localDir, 'jeff.yaml'), YAML.stringify(local));
+
+    const synced = await syncVotesToTeam(repoDir, 'jeff', localDir);
+    expect(synced).toBe(true);
+
+    // Remote should now have merged values
+    const remoteContent = YAML.parse(fs.readFileSync(path.join(repoDir, 'votes', 'jeff.yaml'), 'utf-8'));
+    expect(remoteContent.votes['doc-a'].recalled_count).toBe(2);
+
+    // Local deltas should be cleared
+    const localAfter = YAML.parse(fs.readFileSync(path.join(localDir, 'jeff.yaml'), 'utf-8'));
+    expect(localAfter.deltas).toEqual({});
+  });
+
+  it('returns false when no deltas to sync', async () => {
+    const localDir = path.join(tmpDir, 'local-votes');
+    const repoDir = path.join(tmpDir, 'repo');
+    fs.mkdirSync(localDir, { recursive: true });
+    fs.mkdirSync(path.join(repoDir, 'votes'), { recursive: true });
+
+    const local: UserVotesV2 = {
+      version: 2,
+      votes: { 'doc-a': { recalled_count: 1, upvoted_count: 0, last_recalled_at: '2026-06-01T00:00:00Z' } },
+      deltas: {},
+    };
+    fs.writeFileSync(path.join(localDir, 'jeff.yaml'), YAML.stringify(local));
+
+    const synced = await syncVotesToTeam(repoDir, 'jeff', localDir);
+    expect(synced).toBe(false);
+  });
+});
+
+describe('recallFeedback', () => {
+  beforeEach(() => {
+    vi.doMock('../config.js', () => ({
+      requireInit: () => Promise.resolve({
+        localConfig: { username: 'testuser', repo: { localPath: tmpDir } },
+      }),
+    }));
+  });
+
+  afterEach(() => {
+    vi.doUnmock('../config.js');
+  });
+
+  it('positive increments upvoted_count', async () => {
+    const votesDir = path.join(tmpDir, '.teamai', 'votes');
+    fs.mkdirSync(votesDir, { recursive: true });
+    await incrementRecalled(path.join(votesDir, 'testuser.yaml'), ['doc-a']);
+
+    await recallFeedback({ positive: 'doc-a' });
+
+    const content = fs.readFileSync(path.join(votesDir, 'testuser.yaml'), 'utf-8');
+    const parsed = YAML.parse(content) as UserVotesV2;
+    expect(parsed.votes['doc-a'].upvoted_count).toBe(1);
+  });
+
+  it('negative decrements upvoted_count (floor at 0)', async () => {
+    const votesDir = path.join(tmpDir, '.teamai', 'votes');
+    fs.mkdirSync(votesDir, { recursive: true });
+    await incrementRecalled(path.join(votesDir, 'testuser.yaml'), ['doc-b']);
+
+    await recallFeedback({ negative: 'doc-b' });
+
+    const content = fs.readFileSync(path.join(votesDir, 'testuser.yaml'), 'utf-8');
+    const parsed = YAML.parse(content) as UserVotesV2;
+    expect(parsed.votes['doc-b'].upvoted_count).toBe(0);
+  });
+
+  it('negative on missing doc warns without crashing', async () => {
+    const votesDir = path.join(tmpDir, '.teamai', 'votes');
+    fs.mkdirSync(votesDir, { recursive: true });
+
+    // Should not throw
+    await expect(recallFeedback({ negative: 'nonexistent' })).resolves.not.toThrow();
+  });
+});

--- a/src/builtin-skills.ts
+++ b/src/builtin-skills.ts
@@ -40,7 +40,7 @@ function getBuiltinSkillsDir(): string {
 }
 
 /** Names of CLI built-in skills. Used by push to exclude them from team repo push. */
-export const BUILTIN_SKILL_NAMES = new Set(['teamai-share-learnings', 'team-wiki-codebase']);
+export const BUILTIN_SKILL_NAMES = new Set(['teamai-share-learnings', 'team-wiki-codebase', 'teamai-workflow', 'teamai-import']);
 
 /** Built-in skills that depend on recall being enabled. Skipped when recall is disabled. */
 export const RECALL_DEPENDENT_SKILLS = new Set(['teamai-share-learnings', 'team-wiki-codebase']);

--- a/src/hook-handlers.ts
+++ b/src/hook-handlers.ts
@@ -9,6 +9,8 @@
  * remain unchanged for backward compatibility during migration.
  */
 
+import path from 'node:path';
+
 import type { HookHandler } from './hook-dispatch.js';
 import { deriveSessionId } from './utils/session-id.js';
 import { normalizeToolName } from './utils/tool-names.js';
@@ -34,6 +36,8 @@ const TRACK_TIMEOUT_MS = 5_000;
 const DASHBOARD_TIMEOUT_MS = 5_000;
 /** Contribute-check reads local state + events.jsonl — generally fast. */
 const CONTRIBUTE_CHECK_TIMEOUT_MS = 10_000;
+/** Votes sync at session end: parse transcript + push deltas. */
+const VOTES_SYNC_TIMEOUT_MS = 8_000;
 /** TodoWrite hint is a local dedup-cache check — very fast. */
 const TODOWRITE_HINT_TIMEOUT_MS = 5_000;
 /** MR-hint queries a remote MR/PR API — allow a network round-trip. */
@@ -163,6 +167,42 @@ const contributeCheckHandler: HookHandler = {
   },
 };
 
+const votesSyncHandler: HookHandler = {
+  name: 'votes-sync',
+  async execute(stdin) {
+    if (process.env.TEAMAI_RECALL_DISABLED === '1') return null;
+
+    const transcriptPath = typeof stdin.transcript_path === 'string' ? stdin.transcript_path : null;
+    if (!transcriptPath) return null;
+
+    try {
+      const { parseTranscriptForVotes } = await import('./transcript-parser.js');
+      const { incrementUpvoted, syncVotesToTeam } = await import('./votes.js');
+      const { requireInit } = await import('./config.js');
+
+      // recalledDocIds are already counted by autoUpvote() at recall time;
+      // we only need referencedDocIds (adopted signal) from the transcript.
+      const voteData = await parseTranscriptForVotes(transcriptPath);
+
+      const { localConfig } = await requireInit();
+      const { VOTES_LOCAL_DIR } = await import('./types.js');
+      const votesDir = VOTES_LOCAL_DIR;
+      const votePath = path.join(votesDir, `${localConfig.username}.yaml`);
+
+      if (voteData.referencedDocIds.length > 0) {
+        await incrementUpvoted(votePath, voteData.referencedDocIds);
+      }
+
+      await syncVotesToTeam(localConfig.repo.localPath, localConfig.username, votesDir).catch(() => {
+        // Push failed — will retry next session via reportUsageToTeam
+      });
+    } catch {
+      // Non-critical — votes will sync on next pull
+    }
+    return null;
+  },
+};
+
 const todowriteHintHandler: HookHandler = {
   name: 'todowrite-hint',
   async execute(stdin, _tool) {
@@ -229,6 +269,7 @@ export function buildHandlerRegistry(): HandlerRegistration[] {
     // ─── Stop ─────────────────────────────────────────
     { event: 'stop', matcher: '*', handler: updateHandler, timeoutMs: UPDATE_TIMEOUT_MS },
     { event: 'stop', matcher: '*', handler: contributeCheckHandler, timeoutMs: CONTRIBUTE_CHECK_TIMEOUT_MS },
+    { event: 'stop', matcher: '*', handler: votesSyncHandler, timeoutMs: VOTES_SYNC_TIMEOUT_MS },
     { event: 'stop', matcher: '*', handler: dashboardReportHandler, timeoutMs: DASHBOARD_TIMEOUT_MS },
 
     // ─── PostToolUse ──────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -762,4 +762,116 @@ program
     await deepEnrich({ project: cmdOpts.project, evidenceDir, wikiRoot, maxModules: cmdOpts.maxModules });
   });
 
+program
+  .command('maintenance')
+  .description('Automatic maintenance of team knowledge base')
+  .option('--prune', 'Remove low-confidence learnings')
+  .option('--threshold <n>', 'Confidence threshold for pruning (default 0.15)', parseFloat)
+  .option('--archive', 'Move to archive/ instead of deleting')
+  .option('--confidence-writeback', 'Update frontmatter confidence scores')
+  .option('--update-quality', 'Find stale docs/rules/skills and suggest updates')
+  .option('--dry-run', 'Show what would be done without making changes')
+  .action(async (cmdOpts) => {
+    const { requireInit } = await import('./config.js');
+    const { localConfig } = await requireInit();
+    const repoPath = localConfig.repo.localPath;
+    const votesDir = `${repoPath}/votes`;
+    const learningsDir = `${repoPath}/learnings`;
+
+    if (cmdOpts.confidenceWriteback) {
+      const { computeAllConfidence, writeBackConfidence } = await import('./maintenance/index.js');
+      const map = await computeAllConfidence(votesDir);
+      await writeBackConfidence(learningsDir, map);
+      return;
+    }
+
+    if (cmdOpts.prune) {
+      const { findPruneCandidates, executePrune } = await import('./maintenance/index.js');
+      const candidates = await findPruneCandidates(learningsDir, votesDir, {
+        threshold: cmdOpts.threshold,
+      });
+      if (candidates.length === 0) {
+        const { log } = await import('./utils/logger.js');
+        log.info('No learnings below threshold. Knowledge base is healthy.');
+        return;
+      }
+      const { log } = await import('./utils/logger.js');
+      log.info(`Found ${candidates.length} candidate(s) for pruning:`);
+      for (const c of candidates) {
+        log.info(`  - ${c.filename} (confidence: ${c.confidence.toFixed(2)}, reason: ${c.reason})`);
+      }
+      await executePrune(repoPath, candidates, {
+        dryRun: cmdOpts.dryRun,
+        archive: cmdOpts.archive,
+      });
+      return;
+    }
+
+    if (cmdOpts.updateQuality) {
+      const { findStaleEntries, reportStaleEntries } = await import('./maintenance/index.js');
+      const entries = await findStaleEntries(votesDir, {
+        docs: `${repoPath}/docs`,
+        rules: `${repoPath}/rules`,
+        skills: `${repoPath}/skills`,
+      });
+      reportStaleEntries(entries);
+      return;
+    }
+
+    const { log } = await import('./utils/logger.js');
+    log.info('Usage: teamai maintenance --prune | --confidence-writeback | --update-quality');
+  });
+
+program
+  .command('promote [learningId]')
+  .description('Promote a high-confidence learning to formal knowledge (docs/skills/rules)')
+  .option('--category <cat>', 'Target category: skills | rules | docs')
+  .option('--dry-run', 'Show what would be done without making changes')
+  .action(async (learningId, cmdOpts) => {
+    const { requireInit } = await import('./config.js');
+    const { localConfig } = await requireInit();
+    const repoPath = localConfig.repo.localPath;
+    const votesDir = `${repoPath}/votes`;
+    const learningsDir = `${repoPath}/learnings`;
+    const { findPromotionCandidates, executePromotion } = await import('./maintenance/index.js');
+    const { log } = await import('./utils/logger.js');
+
+    const candidates = await findPromotionCandidates(learningsDir, votesDir);
+
+    if (candidates.length === 0) {
+      log.info('No learnings eligible for promotion yet.');
+      return;
+    }
+
+    if (!learningId) {
+      log.info(`${candidates.length} learning(s) eligible for promotion:`);
+      for (const c of candidates) {
+        log.info(`  - ${c.docId} (confidence: ${c.confidence.toFixed(2)}, suggested: ${c.suggestedCategory})`);
+      }
+      log.info('\nRun: teamai promote <learning-id> [--category <cat>]');
+      return;
+    }
+
+    const candidate = candidates.find((c) => c.docId === learningId);
+    if (!candidate) {
+      log.error(`Learning "${learningId}" not found or not eligible for promotion.`);
+      return;
+    }
+
+    await executePromotion(candidate, repoPath, {
+      category: cmdOpts.category as 'skills' | 'rules' | 'docs' | undefined,
+      dryRun: cmdOpts.dryRun,
+    });
+  });
+
+program
+  .command('recall-feedback', { hidden: true })
+  .description('Record manual feedback for a recalled document')
+  .option('--positive <docId>', 'Upvote a document (marks as actually useful)')
+  .option('--negative <docId>', 'Record negative signal for a document')
+  .action(async (cmdOpts) => {
+    const { recallFeedback } = await import('./votes.js');
+    await recallFeedback({ positive: cmdOpts.positive, negative: cmdOpts.negative });
+  });
+
 program.parse();

--- a/src/index.ts
+++ b/src/index.ts
@@ -808,13 +808,29 @@ program
     }
 
     if (cmdOpts.updateQuality) {
-      const { findStaleEntries, reportStaleEntries } = await import('./maintenance/index.js');
+      const { findStaleEntries, reportStaleEntries, findRelatedAdoptedLearnings, generateUpdateDraft } = await import('./maintenance/index.js');
+      const { writeFile } = await import('./utils/fs.js');
+      const { log } = await import('./utils/logger.js');
       const entries = await findStaleEntries(votesDir, {
         docs: `${repoPath}/docs`,
         rules: `${repoPath}/rules`,
         skills: `${repoPath}/skills`,
       });
       reportStaleEntries(entries);
+
+      if (entries.length === 0 || cmdOpts.dryRun) return;
+
+      log.info('\nGenerating AI-powered update drafts...');
+      for (const entry of entries) {
+        const related = await findRelatedAdoptedLearnings(entry, votesDir, learningsDir);
+        const draft = await generateUpdateDraft(entry, related);
+        if (draft) {
+          const draftPath = `${entry.path}.draft.md`;
+          await writeFile(draftPath, draft);
+          log.success(`  Draft written: ${draftPath}`);
+        }
+      }
+      log.info('\nReview drafts, then rename .draft.md -> .md to apply updates.');
       return;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -762,7 +762,17 @@ program
     await deepEnrich({ project: cmdOpts.project, evidenceDir, wikiRoot, maxModules: cmdOpts.maxModules });
   });
 
-program
+recallCmd
+  .command('feedback')
+  .description('Record manual feedback for a recalled document')
+  .option('--positive <docId>', 'Upvote a document (marks as actually useful)')
+  .option('--negative <docId>', 'Record negative signal for a document')
+  .action(async (cmdOpts) => {
+    const { recallFeedback } = await import('./votes.js');
+    await recallFeedback({ positive: cmdOpts.positive, negative: cmdOpts.negative });
+  });
+
+recallCmd
   .command('maintenance')
   .description('Automatic maintenance of team knowledge base')
   .option('--prune', 'Remove low-confidence learnings')
@@ -835,10 +845,10 @@ program
     }
 
     const { log } = await import('./utils/logger.js');
-    log.info('Usage: teamai maintenance --prune | --confidence-writeback | --update-quality');
+    log.info('Usage: teamai recall maintenance --prune | --confidence-writeback | --update-quality');
   });
 
-program
+recallCmd
   .command('promote [learningId]')
   .description('Promote a high-confidence learning to formal knowledge (docs/skills/rules)')
   .option('--category <cat>', 'Target category: skills | rules | docs')
@@ -864,7 +874,7 @@ program
       for (const c of candidates) {
         log.info(`  - ${c.docId} (confidence: ${c.confidence.toFixed(2)}, suggested: ${c.suggestedCategory})`);
       }
-      log.info('\nRun: teamai promote <learning-id> [--category <cat>]');
+      log.info('\nRun: teamai recall promote <learning-id> [--category <cat>]');
       return;
     }
 
@@ -878,16 +888,6 @@ program
       category: cmdOpts.category as 'skills' | 'rules' | 'docs' | undefined,
       dryRun: cmdOpts.dryRun,
     });
-  });
-
-program
-  .command('recall-feedback', { hidden: true })
-  .description('Record manual feedback for a recalled document')
-  .option('--positive <docId>', 'Upvote a document (marks as actually useful)')
-  .option('--negative <docId>', 'Record negative signal for a document')
-  .action(async (cmdOpts) => {
-    const { recallFeedback } = await import('./votes.js');
-    await recallFeedback({ positive: cmdOpts.positive, negative: cmdOpts.negative });
   });
 
 program.parse();

--- a/src/maintenance/confidence.ts
+++ b/src/maintenance/confidence.ts
@@ -1,0 +1,128 @@
+// -*- coding: utf-8 -*-
+import path from 'node:path';
+
+import matter from 'gray-matter';
+
+import { readFileSafe, writeFile, listFiles } from '../utils/fs.js';
+import { log } from '../utils/logger.js';
+
+export interface ConfidenceFactors {
+  recalledCount: number;
+  upvotedCount: number;
+  lastRecalledAt: string;
+  lastUpvotedAt?: string;
+}
+
+/**
+ * Compute a confidence score (0.0–1.0) for a knowledge document.
+ *
+ * Formula:
+ *   base = min(1.0, recalled * 0.1 + upvoted * 0.3)
+ *   recency = max(0, 1.0 - daysSinceLastRecall / 180)
+ *   ratio = upvoted / max(1, recalled)
+ *   confidence = base * 0.4 + recency * 0.3 + ratio * 0.3
+ */
+export function computeConfidence(factors: ConfidenceFactors): number {
+  const { recalledCount, upvotedCount, lastRecalledAt } = factors;
+
+  const base = Math.min(1.0, recalledCount * 0.1 + upvotedCount * 0.3);
+
+  let daysSinceRecall = 180;
+  if (lastRecalledAt) {
+    const elapsed = Date.now() - new Date(lastRecalledAt).getTime();
+    daysSinceRecall = Math.max(0, elapsed / (1000 * 60 * 60 * 24));
+  }
+  const recency = Math.max(0, 1.0 - daysSinceRecall / 180);
+
+  const ratio = upvotedCount / Math.max(1, recalledCount);
+
+  const score = base * 0.4 + recency * 0.3 + ratio * 0.3;
+  return Math.round(score * 100) / 100;
+}
+
+/**
+ * Aggregate all vote files and compute per-doc confidence.
+ */
+export async function computeAllConfidence(votesDir: string): Promise<Map<string, number>> {
+  const result = new Map<string, number>();
+  const { loadUserVotes } = await import('../votes.js');
+  const files = await listFiles(votesDir);
+
+  const aggregated = new Map<string, { recalled: number; upvoted: number; lastRecalled: string; lastUpvoted?: string }>();
+
+  for (const file of files) {
+    if (!file.endsWith('.yaml') && !file.endsWith('.yml')) continue;
+    try {
+      const data = await loadUserVotes(path.join(votesDir, file));
+      for (const [docId, entry] of Object.entries(data.votes)) {
+        const existing = aggregated.get(docId) ?? { recalled: 0, upvoted: 0, lastRecalled: '' };
+        existing.recalled += entry.recalled_count ?? 0;
+        existing.upvoted += entry.upvoted_count ?? 0;
+        if (entry.last_recalled_at > existing.lastRecalled) {
+          existing.lastRecalled = entry.last_recalled_at;
+        }
+        if (entry.last_upvoted_at && (!existing.lastUpvoted || entry.last_upvoted_at > existing.lastUpvoted)) {
+          existing.lastUpvoted = entry.last_upvoted_at;
+        }
+        aggregated.set(docId, existing);
+      }
+    } catch {
+      log.debug(`confidence: failed to parse votes file: ${file}`);
+    }
+  }
+
+  for (const [docId, data] of aggregated) {
+    const factors: ConfidenceFactors = {
+      recalledCount: data.recalled,
+      upvotedCount: data.upvoted,
+      lastRecalledAt: data.lastRecalled,
+      lastUpvotedAt: data.lastUpvoted,
+    };
+    result.set(docId, computeConfidence(factors));
+  }
+
+  return result;
+}
+
+/**
+ * Write confidence scores back into learning document frontmatter.
+ * Only updates docs whose confidence changed by > 0.05.
+ * Returns count of files updated.
+ */
+export async function writeBackConfidence(
+  learningsDir: string,
+  confidenceMap: Map<string, number>,
+): Promise<number> {
+  let updated = 0;
+  const files = await listFiles(learningsDir);
+
+  for (const file of files) {
+    if (!file.endsWith('.md')) continue;
+    const docId = file.replace(/\.md$/i, '');
+    const newConf = confidenceMap.get(docId);
+    if (newConf === undefined) continue;
+
+    const absPath = path.join(learningsDir, file);
+    const content = await readFileSafe(absPath);
+    if (!content) continue;
+
+    try {
+      const { data, content: body } = matter(content);
+      const existingConf = typeof data.confidence === 'number' ? data.confidence : undefined;
+
+      if (existingConf !== undefined && Math.abs(existingConf - newConf) <= 0.05) continue;
+
+      data.confidence = newConf;
+      const newContent = matter.stringify(body, data);
+      await writeFile(absPath, newContent);
+      updated++;
+    } catch {
+      log.debug(`confidence: failed to update frontmatter for: ${file}`);
+    }
+  }
+
+  if (updated > 0) {
+    log.info(`Updated confidence scores for ${updated} learning(s)`);
+  }
+  return updated;
+}

--- a/src/maintenance/hot-cold.ts
+++ b/src/maintenance/hot-cold.ts
@@ -1,0 +1,27 @@
+// -*- coding: utf-8 -*-
+import type { SearchIndexEntry } from '../types.js';
+
+export const HOT_THRESHOLD = 0.5;
+export const COLD_PENALTY = 0.3;
+
+/**
+ * Annotate search index entries with hotness based on confidence scores.
+ * Entries below HOT_THRESHOLD get a low hotness score; entries above are "hot".
+ */
+export function annotateHotness(
+  entries: SearchIndexEntry[],
+  confidenceMap: Map<string, number>,
+): void {
+  for (const entry of entries) {
+    const docId = entry.filename.replace(/\.md$/i, '');
+    const confidence = confidenceMap.get(docId);
+    entry.confidence = confidence;
+    // No data = new doc (neutral); low confidence = cold; high confidence = hot
+    if (confidence === undefined) {
+      entry.hotness = 1.0;
+    } else {
+      entry.hotness = confidence >= HOT_THRESHOLD ? 1.0 : COLD_PENALTY;
+    }
+  }
+}
+

--- a/src/maintenance/index.ts
+++ b/src/maintenance/index.ts
@@ -1,0 +1,9 @@
+// -*- coding: utf-8 -*-
+export { computeConfidence, computeAllConfidence, writeBackConfidence } from './confidence.js';
+export { findPruneCandidates, executePrune } from './prune.js';
+export type { PruneCandidate, PruneOptions } from './prune.js';
+export { annotateHotness, HOT_THRESHOLD, COLD_PENALTY } from './hot-cold.js';
+export { findStaleEntries, reportStaleEntries } from './quality-update.js';
+export type { StaleEntry, QualityUpdateOptions } from './quality-update.js';
+export { findPromotionCandidates, executePromotion } from './promote.js';
+export type { PromotionCandidate, PromoteOptions } from './promote.js';

--- a/src/maintenance/index.ts
+++ b/src/maintenance/index.ts
@@ -3,7 +3,7 @@ export { computeConfidence, computeAllConfidence, writeBackConfidence } from './
 export { findPruneCandidates, executePrune } from './prune.js';
 export type { PruneCandidate, PruneOptions } from './prune.js';
 export { annotateHotness, HOT_THRESHOLD, COLD_PENALTY } from './hot-cold.js';
-export { findStaleEntries, reportStaleEntries } from './quality-update.js';
+export { findStaleEntries, reportStaleEntries, findRelatedAdoptedLearnings, generateUpdateDraft } from './quality-update.js';
 export type { StaleEntry, QualityUpdateOptions } from './quality-update.js';
 export { findPromotionCandidates, executePromotion } from './promote.js';
 export type { PromotionCandidate, PromoteOptions } from './promote.js';

--- a/src/maintenance/promote.ts
+++ b/src/maintenance/promote.ts
@@ -1,0 +1,168 @@
+// -*- coding: utf-8 -*-
+import path from 'node:path';
+
+import matter from 'gray-matter';
+import { readFileSafe, writeFile, listFiles, ensureDir, copyFile } from '../utils/fs.js';
+import { log } from '../utils/logger.js';
+import { computeAllConfidence } from './confidence.js';
+
+export interface PromotionCandidate {
+  docId: string;
+  filename: string;
+  path: string;
+  confidence: number;
+  upvotedCount: number;
+  userCount: number;
+  title: string;
+  suggestedCategory: 'skills' | 'rules' | 'docs';
+}
+
+export interface PromoteOptions {
+  category?: 'skills' | 'rules' | 'docs';
+  dryRun?: boolean;
+}
+
+const MIN_CONFIDENCE = 0.90;
+const MIN_UPVOTED = 5;
+const MIN_USERS = 2;
+const MIN_AGE_DAYS = 14;
+
+/**
+ * Find learnings eligible for promotion to formal knowledge.
+ */
+export async function findPromotionCandidates(
+  learningsDir: string,
+  votesDir: string,
+): Promise<PromotionCandidate[]> {
+  const confidenceMap = await computeAllConfidence(votesDir);
+  const candidates: PromotionCandidate[] = [];
+
+  const perDoc = await aggregatePerDocVotes(votesDir);
+  const files = await listFiles(learningsDir);
+  const now = Date.now();
+
+  for (const file of files) {
+    if (!file.endsWith('.md')) continue;
+    const docId = file.replace(/\.md$/i, '');
+    const confidence = confidenceMap.get(docId) ?? 0;
+    if (confidence < MIN_CONFIDENCE) continue;
+
+    const docVotes = perDoc.get(docId);
+    if (!docVotes) continue;
+    if (docVotes.upvoted < MIN_UPVOTED) continue;
+    if (docVotes.users.size < MIN_USERS) continue;
+
+    const absPath = path.join(learningsDir, file);
+    const content = await readFileSafe(absPath);
+    if (!content) continue;
+
+    let title = docId;
+    let date = '';
+    try {
+      const { data } = matter(content);
+      title = typeof data.title === 'string' ? data.title : docId;
+      date = typeof data.date === 'string' ? data.date : '';
+      if (data.promoted_to) continue;
+    } catch {
+      continue;
+    }
+
+    if (date) {
+      const ageInDays = (now - new Date(date).getTime()) / (1000 * 60 * 60 * 24);
+      if (ageInDays < MIN_AGE_DAYS) continue;
+    }
+
+    const suggestedCategory = inferCategory(content, title);
+
+    candidates.push({
+      docId,
+      filename: file,
+      path: absPath,
+      confidence,
+      upvotedCount: docVotes.upvoted,
+      userCount: docVotes.users.size,
+      title,
+      suggestedCategory,
+    });
+  }
+
+  return candidates.sort((a, b) => b.confidence - a.confidence);
+}
+
+/**
+ * Execute promotion: copy learning to target category, mark original.
+ */
+export async function executePromotion(
+  candidate: PromotionCandidate,
+  repoPath: string,
+  options: PromoteOptions = {},
+): Promise<string> {
+  const category = options.category ?? candidate.suggestedCategory;
+  const targetDir = path.join(repoPath, category);
+  await ensureDir(targetDir);
+
+  const targetPath = path.join(targetDir, candidate.filename);
+
+  if (options.dryRun) {
+    log.info(`[dry-run] Would promote ${candidate.docId} -> ${category}/${candidate.filename}`);
+    return targetPath;
+  }
+
+  await copyFile(candidate.path, targetPath);
+
+  const content = await readFileSafe(candidate.path);
+  if (content) {
+    const { data, content: body } = matter(content);
+    data.promoted_to = `${category}/${candidate.filename}`;
+    const updated = matter.stringify(body, data);
+    await writeFile(candidate.path, updated);
+  }
+
+  log.success(`Promoted: ${candidate.docId} -> ${category}/${candidate.filename}`);
+  return targetPath;
+}
+
+function inferCategory(content: string, title: string): 'skills' | 'rules' | 'docs' {
+  const lower = (content + ' ' + title).toLowerCase();
+
+  const skillSignals = ['command', 'cli', 'workflow', 'step-by-step', 'procedure', 'how to', 'recipe'];
+  const ruleSignals = ['must', 'never', 'always', 'constraint', 'convention', 'standard', 'rule'];
+  const docSignals = ['architecture', 'design', 'overview', 'background', 'decision', 'context'];
+
+  const skillScore = skillSignals.filter((s) => lower.includes(s)).length;
+  const ruleScore = ruleSignals.filter((s) => lower.includes(s)).length;
+  const docScore = docSignals.filter((s) => lower.includes(s)).length;
+
+  if (ruleScore >= skillScore && ruleScore >= docScore) return 'rules';
+  if (skillScore >= docScore) return 'skills';
+  return 'docs';
+}
+
+async function aggregatePerDocVotes(
+  votesDir: string,
+): Promise<Map<string, { recalled: number; upvoted: number; users: Set<string> }>> {
+  const perDoc = new Map<string, { recalled: number; upvoted: number; users: Set<string> }>();
+  const { loadUserVotes } = await import('../votes.js');
+  const voteFiles = await listFiles(votesDir);
+
+  for (const file of voteFiles) {
+    if (!file.endsWith('.yaml') && !file.endsWith('.yml')) continue;
+    const username = file.replace(/\.(yaml|yml)$/, '');
+    const filePath = path.join(votesDir, file);
+
+    try {
+      const data = await loadUserVotes(filePath);
+      for (const [docId, entry] of Object.entries(data.votes)) {
+        const existing = perDoc.get(docId) ?? { recalled: 0, upvoted: 0, users: new Set<string>() };
+        existing.recalled += entry.recalled_count ?? 0;
+        existing.upvoted += entry.upvoted_count ?? 0;
+        if ((entry.upvoted_count ?? 0) > 0) existing.users.add(username);
+        perDoc.set(docId, existing);
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return perDoc;
+}

--- a/src/maintenance/promote.ts
+++ b/src/maintenance/promote.ts
@@ -72,7 +72,7 @@ export async function findPromotionCandidates(
       if (ageInDays < MIN_AGE_DAYS) continue;
     }
 
-    const suggestedCategory = inferCategory(content, title);
+    const suggestedCategory = await inferCategory(content, title);
 
     candidates.push({
       docId,
@@ -92,6 +92,63 @@ export async function findPromotionCandidates(
 /**
  * Execute promotion: copy learning to target category, mark original.
  */
+/**
+ * Use AI to transform a learning (individual experience) into a generalized
+ * knowledge entry suitable for the target category.
+ *
+ * - skills: rewrite as a step-by-step procedure / SOP with clear triggers
+ * - rules: rewrite as a concise constraint with rationale
+ * - docs: rewrite as reference documentation with context
+ *
+ * Falls back to the original content if AI is unavailable.
+ */
+async function generatePromotedContent(
+  originalContent: string,
+  category: 'skills' | 'rules' | 'docs',
+  title: string,
+): Promise<string> {
+  const categoryGuide: Record<string, string> = {
+    skills: `a reusable skill/SOP. Format it with:
+- A clear "when to use" trigger description
+- Step-by-step numbered procedure
+- Expected outcome
+- Common pitfalls to avoid
+Remove any references to specific dates, people, or one-off incidents. Make it timeless and reusable.`,
+    rules: `a team rule/constraint. Format it with:
+- A one-line rule statement (imperative: "Always X" / "Never Y")
+- Rationale: why this matters (1-2 sentences)
+- Examples of correct and incorrect usage
+Remove anecdotal context. State the constraint as an absolute standard.`,
+    docs: `a reference document. Format it with:
+- Context: what system/component this describes
+- Key concepts and their relationships
+- Architecture decisions and their rationale
+- Current state (as of promotion date)
+Remove personal narrative. Write as objective technical documentation.`,
+  };
+
+  try {
+    const { callClaude } = await import('../utils/ai-client.js');
+
+    const prompt = `You are a technical knowledge engineer promoting a team learning into formal knowledge.
+
+The following "learning" has been repeatedly validated by the team (high confidence, adopted by multiple members). Transform it into ${categoryGuide[category]}
+
+Original learning (title: "${title}"):
+---
+${originalContent}
+---
+
+Output ONLY the transformed markdown content (including YAML frontmatter with title, tags, date set to today). Do NOT include the original learning's confidence or vote-related fields in the frontmatter.`;
+
+    const result = await callClaude(prompt, { timeout: 60_000 });
+    return result.trim();
+  } catch (e) {
+    log.warn(`AI content generation failed, using original content: ${(e as Error).message}`);
+    return originalContent;
+  }
+}
+
 export async function executePromotion(
   candidate: PromotionCandidate,
   repoPath: string,
@@ -108,21 +165,27 @@ export async function executePromotion(
     return targetPath;
   }
 
-  await copyFile(candidate.path, targetPath);
-
-  const content = await readFileSafe(candidate.path);
-  if (content) {
-    const { data, content: body } = matter(content);
-    data.promoted_to = `${category}/${candidate.filename}`;
-    const updated = matter.stringify(body, data);
-    await writeFile(candidate.path, updated);
+  const originalContent = await readFileSafe(candidate.path);
+  if (!originalContent) {
+    log.error(`Cannot read source file: ${candidate.path}`);
+    return targetPath;
   }
+
+  // AI transforms the learning into a generalized format for the target category
+  const promotedContent = await generatePromotedContent(originalContent, category, candidate.title);
+  await writeFile(targetPath, promotedContent);
+
+  // Mark original learning as promoted
+  const { data, content: body } = matter(originalContent);
+  data.promoted_to = `${category}/${candidate.filename}`;
+  const updated = matter.stringify(body, data);
+  await writeFile(candidate.path, updated);
 
   log.success(`Promoted: ${candidate.docId} -> ${category}/${candidate.filename}`);
   return targetPath;
 }
 
-function inferCategory(content: string, title: string): 'skills' | 'rules' | 'docs' {
+function inferCategoryByKeywords(content: string, title: string): 'skills' | 'rules' | 'docs' {
   const lower = (content + ' ' + title).toLowerCase();
 
   const skillSignals = ['command', 'cli', 'workflow', 'step-by-step', 'procedure', 'how to', 'recipe'];
@@ -136,6 +199,40 @@ function inferCategory(content: string, title: string): 'skills' | 'rules' | 'do
   if (ruleScore >= skillScore && ruleScore >= docScore) return 'rules';
   if (skillScore >= docScore) return 'skills';
   return 'docs';
+}
+
+/**
+ * Use AI to determine the best promotion category for a learning.
+ * Falls back to keyword-based inference if AI is unavailable.
+ */
+async function inferCategory(content: string, title: string): Promise<'skills' | 'rules' | 'docs'> {
+  try {
+    const { callClaude } = await import('../utils/ai-client.js');
+
+    const prompt = `Classify the following team knowledge entry into exactly ONE category. Reply with ONLY the category name (no explanation):
+
+- "skills" — reusable workflows, SOPs, step-by-step procedures, CLI recipes, operational playbooks
+- "rules" — mandatory constraints, coding standards, conventions, best practices that MUST be followed
+- "docs" — architecture decisions, system design, background context, reference documentation
+
+Title: ${title}
+
+Content:
+${content.slice(0, 2000)}
+
+Category:`;
+
+    const result = await callClaude(prompt, { timeout: 30_000 });
+    const category = result.trim().toLowerCase().replace(/[^a-z]/g, '');
+
+    if (category === 'skills' || category === 'rules' || category === 'docs') {
+      return category;
+    }
+  } catch {
+    // AI unavailable — fall back to keywords
+  }
+
+  return inferCategoryByKeywords(content, title);
 }
 
 async function aggregatePerDocVotes(

--- a/src/maintenance/prune.ts
+++ b/src/maintenance/prune.ts
@@ -1,0 +1,116 @@
+// -*- coding: utf-8 -*-
+import path from 'node:path';
+
+import matter from 'gray-matter';
+
+import { readFileSafe, listFiles, ensureDir, remove, copyFile } from '../utils/fs.js';
+import { log } from '../utils/logger.js';
+import { computeAllConfidence } from './confidence.js';
+
+export interface PruneCandidate {
+  filename: string;
+  path: string;
+  confidence: number;
+  lastActivity: string;
+  reason: string;
+}
+
+export interface PruneOptions {
+  threshold?: number;
+  dryRun?: boolean;
+  archive?: boolean;
+}
+
+const DEFAULT_THRESHOLD = 0.15;
+const STALE_DAYS = 180;
+
+/**
+ * Identify learning documents below the confidence threshold
+ * or inactive for more than STALE_DAYS.
+ */
+export async function findPruneCandidates(
+  learningsDir: string,
+  votesDir: string,
+  options: PruneOptions = {},
+): Promise<PruneCandidate[]> {
+  const threshold = options.threshold ?? DEFAULT_THRESHOLD;
+  const confidenceMap = await computeAllConfidence(votesDir);
+  const candidates: PruneCandidate[] = [];
+  const files = await listFiles(learningsDir);
+  const now = Date.now();
+
+  for (const file of files) {
+    if (!file.endsWith('.md')) continue;
+    const docId = file.replace(/\.md$/i, '');
+    const absPath = path.join(learningsDir, file);
+    const content = await readFileSafe(absPath);
+    if (!content) continue;
+
+    let date = '';
+    try {
+      const { data } = matter(content);
+      date = typeof data.date === 'string' ? data.date : '';
+    } catch {
+      continue;
+    }
+
+    const confidence = confidenceMap.get(docId);
+    // Skip docs with no vote data — they haven't been recalled yet (new or just migrated)
+    if (confidence === undefined) continue;
+    const daysSinceCreate = date ? (now - new Date(date).getTime()) / (1000 * 60 * 60 * 24) : Infinity;
+
+    if (confidence < threshold) {
+      candidates.push({
+        filename: file,
+        path: absPath,
+        confidence,
+        lastActivity: date,
+        reason: `confidence ${confidence.toFixed(2)} < ${threshold}`,
+      });
+    } else if (daysSinceCreate > STALE_DAYS && confidence < 0.3) {
+      candidates.push({
+        filename: file,
+        path: absPath,
+        confidence,
+        lastActivity: date,
+        reason: `inactive ${isFinite(daysSinceCreate) ? Math.round(daysSinceCreate) + 'd' : 'no-date'}, confidence ${confidence.toFixed(2)}`,
+      });
+    }
+  }
+
+  return candidates.sort((a, b) => a.confidence - b.confidence);
+}
+
+/**
+ * Execute prune: archive or remove low-confidence documents.
+ */
+export async function executePrune(
+  repoPath: string,
+  candidates: PruneCandidate[],
+  options: PruneOptions = {},
+): Promise<{ archived: number; removed: number }> {
+  let archived = 0;
+  let removed = 0;
+
+  if (options.dryRun) {
+    log.info(`[dry-run] Would ${options.archive ? 'archive' : 'remove'} ${candidates.length} file(s)`);
+    return { archived: 0, removed: 0 };
+  }
+
+  for (const candidate of candidates) {
+    if (options.archive) {
+      const archiveDir = path.join(repoPath, 'learnings', '_archive');
+      await ensureDir(archiveDir);
+      await copyFile(candidate.path, path.join(archiveDir, candidate.filename));
+      await remove(candidate.path);
+      archived++;
+    } else {
+      await remove(candidate.path);
+      removed++;
+    }
+  }
+
+  if (archived > 0) log.success(`Archived ${archived} learning(s)`);
+  if (removed > 0) log.success(`Removed ${removed} learning(s)`);
+  return { archived, removed };
+}

--- a/src/maintenance/quality-update.ts
+++ b/src/maintenance/quality-update.ts
@@ -1,7 +1,7 @@
 // -*- coding: utf-8 -*-
 import path from 'node:path';
 
-import { listFiles, pathExists } from '../utils/fs.js';
+import { listFiles, pathExists, readFileSafe } from '../utils/fs.js';
 import { loadUserVotes } from '../votes.js';
 import { log } from '../utils/logger.js';
 
@@ -114,5 +114,94 @@ export function reportStaleEntries(entries: StaleEntry[]): void {
     log.info(
       `  - [${entry.type}] ${entry.docId}: recalled ${entry.recalledCount}x by ${entry.userCount} users, adopted ${entry.upvotedCount}x`,
     );
+  }
+}
+
+/**
+ * Find learnings that users actually adopted (high upvoted_count) during the
+ * same period a stale entry was being ignored. These serve as context for the
+ * AI to understand what the team actually preferred.
+ */
+export async function findRelatedAdoptedLearnings(
+  staleEntry: StaleEntry,
+  votesDir: string,
+  learningsDir: string,
+  limit: number = 5,
+): Promise<string[]> {
+  const perDoc = new Map<string, number>();
+  const voteFiles = await listFiles(votesDir);
+
+  for (const file of voteFiles) {
+    if (!file.endsWith('.yaml') && !file.endsWith('.yml')) continue;
+    try {
+      const data = await loadUserVotes(path.join(votesDir, file));
+      for (const [docId, entry] of Object.entries(data.votes)) {
+        if (docId === staleEntry.docId) continue;
+        if ((entry.upvoted_count ?? 0) > 0) {
+          perDoc.set(docId, (perDoc.get(docId) ?? 0) + (entry.upvoted_count ?? 0));
+        }
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  const sorted = [...perDoc.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit);
+
+  const contents: string[] = [];
+  for (const [docId] of sorted) {
+    const filename = docId.endsWith('.md') ? docId : `${docId}.md`;
+    const filePath = path.join(learningsDir, filename);
+    const content = await readFileSafe(filePath);
+    if (content) contents.push(content);
+  }
+
+  return contents;
+}
+
+/**
+ * Generate an AI-powered update draft for a stale entry, incorporating
+ * insights from learnings that users actually adopted.
+ */
+export async function generateUpdateDraft(
+  staleEntry: StaleEntry,
+  relatedLearnings: string[],
+): Promise<string | null> {
+  const currentContent = await readFileSafe(staleEntry.path);
+  if (!currentContent) return null;
+
+  const { callClaude } = await import('../utils/ai-client.js');
+
+  const learningContext = relatedLearnings.length > 0
+    ? `\n\nThe following learnings were actually adopted by team members (these represent what the team found more useful):\n\n${relatedLearnings.map((l, i) => `--- Learning ${i + 1} ---\n${l}`).join('\n\n')}`
+    : '';
+
+  const prompt = `You are a technical writer updating a team knowledge base entry.
+
+The following ${staleEntry.type} entry has been recalled ${staleEntry.recalledCount} times by ${staleEntry.userCount} team members but was adopted only ${staleEntry.upvotedCount} time(s). This indicates the content is relevant to common queries but not actionable enough to be directly useful.
+
+Current content:
+---
+${currentContent}
+---
+${learningContext}
+
+Please rewrite this entry to be more actionable and directly useful. Keep the same topic but:
+1. Add concrete examples or commands where applicable
+2. Remove outdated or vague information
+3. Incorporate relevant insights from the adopted learnings above
+4. Keep the same YAML frontmatter format (update the date field to today)
+5. Be concise — aim for the same or shorter length
+
+Output ONLY the updated markdown file content (including frontmatter).`;
+
+  try {
+    const draft = await callClaude(prompt);
+    return draft.trim();
+  } catch (e) {
+    log.error(`AI update generation failed: ${(e as Error).message}`);
+    return null;
   }
 }

--- a/src/maintenance/quality-update.ts
+++ b/src/maintenance/quality-update.ts
@@ -1,0 +1,118 @@
+// -*- coding: utf-8 -*-
+import path from 'node:path';
+
+import { listFiles, pathExists } from '../utils/fs.js';
+import { loadUserVotes } from '../votes.js';
+import { log } from '../utils/logger.js';
+
+export interface StaleEntry {
+  docId: string;
+  path: string;
+  recalledCount: number;
+  upvotedCount: number;
+  userCount: number;
+  type: string;
+}
+
+export interface QualityUpdateOptions {
+  minRecalled?: number;
+  maxUpvoted?: number;
+  minUsers?: number;
+  dryRun?: boolean;
+}
+
+const DEFAULT_MIN_RECALLED = 5;
+const DEFAULT_MAX_UPVOTED = 1;
+const DEFAULT_MIN_USERS = 2;
+
+/**
+ * Find docs/rules/skills that are frequently recalled but rarely adopted.
+ * These are candidates for quality improvement.
+ */
+export async function findStaleEntries(
+  votesDir: string,
+  knowledgeDirs: { docs?: string; rules?: string; skills?: string },
+  options: QualityUpdateOptions = {},
+): Promise<StaleEntry[]> {
+  const minRecalled = options.minRecalled ?? DEFAULT_MIN_RECALLED;
+  const maxUpvoted = options.maxUpvoted ?? DEFAULT_MAX_UPVOTED;
+  const minUsers = options.minUsers ?? DEFAULT_MIN_USERS;
+
+  const perDoc = new Map<string, { recalled: number; upvoted: number; users: Set<string> }>();
+
+  const voteFiles = await listFiles(votesDir);
+  for (const file of voteFiles) {
+    if (!file.endsWith('.yaml') && !file.endsWith('.yml')) continue;
+    const username = file.replace(/\.(yaml|yml)$/, '');
+    const filePath = path.join(votesDir, file);
+
+    try {
+      const data = await loadUserVotes(filePath);
+      for (const [docId, entry] of Object.entries(data.votes)) {
+        const existing = perDoc.get(docId) ?? { recalled: 0, upvoted: 0, users: new Set<string>() };
+        existing.recalled += entry.recalled_count ?? 0;
+        existing.upvoted += entry.upvoted_count ?? 0;
+        if ((entry.recalled_count ?? 0) > 0) existing.users.add(username);
+        perDoc.set(docId, existing);
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  const candidates: StaleEntry[] = [];
+
+  for (const [docId, data] of perDoc) {
+    if (data.recalled < minRecalled) continue;
+    if (data.upvoted > maxUpvoted) continue;
+    if (data.users.size < minUsers) continue;
+
+    const entryPath = await resolveDocPath(docId, knowledgeDirs);
+    if (!entryPath) continue;
+
+    const type = entryPath.includes('/docs/') ? 'docs'
+      : entryPath.includes('/rules/') ? 'rules'
+        : entryPath.includes('/skills/') ? 'skills' : 'unknown';
+
+    candidates.push({
+      docId,
+      path: entryPath,
+      recalledCount: data.recalled,
+      upvotedCount: data.upvoted,
+      userCount: data.users.size,
+      type,
+    });
+  }
+
+  return candidates.sort((a, b) => b.recalledCount - a.recalledCount);
+}
+
+async function resolveDocPath(
+  docId: string,
+  dirs: { docs?: string; rules?: string; skills?: string },
+): Promise<string | null> {
+  const filename = docId.endsWith('.md') ? docId : `${docId}.md`;
+  for (const dir of [dirs.docs, dirs.rules, dirs.skills]) {
+    if (!dir) continue;
+    const candidate = path.join(dir, filename);
+    if (await pathExists(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * Log stale entry candidates for user review.
+ */
+export function reportStaleEntries(entries: StaleEntry[]): void {
+  if (entries.length === 0) {
+    log.info('No stale entries found that need quality updates.');
+    return;
+  }
+
+  log.info(`Found ${entries.length} entry(ies) recalled often but rarely adopted:`);
+  for (const entry of entries) {
+    log.info(
+      `  - [${entry.type}] ${entry.docId}: recalled ${entry.recalledCount}x by ${entry.userCount} users, adopted ${entry.upvotedCount}x`,
+    );
+  }
+}

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -1,11 +1,10 @@
 import path from 'node:path';
-import YAML from 'yaml';
 import { requireInit, detectProjectConfig } from './config.js';
 import { loadIndex, buildIndex, search, isLegacyIndex } from './utils/search-index.js';
 import type { SearchResult } from './utils/search-index.js';
-import { readFileSafe, writeFile, ensureDir, pathExists } from './utils/fs.js';
+import { readFileSafe, ensureDir, pathExists } from './utils/fs.js';
 import { log } from './utils/logger.js';
-import type { GlobalOptions, UserVotes, SearchIndex, LocalConfig } from './types.js';
+import type { GlobalOptions, SearchIndex, LocalConfig } from './types.js';
 import { getTeamaiHome } from './types.js';
 import { queryCodeKnowledge } from './code-knowledge-recall.js';
 import type { CodeKnowledgeResult } from './code-knowledge-recall.js';
@@ -91,62 +90,25 @@ export function formatResults(results: ScopedSearchResult[]): string {
 }
 
 /**
- * Auto-upvote: record that the current user found these docs via recall.
- *
- * Idempotent: same user voting for the same doc multiple times has no effect.
- * Writes to both local (~/.teamai/votes/) and team repo (votes/) so the
- * next pull auto-report picks it up.
+ * Auto-upvote: after a successful search, increment recalled_count for each
+ * returned doc using the V2 dual-counter system.
  */
 export async function autoUpvote(
   results: SearchResult[],
   username: string,
-  repoPath: string,
+  _repoPath: string,
 ): Promise<void> {
   if (results.length === 0) return;
 
   try {
-    // Read existing local votes
+    const { incrementRecalled } = await import('./votes.js');
     const votesDir = getVotesLocalDir();
     const localVotePath = path.join(votesDir, `${username}.yaml`);
     await ensureDir(votesDir);
 
-    let userVotes: UserVotes = { votes: {} };
-    const existingContent = await readFileSafe(localVotePath);
-    if (existingContent) {
-      try {
-        const parsed = YAML.parse(existingContent) as UserVotes | null;
-        if (parsed?.votes) {
-          userVotes = parsed;
-        }
-      } catch {
-        log.debug('Corrupt local votes file, resetting');
-      }
-    }
-
-    // Add new votes (idempotent — only add if not already present)
-    const now = new Date().toISOString();
-    let newVotes = 0;
-    for (const result of results) {
-      const docId = result.entry.filename.replace(/\.md$/i, '');
-      if (!userVotes.votes[docId]) {
-        userVotes.votes[docId] = { at: now };
-        newVotes++;
-      }
-    }
-
-    if (newVotes === 0) {
-      log.debug('autoUpvote: all docs already voted, skipping write');
-      return;
-    }
-
-    // Write to local votes dir only — repo copy is handled by
-    // reportUsageToTeam() during `teamai pull`, which properly
-    // commits the file. Writing directly to the repo leaves
-    // uncommitted changes that block `git pull` in `teamai push`.
-    const yamlContent = YAML.stringify(userVotes);
-    await writeFile(localVotePath, yamlContent);
-
-    log.debug(`autoUpvote: recorded ${newVotes} new vote(s) for ${username}`);
+    const docIds = results.map((r) => r.entry.filename.replace(/\.md$/i, ''));
+    await incrementRecalled(localVotePath, docIds);
+    log.debug(`autoUpvote: incremented recalled_count for ${docIds.length} doc(s)`);
   } catch (e) {
     log.error(`autoUpvote failed: ${(e as Error).message}`);
   }

--- a/src/team-push.ts
+++ b/src/team-push.ts
@@ -4,7 +4,7 @@ import { readUsageEvents, truncateUsageAfterReport } from './usage-tracker.js';
 import { aggregateUsage } from './stats.js';
 import { readEvents, aggregateSessionMetrics } from './dashboard-collector.js';
 import { createGit, pushRepoDirectly, pullRepo, resetToCleanMaster } from './utils/git.js';
-import { writeFile, readFileSafe, ensureDir, pathExists, listFiles, readJson, writeJson } from './utils/fs.js';
+import { writeFile, readFileSafe, ensureDir, pathExists, readJson, writeJson } from './utils/fs.js';
 import { log } from './utils/logger.js';
 import type { UserStats, UserInterventionStats, SessionMetrics, TokenUsage, DashboardEvent } from './types.js';
 import { VOTES_LOCAL_DIR, emptyTokenUsage, addTokenUsage } from './types.js';
@@ -360,20 +360,13 @@ export async function reportUsageToTeam(
       filesToPush.push(`stats/${username}.yaml`);
     }
 
-    // Always stage pending local votes (independent of usage events)
+    // Always stage pending local votes (V2 delta-aware merge)
     try {
       if (await pathExists(VOTES_LOCAL_DIR)) {
-        const voteFiles = await listFiles(VOTES_LOCAL_DIR);
-        for (const vf of voteFiles) {
-          if (!vf.endsWith('.yaml') && !vf.endsWith('.yml')) continue;
-          const localVotePath = path.join(VOTES_LOCAL_DIR, vf);
-          const repoVotePath = path.join(repoPath, 'votes', vf);
-          const content = await readFileSafe(localVotePath);
-          if (content) {
-            await ensureDir(path.join(repoPath, 'votes'));
-            await writeFile(repoVotePath, content);
-            filesToPush.push(`votes/${vf}`);
-          }
+        const { syncVotesToTeam } = await import('./votes.js');
+        const synced = await syncVotesToTeam(repoPath, username, VOTES_LOCAL_DIR);
+        if (synced) {
+          filesToPush.push(`votes/${username}.yaml`);
         }
       }
     } catch (e) {

--- a/src/transcript-parser.ts
+++ b/src/transcript-parser.ts
@@ -1,0 +1,101 @@
+// -*- coding: utf-8 -*-
+import fs from 'node:fs';
+import path from 'node:path';
+import readline from 'node:readline';
+
+export interface TranscriptVoteData {
+  recalledDocIds: string[];
+  referencedDocIds: string[];
+}
+
+/**
+ * Parse a Claude Code JSONL transcript file and extract doc IDs
+ * from recall and reference markers in assistant messages.
+ */
+export async function parseTranscriptForVotes(transcriptPath: string): Promise<TranscriptVoteData> {
+  const recalledSet = new Set<string>();
+  const referencedSet = new Set<string>();
+
+  try {
+    const stat = await fs.promises.stat(transcriptPath);
+    if (stat.size === 0) return { recalledDocIds: [], referencedDocIds: [] };
+  } catch {
+    return { recalledDocIds: [], referencedDocIds: [] };
+  }
+
+  const rl = readline.createInterface({
+    input: fs.createReadStream(transcriptPath, { encoding: 'utf-8' }),
+    crlfDelay: Infinity,
+  });
+
+  for await (const line of rl) {
+    const trimmed = line.trim();
+    if (!trimmed || !trimmed.includes('"assistant"')) continue;
+
+    let entry: Record<string, unknown>;
+    try {
+      entry = JSON.parse(trimmed) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+
+    if (entry['type'] !== 'assistant') continue;
+
+    const message = entry['message'] as Record<string, unknown> | undefined;
+    if (!message || !Array.isArray(message['content'])) continue;
+
+    for (const block of message['content'] as Array<Record<string, unknown>>) {
+      if (block['type'] !== 'text') continue;
+      const text = block['text'];
+      if (typeof text !== 'string') continue;
+
+      extractRecalledDocIds(text, recalledSet);
+      extractReferencedDocIds(text, referencedSet);
+    }
+  }
+
+  return {
+    recalledDocIds: [...recalledSet],
+    referencedDocIds: [...referencedSet],
+  };
+}
+
+function extractRecalledDocIds(text: string, out: Set<string>): void {
+  const START = '--- [teamai:recall:start] ---';
+  const END = '--- [teamai:recall:end] ---';
+  const filePattern = /^File:\s*(.+)$/gm;
+
+  let searchFrom = 0;
+  while (true) {
+    const startIdx = text.indexOf(START, searchFrom);
+    if (startIdx === -1) break;
+
+    const endIdx = text.indexOf(END, startIdx + START.length);
+    if (endIdx === -1) break;
+
+    const region = text.slice(startIdx + START.length, endIdx);
+    filePattern.lastIndex = 0;
+
+    let match: RegExpExecArray | null;
+    while ((match = filePattern.exec(region)) !== null) {
+      const filePath = match[1].trim();
+      const docId = path.basename(filePath).replace(/\.md$/i, '');
+      out.add(docId);
+    }
+
+    searchFrom = endIdx + END.length;
+  }
+}
+
+function extractReferencedDocIds(text: string, out: Set<string>): void {
+  const pattern = /<!--\s*teamai:referenced-doc-ids:\s*\[([^\]]*)\]\s*-->/g;
+
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(text)) !== null) {
+    const raw = match[1];
+    for (const item of raw.split(',')) {
+      const docId = item.trim().replace(/^['"]|['"]$/g, '');
+      if (docId) out.add(docId);
+    }
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -716,12 +716,14 @@ export interface SearchIndexEntry {
   path?: string;
   /** Optional hotness score reserved for Phase 4.3 hot/cold splitting. */
   hotness?: number;
+  /** Computed confidence score (0.0–1.0) for maintenance/hot-cold. */
+  confidence?: number;
   /** Snippet from codebase graph recall (depth-dependent content preview). */
   snippet?: string;
 }
 
 /** Schema version of the on-disk search-index.json (bump on breaking change). */
-export const SEARCH_INDEX_VERSION = 5;
+export const SEARCH_INDEX_VERSION = 6;
 
 /** Shape of the search-index.json file. */
 export interface SearchIndex {
@@ -742,6 +744,27 @@ export interface SearchIndex {
 /** Per-user vote file (votes/<user>.yaml). */
 export interface UserVotes {
   votes: Record<string, { at: string }>;
+}
+
+/** Vote entry with dual counters (V2). */
+export interface VoteEntryV2 {
+  recalled_count: number;
+  upvoted_count: number;
+  last_recalled_at: string;
+  last_upvoted_at?: string;
+}
+
+/** Unsynchronized delta for a single document (V2). */
+export interface VoteDelta {
+  recalled_delta: number;
+  upvoted_delta: number;
+}
+
+/** Per-user vote file V2 format (votes/<user>.yaml). */
+export interface UserVotesV2 {
+  version: 2;
+  votes: Record<string, VoteEntryV2>;
+  deltas: Record<string, VoteDelta>;
 }
 
 export const LEARNINGS_LOCAL_DIR = `${TEAMAI_HOME}/learnings`;

--- a/src/utils/search-index.ts
+++ b/src/utils/search-index.ts
@@ -10,6 +10,7 @@ import {
   type SearchIndex,
   type SearchIndexEntry,
   type UserVotes,
+  type VoteEntryV2,
   type KnowledgeType,
 } from '../types.js';
 
@@ -261,8 +262,14 @@ export function titleFromFilename(filename: string): string {
  * Aggregate vote counts from per-user vote files.
  * Returns a map of filename → total vote count.
  */
-async function aggregateVotes(votesDir: string): Promise<Map<string, number>> {
-  const counts = new Map<string, number>();
+interface VoteAggregation {
+  scores: Map<string, number>;
+  confidenceMap: Map<string, number>;
+}
+
+async function aggregateVotes(votesDir: string): Promise<VoteAggregation> {
+  const scores = new Map<string, number>();
+  const agg = new Map<string, { recalled: number; upvoted: number; lastRecalled: string }>();
   const files = await listFiles(votesDir);
 
   for (const file of files) {
@@ -272,10 +279,33 @@ async function aggregateVotes(votesDir: string): Promise<Map<string, number>> {
 
     try {
       const YAML = (await import('yaml')).default;
-      const parsed = YAML.parse(content) as UserVotes | null;
-      if (parsed?.votes) {
-        for (const docId of Object.keys(parsed.votes)) {
-          counts.set(docId, (counts.get(docId) ?? 0) + 1);
+      const parsed = YAML.parse(content) as Record<string, unknown> | null;
+      if (!parsed?.votes) continue;
+
+      if (parsed.version === 2) {
+        const votes = parsed.votes as Record<string, VoteEntryV2>;
+        for (const [docId, entry] of Object.entries(votes)) {
+          const recalled = entry.recalled_count ?? 0;
+          const upvoted = entry.upvoted_count ?? 0;
+          scores.set(docId, (scores.get(docId) ?? 0) + recalled * 0.3 + upvoted * 1.0);
+
+          const existing = agg.get(docId) ?? { recalled: 0, upvoted: 0, lastRecalled: '' };
+          existing.recalled += recalled;
+          existing.upvoted += upvoted;
+          if (entry.last_recalled_at > existing.lastRecalled) {
+            existing.lastRecalled = entry.last_recalled_at;
+          }
+          agg.set(docId, existing);
+        }
+      } else {
+        const votes = (parsed as unknown as UserVotes).votes;
+        for (const [docId, entry] of Object.entries(votes)) {
+          scores.set(docId, (scores.get(docId) ?? 0) + 1);
+
+          const existing = agg.get(docId) ?? { recalled: 0, upvoted: 0, lastRecalled: '' };
+          existing.recalled += 1;
+          if (entry.at > existing.lastRecalled) existing.lastRecalled = entry.at;
+          agg.set(docId, existing);
         }
       }
     } catch {
@@ -283,7 +313,17 @@ async function aggregateVotes(votesDir: string): Promise<Map<string, number>> {
     }
   }
 
-  return counts;
+  const { computeConfidence } = await import('../maintenance/confidence.js');
+  const confidenceMap = new Map<string, number>();
+  for (const [docId, data] of agg) {
+    confidenceMap.set(docId, computeConfidence({
+      recalledCount: data.recalled,
+      upvotedCount: data.upvoted,
+      lastRecalledAt: data.lastRecalled,
+    }));
+  }
+
+  return { scores, confidenceMap };
 }
 
 /**
@@ -471,9 +511,10 @@ export async function buildIndex(
     : optionsOrLearningsDir;
 
   // Aggregate votes once and reuse across all collectors.
-  const voteCounts = opts.votesDir
+  const voteAgg = opts.votesDir
     ? await aggregateVotes(opts.votesDir)
-    : new Map<string, number>();
+    : { scores: new Map<string, number>(), confidenceMap: new Map<string, number>() };
+  const voteCounts = voteAgg.scores;
 
   const entries: SearchIndexEntry[] = [];
 
@@ -491,6 +532,16 @@ export async function buildIndex(
   }
   if (opts.codebaseDir) {
     entries.push(...await collectRecursiveMdEntries(opts.codebaseDir, 'docs', voteCounts));
+  }
+
+  // Annotate entries with confidence/hotness for hot/cold scoring.
+  if (voteAgg.confidenceMap.size > 0) {
+    try {
+      const { annotateHotness } = await import('../maintenance/hot-cold.js');
+      annotateHotness(entries, voteAgg.confidenceMap);
+    } catch {
+      // Non-critical: hot/cold annotation is best-effort
+    }
   }
 
   // Build document-frequency map for IDF weighting.
@@ -641,6 +692,11 @@ export function search(
       // codebase-index.md 额外权重 boost，确保章节摘要优先于普通 docs 返回。
       if (path.basename(entry.path ?? '') === CODEBASE_INDEX_FILENAME) {
         score *= CODEBASE_INDEX_WEIGHT_BOOST;
+      }
+
+      // Hot/cold penalty: entries with low confidence get demoted.
+      if (entry.hotness !== undefined && entry.hotness < 1.0) {
+        score *= entry.hotness;
       }
 
       results.push({ entry, score });

--- a/src/votes.ts
+++ b/src/votes.ts
@@ -1,0 +1,224 @@
+// -*- coding: utf-8 -*-
+import path from 'node:path';
+
+import YAML from 'yaml';
+
+import type { UserVotes, UserVotesV2, VoteEntryV2 } from './types.js';
+import { readFileSafe, writeFile, ensureDir } from './utils/fs.js';
+import { log } from './utils/logger.js';
+
+/**
+ * Migrate v1 votes format to v2 dual-counter format.
+ */
+export function migrateV1ToV2(v1: UserVotes): UserVotesV2 {
+  const votes: Record<string, VoteEntryV2> = {};
+  for (const [docId, entry] of Object.entries(v1.votes)) {
+    votes[docId] = {
+      recalled_count: 1,
+      upvoted_count: 0,
+      last_recalled_at: entry.at,
+    };
+  }
+  return { version: 2, votes, deltas: {} };
+}
+
+/**
+ * Load user votes from a YAML file, auto-migrating v1 to v2 on first read.
+ */
+export async function loadUserVotes(votePath: string): Promise<UserVotesV2> {
+  const content = await readFileSafe(votePath);
+  if (!content) return { version: 2, votes: {}, deltas: {} };
+
+  let parsed: unknown;
+  try {
+    parsed = YAML.parse(content);
+  } catch {
+    return { version: 2, votes: {}, deltas: {} };
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    return { version: 2, votes: {}, deltas: {} };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+
+  if (obj['version'] === 2) {
+    const v2 = obj as unknown as UserVotesV2;
+    if (!v2.deltas) v2.deltas = {};
+    return v2;
+  }
+
+  if (obj['votes'] !== undefined) {
+    const migrated = migrateV1ToV2(obj as unknown as UserVotes);
+    await saveUserVotes(votePath, migrated);
+    return migrated;
+  }
+
+  return { version: 2, votes: {}, deltas: {} };
+}
+
+/**
+ * Persist user votes to a YAML file.
+ */
+export async function saveUserVotes(votePath: string, votes: UserVotesV2): Promise<void> {
+  await ensureDir(path.dirname(votePath));
+  await writeFile(votePath, YAML.stringify(votes));
+}
+
+/**
+ * Increment recalled_count for each docId and record the delta.
+ */
+export async function incrementRecalled(votePath: string, docIds: string[]): Promise<void> {
+  if (docIds.length === 0) return;
+  const data = await loadUserVotes(votePath);
+  const now = new Date().toISOString();
+
+  for (const docId of docIds) {
+    if (!data.votes[docId]) {
+      data.votes[docId] = { recalled_count: 0, upvoted_count: 0, last_recalled_at: '' };
+    }
+    data.votes[docId].recalled_count++;
+    data.votes[docId].last_recalled_at = now;
+
+    if (!data.deltas[docId]) {
+      data.deltas[docId] = { recalled_delta: 0, upvoted_delta: 0 };
+    }
+    data.deltas[docId].recalled_delta++;
+  }
+
+  await saveUserVotes(votePath, data);
+}
+
+/**
+ * Increment upvoted_count for each docId and record the delta.
+ */
+export async function incrementUpvoted(votePath: string, docIds: string[]): Promise<void> {
+  if (docIds.length === 0) return;
+  const data = await loadUserVotes(votePath);
+  const now = new Date().toISOString();
+
+  for (const docId of docIds) {
+    if (!data.votes[docId]) {
+      data.votes[docId] = { recalled_count: 0, upvoted_count: 0, last_recalled_at: '' };
+    }
+    data.votes[docId].upvoted_count++;
+    data.votes[docId].last_upvoted_at = now;
+
+    if (!data.deltas[docId]) {
+      data.deltas[docId] = { recalled_delta: 0, upvoted_delta: 0 };
+    }
+    data.deltas[docId].upvoted_delta++;
+  }
+
+  await saveUserVotes(votePath, data);
+}
+
+/**
+ * Merge local deltas into a remote votes snapshot.
+ * Returns merged result with empty deltas.
+ */
+export function mergeDeltas(local: UserVotesV2, remote: UserVotesV2): UserVotesV2 {
+  const votes: Record<string, VoteEntryV2> = {};
+
+  for (const [docId, entry] of Object.entries(remote.votes)) {
+    votes[docId] = { ...entry };
+  }
+
+  for (const [docId, delta] of Object.entries(local.deltas)) {
+    if (!votes[docId]) {
+      votes[docId] = { recalled_count: 0, upvoted_count: 0, last_recalled_at: '' };
+    }
+
+    votes[docId].recalled_count = Math.max(0, votes[docId].recalled_count + delta.recalled_delta);
+    votes[docId].upvoted_count = Math.max(0, votes[docId].upvoted_count + delta.upvoted_delta);
+
+    const localEntry = local.votes[docId];
+    if (localEntry) {
+      if (localEntry.last_recalled_at > (votes[docId].last_recalled_at ?? '')) {
+        votes[docId].last_recalled_at = localEntry.last_recalled_at;
+      }
+      if (
+        localEntry.last_upvoted_at !== undefined &&
+        localEntry.last_upvoted_at > (votes[docId].last_upvoted_at ?? '')
+      ) {
+        votes[docId].last_upvoted_at = localEntry.last_upvoted_at;
+      }
+    }
+  }
+
+  return { version: 2, votes, deltas: {} };
+}
+
+/**
+ * Sync local vote deltas to the team repo votes file for a given user.
+ * Returns true if sync was performed, false if deltas were empty.
+ */
+export async function syncVotesToTeam(
+  repoPath: string,
+  username: string,
+  localVotesDir: string,
+): Promise<boolean> {
+  const localVotePath = path.join(localVotesDir, `${username}.yaml`);
+  const remoteVotePath = path.join(repoPath, 'votes', `${username}.yaml`);
+
+  const local = await loadUserVotes(localVotePath);
+
+  if (Object.keys(local.deltas).length === 0) {
+    return false;
+  }
+
+  const remote = await loadUserVotes(remoteVotePath);
+  const merged = mergeDeltas(local, remote);
+
+  await saveUserVotes(remoteVotePath, merged);
+  await saveUserVotes(localVotePath, { ...local, votes: merged.votes, deltas: {} });
+
+  return true;
+}
+
+/**
+ * Record manual feedback for a recalled document.
+ */
+export async function recallFeedback(opts: { positive?: string; negative?: string }): Promise<void> {
+  const { requireInit } = await import('./config.js');
+  const { localConfig } = await requireInit();
+  const { username } = localConfig;
+  const { VOTES_LOCAL_DIR } = await import('./types.js');
+  const votePath = path.join(VOTES_LOCAL_DIR, `${username}.yaml`);
+
+  if (opts.positive) {
+    await incrementUpvoted(votePath, [opts.positive]);
+    log.success(`Upvoted: ${opts.positive}`);
+    return;
+  }
+
+  if (opts.negative) {
+    const data = await loadUserVotes(votePath);
+    if (!data.votes[opts.negative]) {
+      log.warn(`Document not found in votes: ${opts.negative}`);
+      return;
+    }
+    const entry = data.votes[opts.negative];
+    if (entry.upvoted_count <= 0) {
+      log.warn(`No upvotes to decrement for: ${opts.negative}`);
+      return;
+    }
+    const existingDelta = data.deltas[opts.negative] ?? { recalled_delta: 0, upvoted_delta: 0 };
+    const updated: UserVotesV2 = {
+      ...data,
+      votes: {
+        ...data.votes,
+        [opts.negative]: { ...entry, upvoted_count: entry.upvoted_count - 1 },
+      },
+      deltas: {
+        ...data.deltas,
+        [opts.negative]: { ...existingDelta, upvoted_delta: existingDelta.upvoted_delta - 1 },
+      },
+    };
+    await saveUserVotes(votePath, updated);
+    log.success(`Negative signal recorded for: ${opts.negative}`);
+    return;
+  }
+
+  log.error('Usage: teamai recall feedback --positive <docId> | --negative <docId>');
+}


### PR DESCRIPTION
## Summary

Implement the complete knowledge base auto-maintenance pipeline (roadmap Phase 3 + Phase 4):

- **Phase 3 — Vote Dual Counter**: V2 vote format with `recalled_count`/`upvoted_count` dual counters, transcript-based adoption detection via Stop hook, delta-based multi-device sync, V1→V2 auto-migration
- **Phase 4 — Automatic Maintenance**: Confidence scoring, hot/cold search demotion, prune command, quality-update detection with AI draft generation, learning promotion with AI content transformation

### New CLI commands
- `teamai recall feedback --positive/--negative <docId>` — manual feedback
- `teamai recall maintenance --prune` — archive low-confidence learnings
- `teamai recall maintenance --confidence-writeback` — update frontmatter scores  
- `teamai recall maintenance --update-quality` — find stale docs/rules/skills + AI draft generation
- `teamai recall promote [learning-id]` — promote high-confidence learnings with AI content transformation

### Key design decisions
- Hot/cold via search-score demotion (no physical directory split)
- Single-pass `aggregateVotes()` produces both scores and confidenceMap (no double I/O)
- New docs with no vote data are neutral (not penalized)
- `SEARCH_INDEX_VERSION` bumped to 6 to force rebuild
- AI generation with graceful fallback (keyword-based) when CLI unavailable
- `--dry-run` resolved for Commander.js subcommand context

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `npm run build` — build success
- [x] `npx vitest run` — 135 files / 1633 tests all passing
- [x] New test coverage: votes (18), transcript-parser (7), confidence (5), prune (4), promote (6)
- [x] Existing recall/hook/search tests pass with V2 format assertions
- [x] Manual E2E: `teamai recall` → V2 votes created → `recall feedback` → upvoted incremented → Stop hook → transcript parsed + upvoted → sync to team repo → `maintenance --confidence-writeback` → frontmatter updated → `maintenance --prune --dry-run` → candidates listed without deletion → `promote --dry-run` → candidates identified

🤖 Generated with [Claude Code](https://claude.com/claude-code)