### PR TITLE
fix(report): populate agent_version in report endpoint

### DIFF
--- a/src/__tests__/agent-version.test.ts
+++ b/src/__tests__/agent-version.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFile } from 'node:child_process';
+import { getAgentVersion, clearVersionCache, _readPlistVersion } from '../agent-version.js';
+
+beforeEach(() => {
+  clearVersionCache();
+});
+
+describe('getAgentVersion', () => {
+  it('detects claude version from CLI', async () => {
+    const ver = await getAgentVersion('claude');
+    // Should be a semver-like string (digits and dots), or empty if not installed
+    if (ver) {
+      expect(ver).toMatch(/^\d+\.\d+\.\d+/);
+    }
+  });
+
+  it('detects cursor version from CLI', async () => {
+    const ver = await getAgentVersion('cursor');
+    if (ver) {
+      expect(ver).toMatch(/^\d+\.\d+\.\d+/);
+    }
+  });
+
+  it('detects codebuddy CLI version', async () => {
+    const ver = await getAgentVersion('codebuddy');
+    if (ver) {
+      expect(ver).toMatch(/^\d+\.\d+/);
+    }
+  });
+
+  it('detects codebuddy IDE version from plist', async () => {
+    const ver = await getAgentVersion('codebuddy-ide');
+    if (ver) {
+      expect(ver).toMatch(/^\d+\.\d+/);
+    }
+  });
+
+  it('detects workbuddy version from plist', async () => {
+    const ver = await getAgentVersion('workbuddy');
+    if (ver) {
+      expect(ver).toMatch(/^\d+\.\d+/);
+    }
+  });
+
+  it('returns empty string for unknown agents', async () => {
+    const ver = await getAgentVersion('nonexistent-agent');
+    expect(ver).toBe('');
+  });
+
+  it('caches results across calls', async () => {
+    const ver1 = await getAgentVersion('claude');
+    const ver2 = await getAgentVersion('claude');
+    expect(ver1).toBe(ver2);
+  });
+});
+
+describe('_readPlistVersion', () => {
+  it('returns empty string for non-existent path', async () => {
+    const ver = await _readPlistVersion('/nonexistent/App.app');
+    expect(ver).toBe('');
+  });
+});

--- a/src/agent-version.ts
+++ b/src/agent-version.ts
@@ -1,0 +1,126 @@
+/**
+ * Detect the installed version of AI coding agents.
+ *
+ * Each agent has its own detection strategy:
+ *  - CLI-based agents: run `<binary> --version` and parse stdout.
+ *  - Electron apps (macOS): read CFBundleShortVersionString from Info.plist.
+ *  - Fallback: return '' when detection fails (best-effort, never throws).
+ */
+
+import { execFile } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { log } from './utils/logger.js';
+
+const VERSION_CACHE = new Map<string, string>();
+
+async function execVersion(bin: string, args: string[] = ['--version']): Promise<string> {
+  return new Promise((resolve) => {
+    execFile(bin, args, { timeout: 5000 }, (err, stdout) => {
+      if (err) {
+        resolve('');
+        return;
+      }
+      resolve(stdout.trim());
+    });
+  });
+}
+
+async function readPlistVersion(appPath: string): Promise<string> {
+  const plistPath = path.join(appPath, 'Contents', 'Info.plist');
+  try {
+    const content = await readFile(plistPath, 'utf-8');
+    const match = content.match(
+      /<key>CFBundleShortVersionString<\/key>\s*<string>([^<]+)<\/string>/,
+    );
+    return match?.[1] ?? '';
+  } catch {
+    return '';
+  }
+}
+
+// ─── Per-agent detection ────────────────────────────────
+
+async function detectClaudeVersion(): Promise<string> {
+  const raw = await execVersion('claude');
+  // "2.1.199 (Claude Code)" → "2.1.199"
+  const match = raw.match(/^([\d.]+)/);
+  return match?.[1] ?? raw;
+}
+
+async function detectCursorVersion(): Promise<string> {
+  // cursor --version outputs multiple lines; version is on the first line
+  const raw = await execVersion('cursor');
+  return raw.split('\n')[0]?.trim() ?? '';
+}
+
+async function detectCodebuddyCliVersion(): Promise<string> {
+  return execVersion('codebuddy');
+}
+
+const CODEBUDDY_IDE_PATHS = [
+  '/Applications/CodeBuddy.app',
+  '/Applications/CodeBuddy CN.app',
+];
+
+async function detectCodebuddyIdeVersion(): Promise<string> {
+  for (const appPath of CODEBUDDY_IDE_PATHS) {
+    const ver = await readPlistVersion(appPath);
+    if (ver) return ver;
+  }
+  return '';
+}
+
+const WORKBUDDY_APP_PATHS = [
+  '/Applications/WorkBuddy.app',
+];
+
+async function detectWorkbuddyVersion(): Promise<string> {
+  for (const appPath of WORKBUDDY_APP_PATHS) {
+    const ver = await readPlistVersion(appPath);
+    if (ver) return ver;
+  }
+  return '';
+}
+
+// ─── Registry ───────────────────────────────────────────
+
+type VersionDetector = () => Promise<string>;
+
+const DETECTORS: Record<string, VersionDetector> = {
+  claude: detectClaudeVersion,
+  cursor: detectCursorVersion,
+  codebuddy: detectCodebuddyCliVersion,
+  'codebuddy-ide': detectCodebuddyIdeVersion,
+  workbuddy: detectWorkbuddyVersion,
+};
+
+/**
+ * Detect the version of a given agent. Returns '' on failure.
+ * Results are cached for the process lifetime (version won't change mid-session).
+ */
+export async function getAgentVersion(agentType: string): Promise<string> {
+  if (VERSION_CACHE.has(agentType)) return VERSION_CACHE.get(agentType)!;
+
+  const detector = DETECTORS[agentType];
+  let version = '';
+  if (detector) {
+    try {
+      version = await detector();
+    } catch {
+      // best-effort
+    }
+  }
+
+  VERSION_CACHE.set(agentType, version);
+  log.debug(`[agent-version] ${agentType} → "${version}"`);
+  return version;
+}
+
+/** Clear the version cache (for testing). */
+export function clearVersionCache(): void {
+  VERSION_CACHE.clear();
+}
+
+/** Exposed for testing: the plist-reading utility. */
+export { readPlistVersion as _readPlistVersion };

--- a/src/status-report.ts
+++ b/src/status-report.ts
@@ -32,6 +32,7 @@ import {
 import { resolveBaseDir, type LocalConfig, type TeamaiConfig } from './types.js';
 import { getMachineId, deriveLocalAgentId } from './machine-id.js';
 import { log } from './utils/logger.js';
+import { getAgentVersion } from './agent-version.js';
 
 // ─── Endpoint mapping (internal, overridable) ───────────────
 
@@ -270,10 +271,11 @@ async function runStatusReportInner(opts: StatusReportOptions): Promise<void> {
   // ① report — SessionStart only.
   if (opts.phase === 'session') {
     const skills = await scanReportableSkills(skillsDir);
+    const agentVersion = await getAgentVersion(agentType);
     const reportBody = {
       local_agent_id: localAgentId,
       agent_type: agentType,
-      agent_version: '',
+      agent_version: agentVersion,
       host_name: os.hostname(),
       os: `${process.platform}/${process.arch}`,
       started_at: new Date().toISOString(),


### PR DESCRIPTION
## Summary

- Report API 的 `agent_version` 字段之前始终为空字符串，现在会正确填充实际版本号
- 新增 `src/agent-version.ts` 模块，支持检测 claude / cursor / codebuddy (CLI + IDE) / workbuddy 的版本
- CLI 工具通过 `--version` 命令检测，macOS Electron 应用通过 Info.plist 解析
- 结果在进程生命周期内缓存（session 内版本不变）

检测结果示例：
```
claude          → 2.1.199
cursor          → 3.9.16
codebuddy       → 2.114.2
codebuddy-ide   → 4.9.15
workbuddy       → 5.2.2
```

## Test plan

- [x] 新增 `agent-version.test.ts` 覆盖所有 agent 检测、缓存机制、未知 agent 降级
- [x] 已有 `status-report.test.ts` 全部通过（10 tests）
- [x] `npx tsc --noEmit` 类型检查通过
- [x] 本地实测 5 个 agent 均能正确检测到版本号

🤖 Generated with [Claude Code](https://claude.com/claude-code)