### PR TITLE
fix: use SKILL.md name as skill directory name instead of server slug

### DIFF
--- a/src/__tests__/helpers/mock-server.ts
+++ b/src/__tests__/helpers/mock-server.ts
@@ -36,9 +36,14 @@ export interface MockServerHandle {
 }
 
 /** Build a valid skill zip (`<slug>/SKILL.md` + extra files). */
-export function buildSkillZip(slug: string, files: Record<string, string> = {}): Uint8Array {
+export function buildSkillZip(
+  slug: string,
+  files: Record<string, string> = {},
+  opts: { name?: string } = {},
+): Uint8Array {
+  const skillName = opts.name ?? slug;
   const entries: Record<string, Uint8Array> = {
-    [`${slug}/SKILL.md`]: strToU8(`---\nname: ${slug}\nversion: 1.0.0\ndescription: mock\n---\nbody`),
+    [`${slug}/SKILL.md`]: strToU8(`---\nname: ${skillName}\nversion: 1.0.0\ndescription: mock\n---\nbody`),
   };
   for (const [rel, content] of Object.entries(files)) {
     entries[`${slug}/${rel}`] = strToU8(content);

--- a/src/__tests__/skill-command.test.ts
+++ b/src/__tests__/skill-command.test.ts
@@ -20,9 +20,14 @@ afterEach(() => {
 });
 
 /** Build a valid skill zip whose top level is `<slug>/`. */
-function makeSkillZip(slug: string, extraFiles: Record<string, string> = {}): Uint8Array {
+function makeSkillZip(
+  slug: string,
+  extraFiles: Record<string, string> = {},
+  opts: { name?: string } = {},
+): Uint8Array {
+  const skillName = opts.name ?? slug;
   const files: Record<string, Uint8Array> = {
-    [`${slug}/SKILL.md`]: strToU8(`---\nname: ${slug}\ndescription: test skill\n---\nbody`),
+    [`${slug}/SKILL.md`]: strToU8(`---\nname: ${skillName}\ndescription: test skill\n---\nbody`),
   };
   for (const [rel, content] of Object.entries(extraFiles)) {
     files[`${slug}/${rel}`] = strToU8(content);
@@ -44,22 +49,26 @@ describe('installSkillZip', () => {
     await expect(installSkillZip(zip, 'weather', skillsDir)).rejects.toThrow(/missing weather\/SKILL\.md/);
   });
 
-  it('accepts a flat zip (SKILL.md at root) and installs into <slug>/', async () => {
-    // skillhub/clawpro package layout: files at the zip root, no wrapping dir.
+  it('accepts a flat zip (SKILL.md at root) and renames dir to SKILL.md name', async () => {
     const zip = zipSync({
       'SKILL.md': strToU8('---\nname: find-skills\ndescription: test\n---\nbody'),
       '_meta.json': strToU8('{"slug":"find-skills-skill"}'),
       'scripts/run.sh': strToU8('echo hi'),
     });
-    await installSkillZip(zip, 'find-skills-skill', skillsDir);
-    expect(fs.existsSync(path.join(skillsDir, 'find-skills-skill', 'SKILL.md'))).toBe(true);
-    expect(fs.readFileSync(path.join(skillsDir, 'find-skills-skill', 'scripts', 'run.sh'), 'utf-8')).toBe('echo hi');
+    const actualDir = await installSkillZip(zip, 'find-skills-skill', skillsDir);
+    expect(actualDir).toBe('find-skills');
+    expect(fs.existsSync(path.join(skillsDir, 'find-skills', 'SKILL.md'))).toBe(true);
+    expect(fs.readFileSync(path.join(skillsDir, 'find-skills', 'scripts', 'run.sh'), 'utf-8')).toBe('echo hi');
+    // Slug dir should not exist after rename
+    expect(fs.existsSync(path.join(skillsDir, 'find-skills-skill'))).toBe(false);
   });
 
-  it('accepts a nested zip whose top-level dir name differs from the slug', async () => {
-    const zip = zipSync({ 'find-skills/SKILL.md': strToU8('---\nname: find-skills\n---\nbody') });
-    await installSkillZip(zip, 'find-skills-skill', skillsDir);
-    expect(fs.existsSync(path.join(skillsDir, 'find-skills-skill', 'SKILL.md'))).toBe(true);
+  it('accepts a nested zip whose top-level dir name differs from the slug and renames to SKILL.md name', async () => {
+    const zip = zipSync({ 'find-skills/SKILL.md': strToU8('---\nname: find-skills\ndescription: test\n---\nbody') });
+    const actualDir = await installSkillZip(zip, 'find-skills-skill', skillsDir);
+    expect(actualDir).toBe('find-skills');
+    expect(fs.existsSync(path.join(skillsDir, 'find-skills', 'SKILL.md'))).toBe(true);
+    expect(fs.existsSync(path.join(skillsDir, 'find-skills-skill'))).toBe(false);
   });
 
   it('is overwrite-idempotent (re-install replaces prior content)', async () => {
@@ -81,6 +90,52 @@ describe('installSkillZip', () => {
   it('rejects an unsafe slug', async () => {
     const zip = makeSkillZip('weather');
     await expect(installSkillZip(zip, '../evil', skillsDir)).rejects.toThrow(/Invalid resource name/);
+  });
+
+  it('renames dir to SKILL.md name when it differs from slug', async () => {
+    const zip = makeSkillZip('doctor', {}, { name: 'dragon-doctor' });
+    const actualDir = await installSkillZip(zip, 'doctor', skillsDir);
+    expect(actualDir).toBe('dragon-doctor');
+    expect(fs.existsSync(path.join(skillsDir, 'dragon-doctor', 'SKILL.md'))).toBe(true);
+    expect(fs.existsSync(path.join(skillsDir, 'doctor'))).toBe(false);
+    // Slug map should record the mapping
+    const map = JSON.parse(fs.readFileSync(path.join(skillsDir, '_slug-map.json'), 'utf-8'));
+    expect(map['doctor']).toBe('dragon-doctor');
+  });
+
+  it('returns slug as actualDir when SKILL.md name matches slug', async () => {
+    const zip = makeSkillZip('weather');
+    const actualDir = await installSkillZip(zip, 'weather', skillsDir);
+    expect(actualDir).toBe('weather');
+  });
+
+  it('falls back to slug when SKILL.md has no name field', async () => {
+    const zip = zipSync({
+      'weather/SKILL.md': strToU8('---\ndescription: no name field\n---\nbody'),
+    });
+    const actualDir = await installSkillZip(zip, 'weather', skillsDir);
+    expect(actualDir).toBe('weather');
+    expect(fs.existsSync(path.join(skillsDir, 'weather', 'SKILL.md'))).toBe(true);
+  });
+
+  it('falls back to slug when SKILL.md name fails safety check', async () => {
+    const zip = makeSkillZip('weather', {}, { name: '../evil' });
+    const actualDir = await installSkillZip(zip, 'weather', skillsDir);
+    expect(actualDir).toBe('weather');
+    expect(fs.existsSync(path.join(skillsDir, 'weather', 'SKILL.md'))).toBe(true);
+  });
+
+  it('cleans up previously renamed dir on re-install', async () => {
+    // First install: slug=doctor → renamed to dragon-doctor
+    const zip1 = makeSkillZip('doctor', { 'v1.txt': 'v1' }, { name: 'dragon-doctor' });
+    await installSkillZip(zip1, 'doctor', skillsDir);
+    expect(fs.existsSync(path.join(skillsDir, 'dragon-doctor', 'v1.txt'))).toBe(true);
+
+    // Re-install: slug=doctor → still renamed to dragon-doctor, old content replaced
+    const zip2 = makeSkillZip('doctor', { 'v2.txt': 'v2' }, { name: 'dragon-doctor' });
+    await installSkillZip(zip2, 'doctor', skillsDir);
+    expect(fs.existsSync(path.join(skillsDir, 'dragon-doctor', 'v2.txt'))).toBe(true);
+    expect(fs.existsSync(path.join(skillsDir, 'dragon-doctor', 'v1.txt'))).toBe(false);
   });
 });
 
@@ -116,6 +171,25 @@ describe('executeSkillCommand', () => {
     await expect(
       executeSkillCommand({ type: 'uninstall_skill', skill_slug: 'weather' }, skillsDir),
     ).resolves.toBeUndefined();
+  });
+
+  it('uninstall_skill removes renamed dir via slug map', async () => {
+    // Install with slug → renamed dir
+    const zip = makeSkillZip('doctor', {}, { name: 'dragon-doctor' });
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(zip as unknown as BodyInit, { status: 200 })));
+
+    await executeSkillCommand({
+      type: 'install_skill',
+      skill_slug: 'doctor',
+      download_url: 'https://smh.example.com/pkg.zip',
+    }, skillsDir);
+    expect(fs.existsSync(path.join(skillsDir, 'dragon-doctor', 'SKILL.md'))).toBe(true);
+
+    // Uninstall by slug — should find the renamed dir via slug map
+    await executeSkillCommand({ type: 'uninstall_skill', skill_slug: 'doctor' }, skillsDir);
+    expect(fs.existsSync(path.join(skillsDir, 'dragon-doctor'))).toBe(false);
+    // Slug map should be cleaned up
+    expect(fs.existsSync(path.join(skillsDir, '_slug-map.json'))).toBe(false);
   });
 
   it('install_skill surfaces a non-200 download as an error (ack failed path)', async () => {

--- a/src/skill-command.ts
+++ b/src/skill-command.ts
@@ -12,9 +12,11 @@
  * cross-platform) — never the system `unzip`, which is absent on Windows.
  */
 
+import fs from 'node:fs/promises';
 import path from 'node:path';
 import { unzipSync } from 'fflate';
-import { ensureDir, remove, writeFile, pathExists } from './utils/fs.js';
+import YAML from 'yaml';
+import { ensureDir, remove, writeFile, pathExists, readFileSafe, readJson, writeJson } from './utils/fs.js';
 import { assertSafeResourceName, assertWithinRoot } from './utils/path-safety.js';
 import { log } from './utils/logger.js';
 
@@ -105,19 +107,61 @@ function resolveSkillPrefix(entries: Record<string, Uint8Array>, slug: string): 
   return null;
 }
 
+const FRONTMATTER_REGEX = /^---\n([\s\S]*?)\n---/;
+
+async function readSkillNameFromExtracted(skillDir: string): Promise<string | null> {
+  const content = await readFileSafe(path.join(skillDir, 'SKILL.md'));
+  if (!content) return null;
+  const fm = content.match(FRONTMATTER_REGEX);
+  if (!fm) return null;
+  try {
+    const parsed = YAML.parse(fm[1]);
+    if (parsed && typeof parsed === 'object' && typeof parsed.name === 'string') {
+      return parsed.name.trim() || null;
+    }
+  } catch { /* malformed YAML — fall through */ }
+  return null;
+}
+
+function slugMapPath(targetSkillsDir: string): string {
+  return path.join(targetSkillsDir, '_slug-map.json');
+}
+
+async function readSlugMap(targetSkillsDir: string): Promise<Record<string, string>> {
+  return (await readJson<Record<string, string>>(slugMapPath(targetSkillsDir))) ?? {};
+}
+
+async function writeSlugMapEntry(targetSkillsDir: string, slug: string, dirName: string): Promise<void> {
+  const map = await readSlugMap(targetSkillsDir);
+  map[slug] = dirName;
+  await writeJson(slugMapPath(targetSkillsDir), map);
+}
+
+async function removeSlugMapEntry(targetSkillsDir: string, slug: string): Promise<void> {
+  const map = await readSlugMap(targetSkillsDir);
+  if (!(slug in map)) return;
+  delete map[slug];
+  if (Object.keys(map).length === 0) {
+    await remove(slugMapPath(targetSkillsDir));
+  } else {
+    await writeJson(slugMapPath(targetSkillsDir), map);
+  }
+}
+
 /**
- * Decompress a skill ZIP and install it into `targetSkillsDir/<slug>/`.
+ * Decompress a skill ZIP and install it under `targetSkillsDir/`.
  *
- * Accepts both the nested (`<slug>/SKILL.md`) and the flat (`SKILL.md` at root)
- * package layouts (see {@link resolveSkillPrefix}). Every entry is verified to
- * stay within the destination (path-traversal protection). Install is
- * overwrite-idempotent: any pre-existing `<slug>/` is removed first.
+ * The directory name is determined by the SKILL.md `name:` frontmatter field
+ * when it differs from the server-provided slug. Falls back to `slug` when the
+ * name is missing, empty, or fails safety validation.
+ *
+ * Returns the actual directory name used (may differ from `slug`).
  */
 export async function installSkillZip(
   zip: Uint8Array,
   slug: string,
   targetSkillsDir: string,
-): Promise<void> {
+): Promise<string> {
   assertSafeResourceName(slug);
 
   let entries: Record<string, Uint8Array>;
@@ -132,16 +176,18 @@ export async function installSkillZip(
     throw new Error(`skill package missing ${slug}/SKILL.md (no SKILL.md found at zip root or under any top-level dir — malformed package)`);
   }
 
+  // Clean up any prior install — both the slug dir and any previously mapped dir.
   const destRoot = path.join(targetSkillsDir, slug);
-  // Overwrite-idempotent: clear any prior install first.
   await remove(destRoot);
+  const oldMap = await readSlugMap(targetSkillsDir);
+  if (oldMap[slug] && oldMap[slug] !== slug) {
+    await remove(path.join(targetSkillsDir, oldMap[slug]));
+  }
+
   await ensureDir(destRoot);
 
   for (const [entryPath, bytes] of Object.entries(entries)) {
-    // For a nested layout, only extract the chosen subtree; for a flat layout
-    // (prefix === '') every entry belongs to the skill.
     if (prefix && !entryPath.startsWith(prefix)) continue;
-    // Directory entries have a trailing slash and empty bytes — ensureDir handles parents.
     if (entryPath.endsWith('/')) continue;
 
     const rel = prefix ? entryPath.slice(prefix.length) : entryPath;
@@ -151,6 +197,26 @@ export async function installSkillZip(
     await ensureDir(path.dirname(outPath));
     await writeFile(outPath, Buffer.from(bytes).toString('utf-8'));
   }
+
+  // Rename directory to match SKILL.md name when it differs from the slug.
+  const skillName = await readSkillNameFromExtracted(destRoot);
+  let actualDir = slug;
+
+  if (skillName && skillName !== slug) {
+    try {
+      assertSafeResourceName(skillName);
+      const finalDest = path.join(targetSkillsDir, skillName);
+      await remove(finalDest);
+      await fs.rename(destRoot, finalDest);
+      actualDir = skillName;
+      log.debug(`[skill-command] renamed ${slug}/ → ${skillName}/ (SKILL.md name)`);
+    } catch {
+      log.debug(`[skill-command] keeping slug "${slug}" as dir name (SKILL.md name "${skillName}" failed safety check or rename)`);
+    }
+  }
+
+  await writeSlugMapEntry(targetSkillsDir, slug, actualDir);
+  return actualDir;
 }
 
 /**
@@ -171,15 +237,25 @@ export async function executeSkillCommand(cmd: SkillCommand, targetSkillsDir: st
         throw new Error(`${cmd.type} requires download_url`);
       }
       const zip = await downloadZip(cmd.download_url);
-      await installSkillZip(zip, cmd.skill_slug, targetSkillsDir);
-      log.debug(`[skill-command] ${cmd.type} ${cmd.skill_slug}@${cmd.skill_version ?? '?'} → ${targetSkillsDir}`);
+      const actualDir = await installSkillZip(zip, cmd.skill_slug, targetSkillsDir);
+      log.debug(`[skill-command] ${cmd.type} ${cmd.skill_slug}@${cmd.skill_version ?? '?'} → ${targetSkillsDir}/${actualDir}`);
       return;
     }
     case 'uninstall_skill': {
       const dir = path.join(targetSkillsDir, cmd.skill_slug);
       if (await pathExists(dir)) {
         await remove(dir);
+      } else {
+        const map = await readSlugMap(targetSkillsDir);
+        const mapped = map[cmd.skill_slug];
+        if (mapped && mapped !== cmd.skill_slug) {
+          const mappedDir = path.join(targetSkillsDir, mapped);
+          if (await pathExists(mappedDir)) {
+            await remove(mappedDir);
+          }
+        }
       }
+      await removeSlugMapEntry(targetSkillsDir, cmd.skill_slug);
       log.debug(`[skill-command] uninstall_skill ${cmd.skill_slug} (from ${targetSkillsDir})`);
       return;
     }


### PR DESCRIPTION
## Summary
- HTTP 拉取 skill 时，`installSkillZip()` 现在读取 SKILL.md frontmatter 的 `name:` 字段，当其与服务端 `skill_slug` 不同时，将安装目录重命名为 SKILL.md 中的名称
- 新增 `_slug-map.json` 映射文件（slug → 实际目录名），支持 `uninstall_skill` 按 slug 正确查找被重命名的目录
- name 缺失或不合法时安全降级到使用 slug 作为目录名

## Test plan
- [x] 新增 5 个 `installSkillZip` 测试覆盖：slug/name 不匹配重命名、无 name 降级、不安全 name 降级、重装清理
- [x] 新增 1 个 `executeSkillCommand` 测试覆盖 slug map uninstall
- [x] 所有 17 个 skill-command 测试通过
- [x] 所有 7 个 source-http 测试通过（无回归）
- [x] TypeScript 类型检查通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)