### PR TITLE
fix(doctor): skip env check when team repo has no env.yaml

### DIFF
--- a/src/__tests__/doctor.test.ts
+++ b/src/__tests__/doctor.test.ts
@@ -142,6 +142,44 @@ describe('doctor — hook checks', () => {
         expect(TEAMAI_HOOK_SUBCOMMANDS).toHaveLength(1);
     });
 
+    it('should pass env check when env/env.yaml does not exist in team repo', async () => {
+        mockedPathExists.mockImplementation(async (filePath: string) => {
+            if (filePath.includes('env/env.yaml')) return false;
+            return true;
+        });
+        mockedReadFileSafe.mockImplementation(async (filePath: string) => {
+            if (filePath.includes('settings.json')) return buildFullHooksContent();
+            return null;
+        });
+
+        await doctor({});
+
+        const allCalls = consoleSpy.mock.calls.map((c) => c[0]);
+        const envLine = allCalls.find((msg: string) => msg.includes('Env variables'));
+        expect(envLine).toContain('✔');
+    });
+
+    it('should pass env check when injectShellProfile is false', async () => {
+        mockedLoadTeamConfig.mockResolvedValue({
+            ...mockTeamConfig,
+            sharing: { env: { injectShellProfile: false } },
+        });
+        mockedPathExists.mockImplementation(async (filePath: string) => {
+            if (filePath.includes('env.sh')) return false;
+            return true;
+        });
+        mockedReadFileSafe.mockImplementation(async (filePath: string) => {
+            if (filePath.includes('settings.json')) return buildFullHooksContent();
+            return null;
+        });
+
+        await doctor({});
+
+        const allCalls = consoleSpy.mock.calls.map((c) => c[0]);
+        const envLine = allCalls.find((msg: string) => msg.includes('Env variables'));
+        expect(envLine).toContain('✔');
+    });
+
     it('should skip tools whose parent directory does not exist', async () => {
         mockedLoadTeamConfig.mockResolvedValue({
             ...mockTeamConfig,

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -129,13 +129,17 @@ export async function doctor(options: GlobalOptions): Promise<void> {
     {
       name: 'Env variables injected in shell profile',
       check: async () => {
+        if (teamConfig?.sharing?.env?.injectShellProfile === false) return true;
+
+        if (!localConfig) return true;
+        const envYamlPath = path.join(localConfig.repo.localPath, 'env', 'env.yaml');
+        if (!await pathExists(envYamlPath)) return true;
+
         const home = process.env.HOME ?? '';
 
-        // Check if env.sh exists
         const envShPath = path.join(home, '.teamai', 'env.sh');
         if (!await pathExists(envShPath)) return false;
 
-        // Check for source line in shell profile
         const shell = process.env.SHELL ?? '';
         const profilePath = shell.includes('zsh')
           ? path.join(home, '.zshrc')


### PR DESCRIPTION
## Summary
- `teamai doctor` 的 "Env variables injected in shell profile" 检查之前无条件执行，当 team repo 没有 `env/env.yaml` 时会误报失败
- 修复后，当 `env/env.yaml` 不存在或 `sharing.env.injectShellProfile` 为 false 时，检查直接跳过（视为通过）

## Test plan
- [x] `npx vitest run src/__tests__/doctor.test.ts` — 7 tests pass
- [x] `npx tsc --noEmit` — no new type errors
- [x] 在无 env.yaml 的 team repo 上运行 `teamai doctor`，确认 env check 显示 ✔

🤖 Generated with [Claude Code](https://claude.com/claude-code)