### PR TITLE
fix(update): handle prerelease versions in compareVersions

### DIFF
--- a/src/__tests__/update.test.ts
+++ b/src/__tests__/update.test.ts
@@ -148,6 +148,24 @@ describe('compareVersions', () => {
     expect(compareVersions('1.0', '1.0.0')).toBe(0);
     expect(compareVersions('1.0.1', '1.0')).toBe(1);
   });
+
+  it('should treat prerelease as older than same numeric release', () => {
+    expect(compareVersions('1.2.3-beta.1', '1.2.3')).toBe(-1);
+    expect(compareVersions('1.2.3', '1.2.3-beta.1')).toBe(1);
+  });
+
+  it('should treat prerelease as older than a higher release', () => {
+    expect(compareVersions('1.2.3-beta.1', '1.2.4')).toBe(-1);
+    expect(compareVersions('1.3.0-alpha.0', '1.3.0')).toBe(-1);
+  });
+
+  it('should treat two prereleases with same core as equal (no deep prerelease ordering)', () => {
+    expect(compareVersions('1.2.3-beta.1', '1.2.3-beta.2')).toBe(0);
+  });
+
+  it('should compare prerelease against lower release correctly', () => {
+    expect(compareVersions('2.0.0-rc.1', '1.9.9')).toBe(1);
+  });
 });
 
 // ─── Unit tests: isCacheValid ───────────────────────────

--- a/src/update.ts
+++ b/src/update.ts
@@ -67,12 +67,17 @@ export async function fetchLatestVersion(
 }
 
 /**
- * Compare two semver version strings (x.y.z format)
+ * Compare two semver version strings.
+ * Handles prerelease suffixes: a version with prerelease (e.g. 1.2.3-beta.1)
+ * is always older than the same numeric version without one (semver §11).
  * Returns: -1 if a < b, 0 if equal, 1 if a > b
  */
 export function compareVersions(a: string, b: string): number {
-  const partsA = a.split('.').map(Number);
-  const partsB = b.split('.').map(Number);
+  const [coreA, preA] = a.split('-', 2);
+  const [coreB, preB] = b.split('-', 2);
+
+  const partsA = coreA.split('.').map(Number);
+  const partsB = coreB.split('.').map(Number);
   const len = Math.max(partsA.length, partsB.length);
   for (let i = 0; i < len; i++) {
     const pa = partsA[i] ?? 0;
@@ -80,6 +85,10 @@ export function compareVersions(a: string, b: string): number {
     if (pa > pb) return 1;
     if (pa < pb) return -1;
   }
+
+  // Numeric cores are equal — prerelease is lower than release (semver §11)
+  if (preA && !preB) return -1;
+  if (!preA && preB) return 1;
   return 0;
 }
 


### PR DESCRIPTION
## Summary
- Fix `compareVersions` to correctly handle prerelease suffixes (e.g. `1.2.3-beta.1`)
- Previously, prerelease versions would produce `NaN` during numeric comparison, causing beta users to never see update prompts for stable releases
- Now splits off the `-<prerelease>` suffix before comparing, and treats prerelease as lower than the same core version (semver §11)

## Test plan
- [x] New unit tests: prerelease < same release, prerelease < higher release, prerelease > lower release
- [x] Existing tests all pass (975 passed)
- [x] Type check passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)