### PR TITLE
chore(release): 0.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teamai-cli",
-  "version": "0.16.8",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teamai-cli",
-      "version": "0.16.8",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teamai-cli",
-  "version": "0.16.8",
+  "version": "0.17.0",
   "description": "TeamAI — the team harness for AI agents (skill sync + shared knowledge base, powered by Git)",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release Notes — v0.17.0

This minor release rolls up 56 PRs (#55-#147) merged into `main` since the last published version (0.16.9).

### 💥 Breaking Changes

- Removed the `auto-recall` PostToolUse hook: teamai no longer passively/implicitly searches the team knowledge base after `Bash`/`Grep`/`WebSearch`/`WebFetch` tool calls. This is superseded by the `teamai-recall` subagent (proactive retrieval with codebase graph drill-down and structured summaries). Existing hook configs are cleaned up automatically on the next `teamai pull` / `hooks inject` (#106)

### ✨ Features

- **Code knowledge graph (wiki-engine)**: multi-language AST code extraction (TS/Python/Go/Java/Rust) + AI enrichment + knowledge reconciler + deep-enrich + graph-aware recall + `team-wiki-codebase` skill (#55, #56, #57, #90, #91, #92, #96)
- **Unified hooks management**: team-declared hooks + built-in hooks as data, `teamai hooks list` command, Codex hooks injection support (#65, #62, #66, #103)
- **Git-free HTTP team repo**: team knowledge base storage without a git dependency + hooks-driven agent status reporting (#68)
- **Progressive recall**: G-document routed progressive retrieval, config-driven enable/disable toggle (`teamai recall`), 7 knowledge retrieval bug fixes (#79-85, #97-100, #102, #106, #126, #135)
- **Dashboard / usage stats**: Human Intervention metric, per-session conversation turns and token usage, CodeBuddy usage parsing, project-scope digest reporting (#70, #75, #78, #105, #107-113, #118, #121-123)
- **Scope isolation**: project and user scopes no longer interfere with each other (#73, #77, #97, #99)
- **Import improvements**: `--dir` uses the code extraction pipeline, MR-triggered incremental teamwiki updates, listr2 progress bar + English CLI output (#71, #74, #76, #112, #117, #127, #128)
- **Agent version reporting**: status-report endpoint now includes `agent_version` (#140)

### 🐛 Fixes

- Security hardening: shell-quote all TGit CLI args and `env.sh` values to prevent injection (#60, #40)
- Fixed a race condition in `graph-index.json` during batch import (#67)
- `init`: auto-select single role, remove redundant role prompt, skip hook injection for tools not installed (#123, #132, #134)
- `doctor`: skip uninstalled tools and show scope, skip env check when team repo has no `env.yaml` (#116, #146)
- `update`: `compareVersions` now handles prerelease versions (#147)
- `skill-command`: use SKILL.md name as directory name when it differs from the server slug (#144)

### 🧹 Chores

- Removed the `teamai-wiki` skill and `wiki/` resource type (superseded by `team-wiki-codebase`) (#90)
- Removed dead code and duplicate compat shims (#96)
- Updated CLAUDE.md git conventions and English output requirement; documented the recall enable/disable toggle in README/usage-guide (#121, #145)

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes (`teamai-cli@0.17.0`)
- [ ] After merge, push tag `v0.17.0` to trigger the GitHub Actions release workflow (publish to public npm)

Made with [Cursor](https://cursor.com)