### PR TITLE
fix(ci): trigger Coding CI on main branch instead of stale master

### DIFF
--- a/.coding-ci.yaml
+++ b/.coding-ci.yaml
@@ -102,14 +102,14 @@ stages:
 trigger:
   branches:
     include:
-    - master
+    - main
   tags:
     include:
     - /^v\d+\.\d+\.\d+/
 mr:
   branches:
     include:
-    - master
+    - main
   is_block_mr: 0
 finally:
   failure:


### PR DESCRIPTION
## Problem

The TGit (git.woa.com) mirror's default branch was renamed from `master` to `main` (`master` was deleted), but `.coding-ci.yaml` still hardcodes `master` in two places:

```yaml
trigger:
  branches:
    include:
    - master        # push-triggered validate(lint+test)/build/e2e
mr:
  branches:
    include:
    - master        # MR-triggered checks
```

Since the rename, pushes and MRs targeting `main` on TGit no longer trigger the validate/build/e2e pipeline. Tag-triggered publish (e.g. the v0.17.0 release) is unaffected since it matches an independent `tags.include` pattern.

This file has no effect on GitHub CI (which uses `.github/workflows/`), but it's kept in sync via the periodic TGit↔GitHub sync process, so fixing it here prevents it from being reverted back to `master` next time TGit syncs from `main`.

## Change

Replace `master` with `main` in `trigger.branches.include` and `mr.branches.include`.

Made with [Cursor](https://cursor.com)