### PR TITLE
fix(test): bump vitest default timeout to 15s for CI stability

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,10 @@ export default defineConfig({
   test: {
     include: ['src/__tests__/**/*.test.ts'],
     exclude: ['src/__tests__/e2e/**', 'src/__tests__/*-e2e.test.ts'],
+    // CI workers can be resource-constrained under parallel load, which made
+    // otherwise-fast tests sporadically exceed vitest's 5s default timeout.
+    testTimeout: 15000,
+    hookTimeout: 15000,
     coverage: {
       provider: 'v8',
       reporter: ['cobertura', 'text'],


### PR DESCRIPTION
## Summary
- Bump vitest's `testTimeout`/`hookTimeout` from the 5s default to 15s.
- The internal Coding CI (tnpm) runner can be resource-constrained under parallel test load, which caused otherwise-fast/mocked unit tests (`agent-skills`, `ci-extract-mr`, `import-dir`, etc.) to sporadically time out at exactly 5000ms — reproduced twice via manual pipeline re-runs.
- This went unnoticed until now because Coding CI wasn't triggering on `main`-targeted MRs due to the stale `master` branch reference fixed in #149.

## Test plan
- [x] `npx vitest run` locally: full suite passes except one pre-existing, unrelated assertion failure in `import-repo-merge.test.ts` (not a timeout, confirmed to fail identically without this change too — tracked separately).
- [x] `npx tsc --noEmit` passes.

Made with [Cursor](https://cursor.com)