### PR TITLE
feat(init): add --agent flag to limit hooks injection to a single tool

### DIFF
--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -400,6 +400,49 @@ describe('hooks', () => {
         process.env.HOME = originalHome;
       }
     });
+
+    it('filterAgents limits injection to specified tools only', async () => {
+      mockFiles = {};
+      const originalHome = process.env.HOME;
+      process.env.HOME = '/test-home';
+
+      try {
+        await injectHooksToAllTools({
+          claude: { settings: '.claude/settings.json' },
+          codebuddy: { settings: '.codebuddy/settings.json' },
+          workbuddy: { settings: '.workbuddy/settings.json' },
+        }, undefined, ['codebuddy']);
+
+        expect(mockFiles[path.join('/test-home', '.codebuddy/settings.json')]).toBeDefined();
+        expect(mockFiles[path.join('/test-home', '.claude/settings.json')]).toBeUndefined();
+        expect(mockFiles[path.join('/test-home', '.workbuddy/settings.json')]).toBeUndefined();
+      } finally {
+        process.env.HOME = originalHome;
+      }
+    });
+
+    it('filterAgents is additive — second call adds without removing first', async () => {
+      mockFiles = {};
+      const originalHome = process.env.HOME;
+      process.env.HOME = '/test-home';
+
+      const toolPaths = {
+        claude: { settings: '.claude/settings.json' },
+        codebuddy: { settings: '.codebuddy/settings.json' },
+        workbuddy: { settings: '.workbuddy/settings.json' },
+      };
+
+      try {
+        await injectHooksToAllTools(toolPaths, undefined, ['codebuddy']);
+        await injectHooksToAllTools(toolPaths, undefined, ['workbuddy']);
+
+        expect(mockFiles[path.join('/test-home', '.codebuddy/settings.json')]).toBeDefined();
+        expect(mockFiles[path.join('/test-home', '.workbuddy/settings.json')]).toBeDefined();
+        expect(mockFiles[path.join('/test-home', '.claude/settings.json')]).toBeUndefined();
+      } finally {
+        process.env.HOME = originalHome;
+      }
+    });
   });
 
   describe('format alignment', () => {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -502,9 +502,10 @@ export async function getHookStatus(settingsPath: string, tool?: string): Promis
  * Only writes to tools whose root directory already exists on disk,
  * preventing creation of config dirs for tools the user hasn't installed.
  */
-export async function injectHooksToAllTools(toolPaths: Record<string, { settings?: string }>, baseDir?: string): Promise<void> {
+export async function injectHooksToAllTools(toolPaths: Record<string, { settings?: string }>, baseDir?: string, filterAgents?: string[]): Promise<void> {
   const resolvedBaseDir = baseDir ?? (process.env.HOME ?? '');
   for (const [tool, paths] of Object.entries(toolPaths)) {
+    if (filterAgents && !filterAgents.includes(tool)) continue;
     if (paths.settings) {
       const toolRoot = path.join(resolvedBaseDir, paths.settings.split('/')[0]);
       if (!await pathExists(toolRoot)) continue;
@@ -538,9 +539,10 @@ export async function reconcileHooksToAllTools(
   baseDir: string,
   teamDefs: HookDef[],
   manifestPath: string,
-  opts: { removeAll?: boolean; builtinOverride?: BuiltinHookOverride; force?: boolean } = {},
+  opts: { removeAll?: boolean; builtinOverride?: BuiltinHookOverride; force?: boolean; filterAgents?: string[] } = {},
 ): Promise<void> {
   for (const [tool, paths] of Object.entries(toolPaths)) {
+    if (opts.filterAgents && !opts.filterAgents.includes(tool)) continue;
     if (!paths.settings) continue;
     if (!opts.force) {
       const toolRoot = path.join(baseDir, paths.settings.split('/')[0]);
@@ -568,7 +570,7 @@ export async function reconcileHooksToAllTools(
 export async function reconcileTeamHooksForConfig(
   teamConfig: TeamaiConfig,
   localConfig: LocalConfig,
-  opts: { removeAll?: boolean; auto?: boolean; silent?: boolean } = {},
+  opts: { removeAll?: boolean; auto?: boolean; silent?: boolean; filterAgents?: string[] } = {},
 ): Promise<HookDef[]> {
   const { defs: teamDefs, builtin } = opts.removeAll
     ? { defs: [] as HookDef[], builtin: undefined }
@@ -578,6 +580,7 @@ export async function reconcileTeamHooksForConfig(
   await reconcileHooksToAllTools(teamConfig.toolPaths, baseDir, teamDefs, manifestPath, {
     removeAll: opts.removeAll,
     builtinOverride: builtin,
+    filterAgents: opts.filterAgents,
   });
   return teamDefs;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ program
   .option('--token <key>', 'API key for HTTP team repo / status reporting (stored 0600, never committed). Also reads TEAMAI_API_TOKEN.')
   .option('--scope <scope>', 'Scope: user (default) or project')
   .option('--role <id>', 'Primary role ID (e.g. hai_dev) for non-interactive setup')
+  .option('--agent <name>', 'Only inject hooks into this agent (e.g. claude, codebuddy, workbuddy). Additive on repeated runs.')
   .option('--force', 'Overwrite existing config without confirmation')
   .action(async (cmdOpts) => {
     const globalOpts = program.opts() as GlobalOptions;

--- a/src/init.ts
+++ b/src/init.ts
@@ -107,7 +107,7 @@ export function validateScopeMatch(remoteScope: Scope | undefined, localScope: S
  */
 export async function initHttp(
   url: string,
-  options: GlobalOptions & { scope?: string; role?: string; force?: boolean; token?: string },
+  options: GlobalOptions & { scope?: string; role?: string; agent?: string; force?: boolean; token?: string },
 ): Promise<void> {
   const { resolveApiKey, saveApiKey, getApiKeyPath } = await import('./api-key.js');
   const { materializeHttpRepo, RepoNotAvailableError } = await import('./source-http.js');
@@ -216,7 +216,8 @@ export async function initHttp(
 
   // Step 5: inject hooks (built-in dispatch incl. the reporter) via the same
   // authoritative path the git init uses, so HTTP consumers behave identically.
-  await reconcileTeamHooksForConfig(teamConfig, localConfig);
+  const filterAgents = options.agent ? [options.agent] : undefined;
+  await reconcileTeamHooksForConfig(teamConfig, localConfig, { filterAgents });
 
   if (reportingOnly) {
     log.success('teamai initialized (HTTP, reporting-only — /repo not live yet)!');
@@ -228,7 +229,7 @@ export async function initHttp(
   closePrompt();
 }
 
-export async function init(options: GlobalOptions & { repo?: string; scope?: string; role?: string; force?: boolean; http?: string; token?: string }): Promise<void> {
+export async function init(options: GlobalOptions & { repo?: string; scope?: string; role?: string; agent?: string; force?: boolean; http?: string; token?: string }): Promise<void> {
   if (options.http) {
     return initHttp(options.http, options);
   }
@@ -557,7 +558,8 @@ export async function init(options: GlobalOptions & { repo?: string; scope?: str
   // Step 7: Inject built-in + team hooks into AI tools
   const reloadedTeamConfig = await loadTeamConfig(localPath);
   if (reloadedTeamConfig) {
-    await reconcileTeamHooksForConfig(reloadedTeamConfig, localConfig);
+    const filterAgents = options.agent ? [options.agent] : undefined;
+    await reconcileTeamHooksForConfig(reloadedTeamConfig, localConfig, { filterAgents });
   }
 
   log.success('teamai initialized successfully!');


### PR DESCRIPTION
## Summary

- Add `--agent <name>` option to `teamai init` that restricts hooks injection to only the specified AI tool (e.g. `claude`, `codebuddy`, `workbuddy`)
- Multiple runs with different `--agent` values are additive — existing hooks in other tools are preserved
- When `--agent` is omitted, behavior is unchanged (all tools get hooks injected)
- Works in both Git mode (`--repo`) and HTTP mode (`--http`)

## Motivation

When the setup prompt is triggered inside a specific tool (e.g. CodeBuddy), users only want hooks injected into that tool — not into all installed tools. This avoids unexpected side effects when switching between tools.

## Test plan

- [ ] `teamai init --http ... --agent codebuddy` only injects hooks into `~/.codebuddy/settings.json`
- [ ] Running again with `--agent workbuddy --force` adds hooks to workbuddy without removing codebuddy's
- [ ] Running without `--agent` injects into all tools (backward compatible)
- [ ] Unit tests for `filterAgents` parameter pass (`npx vitest run src/__tests__/hooks.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)