### PR TITLE
feat(init): add --agent flag to limit hooks injection per tool

### DIFF
--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -400,6 +400,73 @@ describe('hooks', () => {
         process.env.HOME = originalHome;
       }
     });
+
+    it('filterAgents limits injection to specified tools only', async () => {
+      const originalHome = process.env.HOME;
+      process.env.HOME = '/test-home';
+
+      try {
+        await injectHooksToAllTools(
+          {
+            claude: { settings: '.claude/settings.json' },
+            codebuddy: { settings: '.codebuddy/settings.json' },
+            workbuddy: { settings: '.workbuddy/settings.json' },
+          },
+          undefined,
+          ['codebuddy'],
+        );
+
+        expect(mockFiles[path.join('/test-home', '.claude/settings.json')]).toBeUndefined();
+        expect(mockFiles[path.join('/test-home', '.codebuddy/settings.json')]).toBeDefined();
+        expect(mockFiles[path.join('/test-home', '.workbuddy/settings.json')]).toBeUndefined();
+      } finally {
+        process.env.HOME = originalHome;
+      }
+    });
+
+    it('filterAgents allows multiple agents (additive init runs)', async () => {
+      const originalHome = process.env.HOME;
+      process.env.HOME = '/test-home';
+
+      try {
+        await injectHooksToAllTools(
+          {
+            claude: { settings: '.claude/settings.json' },
+            codebuddy: { settings: '.codebuddy/settings.json' },
+            workbuddy: { settings: '.workbuddy/settings.json' },
+          },
+          undefined,
+          ['codebuddy', 'workbuddy'],
+        );
+
+        expect(mockFiles[path.join('/test-home', '.claude/settings.json')]).toBeUndefined();
+        expect(mockFiles[path.join('/test-home', '.codebuddy/settings.json')]).toBeDefined();
+        expect(mockFiles[path.join('/test-home', '.workbuddy/settings.json')]).toBeDefined();
+      } finally {
+        process.env.HOME = originalHome;
+      }
+    });
+
+    it('undefined filterAgents injects into all tools (backward compat)', async () => {
+      const originalHome = process.env.HOME;
+      process.env.HOME = '/test-home';
+
+      try {
+        await injectHooksToAllTools(
+          {
+            claude: { settings: '.claude/settings.json' },
+            codebuddy: { settings: '.codebuddy/settings.json' },
+          },
+          undefined,
+          undefined,
+        );
+
+        expect(mockFiles[path.join('/test-home', '.claude/settings.json')]).toBeDefined();
+        expect(mockFiles[path.join('/test-home', '.codebuddy/settings.json')]).toBeDefined();
+      } finally {
+        process.env.HOME = originalHome;
+      }
+    });
   });
 
   describe('format alignment', () => {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -502,9 +502,10 @@ export async function getHookStatus(settingsPath: string, tool?: string): Promis
  * Only writes to tools whose root directory already exists on disk,
  * preventing creation of config dirs for tools the user hasn't installed.
  */
-export async function injectHooksToAllTools(toolPaths: Record<string, { settings?: string }>, baseDir?: string): Promise<void> {
+export async function injectHooksToAllTools(toolPaths: Record<string, { settings?: string }>, baseDir?: string, filterAgents?: string[]): Promise<void> {
   const resolvedBaseDir = baseDir ?? (process.env.HOME ?? '');
   for (const [tool, paths] of Object.entries(toolPaths)) {
+    if (filterAgents && !filterAgents.includes(tool)) continue;
     if (paths.settings) {
       const toolRoot = path.join(resolvedBaseDir, paths.settings.split('/')[0]);
       if (!await pathExists(toolRoot)) continue;
@@ -538,9 +539,10 @@ export async function reconcileHooksToAllTools(
   baseDir: string,
   teamDefs: HookDef[],
   manifestPath: string,
-  opts: { removeAll?: boolean; builtinOverride?: BuiltinHookOverride; force?: boolean } = {},
+  opts: { removeAll?: boolean; builtinOverride?: BuiltinHookOverride; force?: boolean; filterAgents?: string[] } = {},
 ): Promise<void> {
   for (const [tool, paths] of Object.entries(toolPaths)) {
+    if (opts.filterAgents && !opts.filterAgents.includes(tool)) continue;
     if (!paths.settings) continue;
     if (!opts.force) {
       const toolRoot = path.join(baseDir, paths.settings.split('/')[0]);
@@ -568,16 +570,18 @@ export async function reconcileHooksToAllTools(
 export async function reconcileTeamHooksForConfig(
   teamConfig: TeamaiConfig,
   localConfig: LocalConfig,
-  opts: { removeAll?: boolean; auto?: boolean; silent?: boolean } = {},
+  opts: { removeAll?: boolean; auto?: boolean; silent?: boolean; filterAgents?: string[] } = {},
 ): Promise<HookDef[]> {
   const { defs: teamDefs, builtin } = opts.removeAll
     ? { defs: [] as HookDef[], builtin: undefined }
     : await resolveTeamHooks(teamConfig, localConfig.repo.localPath, { auto: opts.auto, silent: opts.silent });
   const baseDir = resolveBaseDir(localConfig);
   const manifestPath = getManagedHooksPath(localConfig.scope, localConfig.projectRoot);
+  const filterAgents = opts.filterAgents ?? localConfig.enabledAgents;
   await reconcileHooksToAllTools(teamConfig.toolPaths, baseDir, teamDefs, manifestPath, {
     removeAll: opts.removeAll,
     builtinOverride: builtin,
+    filterAgents,
   });
   return teamDefs;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ program
   .option('--token <key>', 'API key for HTTP team repo / status reporting (stored 0600, never committed). Also reads TEAMAI_API_TOKEN.')
   .option('--scope <scope>', 'Scope: user (default) or project')
   .option('--role <id>', 'Primary role ID (e.g. hai_dev) for non-interactive setup')
+  .option('--agent <name>', 'Only inject hooks into this agent (e.g. claude, codebuddy, workbuddy). Additive on repeated runs.')
   .option('--force', 'Overwrite existing config without confirmation')
   .action(async (cmdOpts) => {
     const globalOpts = program.opts() as GlobalOptions;

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,6 +1,6 @@
 import YAML from 'yaml';
 import path from 'node:path';
-import { saveLocalConfig, loadTeamConfig, saveLocalConfigForScope, loadStateForScope, saveStateForScope } from './config.js';
+import { saveLocalConfig, loadTeamConfig, saveLocalConfigForScope, loadLocalConfigForScope, loadStateForScope, saveStateForScope } from './config.js';
 import { reconcileTeamHooksForConfig } from './hooks.js';
 import { configureGitUser, initRepo } from './utils/git.js';
 import { pushRepoDirectly } from './utils/git.js';
@@ -107,7 +107,7 @@ export function validateScopeMatch(remoteScope: Scope | undefined, localScope: S
  */
 export async function initHttp(
   url: string,
-  options: GlobalOptions & { scope?: string; role?: string; force?: boolean; token?: string },
+  options: GlobalOptions & { scope?: string; role?: string; agent?: string; force?: boolean; token?: string },
 ): Promise<void> {
   const { resolveApiKey, saveApiKey, getApiKeyPath } = await import('./api-key.js');
   const { materializeHttpRepo, RepoNotAvailableError } = await import('./source-http.js');
@@ -196,6 +196,13 @@ export async function initHttp(
     }
   }
 
+  // Persist --agent into enabledAgents (additive across runs)
+  if (options.agent) {
+    const existing = await loadLocalConfigForScope(scope, projectRoot);
+    const prev = existing?.enabledAgents ?? [];
+    localConfig.enabledAgents = [...new Set([...prev, options.agent])];
+  }
+
   await ensureDir(teamaiHome);
   if (scope === 'project') {
     await saveLocalConfigForScope(localConfig, scope, projectRoot);
@@ -216,7 +223,8 @@ export async function initHttp(
 
   // Step 5: inject hooks (built-in dispatch incl. the reporter) via the same
   // authoritative path the git init uses, so HTTP consumers behave identically.
-  await reconcileTeamHooksForConfig(teamConfig, localConfig);
+  const filterAgents = options.agent ? [options.agent] : undefined;
+  await reconcileTeamHooksForConfig(teamConfig, localConfig, { filterAgents });
 
   if (reportingOnly) {
     log.success('teamai initialized (HTTP, reporting-only — /repo not live yet)!');
@@ -228,7 +236,7 @@ export async function initHttp(
   closePrompt();
 }
 
-export async function init(options: GlobalOptions & { repo?: string; scope?: string; role?: string; force?: boolean; http?: string; token?: string }): Promise<void> {
+export async function init(options: GlobalOptions & { repo?: string; scope?: string; role?: string; agent?: string; force?: boolean; http?: string; token?: string }): Promise<void> {
   if (options.http) {
     return initHttp(options.http, options);
   }
@@ -509,6 +517,13 @@ export async function init(options: GlobalOptions & { repo?: string; scope?: str
     }
   }
 
+  // Persist --agent into enabledAgents (additive across runs)
+  if (options.agent) {
+    const existing = await loadLocalConfigForScope(scope, projectRoot);
+    const prev = existing?.enabledAgents ?? [];
+    localConfig.enabledAgents = [...new Set([...prev, options.agent])];
+  }
+
   await ensureDir(teamaiHome);
 
   if (scope === 'project') {
@@ -557,7 +572,8 @@ export async function init(options: GlobalOptions & { repo?: string; scope?: str
   // Step 7: Inject built-in + team hooks into AI tools
   const reloadedTeamConfig = await loadTeamConfig(localPath);
   if (reloadedTeamConfig) {
-    await reconcileTeamHooksForConfig(reloadedTeamConfig, localConfig);
+    const filterAgents = options.agent ? [options.agent] : undefined;
+    await reconcileTeamHooksForConfig(reloadedTeamConfig, localConfig, { filterAgents });
   }
 
   log.success('teamai initialized successfully!');

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -1030,7 +1030,7 @@ async function autoMigrateHooksIfNeeded(): Promise<void> {
   const { injectHooksToAllTools } = await import('./hooks.js');
   const { localConfig, teamConfig } = await autoDetectInit();
   const baseDir = resolveBaseDir(localConfig);
-  await injectHooksToAllTools(teamConfig.toolPaths, baseDir);
+  await injectHooksToAllTools(teamConfig.toolPaths, baseDir, localConfig.enabledAgents);
   log.debug('Hooks migrated to dispatch format');
 }
 
@@ -1169,6 +1169,7 @@ async function reconcileHooksAllScopes(
       const teamDefs = await reconcileTeamHooksForConfig(teamConfig, localConfig, {
         auto: true,
         silent: options.silent,
+        filterAgents: localConfig.enabledAgents,
       });
       if (teamDefs.length > 0) {
         log.debug(`[${localConfig.scope}] Reconciled ${teamDefs.length} team hook(s)`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -187,6 +187,8 @@ export const LocalConfigSchema = z.object({
   subscribedTags: z.array(z.string()).optional(),
   /** User-level override for recall feature. When set, takes precedence over team config. */
   recallEnabled: z.boolean().optional(),
+  /** When set, only inject hooks into these agents. Additive across multiple init --agent runs. */
+  enabledAgents: z.array(z.string()).optional(),
 });
 
 export type LocalConfig = z.infer<typeof LocalConfigSchema>;


### PR DESCRIPTION
## Summary
- Adds `teamai init --agent <name>` option to restrict hooks injection to a single AI tool
- Multiple runs are additive: `--agent codebuddy` then `--agent workbuddy` enables both
- Persists `enabledAgents` in local config so `teamai pull` respects the restriction

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run src/__tests__/hooks.test.ts` — 38 tests pass (3 new)
- [x] `npx vitest run` — 1655/1656 pass (1 pre-existing unrelated failure)
- [x] `teamai init --http <url> --token <key> --agent codebuddy` → only .codebuddy gets hooks
- [x] `teamai pull` → hooks remain only in .codebuddy
- [x] `teamai init --agent workbuddy` → now both .codebuddy and .workbuddy have hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)