### PR TITLE
chore(release): 0.17.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teamai-cli",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teamai-cli",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teamai-cli",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "TeamAI — the team harness for AI agents (skill sync + shared knowledge base, powered by Git)",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release Notes — v0.17.1

将版本号从 `0.17.0` 提升到 `0.17.1`，用于发布 npm + tnpm 正式版本。

汇总自上次发布 `0.17.0` 以来的改动 (#137, #149, #150, #155)：

### ✨ 新功能

- **知识库投票 + 自动维护体系** (#137)：V2 双计数器投票（recalled/upvoted）、Stop hook 自动 upvote 并同步团队仓库、置信度计算（recall+upvote × recency × adoption-ratio）、热/冷搜索降权、`teamai recall maintenance --prune/--confidence-writeback/--update-quality`、`teamai recall promote`（高置信度学习条目自动提升为正式 docs/skills/rules）、`teamai recall feedback --positive/--negative`
- **`teamai init --agent <name>`** (#155)：限定 hooks 仅注入到单个 AI 工具，多次运行可叠加；设置持久化为 `enabledAgents`，`teamai pull` 同样遵守

### 🔧 其他

- 修复工蜂 Coding CI 触发分支从 `master` 改为 `main` (#149)
- 提高 vitest 默认超时到 15s，提升 CI 稳定性 (#150)

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx vitest run`（合入前已在各自 PR 中验证）
- [ ] 合并后打 tag 触发 GitHub Actions 发布 npm，并核对 registry 上版本号

Made with [Cursor](https://cursor.com)