### PR TITLE
chore(release): 0.17.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teamai-cli",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teamai-cli",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teamai-cli",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "TeamAI — the team harness for AI agents (skill sync + shared knowledge base, powered by Git)",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release Notes — v0.17.2

将版本号从 `0.17.1` 提升到 `0.17.2`，用于发布 npm + tnpm 正式版本。

汇总自上次发布 `0.17.1` 以来的改动 (#158)：

### 🐛 修复

- `teamai-recall` 规则与 TodoWrite hint 之前用 MUST/强制语言逼着 AI 每次都搜索知识库，即使用户已经给了上下文、答案就在本地文件里、或者改动很琐碎——浪费 token。改为 SHOULD + 三条明确的跳过条件，让 AI 自行判断何时召回有价值 (#158)

## Test plan

- [x] `npx tsc --noEmit` 通过
- [x] `npx vitest run`：1656 个测试中 1655 通过；唯一失败项 `import-repo-merge.test.ts` 是既有问题，与本次改动无关

Made with [Cursor](https://cursor.com)