### PR TITLE
fix(contribute-check): five root causes preventing hint from ever firing

### DIFF
--- a/src/__tests__/contribute-check-e2e.test.ts
+++ b/src/__tests__/contribute-check-e2e.test.ts
@@ -153,11 +153,14 @@ describe('contribute-check E2E', () => {
     expect(code).toBe(0);
     expect(stdout).not.toBe('');
 
-    // Should be valid JSON with stopReason (Stop hook schema)
+    // Stop hook output must use hookSpecificOutput.additionalContext, not
+    // stopReason (which only applies to `continue:false` aborts).
     const parsed = JSON.parse(stdout);
-    expect(parsed.stopReason).toBeDefined();
-    expect(parsed.stopReason).toContain('[teamai]');
-    expect(parsed.stopReason).toContain('/teamai-share-learnings');
+    expect(parsed.hookSpecificOutput).toBeDefined();
+    expect(parsed.hookSpecificOutput.hookEventName).toBe('Stop');
+    expect(parsed.hookSpecificOutput.additionalContext).toContain('[teamai]');
+    expect(parsed.hookSpecificOutput.additionalContext).toContain('/teamai-share-learnings');
+    expect(parsed.stopReason).toBeUndefined();
   });
 
   it('produces no output for a trivial session below threshold', async () => {

--- a/src/__tests__/contribute-check.test.ts
+++ b/src/__tests__/contribute-check.test.ts
@@ -11,7 +11,7 @@ import {
 import { appendEvent } from '../dashboard-collector.js';
 import {
   CONTRIBUTE_BASE_THRESHOLD,
-  CONTRIBUTE_SCORE_CACHE_MS,
+  CONTRIBUTE_FASTPATH_TTL_MS,
   CONTRIBUTE_SMART_THRESHOLD,
 } from '../types.js';
 import type { ContributeState, DashboardEvent } from '../types.js';
@@ -316,7 +316,8 @@ describe('contributeCheckForSession', () => {
 
   it('fast-path expires: low toolCount + STALE cache → re-evaluate (state updated)', async () => {
     const sessionId = 'fp-stale';
-    const veryOld = Date.now() - CONTRIBUTE_SCORE_CACHE_MS - 1000;
+    // Snapshot far outside the debounce window (much older than 5 min).
+    const veryOld = Date.now() - CONTRIBUTE_FASTPATH_TTL_MS - 60 * 60 * 1000;
     await writeContributeState(sessionId, {
       contributed: false,
       toolCount: CONTRIBUTE_BASE_THRESHOLD - 1,
@@ -332,6 +333,52 @@ describe('contributeCheckForSession', () => {
     // and the high-scoring session produced a hint.
     expect(after.lastEvaluated).toBeGreaterThan(veryOld);
     expect(after.toolCount).toBeGreaterThanOrEqual(50);
+    expect(after.smartScore).toBeGreaterThanOrEqual(CONTRIBUTE_SMART_THRESHOLD);
+    expect(result.hint).not.toBeNull();
+  });
+
+  // Regression: a stale toolCount=0 snapshot must not suppress evaluation
+  // once it falls outside the debounce window.
+  it('fast-path debounce: low-toolCount snapshot older than 5min → re-evaluate (regression)', async () => {
+    const sessionId = 'fp-debounce-expired';
+    const tenMinAgo = Date.now() - CONTRIBUTE_FASTPATH_TTL_MS - 5 * 60 * 1000;
+    await writeContributeState(sessionId, {
+      contributed: false,
+      toolCount: 0,                    // snapshot captured before tools ran
+      lastEvaluated: tenMinAgo,        // 10 min ago — past the 5-min debounce
+      smartScore: 0,
+    });
+    await seedHighScoreSession(sessionId);
+
+    const result = await contributeCheckForSession(sessionId);
+    const after = await readContributeState(sessionId);
+
+    expect(after.toolCount).toBeGreaterThanOrEqual(50);
+    expect(after.smartScore).toBeGreaterThanOrEqual(CONTRIBUTE_SMART_THRESHOLD);
+    expect(result.hint).not.toBeNull();
+  });
+
+  // Regression: even when all display fields (smartScore/toolCount/uniqueTools)
+  // are present in state, they must not be reused as a "cache hit" past the
+  // debounce window — Layer 2 now shares the same debounce as Layer 1.
+  it('layer-2 cache-hit expiry: stale (smartScore=0, toolCount=0) past debounce → re-scan events', async () => {
+    const sessionId = 'l2-cache-stale';
+    const tenMinAgo = Date.now() - CONTRIBUTE_FASTPATH_TTL_MS - 5 * 60 * 1000;
+    await writeContributeState(sessionId, {
+      contributed: false,
+      toolCount: 0,
+      uniqueTools: 0,
+      smartScore: 0,
+      lastEvaluated: tenMinAgo,
+    });
+    await seedHighScoreSession(sessionId);
+
+    const result = await contributeCheckForSession(sessionId);
+    const after = await readContributeState(sessionId);
+
+    // Must have re-scanned events, not reused the stale (score=0) cache.
+    expect(after.toolCount).toBeGreaterThanOrEqual(50);
+    expect(after.smartScore).toBeGreaterThan(0);
     expect(after.smartScore).toBeGreaterThanOrEqual(CONTRIBUTE_SMART_THRESHOLD);
     expect(result.hint).not.toBeNull();
   });

--- a/src/__tests__/hook-handlers.test.ts
+++ b/src/__tests__/hook-handlers.test.ts
@@ -90,6 +90,60 @@ describe('hook-handlers registry', () => {
     expect(stopHandlers).toContain('dashboard-report');
   });
 
+  // Regression: handler used to hard-require stdin.session_id (returned null
+  // otherwise) and derived it differently from dashboard-collector, leaving
+  // sessionEvents empty. Now it uses the shared deriveSessionId helper.
+  it('contribute-check handler derives session id even when stdin.session_id is missing', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'stop' && r.handler.name === 'contribute-check',
+    )!.handler;
+
+    mockContributeCheckForSession.mockResolvedValueOnce({ hint: null });
+
+    const originalEnv = process.env.CLAUDE_SESSION_ID;
+    delete process.env.CLAUDE_SESSION_ID;
+    try {
+      const result = await handler.execute({ cwd: '/tmp/some-project' }, 'claude');
+      expect(result).toBeNull();
+      expect(mockContributeCheckForSession).toHaveBeenCalledOnce();
+      const [sessionId, cwd] = mockContributeCheckForSession.mock.calls[0];
+      expect(typeof sessionId).toBe('string');
+      expect(sessionId.length).toBeGreaterThan(0);
+      // PID fallback embeds the cwd
+      expect(sessionId).toContain('/tmp/some-project');
+      expect(cwd).toBe('/tmp/some-project');
+    } finally {
+      if (originalEnv !== undefined) process.env.CLAUDE_SESSION_ID = originalEnv;
+    }
+  });
+
+  it('contribute-check handler prefers explicit session_id when present', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'stop' && r.handler.name === 'contribute-check',
+    )!.handler;
+
+    mockContributeCheckForSession.mockResolvedValueOnce({ hint: null });
+
+    await handler.execute({ session_id: 'sid-abc', cwd: '/x' }, 'claude');
+    expect(mockContributeCheckForSession).toHaveBeenCalledWith('sid-abc', '/x');
+  });
+
+  it('contribute-check handler routes hint through formatStopHookOutput for cursor', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'stop' && r.handler.name === 'contribute-check',
+    )!.handler;
+
+    mockContributeCheckForSession.mockResolvedValueOnce({ hint: '[teamai] hello' });
+
+    const result = await handler.execute({ session_id: 's', cwd: '/x' }, 'cursor');
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result!);
+    expect(parsed.followup_message).toBe('[teamai] hello');
+  });
+
   it('post-tool-use wildcard has dashboard-report', () => {
     const registry = buildHandlerRegistry();
     const wildcardHandlers = registry

--- a/src/__tests__/hook-output.test.ts
+++ b/src/__tests__/hook-output.test.ts
@@ -16,17 +16,30 @@ describe('formatStopHookOutput', () => {
     expect(parsed.hookSpecificOutput.additionalContext).toBe('msg');
   });
 
-  it('cursor: returns {message} format', () => {
+  it('cursor: returns {followup_message} format', () => {
     const result = formatStopHookOutput('test', 'cursor');
     const parsed = JSON.parse(result);
-    expect(parsed.message).toBe('test');
+    expect(parsed.followup_message).toBe('test');
     expect(parsed.hookSpecificOutput).toBeUndefined();
+    expect(parsed.message).toBeUndefined();
   });
 
-  it('unknown tool: defaults to hookSpecificOutput', () => {
+  it('unknown tool: defaults to hookSpecificOutput (Claude schema)', () => {
     const result = formatStopHookOutput('x', 'codex');
     const parsed = JSON.parse(result);
     expect(parsed.hookSpecificOutput.additionalContext).toBe('x');
+  });
+
+  it('workbuddy: uses Claude hookSpecificOutput format', () => {
+    const result = formatStopHookOutput('wb', 'workbuddy');
+    const parsed = JSON.parse(result);
+    expect(parsed.hookSpecificOutput.additionalContext).toBe('wb');
+  });
+
+  it('tool identifier is case-insensitive for cursor detection', () => {
+    const result = formatStopHookOutput('t', 'Cursor');
+    const parsed = JSON.parse(result);
+    expect(parsed.followup_message).toBe('t');
   });
 
   it('returns valid JSON string', () => {

--- a/src/__tests__/logger.test.ts
+++ b/src/__tests__/logger.test.ts
@@ -10,7 +10,7 @@ vi.mock('chalk', () => ({
   default: { blue: (s: string) => s, green: (s: string) => s, yellow: (s: string) => s, red: (s: string) => s, gray: (s: string) => s, dim: (s: string) => s },
 }));
 
-import { log, setVerbose, setSilent, MAX_LOG_BYTES, _setLogFilePath, _resetState } from '../utils/logger.js';
+import { log, setVerbose, setSilent, setStderrOnly, MAX_LOG_BYTES, _setLogFilePath, _resetState } from '../utils/logger.js';
 
 let tmpDir: string;
 let logFile: string;
@@ -21,12 +21,14 @@ beforeEach(() => {
   _setLogFilePath(logFile);
   setVerbose(false);
   setSilent(false);
+  setStderrOnly(false);
 });
 
 afterEach(() => {
   _resetState();
   setVerbose(false);
   setSilent(false);
+  setStderrOnly(false);
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
@@ -126,6 +128,49 @@ describe('levels', () => {
     expect(lines).toHaveLength(2);
     expect(lines[0]).toContain('[DEBUG]');
     expect(lines[1]).toContain('[ERROR]');
+  });
+});
+
+describe('stderr-only mode (hook-dispatch path)', () => {
+  it('routes info to stderr when enabled, keeping stdout clean', () => {
+    const stdoutSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    setStderrOnly(true);
+    log.info('hook progress');
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    expect(stderrSpy).toHaveBeenCalled();
+    expect(String(stderrSpy.mock.calls[0][0])).toContain('hook progress');
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  it('routes success/warn to stderr when enabled', () => {
+    const stdoutSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    setStderrOnly(true);
+    log.success('done');
+    log.warn('be careful');
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    expect(stderrSpy).toHaveBeenCalledTimes(2);
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  it('keeps error on stderr (unchanged behavior)', () => {
+    const stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    setStderrOnly(true);
+    log.error('boom');
+    expect(stderrSpy).toHaveBeenCalled();
+    stderrSpy.mockRestore();
+  });
+
+  it('reverts to stdout when disabled', () => {
+    const stdoutSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    setStderrOnly(true);
+    setStderrOnly(false);
+    log.info('back to normal');
+    expect(stdoutSpy).toHaveBeenCalled();
+    stdoutSpy.mockRestore();
   });
 });
 

--- a/src/contribute-check.ts
+++ b/src/contribute-check.ts
@@ -10,7 +10,7 @@ import type { ContributeState, DashboardEvent } from './types.js';
 import {
   CONTRIBUTE_SMART_THRESHOLD,
   CONTRIBUTE_BASE_THRESHOLD,
-  CONTRIBUTE_SCORE_CACHE_MS,
+  CONTRIBUTE_FASTPATH_TTL_MS,
   CONTRIBUTE_KNOWLEDGE_GAP_BONUS,
   CONTRIBUTE_LOW_QUALITY_BONUS,
   CONTRIBUTE_LOW_QUALITY_THRESHOLD,
@@ -33,8 +33,8 @@ import {
 //      │   ├─ state.contributed → exit(no hint)
 //      │   └─ state.hinted      → exit(no hint, dedup)
 //      │
-//      ├─ Layer 1 fast-path:
-//      │   └─ toolCount < BASE_THRESHOLD AND lastEvaluated within CACHE TTL
+//      ├─ Layer 1 fast-path (short debounce, NOT long-term suppression):
+//      │   └─ toolCount < BASE_THRESHOLD AND lastEvaluated within FASTPATH_TTL_MS (5 min)
 //      │      → exit(no hint), no events read
 //      │
 //      ├─ Layer 2:
@@ -354,9 +354,9 @@ function buildHint(totalToolCalls: number, uniqueTools: number, isKnowledgeGap: 
  *     - state.contributed → skip (user already ran /contribute)
  *     - state.hinted      → skip (hint already emitted, dedup)
  *
- *   Layer 1 fast-path (skips events.jsonl read):
- *     - toolCount < BASE_THRESHOLD AND lastEvaluated within CACHE TTL
- *       → skip (small session, recently checked)
+ *   Layer 1 fast-path (short debounce, skips events.jsonl read):
+ *     - toolCount < BASE_THRESHOLD AND lastEvaluated within FASTPATH_TTL_MS (5 min)
+ *       → skip (small session, just re-evaluated — debounce repeat Stop hooks)
  *
  *   Layer 2 score resolution:
  *     - cache hit:  smartScore + display fields present, lastEvaluated fresh
@@ -389,16 +389,19 @@ export async function contributeCheckForSession(
     return { hint: null };
   }
 
-  const cacheFresh =
-    state.lastEvaluated !== undefined && now - state.lastEvaluated < CONTRIBUTE_SCORE_CACHE_MS;
+  // Shared debounce for Layer 1 (skip events read) and Layer 2 (reuse cached
+  // score). Beyond this window we always re-read events.jsonl so a stale
+  // snapshot can't suppress a session that got busier later on.
+  const debounceFresh =
+    state.lastEvaluated !== undefined && now - state.lastEvaluated < CONTRIBUTE_FASTPATH_TTL_MS;
 
-  // Layer 1 fast-path
+  // Layer 1 fast-path — skip events read for small, recently-evaluated sessions.
   if (
-    cacheFresh &&
+    debounceFresh &&
     state.toolCount !== undefined &&
     state.toolCount < CONTRIBUTE_BASE_THRESHOLD
   ) {
-    log.debug(`contribute-check: fast-path skip (toolCount ${state.toolCount} < ${CONTRIBUTE_BASE_THRESHOLD}, cache fresh)`);
+    log.debug(`contribute-check: fast-path skip (toolCount ${state.toolCount} < ${CONTRIBUTE_BASE_THRESHOLD}, debounce fresh)`);
     return { hint: null };
   }
 
@@ -410,7 +413,7 @@ export async function contributeCheckForSession(
   let sessionStartIso: string | undefined;
 
   const cachedDisplayAvailable =
-    cacheFresh
+    debounceFresh
     && state.smartScore !== undefined
     && state.toolCount !== undefined
     && state.uniqueTools !== undefined;
@@ -488,6 +491,11 @@ export async function contributeCheckForSession(
  * so the AI will naturally suggest /contribute to the user.
  */
 export async function contributeCheck(toolArg?: string): Promise<void> {
+  // Same stdout-exclusive contract as hook-dispatch-cli — log lines mixed
+  // into stdout break Claude Code's JSON parse and silently drop the hint.
+  const { setStderrOnly } = await import('./utils/logger.js');
+  setStderrOnly(true);
+
   const stdinData = await readStdinAndDeriveSession();
   if (!stdinData) {
     log.debug('contribute-check: no STDIN data or no session ID');
@@ -496,8 +504,8 @@ export async function contributeCheck(toolArg?: string): Promise<void> {
 
   const { hint } = await contributeCheckForSession(stdinData.sessionId, stdinData.cwd);
   if (hint !== null) {
-    // Stop schema has no hookSpecificOutput; use stopReason
-    process.stdout.write(JSON.stringify({ stopReason: hint }));
+    const { formatStopHookOutput } = await import('./utils/hook-output.js');
+    process.stdout.write(formatStopHookOutput(hint, toolArg ?? 'claude'));
   }
 }
 

--- a/src/hook-dispatch-cli.ts
+++ b/src/hook-dispatch-cli.ts
@@ -1,13 +1,13 @@
 /**
  * CLI entry point for `teamai hook-dispatch <event> --tool <tool> [--matcher <m>]`.
- *
- * Reads STDIN once, creates the dispatcher with the full handler registry,
- * and dispatches to all matching handlers. Outputs any handler result to STDOUT.
+ * Reads STDIN once, fans out to all matching handlers, writes at most one
+ * handler's output to STDOUT. STDOUT is reserved for the AI-tool hook JSON
+ * payload; all log lines go to STDERR (see setStderrOnly below).
  */
 
 import { createDispatcher } from './hook-dispatch.js';
 import { buildHandlerRegistry } from './hook-handlers.js';
-import { log } from './utils/logger.js';
+import { log, setStderrOnly } from './utils/logger.js';
 
 /** Read STDIN fully. Returns empty string if STDIN is a TTY. */
 async function readStdin(): Promise<string> {
@@ -23,7 +23,9 @@ async function readStdin(): Promise<string> {
  * Main CLI handler for hook-dispatch.
  */
 export async function hookDispatchCli(event: string, tool: string, matcher: string): Promise<void> {
-  // Read STDIN once — shared across all handlers
+  // Reserve STDOUT for the dispatcher's hook payload; log lines go to STDERR.
+  setStderrOnly(true);
+
   const raw = await readStdin();
   let stdin: Record<string, unknown> = {};
   if (raw.trim()) {

--- a/src/hook-handlers.ts
+++ b/src/hook-handlers.ts
@@ -155,9 +155,9 @@ const contributeCheckHandler: HookHandler = {
     const { contributeCheckForSession } = await import('./contribute-check.js');
     const { formatStopHookOutput } = await import('./utils/hook-output.js');
 
-    const sessionId = typeof stdin.session_id === 'string' ? stdin.session_id : null;
-    if (!sessionId) return null;
-
+    // Match dashboard-collector's derivation so events and contribute state
+    // share the same session id even when stdin.session_id is absent.
+    const sessionId = deriveSessionId(stdin, { includeCwd: true });
     const cwd = typeof stdin.cwd === 'string' ? stdin.cwd : undefined;
     const { hint } = await contributeCheckForSession(sessionId, cwd);
     if (hint) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -637,8 +637,13 @@ export const CONTRIBUTE_BASE_THRESHOLD = 15;
 /** Smart score threshold: minimum score to show contribute hint */
 export const CONTRIBUTE_SMART_THRESHOLD = 35;
 
-/** Cache smart score for this many ms (6 hours) */
-export const CONTRIBUTE_SCORE_CACHE_MS = 6 * 60 * 60 * 1000;
+/**
+ * Debounce TTL for contribute-check re-evaluation. Within this window the
+ * last-known toolCount / smartScore snapshot is trusted; beyond it we always
+ * re-read events.jsonl so a late burst of tool usage isn't missed by a stale
+ * zero-score snapshot.
+ */
+export const CONTRIBUTE_FASTPATH_TTL_MS = 5 * 60 * 1000;
 
 /** Phase 2: bonus when all recalls return zero results (knowledge gap) */
 export const CONTRIBUTE_KNOWLEDGE_GAP_BONUS = 20;

--- a/src/utils/hook-output.ts
+++ b/src/utils/hook-output.ts
@@ -1,23 +1,21 @@
 /**
- * Multi-tool-aware hook output formatting.
+ * Format Stop hook STDOUT for the given AI tool.
  *
- * Different AI tools parse Stop hook STDOUT differently:
- * - Claude Code / CodeBuddy: hookSpecificOutput.additionalContext → visible to AI
- * - Cursor: direct JSON message → shown in UI
- * - Codex etc.: default hookSpecificOutput (maximum compatibility)
- */
-
-/**
- * Format Stop hook output so the AI can see the hint content.
- *
- * @param message  Hint text to pass to the AI
- * @param tool     Current AI tool identifier (claude / cursor / codebuddy / codex / etc.)
- * @returns        JSON string to write to STDOUT
+ * Schema choice per tool:
+ * - Cursor: `{ followup_message }`  (Cursor stop hook docs)
+ * - Everyone else (Claude / CodeBuddy / WorkBuddy / Codex / unknown):
+ *   `{ hookSpecificOutput: { hookEventName: 'Stop', additionalContext } }`
+ *   (Claude Code stop hook docs — the "additional context that continues
+ *   the conversation" branch, NOT top-level `stopReason`, which requires
+ *   `continue:false` and aborts the run.)
  */
 export function formatStopHookOutput(message: string, tool: string): string {
-  if (tool === 'cursor') {
-    return JSON.stringify({ message });
+  const normalized = tool?.toLowerCase() ?? '';
+
+  if (normalized === 'cursor') {
+    return JSON.stringify({ followup_message: message });
   }
+
   return JSON.stringify({
     hookSpecificOutput: {
       hookEventName: 'Stop',

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -5,6 +5,7 @@ import ora, { type Ora } from 'ora';
 
 let verboseEnabled = false;
 let silentMode = false;
+let stderrMode = false;
 
 // ─── File transport ─────────────────────────────────────
 //
@@ -111,18 +112,35 @@ export function setSilent(s: boolean): void {
   silentMode = s;
 }
 
+/**
+ * Route non-error log output to stderr. Used by hook-dispatch commands to
+ * keep stdout as a clean JSON channel for the AI tool.
+ */
+export function setStderrOnly(s: boolean): void {
+  stderrMode = s;
+}
+
+/** Write a "non-error" log line. Goes to stderr in hook mode, stdout otherwise. */
+function writeInfoLine(line: string): void {
+  if (stderrMode) {
+    console.error(line);
+  } else {
+    console.log(line);
+  }
+}
+
 export const log = {
   info(msg: string): void {
     if (silentMode) return;
-    console.log(chalk.blue('ℹ'), msg);
+    writeInfoLine(`${chalk.blue('ℹ')} ${msg}`);
   },
   success(msg: string): void {
     if (silentMode) return;
-    console.log(chalk.green('✔'), msg);
+    writeInfoLine(`${chalk.green('✔')} ${msg}`);
   },
   warn(msg: string): void {
     if (silentMode) return;
-    console.log(chalk.yellow('⚠'), msg);
+    writeInfoLine(`${chalk.yellow('⚠')} ${msg}`);
   },
   error(msg: string): void {
     console.error(chalk.red('✖'), msg);
@@ -131,11 +149,11 @@ export const log = {
   debug(msg: string): void {
     writeToFile('DEBUG', msg);
     if (!verboseEnabled || silentMode) return;
-    console.log(chalk.gray('  [debug]'), msg);
+    writeInfoLine(`${chalk.gray('  [debug]')} ${msg}`);
   },
   dim(msg: string): void {
     if (silentMode) return;
-    console.log(chalk.dim(msg));
+    writeInfoLine(chalk.dim(msg));
   },
 };
 


### PR DESCRIPTION
## Summary

End-to-end investigation (starting from the user report "I have never seen a contribute prompt") turned up **five** independent bugs in the `contribute-check` pipeline. Any one of them is sufficient to swallow the hint; all five must be fixed before an end user sees anything. This PR fixes them together.

### The bug chain

| # | Location | Bug | Effect |
|---|---|---|---|
| 1 | `contribute-check.ts` Layer 1 fast-path | `toolCount < 15` snapshot trusted for 6h | Session captured `toolCount=0` at first Stop → suppressed for half a day |
| 2 | `hook-handlers.ts:158` | Hard-required `stdin.session_id`, derived id differently from `dashboard-collector` | Cursor/Codex tools without the field → null return; even with it, `sessionEvents` filter never matched → `toolCount` stuck at 0 |
| 3 | `utils/hook-output.ts:19` + `contribute-check.ts:500` | Cursor branch used `{message}` (correct field: `followup_message`); direct CLI entry used `{stopReason}` (only valid with `continue:false`) | Cursor: silent drop. Claude direct entry: hint field ignored |
| 4 | `contribute-check.ts` Layer 2 cache-hit | Even after Fix 1, the Layer 2 branch reused stale `smartScore=0` for 6h | Regression of Fix 1 — reproduced the same "stuck at 0" behavior at a different layer |
| 5 | `hook-dispatch-cli.ts` + `logger.ts` | `update` and `dashboard-collector` log lines went to stdout, mixed into hint JSON | Claude Code failed to parse the whole stdout as JSON → hint dropped even when correctly generated |

The last one is the final coffin nail: even a session that scores above threshold, has a valid session id, and formats stdout correctly still can't deliver the hint if any other handler prints a log line to stdout in the same process.

### Changes

- **Fix 1+4**: unify both fast-path layers on a **5-min debounce** (`CONTRIBUTE_FASTPATH_TTL_MS`). Old `CONTRIBUTE_SCORE_CACHE_MS` deleted (no remaining callers).
- **Fix 2**: `contributeCheckHandler` uses `deriveSessionId(stdin, {includeCwd: true})`, matching `dashboard-collector.ts`.
- **Fix 3**:
  - `formatStopHookOutput('cursor', msg)` returns `{followup_message}` per Cursor's stop hook schema.
  - Fallback (claude / codebuddy / workbuddy / codex / unknown) returns `{hookSpecificOutput: {hookEventName: 'Stop', additionalContext}}`.
  - Legacy `teamai contribute-check` CLI entry routes through `formatStopHookOutput` too — no more `stopReason`.
- **Fix 5**: adds `setStderrOnly(true)` to `utils/logger.ts`; enabled by both `hookDispatchCli` and the direct `contributeCheck` CLI entry so `log.info/success/warn` go to stderr. `log.error` and `debug.log` file transport unchanged.

### Multi-tool compatibility

Verified via `teamai hook-dispatch stop --tool <tool>` with real Claude-Code-shaped STDIN, from a clean HOME:

| Tool | STDOUT | JSON valid? |
|---|---|---|
| claude | `{"hookSpecificOutput":{"hookEventName":"Stop","additionalContext":"..."}}` | ✅ |
| codebuddy | same | ✅ |
| workbuddy | same | ✅ |
| codex | same (fallback) | ✅ |
| cursor | `{"followup_message":"..."}` | ✅ |

### API surface

- **New export**: `setStderrOnly(s: boolean)` in `utils/logger.ts`.
- **Removed**: `CONTRIBUTE_SCORE_CACHE_MS` from `types.ts` — grep confirmed no external references remain in the repo.
- **Behavior change**: hook-dispatch STDOUT is now guaranteed to be a single JSON document (or empty). Log lines go to STDERR.

### Testing

- **Unit**: 1687 pass (12 new regression tests across the fixes)
- **E2E**: 54 pass, including a new Stop hook schema assertion (`hookSpecificOutput.additionalContext`, not `stopReason`)
- **Manual user-flow simulation**: from a fresh `HOME`, drove `SessionStart → UserPromptSubmit → 50 × PostToolUse → Stop` through `hook-dispatch` with real Claude-Code STDIN payloads. All four scenarios behaved correctly:
  - Rich session (50 tools) → hint fires, STDOUT is valid JSON containing `/teamai-share-learnings`
  - Short session (5 tools) → no hint (smartScore below threshold)
  - Second Stop on hinted session → dedup, empty STDOUT
  - Gradual session (3 tools + 10 min later, 50 more) → second Stop re-scores and fires (the exact scenario Fix 1+4 targets)

### Tradeoff acknowledged

Shortening the debounce from 6h to 5min raises the frequency of `events.jsonl` re-scans. In practice the file is bounded by dashboard compaction and Stop hook has a 15s timeout, so the extra I/O is small. Not benchmarked with tens of thousands of events; incremental read is a plausible follow-up if a scale issue surfaces.

## Test plan

- [x] `npm test` passes (1687/1687)
- [x] `npm run test:e2e` passes (54/54 excluding pre-existing skips)
- [x] `npx tsc --noEmit` clean
- [x] Manual user-flow: fresh HOME → `hook-dispatch stop` → hint visible in valid JSON stdout for all 5 tools
- [x] Regression: gradual session (early low toolCount → later burst) triggers hint
- [x] Dedup: second Stop after hint doesn't re-fire