### PR TITLE
fix(local-agent): name HTTP-synced skills by SKILL.md name, not server slug

### DIFF
--- a/src/__tests__/local-agent.test.ts
+++ b/src/__tests__/local-agent.test.ts
@@ -299,7 +299,7 @@ describe('local-agent: skill directory naming (SKILL.md name vs server slug)', (
       // downloadResource passes a URL object; report/sync pass strings.
       const url = String(input);
       if (url.includes('/skill.zip') && zip) {
-        return new Response(zip);
+        return new Response(Buffer.from(zip));
       }
       if (url.includes('/local-agent/sync')) {
         return new Response(JSON.stringify({ ok: true, commands: [command] }));

--- a/src/__tests__/local-agent.test.ts
+++ b/src/__tests__/local-agent.test.ts
@@ -279,3 +279,87 @@ describe('local-agent: security — token file permissions', () => {
     expect(mode).toBe(0o600);
   });
 });
+
+describe('local-agent: skill directory naming (SKILL.md name vs server slug)', () => {
+  // Build a real skill zip whose SKILL.md `name:` may differ from the slug.
+  async function makeSkillZip(skillName: string): Promise<Uint8Array> {
+    const { zipSync, strToU8 } = await import('fflate');
+    const skillMd = `---\nname: ${skillName}\ndescription: test skill\n---\n# ${skillName}\nbody\n`;
+    return zipSync({ [`${skillName}/SKILL.md`]: strToU8(skillMd) });
+  }
+
+  // Run a single install/uninstall command through the full sync path.
+  async function runCommand(command: Record<string, unknown>, zip?: Uint8Array) {
+    // codebuddy must look "installed" or pullItem skips it.
+    await fse.ensureDir(path.join(tmpDir, '.codebuddy', 'skills'));
+    await setupConfig();
+
+    const acks: Array<Record<string, unknown>> = [];
+    const fetchMock = vi.fn(async (input: string | URL, init?: { body?: string }) => {
+      // downloadResource passes a URL object; report/sync pass strings.
+      const url = String(input);
+      if (url.includes('/skill.zip') && zip) {
+        return new Response(zip);
+      }
+      if (url.includes('/local-agent/sync')) {
+        return new Response(JSON.stringify({ ok: true, commands: [command] }));
+      }
+      if (url.includes('/commands/ack')) {
+        acks.push(JSON.parse(init?.body ?? '{}'));
+      }
+      return new Response(JSON.stringify({ ok: true }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ cwd: tmpDir, tool: 'codebuddy', status: 'running' });
+    return acks;
+  }
+
+  const codebuddySkillsDir = () => path.join(tmpDir, '.codebuddy', 'skills');
+  const port = 41999;
+
+  it('installs the skill under its SKILL.md name, not the server slug', async () => {
+    const zip = await makeSkillZip('my-real-skill-name');
+    const acks = await runCommand({
+      id: 1,
+      type: 'install_skill',
+      skill_slug: 'server-slug-xyz',
+      skill_version: '1.0.0',
+      download_url: `http://127.0.0.1:${port}/skill.zip`,
+    }, zip);
+
+    expect(acks[0]?.status).toBe('success');
+    expect(await fse.pathExists(path.join(codebuddySkillsDir(), 'my-real-skill-name'))).toBe(true);
+    expect(await fse.pathExists(path.join(codebuddySkillsDir(), 'server-slug-xyz'))).toBe(false);
+
+    // Manifest keeps the slug as key but records the on-disk dir name.
+    const manifest = await fse.readJson(path.join(tmpDir, '.teamai', 'local-agent', 'manifest.json'));
+    expect(manifest.scopes.user.skills['server-slug-xyz'].dir_name).toBe('my-real-skill-name');
+  });
+
+  it('uninstalls by slug and removes the SKILL.md-name directory', async () => {
+    const zip = await makeSkillZip('my-real-skill-name');
+    await runCommand({
+      id: 1, type: 'install_skill', skill_slug: 'server-slug-xyz',
+      skill_version: '1.0.0', download_url: `http://127.0.0.1:${port}/skill.zip`,
+    }, zip);
+    expect(await fse.pathExists(path.join(codebuddySkillsDir(), 'my-real-skill-name'))).toBe(true);
+
+    await runCommand({ id: 2, type: 'uninstall_skill', skill_slug: 'server-slug-xyz' });
+    expect(await fse.pathExists(path.join(codebuddySkillsDir(), 'my-real-skill-name'))).toBe(false);
+  });
+
+  it('falls back to the slug when SKILL.md name equals the slug', async () => {
+    const zip = await makeSkillZip('server-slug-xyz');
+    await runCommand({
+      id: 1, type: 'install_skill', skill_slug: 'server-slug-xyz',
+      skill_version: '1.0.0', download_url: `http://127.0.0.1:${port}/skill.zip`,
+    }, zip);
+
+    expect(await fse.pathExists(path.join(codebuddySkillsDir(), 'server-slug-xyz'))).toBe(true);
+    // No rename happened, so no dir_name is recorded.
+    const manifest = await fse.readJson(path.join(tmpDir, '.teamai', 'local-agent', 'manifest.json'));
+    expect(manifest.scopes.user.skills['server-slug-xyz'].dir_name).toBeUndefined();
+  });
+});

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -22,6 +22,7 @@ import { injectHooksToAllTools } from './hooks.js';
 import { parseHookEvent, appendEvent, compactEvents } from './dashboard-collector.js';
 import { getCurrentVersion } from './package-info.js';
 import { getMachineId, deriveLocalAgentId } from './machine-id.js';
+import { assertSafeResourceName } from './utils/path-safety.js';
 import {
   TEAMAI_HOME,
   TEAMAI_TOKEN_PATH,
@@ -78,6 +79,12 @@ interface ManifestResource {
   display_name?: string;
   source?: string;
   installed_at: string;
+  /**
+   * Actual on-disk directory name for skills. Equals the SKILL.md `name:` when
+   * it differs from the server slug, else the slug. Used at uninstall time to
+   * locate the directory by slug (the manifest key stays the slug).
+   */
+  dir_name?: string;
 }
 
 interface ManifestScope {
@@ -794,6 +801,26 @@ async function readFrontmatter(filePath: string): Promise<Record<string, unknown
   }
 }
 
+/**
+ * Decide the on-disk directory name for a skill. The SKILL.md `name:` field is
+ * the source of truth for how the skill is identified by the AI tool, so use it
+ * when it differs from the server-provided slug (matching the git-path behaviour
+ * in skill-command.ts / #144). Falls back to the slug when the name is missing,
+ * empty, equal to the slug, or fails path-safety validation.
+ */
+async function resolveSkillDirName(skillRoot: string, slug: string): Promise<string> {
+  const fm = await readFrontmatter(path.join(skillRoot, 'SKILL.md'));
+  const name = typeof fm.name === 'string' ? fm.name.trim() : '';
+  if (!name || name === slug) return slug;
+  try {
+    assertSafeResourceName(name);
+    return name;
+  } catch {
+    log.debug(`[local-agent] keeping slug "${slug}" as skill dir (SKILL.md name "${name}" failed safety check)`);
+    return slug;
+  }
+}
+
 async function installDownloadedResource(input: {
   config: LocalAgentConfig;
   command: LocalAgentCommand;
@@ -818,20 +845,25 @@ async function installDownloadedResource(input: {
     const localConfig = createResourceLocalConfig(input.config, input.scope, repoPath, input.workspacePath);
     const now = new Date().toISOString();
     let displayName = input.command.display_name ?? input.slug;
+    // On-disk skill directory name (SKILL.md name when it differs from slug).
+    // Stays the slug for rules/claudemd. Recorded in the manifest so uninstall
+    // can find the directory by slug.
+    let skillDirName = input.slug;
 
     if (input.kind === 'skill') {
       const extractDir = await extractZip(downloadedPath);
       const skillRoot = await findSkillRoot(extractDir);
-      const dest = path.join(repoPath, 'skills', input.slug);
+      skillDirName = await resolveSkillDirName(skillRoot, input.slug);
+      const dest = path.join(repoPath, 'skills', skillDirName);
       await remove(dest);
       await fse.copy(skillRoot, dest, { overwrite: true });
       const fm = await readFrontmatter(path.join(dest, 'SKILL.md'));
       displayName = typeof fm.name === 'string' ? fm.name : displayName;
       await new SkillsHandler().pullItem({
-        name: input.slug,
+        name: skillDirName,
         type: 'skills',
         sourcePath: dest,
-        relativePath: `skills/${input.slug}`,
+        relativePath: `skills/${skillDirName}`,
       }, teamConfig, localConfig);
     } else if (input.kind === 'rule') {
       const ruleFile = await resolveMarkdownFromDownload(downloadedPath, input.slug);
@@ -856,6 +888,7 @@ async function installDownloadedResource(input: {
       display_name: displayName,
       source: 'enterprise',
       installed_at: now,
+      ...(input.kind === 'skill' && skillDirName !== input.slug ? { dir_name: skillDirName } : {}),
     };
     await saveManifest(manifest);
     return version;
@@ -878,7 +911,10 @@ async function uninstallResource(input: {
   const scopeManifest = getManifestScope(manifest, input.scope, input.workspacePath);
 
   if (input.kind === 'skill') {
-    await new SkillsHandler().removeItem(input.slug, teamConfig, localConfig);
+    // The directory was created under the SKILL.md name (recorded as dir_name);
+    // remove by that name, falling back to the slug for older installs.
+    const dirName = scopeManifest.skills[input.slug]?.dir_name ?? input.slug;
+    await new SkillsHandler().removeItem(dirName, teamConfig, localConfig);
   } else if (input.kind === 'rule') {
     await new RulesHandler().removeItem(input.slug, teamConfig, localConfig);
   } else {


### PR DESCRIPTION
## Problem

Skills delivered over the **HTTP local-agent** path were installed into a directory named after the server-provided `skill_slug`. But the AI tool identifies a skill by its SKILL.md `name:` frontmatter, and the two can differ. So a skill whose backend slug is `skillsaaa` but whose SKILL.md name is `my-real-skill-name` landed at `~/.codebuddy/skills/skillsaaa` — unrecognizable to the tool.

The git-native install path already handles this (reads SKILL.md name, renames the dir, keeps a slug→dir map for uninstall) via #144 in `src/skill-command.ts`. The HTTP path in `src/local-agent.ts` never got the same treatment.

**Not a regression from #161.** I verified by building the prior internal release (`0.17.1-beta.2`) and reproducing identical slug-based naming with a real CLI run — this gap has existed in the HTTP path since it was introduced (#152). #161 (deterministic id + install hardening) did not touch skill naming.

## Fix (`src/local-agent.ts`)

- `resolveSkillDirName(skillRoot, slug)` reads the SKILL.md `name:` after extraction and uses it as the on-disk directory name when it differs from the slug and passes `assertSafeResourceName`. Falls back to the slug when the name is missing, equal to the slug, or unsafe — mirroring #144's behaviour.
- The install manifest records `dir_name` (keyed by slug). `uninstall_skill` reads it to remove the SKILL.md-name directory when the backend only knows the slug (older installs without `dir_name` fall back to slug).

## Test Plan

- [x] `npx tsc --noEmit`
- [x] `npx vitest run src/__tests__/local-agent.test.ts` — 11 passed (3 new: install-by-name, uninstall-by-slug-removes-name-dir, fallback-to-slug)
- [x] `npx vitest run` — full suite green except one pre-existing unrelated failure (`import-repo-merge.test.ts`, red on clean `tencent/main`)
- [x] `npm run build`
- [x] **E2E:** real CLI `hook-dispatch --tool codebuddy` against a mock server. Backend sends `skill_slug=skillsaaa`, SKILL.md `name: my-real-skill-name`:
  - install → `~/.codebuddy/skills/my-real-skill-name` (SKILL.md name, not the slug)
  - uninstall by slug → directory removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)