### PR TITLE
fix(local-agent): add /api prefix to user-groups endpoint

### DIFF
--- a/src/__tests__/local-agent.test.ts
+++ b/src/__tests__/local-agent.test.ts
@@ -80,9 +80,9 @@ describe('local-agent: emitBindingHint via reportAndSyncLocalAgent', () => {
     const { execFileSync } = await import('node:child_process');
     execFileSync('git', ['init'], { cwd: projectDir, stdio: 'ignore' });
 
-    // Mock global fetch to handle /user-groups/mine and /local-agent/report
+    // Mock global fetch to handle /api/user-groups/mine and /api/local-agent/report
     const fetchMock = vi.fn(async (url: string) => {
-      if (url.includes('/user-groups/mine')) {
+      if (url.includes('/api/user-groups/mine')) {
         return new Response(JSON.stringify({
           ok: true,
           groups: [

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -339,7 +339,7 @@ async function appendReporterQueue(entry: unknown): Promise<void> {
 export async function fetchUserGroups(config: LocalAgentConfig): Promise<LocalAgentGroup[]> {
   const response = await localAgentFetch<{ ok?: boolean; groups?: LocalAgentGroup[] }>(
     config,
-    '/user-groups/mine',
+    '/api/user-groups/mine',
     { method: 'GET' },
   );
   return response.groups ?? [];


### PR DESCRIPTION
## Problem

`fetchUserGroups` requested `/user-groups/mine`, which is missing the `/api` prefix that every other local-agent endpoint uses:

- `/api/local-agent/report`
- `/api/local-agent/sync`
- `/api/local-agent/commands/ack`

Because the group fetch hit a non-existent route, the request failed and was swallowed by the `catch` in `ensureWorkspaceBinding` (`log.debug` only). The net effect: **the project-binding prompt never fired** — the exact symptom this fixes.

## Fix

Align `fetchUserGroups` with the rest of the API surface:

```diff
-    '/user-groups/mine',
+    '/api/user-groups/mine',
```

Also updated the test mock's comment and URL matcher for accuracy.

## Test Plan

- [x] `npx tsc --noEmit` — passes
- [x] `npx vitest run src/__tests__/local-agent.test.ts` — the `bindCurrentProject` test (which exercises the updated fetch mock) passes. (3 pre-existing failures in the unrelated "skill directory naming" suite exist on clean `origin/main` and are not touched by this change.)
- [x] `npm run build` — succeeds; verified compiled `dist/index.js` emits `"/api/user-groups/mine"`.
- [x] **Real E2E**: ran the built CLI `bind-project --group-id 100` against a local mock HTTP server with `TEAMAI_HTTP_ENDPOINT` set. Server logged `REQUESTED_PATH /api/user-groups/mine` and the CLI successfully bound the project.
