### PR TITLE
fix(local-agent): rename binding-prompt org label to ClawPro组织

### DIFF
--- a/src/__tests__/local-agent.test.ts
+++ b/src/__tests__/local-agent.test.ts
@@ -120,6 +120,8 @@ describe('local-agent: emitBindingHint via reportAndSyncLocalAgent', () => {
 
     const parsed = JSON.parse(output.trim().split('\n').find((l) => l.includes('hookSpecificOutput'))!);
     const ctx = parsed.hookSpecificOutput.additionalContext;
+    expect(ctx).toContain('[ClawPro组织 绑定提示]');
+    expect(ctx).toContain('当前项目未绑定ClawPro组织');
     expect(ctx).toContain('绑定到「alpha」组织');
     expect(ctx).toContain('绑定到「beta」组织');
     expect(ctx).toContain('不绑定，以后也不再提示');

--- a/src/index.ts
+++ b/src/index.ts
@@ -530,7 +530,7 @@ program
 
 program
   .command('bind-project')
-  .description('Bind the current project to a TeamAI organization/group for HTTP local-agent sync')
+  .description('Bind the current project to a ClawPro organization/group for HTTP local-agent sync')
   .option('--group-id <id>', 'Group ID from /user-groups/mine')
   .option('--skip', 'Mark current project as skipped (never prompt again)')
   .action(async (cmdOpts) => {

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -495,10 +495,10 @@ async function emitBindingHint(
   const choices = groups.map((g, i) => `${i + 1}. 绑定到「${g.name}」组织`);
   const actions = groups.map((g, i) => `- 用户回复 ${i + 1} → 执行 \`teamai bind-project --group-id ${g.id}\`，完成后回复"绑定完成，请开新会话生效"`);
   const context = [
-    '[TeamAI 绑定提示] 你必须原样展示下面的选项列表，不得修改编号或内容。等用户回复数字后执行对应命令。',
+    '[ClawPro组织 绑定提示] 你必须原样展示下面的选项列表，不得修改编号或内容。等用户回复数字后执行对应命令。',
     '',
     '---',
-    '当前项目未绑定 TeamAI 组织。绑定后可同步团队 skills/rules。请回复数字选择：',
+    '当前项目未绑定ClawPro组织。绑定后可同步团队 skills/rules。请回复数字选择：',
     '',
     ...choices,
     `${skipNum}. 不绑定，以后也不再提示`,


### PR DESCRIPTION
## What

Rename the organization label from `TeamAI` to `ClawPro组织` / `ClawPro` in the two user-facing places that refer to the **organization users bind to**:

1. The **project-binding hint** emitted by `emitBindingHint` (shown when a project is not yet bound).
2. The **`bind-project` command help text**.

Both referred to the org as "TeamAI"; this aligns them with the intended organization branding.

> Scope is intentionally limited to org-label wording. Product-name uses of "TeamAI" (product tagline, `TeamAI Dashboard`, `~/.teamai` home dir, MR-comment section titles) are **not** touched — those name the product, not the organization.

## Changes

**Binding hint** (`src/local-agent.ts`):
```diff
-    '[TeamAI 绑定提示] 你必须原样展示下面的选项列表，...'
+    '[ClawPro组织 绑定提示] 你必须原样展示下面的选项列表，...'
...
-    '当前项目未绑定 TeamAI 组织。绑定后可同步团队 skills/rules。请回复数字选择：'
+    '当前项目未绑定ClawPro组织。绑定后可同步团队 skills/rules。请回复数字选择：'
```

**`bind-project` help** (`src/index.ts`):
```diff
-  .description('Bind the current project to a TeamAI organization/group for HTTP local-agent sync')
+  .description('Bind the current project to a ClawPro organization/group for HTTP local-agent sync')
```
(Uses bare `ClawPro` here since the following `organization/group` already conveys the org structure — `ClawPro组织 organization` would read redundantly.)

Also added two assertions to the existing `emitBindingHint` test to lock the new hint labels and guard against regression.

## Test Plan

- [x] `npx tsc --noEmit` — passes
- [x] `npx vitest run` (the `emitBindingHint` "unbound" test) — passes with the new `[ClawPro组织 绑定提示]` / `当前项目未绑定ClawPro组织` assertions. Drives the real `reportAndSyncLocalAgent → emitBindingHint` path and asserts the exact `additionalContext` sent to the hook.
- [x] `npm run build` — succeeds.
- [x] **Real CLI**: `node dist/index.js bind-project --help` prints `Bind the current project to a ClawPro organization/group for HTTP local-agent sync`.
- [x] Confirmed no remaining org-label `TeamAI` reference in the binding prompt or bind-project help (`grep`).
