### PR TITLE
fix(local-agent): resolve home dir cross-platform so Windows WorkBuddy hooks find config

### DIFF
--- a/src/__tests__/home.test.ts
+++ b/src/__tests__/home.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import os from 'node:os';
+import { resolveHomeDir } from '../utils/home.js';
+
+describe('resolveHomeDir', () => {
+  const origPlatform = process.platform;
+  const origHome = process.env.HOME;
+  const origUserProfile = process.env.USERPROFILE;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: origPlatform });
+    if (origHome === undefined) delete process.env.HOME;
+    else process.env.HOME = origHome;
+    if (origUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = origUserProfile;
+  });
+
+  it('non-Windows: returns HOME when set', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    process.env.HOME = '/home/alice';
+    expect(resolveHomeDir()).toBe('/home/alice');
+  });
+
+  it('non-Windows: falls back to os.homedir() when HOME is empty', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    process.env.HOME = '';
+    expect(resolveHomeDir()).toBe(os.homedir());
+  });
+
+  it('Windows: prefers USERPROFILE over a shell-injected HOME', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    process.env.HOME = '/home/gitbashuser';
+    process.env.USERPROFILE = 'C:\\Users\\bob';
+    expect(resolveHomeDir()).toBe('C:\\Users\\bob');
+  });
+
+  it('Windows: falls back to os.homedir() when USERPROFILE is unset', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    delete process.env.USERPROFILE;
+    process.env.HOME = '/home/gitbashuser';
+    expect(resolveHomeDir()).toBe(os.homedir());
+  });
+});

--- a/src/__tests__/local-agent.test.ts
+++ b/src/__tests__/local-agent.test.ts
@@ -47,6 +47,65 @@ async function setupConfig(bindings: Record<string, unknown> = {}) {
   });
 }
 
+describe('local-agent: resolveHomeDir — cross-platform HOME resolution', () => {
+  const origPlatform = process.platform;
+  let origHomeEnv: string | undefined;
+  let origUserProfile: string | undefined;
+
+  beforeEach(() => {
+    origHomeEnv = process.env.HOME;
+    origUserProfile = process.env.USERPROFILE;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: origPlatform });
+    if (origHomeEnv === undefined) delete process.env.HOME;
+    else process.env.HOME = origHomeEnv;
+    if (origUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = origUserProfile;
+  });
+
+  it('non-Windows: uses HOME when set (preserves current behavior / test isolation)', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    process.env.HOME = '/home/linuxuser';
+    const { resolveHomeDir } = await import('../local-agent.js');
+    expect(resolveHomeDir()).toBe('/home/linuxuser');
+  });
+
+  it('Windows: prefers USERPROFILE over a shell-injected HOME', async () => {
+    // WorkBuddy's bundled bash injects a Unix-style HOME (e.g. /home/xxx) that
+    // does not match the real Windows profile where config.json lives. Native
+    // Windows Node must resolve to USERPROFILE, not that bash HOME.
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    process.env.HOME = '/home/gitbashuser';
+    process.env.USERPROFILE = 'C:\\Users\\jaelgeng';
+    const { resolveHomeDir } = await import('../local-agent.js');
+    expect(resolveHomeDir()).toBe('C:\\Users\\jaelgeng');
+  });
+
+  it('Windows: loadLocalAgentConfig finds config under USERPROFILE despite a wrong HOME', async () => {
+    // End-to-end of the fix: config.json lives under the real profile (tmpDir),
+    // HOME points somewhere else (as WorkBuddy's bash would). The loader must
+    // still find it — otherwise the binding hint silently no-ops on Windows.
+    const configDir = path.join(tmpDir, '.teamai', 'local-agent');
+    await fse.ensureDir(configDir);
+    await fse.writeJson(path.join(configDir, 'config.json'), {
+      endpoint: 'https://real.example.com/api',
+      token: 'hk-real',
+      workspaceBindings: {},
+    });
+
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    process.env.HOME = '/home/gitbashuser'; // wrong dir, no config here
+    process.env.USERPROFILE = tmpDir;       // real profile where config lives
+
+    const { loadLocalAgentConfig } = await import('../local-agent.js');
+    const config = await loadLocalAgentConfig();
+    expect(config).not.toBeNull();
+    expect(config?.endpoint).toBe('https://real.example.com/api');
+  });
+});
+
 describe('local-agent: bindCurrentProject --skip', () => {
   it('writes groupId 0 and __skipped__ marker to config', async () => {
     await setupConfig();

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -23,6 +23,7 @@ import { parseHookEvent, appendEvent, compactEvents } from './dashboard-collecto
 import { getCurrentVersion } from './package-info.js';
 import { getMachineId, deriveLocalAgentId } from './machine-id.js';
 import { assertSafeResourceName } from './utils/path-safety.js';
+import { resolveHomeDir } from './utils/home.js';
 import {
   TEAMAI_HOME,
   TEAMAI_TOKEN_PATH,
@@ -125,8 +126,15 @@ interface LocalAgentContext {
   event?: DashboardEvent;
 }
 
+/**
+ * Resolve the user's home directory in a way that survives WorkBuddy's bundled
+ * bash on Windows. Re-exported from utils/home for backward compatibility with
+ * existing tests; see that module for the full rationale.
+ */
+export { resolveHomeDir };
+
 function getTeamaiHomePath(): string {
-  return path.join(process.env.HOME ?? '', '.teamai');
+  return path.join(resolveHomeDir(), '.teamai');
 }
 
 function getLocalAgentHome(): string {
@@ -944,7 +952,7 @@ async function syncClaudemd(
 
   const baseDir = localConfig.scope === 'project' && localConfig.projectRoot
     ? localConfig.projectRoot
-    : process.env.HOME ?? '';
+    : resolveHomeDir();
 
   for (const [tool, toolPath] of Object.entries(teamConfig.toolPaths)) {
     if (!toolPath.claudemd) continue;
@@ -1194,7 +1202,7 @@ export async function initLocalAgentHttp(options: {
   }
 
   const teamConfig = createLocalAgentTeamConfig(endpoint);
-  await injectHooksToAllTools(teamConfig.toolPaths, process.env.HOME ?? '');
+  await injectHooksToAllTools(teamConfig.toolPaths, resolveHomeDir());
   log.success(`HTTP local agent initialized at ${getConfigPath()}`);
 }
 

--- a/src/utils/home.ts
+++ b/src/utils/home.ts
@@ -1,0 +1,26 @@
+import os from 'node:os';
+
+/**
+ * Resolve the user's home directory in a way that survives WorkBuddy's bundled
+ * bash on Windows.
+ *
+ * WorkBuddy invokes hooks via `bash -lc "..."`, and that bash injects a
+ * Unix-style HOME (e.g. /home/xxx) that does NOT match the native Windows
+ * profile (C:\Users\xxx) where teamai's config and debug.log live. Trusting HOME
+ * there makes the CLI look in the wrong directory — config loads fail (the
+ * binding hint silently no-ops) and hook debug.log lands somewhere invisible.
+ *
+ * On Windows we therefore prefer USERPROFILE / os.homedir() (native Node reads
+ * the real profile via the OS, ignoring the bash-injected HOME). On other
+ * platforms we keep HOME first to preserve existing behavior and test isolation
+ * (tests set process.env.HOME to a temp dir).
+ *
+ * This module intentionally has no internal dependencies so it can be imported
+ * from foundational utilities like the logger without risking a cycle.
+ */
+export function resolveHomeDir(): string {
+  if (process.platform === 'win32') {
+    return process.env.USERPROFILE || os.homedir() || process.env.HOME || '';
+  }
+  return process.env.HOME || os.homedir() || '';
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import chalk from 'chalk';
 import ora, { type Ora } from 'ora';
+import { resolveHomeDir } from './home.js';
 
 let verboseEnabled = false;
 let silentMode = false;
@@ -32,7 +33,7 @@ let _writing = false;
 
 function getLogFilePath(): string {
   if (!_logFilePath) {
-    _logFilePath = path.join(process.env.HOME ?? '/tmp', '.teamai', 'debug.log');
+    _logFilePath = path.join(resolveHomeDir() || '/tmp', '.teamai', 'debug.log');
   }
   return _logFilePath;
 }


### PR DESCRIPTION
## Problem

The organization **binding hint** never appears in **WorkBuddy on Windows**, while it works in Claude / CodeBuddy on Linux.

### Root cause

WorkBuddy fires hooks via `bash -lc "teamai hook-dispatch prompt-submit --stdin --tool workbuddy ..."`. Its bundled bash injects a **Unix-style `HOME`** (e.g. `/home/xxx`) that does **not** match the native Windows profile (`C:\Users\xxx`) where `~/.teamai/local-agent/config.json` actually lives.

`getTeamaiHomePath()` (and the logger) trusted `process.env.HOME` verbatim:

```ts
path.join(process.env.HOME ?? '', '.teamai')
```

So on Windows the hook process looked in the wrong directory:

1. `loadLocalAgentConfig()` finds no `config.json` → returns `null`
2. `reportAndSyncLocalAgent()` bails at its first line (`if (!config) return false`)
3. `emitBindingHint()` is never reached → **no hint**
4. The hook's `debug.log` was also written to the wrong dir, so the failure left almost no trace (only the SessionStart init line, written earlier from a native-terminal `teamai init`)

Linux (claude/codebuddy) was unaffected because `HOME` there already matches the real profile.

This was reproduced locally: pointing `HOME` at a directory without the config makes the hook's debug.log contain only the `dashboard: recorded prompt_submit` line — exactly matching the Windows symptom.

## Fix

Add `src/utils/home.ts` → `resolveHomeDir()` (dependency-free, so the logger can import it without a cycle):

```ts
export function resolveHomeDir(): string {
  if (process.platform === 'win32') {
    return process.env.USERPROFILE || os.homedir() || process.env.HOME || '';
  }
  return process.env.HOME || os.homedir() || '';
}
```

- **Windows**: prefer `USERPROFILE` / `os.homedir()` — native Node reads the real profile via the OS, ignoring the bash-injected `HOME`.
- **Other platforms**: keep `HOME` first, preserving current behavior and test isolation (tests set `process.env.HOME` to a temp dir).

Routed `getTeamaiHomePath`, `syncClaudemd` base dir, `initLocalAgentHttp` hook injection, and the logger's debug.log path through it.

## Test Plan

- [x] `npx tsc --noEmit` — passes
- [x] New unit tests (`src/__tests__/home.test.ts`) cover all four branches: non-Windows HOME / HOME-empty fallback, Windows USERPROFILE preference / USERPROFILE-unset fallback
- [x] New integration test (`local-agent.test.ts`): with `platform=win32`, `HOME` pointing elsewhere and `USERPROFILE` at the real profile, `loadLocalAgentConfig()` still loads the config
- [x] `npx vitest run` — full suite green except 3 pre-existing "skill directory naming" failures that also fail on clean `origin/main` (unrelated to this change)
- [x] `npm run build` — succeeds; verified `dist/index.js` contains the `win32` / `USERPROFILE` branch
- [x] **Linux regression e2e**: ran the built CLI `hook-dispatch prompt-submit --stdin --tool workbuddy` with `HOME` at the config dir — config loads and the full report/sync flow runs (3 debug.log lines), confirming no regression on the working platforms
