### PR TITLE
feat(local-agent): backend request logging, 12h update cache, WorkBuddy hook timeout

### DIFF
--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -547,6 +547,30 @@ describe('hooks', () => {
       }
     });
 
+    it('WorkBuddy hooks have timeout values (claude-format inner entry)', async () => {
+      await injectHooks('/test/settings.json', 'workbuddy');
+      const result = mockFiles['/test/settings.json'] as {
+        hooks: Record<string, Array<{ hooks: Array<{ timeout?: number }> }>>;
+      };
+      for (const entries of Object.values(result.hooks)) {
+        for (const entry of entries) {
+          expect(entry.hooks[0].timeout).toBeGreaterThan(0);
+        }
+      }
+    });
+
+    it('Claude hooks carry no timeout (byte-compat baseline preserved)', async () => {
+      await injectHooks('/test/settings.json', 'claude');
+      const result = mockFiles['/test/settings.json'] as {
+        hooks: Record<string, Array<{ hooks: Array<{ timeout?: number }> }>>;
+      };
+      for (const entries of Object.values(result.hooks)) {
+        for (const entry of entries) {
+          expect(entry.hooks[0].timeout).toBeUndefined();
+        }
+      }
+    });
+
     it('Claude hooks have [teamai] description prefix', async () => {
       await injectHooks('/test/settings.json', 'claude');
       const result = mockFiles['/test/settings.json'] as { hooks: Record<string, Array<{ description?: string }>> };

--- a/src/builtin-hooks.ts
+++ b/src/builtin-hooks.ts
@@ -29,35 +29,36 @@ interface BuiltinHookSpec {
   dispatchEvent: string;
   /** matcher ("*" = wildcard, no --matcher arg, omitted in Cursor output). */
   matcher: string;
-  /** Cursor on-disk timeout (Claude builtin entries carry no timeout). */
-  cursorTimeout: number;
+  /** Per-hook timeout in seconds (rendered for Cursor and WorkBuddy). */
+  timeoutSec: number;
 }
 
 const BUILTIN_HOOK_SPECS: BuiltinHookSpec[] = [
-  { key: 'Hook dispatch session-start', event: 'SessionStart', dispatchEvent: 'session-start', matcher: '*', cursorTimeout: 60 },
-  { key: 'Hook dispatch stop', event: 'Stop', dispatchEvent: 'stop', matcher: '*', cursorTimeout: 15 },
-  { key: 'Hook dispatch post-tool-use wildcard', event: 'PostToolUse', dispatchEvent: 'post-tool-use', matcher: '*', cursorTimeout: 10 },
-  { key: 'Hook dispatch post-tool-use Skill', event: 'PostToolUse', dispatchEvent: 'post-tool-use', matcher: 'Skill', cursorTimeout: 10 },
-  { key: 'Hook dispatch post-tool-use TodoWrite', event: 'PostToolUse', dispatchEvent: 'post-tool-use', matcher: 'TodoWrite', cursorTimeout: 3 },
-  { key: 'Hook dispatch prompt-submit', event: 'UserPromptSubmit', dispatchEvent: 'prompt-submit', matcher: '*', cursorTimeout: 10 },
+  { key: 'Hook dispatch session-start', event: 'SessionStart', dispatchEvent: 'session-start', matcher: '*', timeoutSec: 60 },
+  { key: 'Hook dispatch stop', event: 'Stop', dispatchEvent: 'stop', matcher: '*', timeoutSec: 15 },
+  { key: 'Hook dispatch post-tool-use wildcard', event: 'PostToolUse', dispatchEvent: 'post-tool-use', matcher: '*', timeoutSec: 10 },
+  { key: 'Hook dispatch post-tool-use Skill', event: 'PostToolUse', dispatchEvent: 'post-tool-use', matcher: 'Skill', timeoutSec: 10 },
+  { key: 'Hook dispatch post-tool-use TodoWrite', event: 'PostToolUse', dispatchEvent: 'post-tool-use', matcher: 'TodoWrite', timeoutSec: 3 },
+  { key: 'Hook dispatch prompt-submit', event: 'UserPromptSubmit', dispatchEvent: 'prompt-submit', matcher: '*', timeoutSec: 10 },
 ];
 
 /**
  * Build the built-in hook definitions for a tool.
  *
- * Tool-specific by design: Claude/CodeBuddy entries carry no timeout (matching
- * the historical output) while Cursor entries carry per-hook timeouts. The
+ * Tool-specific by design: Cursor and WorkBuddy entries carry per-hook timeouts
+ * so a slow/unreachable backend hook cannot hang the host; Claude/CodeBuddy
+ * entries carry no timeout (matching the historical byte-compat output). The
  * reconcile engine renders the same HookDef into each tool's on-disk shape.
  */
 export function builtinHookDefs(tool: string): HookDef[] {
-  const isCursor = tool === 'cursor';
+  const withTimeout = tool === 'cursor' || tool === 'workbuddy';
   return BUILTIN_HOOK_SPECS.map((spec) => ({
     source: 'builtin' as const,
     key: spec.key,
     event: spec.event,
     matcher: spec.matcher,
     command: getDispatchCommand(spec.dispatchEvent, tool, spec.matcher),
-    timeout: isCursor ? spec.cursorTimeout : undefined,
+    timeout: withTimeout ? spec.timeoutSec : undefined,
     description: `${TEAMAI_HOOK_DESCRIPTION_PREFIX} ${spec.key}`,
   }));
 }

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -23,6 +23,7 @@ import { parseHookEvent, appendEvent, compactEvents } from './dashboard-collecto
 import { getCurrentVersion } from './package-info.js';
 import { getMachineId, deriveLocalAgentId } from './machine-id.js';
 import { assertSafeResourceName } from './utils/path-safety.js';
+import { logHttpRequest, logHttpResponse } from './utils/http-log.js';
 import {
   TEAMAI_HOME,
   TEAMAI_TOKEN_PATH,
@@ -298,13 +299,16 @@ async function localAgentFetch<T>(
   route: string,
   init?: RequestInit,
 ): Promise<T> {
-  const response = await fetch(`${config.endpoint}${route}`, {
-    ...init,
-    headers: {
-      ...authHeaders(config, init?.body !== undefined),
-      ...(init?.headers ?? {}),
-    },
-  });
+  const tag = `[local-agent ${(config.localAgentId ?? 'unknown').slice(-6)}]`;
+  const method = init?.method ?? 'GET';
+  const url = `${config.endpoint}${route}`;
+  const headers: Record<string, string> = {
+    ...authHeaders(config, init?.body !== undefined),
+    ...((init?.headers as Record<string, string> | undefined) ?? {}),
+  };
+  logHttpRequest(tag, method, url, headers, init?.body);
+
+  const response = await fetch(url, { ...init, headers });
   const text = await response.text();
   let body: unknown = null;
   if (text.trim()) {
@@ -314,6 +318,7 @@ async function localAgentFetch<T>(
       body = text;
     }
   }
+  logHttpResponse(tag, method, url, response.status, response.statusText, body);
   if (!response.ok) {
     const message = typeof body === 'object' && body && 'error' in body
       ? String((body as { error: unknown }).error)

--- a/src/status-report.ts
+++ b/src/status-report.ts
@@ -32,6 +32,7 @@ import {
 import { resolveBaseDir, type LocalConfig, type TeamaiConfig } from './types.js';
 import { getMachineId, deriveLocalAgentId } from './machine-id.js';
 import { log } from './utils/logger.js';
+import { logHttpRequest, logHttpResponse } from './utils/http-log.js';
 import { getAgentVersion } from './agent-version.js';
 
 // ─── Endpoint mapping (internal, overridable) ───────────────
@@ -187,19 +188,31 @@ async function flushQueue(apiKey: string): Promise<void> {
 // ─── HTTP ───────────────────────────────────────────────────
 
 async function postJson(url: string, apiKey: string, body: unknown): Promise<unknown> {
+  const tag = '[status-report]';
+  const headers = {
+    Authorization: `Bearer ${apiKey}`,
+    'Content-Type': 'application/json',
+  };
+  logHttpRequest(tag, 'POST', url, headers, body);
   const res = await fetch(url, {
     method: 'POST',
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      'Content-Type': 'application/json',
-    },
+    headers,
     body: JSON.stringify(body),
   });
+  const text = await res.text();
+  let parsed: unknown = null;
+  if (text.trim()) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = text;
+    }
+  }
+  logHttpResponse(tag, 'POST', url, res.status, res.statusText, parsed);
   if (!res.ok) {
     throw new Error(`HTTP ${res.status}`);
   }
-  const text = await res.text();
-  return text ? JSON.parse(text) : {};
+  return parsed ?? {};
 }
 
 // ─── Main entry ─────────────────────────────────────────────

--- a/src/update.ts
+++ b/src/update.ts
@@ -23,7 +23,7 @@ const TNPM_REGISTRY = 'http://r.tnpm.oa.com';
 
 const VERSION_CHECK_TIMEOUT = 5000;
 const INSTALL_TIMEOUT = 60000;
-const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const CACHE_TTL_MS = 12 * 60 * 60 * 1000; // 12 hours
 
 // ─── Helpers ────────────────────────────────────────────
 

--- a/src/utils/http-log.ts
+++ b/src/utils/http-log.ts
@@ -1,0 +1,67 @@
+/**
+ * Debug logging for backend HTTP requests (local-agent report/sync/ack).
+ *
+ * Logs the full request (method / url / headers / body), the response body,
+ * and the status code to log.debug — which persists to ~/.teamai/debug.log
+ * regardless of verbose mode, so a failed backend call is diagnosable after
+ * the fact. Sensitive headers (Authorization, X-API-Token) are redacted so
+ * tokens never land in the log file. Request/response bodies are logged
+ * verbatim — the current backend payloads carry no secrets (credentials live
+ * only in headers); add body redaction here if that ever changes.
+ */
+
+import { log } from './logger.js';
+
+/** Header names whose values must be masked before logging. */
+const SENSITIVE_HEADER_RE = /^(authorization|x-api-token|x-api-key|cookie)$/i;
+
+/** Mask a sensitive header value, preserving an auth scheme prefix if present. */
+function redactValue(value: string): string {
+  const scheme = value.match(/^(Bearer|Basic|Token)\s+/i);
+  return scheme ? `${scheme[1]} ***` : '***';
+}
+
+/** Return a copy of headers with sensitive values replaced by "***". */
+export function redactHeaders(headers: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    out[key] = SENSITIVE_HEADER_RE.test(key) ? redactValue(value) : value;
+  }
+  return out;
+}
+
+/** Truncate an over-long body string so the log file stays readable. */
+function previewBody(body: unknown, maxLen = 4096): string {
+  if (body === undefined || body === null) return '(empty)';
+  const text = typeof body === 'string' ? body : JSON.stringify(body);
+  return text.length > maxLen ? `${text.slice(0, maxLen)}… (${text.length} bytes total)` : text;
+}
+
+/** Log an outgoing backend request (headers redacted). */
+export function logHttpRequest(
+  tag: string,
+  method: string,
+  url: string,
+  headers: Record<string, string>,
+  body?: unknown,
+): void {
+  log.debug(`${tag} → ${method} ${url}`);
+  log.debug(`${tag}   headers: ${JSON.stringify(redactHeaders(headers))}`);
+  if (body !== undefined) {
+    log.debug(`${tag}   body: ${previewBody(body)}`);
+  }
+}
+
+/** Log a backend response — the status code plus the response body. */
+export function logHttpResponse(
+  tag: string,
+  method: string,
+  url: string,
+  status: number,
+  statusText: string,
+  body: unknown,
+): void {
+  const level = status >= 400 ? 'ERROR' : 'OK';
+  log.debug(`${tag} ← ${status} ${statusText} [${level}] ${method} ${url}`);
+  log.debug(`${tag}   response: ${previewBody(body)}`);
+}


### PR DESCRIPTION
## Summary

Three backend-observability / robustness improvements, driven by diagnosing why the org **binding hint** never surfaced in WorkBuddy:

1. **Full backend request/response logging.** `local-agent` report/sync/ack calls (`localAgentFetch`) and the `status-report` reporter (`postJson`) now log the complete request (method / url / headers / body), the response body, and the HTTP status code (错误码) to `log.debug`. Since `log.debug` persists to `~/.teamai/debug.log` regardless of verbose mode, a failed backend call is now diagnosable after the fact — which was previously near-impossible.

2. **Update-check cache TTL 24h → 12h.** `src/update.ts` `CACHE_TTL_MS`.

3. **WorkBuddy built-in hooks now carry a per-hook `timeout`.** Previously only Cursor emitted timeouts; Claude/CodeBuddy/WorkBuddy did not. A slow or unreachable backend hook could therefore hang the WorkBuddy host with no upper bound. WorkBuddy now reuses the same per-event values validated for Cursor (session-start 60s, stop 15s, post-tool-use 10/10/3s, prompt-submit 10s). Claude/CodeBuddy intentionally stay timeout-free to preserve the golden byte-compat output.

## Security

- Sensitive headers (`Authorization`, `X-API-Token`, `x-api-key`, `cookie`) are redacted to `***` before logging — tokens never land in the log file. Auth scheme prefixes (`Bearer`/`Basic`/`Token`) are preserved for readability.
- Request/response bodies are logged verbatim; current backend payloads carry no secrets (credentials live only in headers). A code comment flags this so body redaction can be added if payloads ever change.

## New files

- `src/utils/http-log.ts` — redaction + request/response debug logging helpers.

## Test Plan

- [x] `npx tsc --noEmit` — passes
- [x] `npm run build` — succeeds
- [x] New unit tests in `hooks.test.ts`: WorkBuddy hooks carry timeout; Claude hooks carry none (byte-compat baseline preserved)
- [x] Existing `hooks-golden.test.ts` (claude / claude-internal / codebuddy / cursor) stays byte-identical — confirms Claude/CodeBuddy output is unchanged
- [x] `update.test.ts` (38), `status-report.test.ts` (10), `builtin-hooks.test.ts` (6) — all green
- [x] **E2E — backend logging**: ran built CLI `hook-dispatch session-start --stdin --tool workbuddy` against an unreachable endpoint; `~/.teamai/debug.log` recorded request line, redacted headers (`Bearer ***` / `***`), request body, `← 404 [ERROR]` status, and response body. Confirmed **no plaintext token** in the log.
- [x] **E2E — WorkBuddy timeout**: ran built CLI `hooks inject`; verified `~/.workbuddy/settings.json` has `timeout` on all 6 hooks (60/15/10/10/3/10) and `~/.claude/settings.json` has none.

> Note: 3 pre-existing `skill directory naming` tests in `local-agent.test.ts` fail in the CI/sandbox environment due to a missing `unzip` binary (skill install unzips packages). They fail identically on clean `upstream/main` without this change — unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)