### PR TITLE
feat(source): add HTTP source (report/sync/ack) alongside a git main repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,25 @@ teamai source remove other-team
 
 Subscribed skills sync to your local machine on `teamai pull` and coexist with your own team's skills.
 
+### HTTP source (report/sync/ack)
+
+The subscriptions above are **git** sources. You can additionally attach a single **HTTP** source that uses the report/sync/ack lifecycle — the same one an `init --http` consumer gets — **alongside your existing git main repo**, without changing it:
+
+```bash
+# Attach an HTTP source (git main repo stays untouched)
+teamai source add-http https://your-team-host/api --token <api-key>
+
+# See it listed under "HTTP source"
+teamai source list
+
+# Detach it (uninstalls its resources, clears its config)
+teamai source remove-http
+```
+
+The HTTP source reports status and pulls down skills/rules/CLAUDE.md commands on each AI session, driven by the `hook-dispatch` hook that `teamai init` already installs. Users who never run `add-http` are unaffected.
+
+Only one HTTP source is supported, and it is meant for **git-based** main repos: if your main repo is itself an HTTP backend (`init --http`), it already owns the HTTP config, so `add-http` is rejected.
+
 ## Scope
 
 TeamAI supports two scopes that can coexist:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -300,6 +300,25 @@ teamai source remove other-team
 
 订阅源的 skills 在 `teamai pull` 时自动同步到本地，与团队自有 skills 共存。
 
+### HTTP source（report/sync/ack）
+
+上面的订阅源是 **git** 源。你还可以在**不改动现有 git 主仓**的前提下，额外挂一个 **HTTP** 源，它走 report/sync/ack 生命周期——与 `init --http` 消费者所用的完全相同：
+
+```bash
+# 挂一个 HTTP 源（git 主仓保持不变）
+teamai source add-http https://your-team-host/api --token <api-key>
+
+# 在 "HTTP source" 分区查看
+teamai source list
+
+# 移除（卸载其资源并清空配置）
+teamai source remove-http
+```
+
+HTTP 源在每次 AI 会话时上报状态并拉取 skills/rules/CLAUDE.md 指令命令，由 `teamai init` 已安装的 `hook-dispatch` hook 驱动。从不执行 `add-http` 的用户不受任何影响。
+
+仅支持一个 HTTP 源，且面向 **git 主仓**用户：若你的主仓本身就是 HTTP 后端（`init --http`），它已占用 HTTP 配置，此时 `add-http` 会被拒绝。
+
 ## Scope（作用域）
 
 TeamAI 支持两种 scope，可以共存：

--- a/src/index.ts
+++ b/src/index.ts
@@ -327,6 +327,26 @@ sourceCmd
   });
 
 sourceCmd
+  .command('add-http <endpoint>')
+  .description('Add an HTTP source (report/sync/ack) alongside a git main repo')
+  .option('--token <key>', 'API token for the HTTP endpoint (stored 0600, never committed)')
+  .option('--force', 'Overwrite an existing HTTP source config')
+  .action(async (endpoint: string, cmdOpts) => {
+    const globalOpts = program.opts() as GlobalOptions;
+    const { sourceAddHttp } = await import('./source.js');
+    await sourceAddHttp(endpoint, { ...globalOpts, ...cmdOpts });
+  });
+
+sourceCmd
+  .command('remove-http')
+  .description('Remove the HTTP source and clean up its resources')
+  .action(async () => {
+    const globalOpts = program.opts() as GlobalOptions;
+    const { sourceRemoveHttp } = await import('./source.js');
+    await sourceRemoveHttp(globalOpts);
+  });
+
+sourceCmd
   .command('list')
   .description('List all configured sources')
   .action(async () => {

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -1300,6 +1300,84 @@ export async function pullLocalAgentForCwd(context?: LocalAgentContext): Promise
   });
 }
 
+/** Summary of the configured HTTP local-agent bypass, for `teamai source list`. */
+export interface LocalAgentSummary {
+  endpoint: string;
+  boundGroups: Array<{ path: string; groupName?: string; groupId: number }>;
+  resourceCounts: { skills: number; rules: number; claudemd: number };
+}
+
+/**
+ * Describe the configured HTTP local-agent bypass (report/sync/ack), or null when
+ * none is configured. Used by `teamai source list` to show the HTTP side channel
+ * alongside git cross-team sources.
+ */
+export async function describeLocalAgent(): Promise<LocalAgentSummary | null> {
+  const config = await loadLocalAgentConfig();
+  if (!config) return null;
+
+  const boundGroups = Object.entries(config.workspaceBindings)
+    // groupId 0 is the "__skipped__" sentinel — not a real binding.
+    .filter(([, b]) => b.groupId !== 0)
+    .map(([workspacePath, b]) => ({ path: workspacePath, groupName: b.groupName, groupId: b.groupId }));
+
+  const manifest = await loadManifest();
+  const counts = { skills: 0, rules: 0, claudemd: 0 };
+  for (const scope of Object.values(manifest.scopes)) {
+    counts.skills += Object.keys(scope.skills ?? {}).length;
+    counts.rules += Object.keys(scope.rules ?? {}).length;
+    counts.claudemd += Object.keys(scope.claudemd ?? {}).length;
+  }
+
+  return { endpoint: config.endpoint, boundGroups, resourceCounts: counts };
+}
+
+/** Parse a manifest scope key back into (scope, workspacePath). */
+function parseScopeKey(key: string): { scope: LocalAgentScope; workspacePath?: string } {
+  if (key.startsWith('project:')) {
+    return { scope: 'project', workspacePath: key.slice('project:'.length) || undefined };
+  }
+  return { scope: key === 'instance' ? 'instance' : 'user' };
+}
+
+/**
+ * Tear down the HTTP local-agent bypass: uninstall every resource recorded in the
+ * manifest (skills/rules/claudemd, across all scopes) from the AI tool dirs, then
+ * remove the whole ~/.teamai/local-agent/ directory (config + manifest + queue).
+ *
+ * Best-effort per resource: a single failed uninstall is logged and skipped so a
+ * stale entry cannot block the teardown.
+ */
+export async function removeLocalAgentHttp(): Promise<void> {
+  const config = await loadLocalAgentConfig();
+  if (!config) {
+    log.info('No HTTP source configured — nothing to remove.');
+    return;
+  }
+
+  const manifest = await loadManifest();
+  for (const [key, scopeManifest] of Object.entries(manifest.scopes)) {
+    const { scope, workspacePath } = parseScopeKey(key);
+    const kinds: Array<[ResourceKind, CommandResourceKind]> = [
+      ['skills', 'skill'],
+      ['rules', 'rule'],
+      ['claudemd', 'claudemd'],
+    ];
+    for (const [manifestField, kind] of kinds) {
+      for (const slug of Object.keys(scopeManifest[manifestField] ?? {})) {
+        try {
+          await uninstallResource({ config, kind, slug, scope, workspacePath });
+        } catch (e) {
+          log.debug(`local-agent: failed to uninstall ${kind} "${slug}": ${(e as Error).message}`);
+        }
+      }
+    }
+  }
+
+  await remove(getLocalAgentHome());
+  log.success('HTTP source removed (resources uninstalled, config cleared).');
+}
+
 export async function bindCurrentProject(options?: { groupId?: number; skip?: boolean; cwd?: string }): Promise<void> {
   const workspacePath = await resolveWorkspacePath(options?.cwd ?? process.cwd());
   if (!workspacePath) {

--- a/src/source.ts
+++ b/src/source.ts
@@ -212,25 +212,101 @@ export async function sourceRemove(name: string, options: GlobalOptions): Promis
 }
 
 /**
- * List all configured sources.
+ * List all configured sources: team-level git cross-team sources (from
+ * teamai.yaml) plus the personal HTTP bypass (report/sync/ack), if configured.
  */
 export async function sourceList(): Promise<void> {
-  const { teamConfig } = await autoDetectInit();
-  const sources = teamConfig.sources ?? [];
+  // Git cross-team sources come from the team config. Tolerate a missing init:
+  // the HTTP bypass is independent of the team repo, so still show it.
+  let gitSources: SourceConfig[] = [];
+  try {
+    const { teamConfig } = await autoDetectInit();
+    gitSources = teamConfig.sources ?? [];
+  } catch {
+    // Not initialized (no team repo) — only the HTTP bypass may exist.
+  }
 
-  if (sources.length === 0) {
-    log.info('No sources configured. Use `teamai source add <url>` to add one.');
+  const { describeLocalAgent } = await import('./local-agent.js');
+  const httpSource = await describeLocalAgent();
+
+  if (gitSources.length === 0 && !httpSource) {
+    log.info('No sources configured. Use `teamai source add <url>` or `teamai source add-http <endpoint>`.');
     return;
   }
 
-  log.info(`Configured sources (${sources.length}):`);
-  for (const source of sources) {
-    const repoDir = getSourceRepoDir(source.name);
-    const cloned = await pathExists(repoDir);
-    const status = cloned ? '(synced)' : '(not yet synced)';
-    log.info(`  ${source.name} ${status}`);
-    log.dim(`    ${source.repo}`);
+  if (gitSources.length > 0) {
+    log.info(`Git cross-team sources (${gitSources.length}):`);
+    for (const source of gitSources) {
+      const repoDir = getSourceRepoDir(source.name);
+      const cloned = await pathExists(repoDir);
+      const status = cloned ? '(synced)' : '(not yet synced)';
+      log.info(`  ${source.name} ${status}`);
+      log.dim(`    ${source.repo}`);
+    }
   }
+
+  if (httpSource) {
+    const { skills, rules, claudemd } = httpSource.resourceCounts;
+    log.info('HTTP source (report/sync/ack):');
+    log.info(`  ${httpSource.endpoint}`);
+    log.dim(`    ${skills} skill(s), ${rules} rule(s), ${claudemd} claude.md`);
+    for (const g of httpSource.boundGroups) {
+      log.dim(`    bound: ${g.groupName ?? g.groupId} — ${g.path}`);
+    }
+  }
+}
+
+/**
+ * Add a personal HTTP source (report/sync/ack side channel) alongside the git
+ * main repo. Reuses the local-agent bypass so a git-based user gets the same
+ * report/sync/ack lifecycle an `init --http` user has, without touching the git
+ * main repo.
+ *
+ * Rejected when the main repo itself is HTTP: that setup already owns the single
+ * local-agent config, and a second endpoint would silently overwrite it.
+ */
+export async function sourceAddHttp(
+  endpoint: string,
+  options: { token?: string; force?: boolean } & GlobalOptions,
+): Promise<void> {
+  const trimmed = endpoint.trim();
+  if (!trimmed) {
+    log.error('Endpoint is required. Usage: teamai source add-http <endpoint> --token <key>');
+    return;
+  }
+
+  // Guard: if the main repo is already an HTTP backend, it owns the single
+  // local-agent config — refuse rather than overwrite its endpoint.
+  const { loadLocalConfig, detectProjectConfig } = await import('./config.js');
+  const mainConfig = (await detectProjectConfig()) ?? (await loadLocalConfig());
+  if (mainConfig?.repo.kind === 'http') {
+    log.error('Your main team repo is already an HTTP backend, which owns the HTTP source config.');
+    log.info('An HTTP bypass is only for git-based main repos. Nothing changed.');
+    return;
+  }
+
+  if (options.dryRun) {
+    log.info(`[dry-run] Would add HTTP source ${trimmed}`);
+    return;
+  }
+
+  const { initLocalAgentHttp } = await import('./local-agent.js');
+  // force: true so re-running add-http updates the bypass's own endpoint/token.
+  await initLocalAgentHttp({ endpoint: trimmed, token: options.token, force: true });
+  log.success(`HTTP source added (${trimmed}).`);
+  log.info('It will report/sync on the next AI session (via the hook-dispatch hook already installed).');
+}
+
+/**
+ * Remove the personal HTTP source: uninstall its resources and clear its config.
+ */
+export async function sourceRemoveHttp(options: GlobalOptions): Promise<void> {
+  if (options.dryRun) {
+    log.info('[dry-run] Would remove the HTTP source');
+    return;
+  }
+  const { removeLocalAgentHttp } = await import('./local-agent.js');
+  await removeLocalAgentHttp();
 }
 
 /**


### PR DESCRIPTION
## What

Lets a **git-based** user attach a single **HTTP source** that runs the same report/sync/ack lifecycle an `init --http` consumer has — **alongside** the git main repo, without changing it.

The report/sync/ack logic (`local-agent.ts`) already decouples from `repo.kind` — it is gated only by whether `loadLocalAgentConfig()` returns a config. Previously only `teamai init --http` wrote that config, so git users could never report/sync. This PR adds the entry point they were missing; **no report/sync/ack code was moved or rewritten**.

## Commands

```bash
teamai source add-http <endpoint> --token <key>   # attach (git main repo untouched)
teamai source list                                # shows it under "HTTP source"
teamai source remove-http                          # uninstall resources + clear config
```

## Behavior

- `add-http` reuses `initLocalAgentHttp`; **rejected when the main repo is itself HTTP** (`init --http`), since that setup already owns the single local-agent config and a second endpoint would silently overwrite it.
- `remove-http` uninstalls every manifest-recorded resource (skills/rules/claudemd, all scopes) then clears `~/.teamai/local-agent/`.
- `source list` now shows the HTTP source next to git cross-team sources, and tolerates an uninitialized team repo (the HTTP bypass is independent).
- Users who never run `add-http` are unaffected — `loadLocalAgentConfig()` stays null and the hook path no-ops.

## Changes

| File | Change |
|------|--------|
| `src/local-agent.ts` | new `describeLocalAgent()` + `removeLocalAgentHttp()` |
| `src/source.ts` | `sourceAddHttp()` / `sourceRemoveHttp()` + `sourceList()` shows HTTP source |
| `src/index.ts` | register `source add-http` / `source remove-http` |
| `README.md` / `README.zh-CN.md` | documented in sync |

## Test Plan

- [x] `npx tsc --noEmit` — passes
- [x] `npm run build` — succeeds
- [x] `npx vitest run` — 1679 passed; the one `import-repo-merge` failure is pre-existing on main, unrelated to this diff
- [x] `local-agent.test.ts` (12) + `source*.test.ts` (19) — all pass after rebasing onto latest main (`f2ffd26`, incl. #167)
- [x] **E2E, isolated HOME + real backend**: `add-http` → `bind-project` → sync returns 2 `install_skill` → downloads real zips → lands in manifest → `POST /commands/ack` returns success → `remove-http` cleans up
- [x] **E2E, real backend, live IDE**: report/sync verified from both `claude` and **`codebuddy`** hook sessions (`report OK` / `sync OK`, `200 OK`)
- [x] **Conflict branch, real env**: on an HTTP main repo, `add-http` correctly rejects with no side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)