### PR TITLE
fix(local-agent): unify debug log tag across HTTP and report/sync lines

### DIFF
--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -183,6 +183,16 @@ function resolveLocalAgentId(context: LocalAgentContext): string {
   return deriveLocalAgentId(agentType, getMachineId(), getLocalAgentHome());
 }
 
+/**
+ * Build the unified log tag for local-agent debug output: `[<id6>] [<tool>]` —
+ * the last 6 chars of the derived agent id plus the agent name (tool), so every
+ * line (HTTP request/response, report/sync, command ack) reads the same way.
+ */
+function localAgentTag(context: LocalAgentContext): string {
+  const tool = context.tool ?? 'workbuddy';
+  return `[${resolveLocalAgentId(context).slice(-6)}] [${tool}]`;
+}
+
 function scopeKey(scope: LocalAgentScope, workspacePath?: string): string {
   return scope === 'project' ? `project:${workspacePath ?? ''}` : scope;
 }
@@ -299,11 +309,10 @@ function authHeaders(config: LocalAgentConfig, json = true): Record<string, stri
 
 async function localAgentFetch<T>(
   config: LocalAgentConfig,
-  agentId: string,
+  tag: string,
   route: string,
   init?: RequestInit,
 ): Promise<T> {
-  const tag = `[local-agent ${agentId.slice(-6)}]`;
   const method = init?.method ?? 'GET';
   const url = `${config.endpoint}${route}`;
   const headers: Record<string, string> = {
@@ -348,7 +357,7 @@ async function appendReporterQueue(entry: unknown): Promise<void> {
 export async function fetchUserGroups(config: LocalAgentConfig): Promise<LocalAgentGroup[]> {
   const response = await localAgentFetch<{ ok?: boolean; groups?: LocalAgentGroup[] }>(
     config,
-    resolveLocalAgentId({}),
+    localAgentTag({}),
     '/api/user-groups/mine',
     { method: 'GET' },
   );
@@ -1077,13 +1086,13 @@ async function removeClaudeMdSection(
 
 async function ackCommand(
   config: LocalAgentConfig,
-  agentId: string,
+  tag: string,
   command: LocalAgentCommand,
   status: 'success' | 'failed',
   version?: string,
   error?: string,
 ): Promise<void> {
-  await localAgentFetch(config, agentId, '/api/local-agent/commands/ack', {
+  await localAgentFetch(config, tag, '/api/local-agent/commands/ack', {
     method: 'POST',
     body: JSON.stringify({
       id: command.id,
@@ -1128,18 +1137,17 @@ async function processCommands(
   commands: LocalAgentCommand[],
   context: LocalAgentContext,
 ): Promise<void> {
-  const agentId = resolveLocalAgentId(context);
-  const tag = `[${agentId.slice(-6)}] [${context.tool}]`;
+  const tag = localAgentTag(context);
   for (const command of commands) {
     try {
       const version = await executeCommand(config, command, context);
-      await ackCommand(config, agentId, command, 'success', version);
+      await ackCommand(config, tag, command, 'success', version);
       log.debug(`${tag} command ${command.id} (${command.type ?? ''}) succeeded`);
     } catch (e) {
       const error = (e as Error).message;
       log.error(`${tag} command ${command.id} failed: ${error}`);
       try {
-        await ackCommand(config, agentId, command, 'failed', undefined, error);
+        await ackCommand(config, tag, command, 'failed', undefined, error);
       } catch (ackError) {
         log.debug(`${tag} failed to ack command ${command.id}: ${(ackError as Error).message}`);
       }
@@ -1159,13 +1167,12 @@ export async function reportAndSyncLocalAgent(context: LocalAgentContext): Promi
     await emitBindingHint(config, workspacePath);
   }
 
-  const agentId = resolveLocalAgentId(context);
-  const tag = `[${agentId.slice(-6)}] [${context.tool}]`;
+  const tag = localAgentTag(context);
   log.debug(`${tag} run: endpoint=${config.endpoint}`);
 
   try {
     const reportPayload = await buildReportPayload(config, context);
-    await localAgentFetch(config, agentId, '/api/local-agent/report', {
+    await localAgentFetch(config, tag, '/api/local-agent/report', {
       method: 'POST',
       body: JSON.stringify(reportPayload),
     });
@@ -1174,7 +1181,7 @@ export async function reportAndSyncLocalAgent(context: LocalAgentContext): Promi
     const syncPayload = await buildSyncPayload(config, context);
     const syncResponse = await localAgentFetch<{ ok?: boolean; commands?: LocalAgentCommand[] }>(
       config,
-      agentId,
+      tag,
       '/api/local-agent/sync',
       { method: 'POST', body: JSON.stringify(syncPayload) },
     );


### PR DESCRIPTION
## Problem

The local-agent debug log mixed two tag formats within a single hook fire:

- HTTP request/response lines (`localAgentFetch`): `[local-agent 2bcf67]` — has the `local-agent` prefix but **no agent name**, so an HTTP line couldn't be traced to which agent made it.
- report / sync / command result lines: `[2bcf67] [codebuddy]` — has the agent name but no prefix.

Example (before):

```
[local-agent 2bcf67] → POST .../api/local-agent/sync
[local-agent 2bcf67] ← 200 OK POST .../api/local-agent/sync
[2bcf67] [codebuddy] sync OK (0 command(s))
```

## Fix

- Add a single `localAgentTag(context)` helper producing the unified `[<id6>] [<tool>]`.
- Change `localAgentFetch` / `ackCommand` to take the built `tag` (they previously took a bare `agentId` only to build the tag), so HTTP lines now carry the agent name too.
- Converge all call sites (`fetchUserGroups`, `processCommands`, `reportAndSyncLocalAgent`) onto the helper.

No HTTP semantics or payloads changed — this is log-tag only.

After:

```
[2bcf67] [codebuddy] → POST .../api/local-agent/sync
[2bcf67] [codebuddy] ← 200 OK [OK] POST .../api/local-agent/sync
[2bcf67] [codebuddy] sync OK (0 command(s))
```

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run src/__tests__/local-agent.test.ts` — 12/12 pass
- [x] `npm run build` succeeds
- [x] End-to-end: triggered a real `hook-dispatch stop --tool codebuddy` against the live backend; all 13 debug.log lines now use the single `[2bcf67] [codebuddy]` format (verified the old `[local-agent 2bcf67]` shape is gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)