### PR TITLE
fix(local-agent): report detected agent version, not teamai-cli's own

### DIFF
--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -22,7 +22,7 @@ import { ResourceHandler } from './resources/base.js';
 import { RulesHandler, SkillsHandler } from './resources/index.js';
 import { injectHooksToAllTools } from './hooks.js';
 import { parseHookEvent, appendEvent, compactEvents } from './dashboard-collector.js';
-import { getCurrentVersion } from './package-info.js';
+import { getAgentVersion } from './agent-version.js';
 import { getMachineId, deriveLocalAgentId } from './machine-id.js';
 import { EXCLUDED_RULE_NAMES } from './builtin-rules.js';
 import { assertSafeResourceName } from './utils/path-safety.js';
@@ -662,7 +662,7 @@ export async function buildReportPayload(
 
   const payload: Record<string, unknown> = {
     agent_type: tool,
-    agent_version: getCurrentVersion(),
+    agent_version: await getAgentVersion(tool),
     local_agent_id: resolveLocalAgentId(context),
     host_name: os.hostname(),
     os: os.platform(),


### PR DESCRIPTION
## Problem

`buildReportPayload` (the HTTP `reportAndSyncLocalAgent` path) set `agent_version` from `getCurrentVersion()`, which returns **teamai-cli's own** package version (e.g. `0.17.2`). As a result every report carried the CLI's version instead of the reported agent's real version.

Observed in `~/.teamai/debug.log` — a **codebuddy** report showed the CLI version instead of the installed CodeBuddy build:

```
[DEBUG] [2bcf67] [codebuddy]   body: {"agent_type":"codebuddy","agent_version":"0.17.3-beta.10", ...}
```

## Root cause

Two report paths existed with divergent version sources:

- `status-report.ts` (correct): `getAgentVersion(agentType)` — detects the target tool's real version.
- `local-agent.ts` `buildReportPayload` (wrong): `getCurrentVersion()` — teamai-cli's own package version.

## Fix

Switch `buildReportPayload` to `getAgentVersion(tool)`, the same per-agent detector `status-report.ts` already uses (`claude`/`codebuddy --version`, IDE `Info.plist`). Unused `getCurrentVersion` import removed. Two-line change.

## Test Plan

- [x] `npx tsc --noEmit` — passes
- [x] `npx vitest run src/__tests__/local-agent.test.ts src/__tests__/status-report.test.ts` — 22 passed
- [x] `npm run build` — success
- [x] **End-to-end** (isolated `$HOME`, mock HTTP endpoint via `TEAMAI_HTTP_ENDPOINT`, trigger `hook-dispatch session-start --stdin`):
  - `--tool claude` → report body `"agent_version":"2.1.205"` (matches `claude --version`), not `0.17.2` ✅
  - `--tool codebuddy` → report body `"agent_version":"2.117.2"` (matches `codebuddy --version`), not `0.17.2` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)