### PR TITLE
feat(local-agent): gate org-binding prompt behind TEAMAI_BIND_PROMPT_ENABLED (default off)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ The value you pass to `--http <baseUrl>` is the base; every endpoint is relative
 | `TEAMAI_REPORT_PATHS` | JSON `{ "report", "sync", "ack" }` to override the three reporter paths |
 | `TEAMAI_REPORT_AGENTS` | Comma-separated agents that report (default `workbuddy,codebuddy`) |
 | `TEAMAI_SKILL_DOWNLOAD_HOSTS` | Comma-separated host allowlist for skill `download_url` (empty = allow all) |
+| `TEAMAI_BIND_PROMPT_ENABLED` | Set to `1` to enable the org-binding prompt (TTY prompt + injected hook hint). Off by default; `teamai bind-project` works regardless |
 
 </details>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -119,6 +119,7 @@ teamai init --http https://your-team-host/api --token <api-key>
 | `TEAMAI_REPORT_PATHS` | JSON `{ "report", "sync", "ack" }`，覆盖 reporter 三个路径 |
 | `TEAMAI_REPORT_AGENTS` | 参与上报的 agent，逗号分隔（默认 `workbuddy,codebuddy`） |
 | `TEAMAI_SKILL_DOWNLOAD_HOSTS` | skill `download_url` 的 host 白名单，逗号分隔（空 = 全部放行） |
+| `TEAMAI_BIND_PROMPT_ENABLED` | 设为 `1` 开启组织绑定提示（TTY 交互提示 + 注入的 hook 提示）。默认关闭；`teamai bind-project` 手动命令不受影响 |
 
 </details>
 

--- a/src/__tests__/local-agent.test.ts
+++ b/src/__tests__/local-agent.test.ts
@@ -22,6 +22,8 @@ beforeEach(async () => {
   origHome = process.env.HOME;
   process.env.HOME = tmpDir;
   origPpid = process.ppid;
+  // Bind prompt is off by default — start each test from that baseline.
+  delete process.env.TEAMAI_BIND_PROMPT_ENABLED;
   // Clean hint markers
   const markerPath = path.join(os.tmpdir(), `teamai-bind-hint-${process.ppid}`);
   await fse.remove(markerPath);
@@ -29,6 +31,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   process.env.HOME = origHome;
+  delete process.env.TEAMAI_BIND_PROMPT_ENABLED;
   const markerPath = path.join(os.tmpdir(), `teamai-bind-hint-${origPpid}`);
   await fse.remove(markerPath);
   await fse.remove(tmpDir);
@@ -123,6 +126,7 @@ describe('local-agent: bindCurrentProject --skip', () => {
 
 describe('local-agent: emitBindingHint via reportAndSyncLocalAgent', () => {
   it('outputs hookSpecificOutput with choices when project is unbound', async () => {
+    process.env.TEAMAI_BIND_PROMPT_ENABLED = '1';
     await setupConfig();
     const projectDir = path.join(tmpDir, 'unbound-project');
     await fse.ensureDir(projectDir);
@@ -179,7 +183,43 @@ describe('local-agent: emitBindingHint via reportAndSyncLocalAgent', () => {
     expect(ctx).toContain('teamai bind-project --skip');
   });
 
+  it('does NOT emit hint by default when TEAMAI_BIND_PROMPT_ENABLED is unset', async () => {
+    // No process.env.TEAMAI_BIND_PROMPT_ENABLED — bind prompt is off by default.
+    await setupConfig();
+    const projectDir = path.join(tmpDir, 'default-off-project');
+    await fse.ensureDir(projectDir);
+    const { execFileSync } = await import('node:child_process');
+    execFileSync('git', ['init'], { cwd: projectDir, stdio: 'ignore' });
+
+    const fetchMock = vi.fn(async (_url: string) => new Response(JSON.stringify({ ok: true })));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const stdoutChunks: string[] = [];
+    const origWrite = process.stdout.write;
+    process.stdout.write = ((chunk: string | Buffer) => {
+      stdoutChunks.push(typeof chunk === 'string' ? chunk : chunk.toString());
+      return true;
+    }) as typeof process.stdout.write;
+
+    try {
+      const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+      await reportAndSyncLocalAgent({
+        cwd: projectDir,
+        tool: 'claude',
+        event: { type: 'prompt_submit', timestamp: new Date().toISOString(), sessionId: 'test-session', tool: 'claude' },
+      });
+    } finally {
+      process.stdout.write = origWrite;
+    }
+
+    const output = stdoutChunks.join('');
+    expect(output).not.toContain('hookSpecificOutput');
+    // user-groups must not even be fetched when the prompt is disabled
+    expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/api/user-groups/mine'))).toBe(false);
+  });
+
   it('does NOT emit hint when project is already bound', async () => {
+    process.env.TEAMAI_BIND_PROMPT_ENABLED = '1';
     const projectDir = path.join(tmpDir, 'bound-project');
     await fse.ensureDir(projectDir);
     const { execFileSync } = await import('node:child_process');
@@ -215,6 +255,7 @@ describe('local-agent: emitBindingHint via reportAndSyncLocalAgent', () => {
   });
 
   it('does NOT emit hint when project is skipped (groupId 0)', async () => {
+    process.env.TEAMAI_BIND_PROMPT_ENABLED = '1';
     const projectDir = path.join(tmpDir, 'skipped-project');
     await fse.ensureDir(projectDir);
     const { execFileSync } = await import('node:child_process');

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -491,6 +491,16 @@ async function ensureWorkspaceBinding(
   process.stdout.write(hookOutput + '\n');
 }
 
+/**
+ * The organization-binding prompt (TTY prompt + injected hook context) is
+ * off by default. Enable it explicitly with `TEAMAI_BIND_PROMPT_ENABLED=1`.
+ * The manual `teamai bind-project` command is always available regardless.
+ */
+function isBindPromptEnabled(): boolean {
+  const flag = process.env.TEAMAI_BIND_PROMPT_ENABLED;
+  return flag === '1' || flag === 'true';
+}
+
 async function emitBindingHint(
   config: LocalAgentConfig,
   workspacePath: string,
@@ -1160,11 +1170,13 @@ export async function reportAndSyncLocalAgent(context: LocalAgentContext): Promi
   if (!config) return false;
 
   const workspacePath = await resolveWorkspacePath(context.cwd);
-  if (context.event?.type === 'session_start' && workspacePath) {
-    await ensureWorkspaceBinding(config, workspacePath);
-  }
-  if (context.event?.type === 'prompt_submit' && workspacePath) {
-    await emitBindingHint(config, workspacePath);
+  if (isBindPromptEnabled() && workspacePath) {
+    if (context.event?.type === 'session_start') {
+      await ensureWorkspaceBinding(config, workspacePath);
+    }
+    if (context.event?.type === 'prompt_submit') {
+      await emitBindingHint(config, workspacePath);
+    }
   }
 
   const tag = localAgentTag(context);


### PR DESCRIPTION
## What

The organization-binding prompt was **on by default**. This PR makes it **opt-in**.

Previously two triggers fired unconditionally on every unbound project:
- `ensureWorkspaceBinding` — on `session_start` (TTY prompt + injected `SessionStart` hook context)
- `emitBindingHint` — on `prompt_submit` (injected `UserPromptSubmit` context forcing the AI to render the binding menu)

There was no way to turn them off.

## Change

Both triggers are now gated behind a single env flag `TEAMAI_BIND_PROMPT_ENABLED`:
- Unset (default) → prompt is **off**; the `user-groups` endpoint is not even fetched.
- Set to `1` or `true` → prompt behaves exactly as before.

The manual `teamai bind-project` command is **unaffected** and always available.

Follows the existing env-toggle convention in the codebase (`TEAMAI_RECALL_DISABLED`, `TEAMAI_HOOKS_DISABLED`, `TEAMAI_MR_HINT_DISABLED`), using an *enable* flag here since the default is now off.

## Files

- `src/local-agent.ts` — add `isBindPromptEnabled()` helper; wrap both trigger points.
- `src/__tests__/local-agent.test.ts` — isolate the env in setup/teardown; existing binding tests set the flag; new test asserts default-off emits nothing and does not fetch user-groups.
- `README.md` / `README.zh-CN.md` — document the new env var (bilingual, kept in sync).

## Test Plan

- [x] `npx tsc --noEmit` — passes
- [x] `npx vitest run src/__tests__/local-agent.test.ts` — 13/13 pass
- [x] Real CLI E2E via `teamai hook-dispatch` (isolated HOME + local mock server):
  - Default (no env): `prompt_submit` and `session_start` inject **no** binding context (0 occurrences)
  - `TEAMAI_BIND_PROMPT_ENABLED=1`: both paths inject the full binding menu (1 occurrence)

> Note: the pre-existing `import-repo-merge.test.ts` failure is unrelated to this change — verified it also fails on a clean baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)