### PR TITLE
fix(local-agent): derive local_agent_id from per-tool install dir, not teamai home

### DIFF
--- a/src/__tests__/local-agent.test.ts
+++ b/src/__tests__/local-agent.test.ts
@@ -96,6 +96,54 @@ describe('local-agent: buildReportPayload disk scan', () => {
   });
 });
 
+describe('local-agent: local_agent_id derivation (per-tool install dir)', () => {
+  it('derives the id from ~/.<tool>, matching the historical status-report口径', async () => {
+    await setupConfig();
+    const { buildReportPayload, loadLocalAgentConfig } = await import('../local-agent.js');
+    const { deriveLocalAgentId, getMachineId } = await import('../machine-id.js');
+    const config = await loadLocalAgentConfig();
+
+    const payload = (await buildReportPayload(config!, { tool: 'codebuddy' })) as {
+      local_agent_id: string;
+    };
+
+    // Expected = same deterministic algorithm, seeded with the tool's own dir
+    // (~/.codebuddy), NOT the teamai home. This keeps the id byte-for-byte
+    // identical to what the status-report path produced pre-upgrade.
+    const expected = deriveLocalAgentId('codebuddy', getMachineId(), path.join(tmpDir, '.codebuddy'));
+    expect(payload.local_agent_id).toBe(expected);
+    // It must NOT be seeded with the teamai home (the drifted口径).
+    const drifted = deriveLocalAgentId('codebuddy', getMachineId(), path.join(tmpDir, '.teamai', 'local-agent'));
+    expect(payload.local_agent_id).not.toBe(drifted);
+  });
+
+  it('gives claude and codebuddy different ids on the same machine', async () => {
+    await setupConfig();
+    const { buildReportPayload, loadLocalAgentConfig } = await import('../local-agent.js');
+    const config = await loadLocalAgentConfig();
+
+    const claude = (await buildReportPayload(config!, { tool: 'claude' })) as { local_agent_id: string };
+    const codebuddy = (await buildReportPayload(config!, { tool: 'codebuddy' })) as { local_agent_id: string };
+
+    expect(claude.local_agent_id).not.toBe(codebuddy.local_agent_id);
+  });
+
+  it('honors TEAMAI_LOCAL_AGENT_ID override', async () => {
+    await setupConfig();
+    const prev = process.env.TEAMAI_LOCAL_AGENT_ID;
+    process.env.TEAMAI_LOCAL_AGENT_ID = 'pinned-xyz';
+    try {
+      const { buildReportPayload, loadLocalAgentConfig } = await import('../local-agent.js');
+      const config = await loadLocalAgentConfig();
+      const payload = (await buildReportPayload(config!, { tool: 'codebuddy' })) as { local_agent_id: string };
+      expect(payload.local_agent_id).toBe('pinned-xyz');
+    } finally {
+      if (prev === undefined) delete process.env.TEAMAI_LOCAL_AGENT_ID;
+      else process.env.TEAMAI_LOCAL_AGENT_ID = prev;
+    }
+  });
+});
+
 describe('local-agent: bindCurrentProject --skip', () => {
   it('writes groupId 0 and __skipped__ marker to config', async () => {
     await setupConfig();

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -167,20 +167,40 @@ function normalizeEndpoint(endpoint: string): string {
 }
 
 /**
+ * Resolve the per-tool install directory that seeds the local_agent_id hash.
+ *
+ * This must match the historical status-report口径 — `~/.<tool>` — so that a
+ * machine upgrading from the status-report era keeps the same id instead of
+ * drifting. It is derived from the same toolPaths map buildReportPayload uses:
+ * `~/<dirname(skills)>` (e.g. `.codebuddy/skills` → `~/.codebuddy`). Unknown
+ * tools fall back to `~/.<tool>`, still deterministic and distinct per tool.
+ * Note: install_path only feeds the local hash — it never leaves the machine.
+ */
+function resolveAgentInstallPath(agentType: string): string {
+  const home = process.env.HOME ?? '';
+  const skillsRel = createLocalAgentTeamConfig('').toolPaths[agentType]?.skills;
+  const rel = skillsRel ? path.dirname(skillsRel) : `.${agentType}`;
+  return path.join(home, rel);
+}
+
+/**
  * Resolve the local_agent_id for the current invocation.
  *
  * Deterministic per (detected tool + machine + install dir) — same tool on the
  * same machine always yields the same id, so the backend sees a stable agent
  * instead of a fresh random one every hook fire. The tool is auto-detected from
  * the hook's --tool flag (context.tool); different tools (claude / codebuddy /
- * workbuddy) get different ids by design. TEAMAI_LOCAL_AGENT_ID still overrides
- * for explicit pinning.
+ * workbuddy) get different ids because agent_type AND the per-tool install dir
+ * (~/.<tool>) both feed the hash. install_path uses the tool's own dir (not the
+ * teamai home) to stay byte-for-byte identical to the historical status-report
+ * derivation, avoiding an id change on upgrade. TEAMAI_LOCAL_AGENT_ID still
+ * overrides for explicit pinning.
  */
 function resolveLocalAgentId(context: LocalAgentContext): string {
   const envOverride = process.env.TEAMAI_LOCAL_AGENT_ID;
   if (envOverride) return envOverride;
   const agentType = context.tool ?? 'workbuddy';
-  return deriveLocalAgentId(agentType, getMachineId(), getLocalAgentHome());
+  return deriveLocalAgentId(agentType, getMachineId(), resolveAgentInstallPath(agentType));
 }
 
 /**


### PR DESCRIPTION
## Problem

The HTTP local-agent path seeds `deriveLocalAgentId()` with `getLocalAgentHome()` (`~/.teamai/local-agent`) — the **same** `install_path` for every tool. The historical status-report path instead used the tool's **own** dir (`~/.codebuddy`, `~/.claude`, from `toolPaths` skills dirname).

Since `install_path` feeds the id hash, a machine upgrading from the status-report era saw its `local_agent_id` **change**, so the backend counted one agent as two.

Measured on one machine (codebuddy):
- status-report era (0.17.2): `370e8ec0bf05fd60`
- current HTTP local-agent: `101a235cb52bcf67`

## Fix

**The algorithm is unchanged** (`machine-id.ts` untouched). Only the `install_path` input is realigned to the per-tool dir:

- New `resolveAgentInstallPath(agentType)` returns `~/<dirname(toolPaths[tool].skills)>` (e.g. `.codebuddy/skills` → `~/.codebuddy`), reusing the same `toolPaths` map `buildReportPayload` already uses. Unknown tools fall back to `~/.<tool>`.
- `resolveLocalAgentId` uses it instead of `getLocalAgentHome()`.
- `TEAMAI_LOCAL_AGENT_ID` override preserved.

Result: upgraded ids match the status-report era **byte-for-byte**, and different tools still get **distinct** ids (both `agent_type` and the per-tool dir feed the hash).

## Migration note

This changes the id **once more** for users already on the drifted (`~/.teamai/local-agent`) build, bringing them back in line with the larger status-report-era population. One-time realignment, by design.

## Test Plan

- [x] `npx tsc --noEmit` — passes
- [x] `npx vitest run src/__tests__/local-agent.test.ts src/__tests__/machine-id.test.ts` — 23 passed (incl. 3 new: per-tool口径, claude≠codebuddy, env override)
- [x] **End-to-end** (`teamai init --http` + `codebuddy -p test`, real backend):
  - codebuddy `local_agent_id` == `370e8ec0bf05fd60` (matches 0.17.2) ✅
  - claude `local_agent_id` == `8d8d13e2321c9482`, and ≠ codebuddy ✅
  - backend receipts: `local-codebuddy-05fd60`, `local-claude-1c9482`

🤖 Generated with [Claude Code](https://claude.com/claude-code)