### PR TITLE
fix(local-agent): scope install/uninstall to the triggering tool only

### DIFF
--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -969,7 +969,10 @@ async function installDownloadedResource(input: {
     const fullTeamConfig = createLocalAgentTeamConfig(input.config.endpoint);
     const tool = input.tool ?? 'workbuddy';
     const toolPath = fullTeamConfig.toolPaths[tool];
-    const teamConfig = { ...fullTeamConfig, toolPaths: toolPath ? { [tool]: toolPath } : {} };
+    if (!toolPath) {
+      throw new Error(`Unknown tool "${tool}": no toolPaths entry found`);
+    }
+    const teamConfig = { ...fullTeamConfig, toolPaths: { [tool]: toolPath } };
     const localConfig = createResourceLocalConfig(input.config, input.scope, repoPath, input.workspacePath);
     const now = new Date().toISOString();
     let displayName = input.command.display_name ?? input.slug;
@@ -1037,7 +1040,10 @@ async function uninstallResource(input: {
   const fullTeamConfig = createLocalAgentTeamConfig(input.config.endpoint);
   const tool = input.tool ?? 'workbuddy';
   const toolPath = fullTeamConfig.toolPaths[tool];
-  const teamConfig = { ...fullTeamConfig, toolPaths: toolPath ? { [tool]: toolPath } : {} };
+  if (!toolPath) {
+    throw new Error(`Unknown tool "${tool}": no toolPaths entry found`);
+  }
+  const teamConfig = { ...fullTeamConfig, toolPaths: { [tool]: toolPath } };
   const localConfig = createResourceLocalConfig(input.config, input.scope, repoPath, input.workspacePath);
   const manifest = await loadManifest();
   const scopeManifest = getManifestScope(manifest, input.scope, input.workspacePath);

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -952,6 +952,7 @@ async function installDownloadedResource(input: {
   slug: string;
   scope: LocalAgentScope;
   workspacePath?: string;
+  tool?: string;
 }): Promise<string | undefined> {
   if (!input.command.download_url) {
     throw new Error(`Missing download_url for ${input.command.type ?? 'install_skill'}`);
@@ -965,7 +966,10 @@ async function installDownloadedResource(input: {
 
   const downloadedPath = await downloadResource(input.command.download_url);
   try {
-    const teamConfig = createLocalAgentTeamConfig(input.config.endpoint);
+    const fullTeamConfig = createLocalAgentTeamConfig(input.config.endpoint);
+    const tool = input.tool ?? 'workbuddy';
+    const toolPath = fullTeamConfig.toolPaths[tool];
+    const teamConfig = { ...fullTeamConfig, toolPaths: toolPath ? { [tool]: toolPath } : {} };
     const localConfig = createResourceLocalConfig(input.config, input.scope, repoPath, input.workspacePath);
     const now = new Date().toISOString();
     let displayName = input.command.display_name ?? input.slug;
@@ -1027,9 +1031,13 @@ async function uninstallResource(input: {
   slug: string;
   scope: LocalAgentScope;
   workspacePath?: string;
+  tool?: string;
 }): Promise<void> {
   const repoPath = getResourceRepoPath(input.scope, input.workspacePath);
-  const teamConfig = createLocalAgentTeamConfig(input.config.endpoint);
+  const fullTeamConfig = createLocalAgentTeamConfig(input.config.endpoint);
+  const tool = input.tool ?? 'workbuddy';
+  const toolPath = fullTeamConfig.toolPaths[tool];
+  const teamConfig = { ...fullTeamConfig, toolPaths: toolPath ? { [tool]: toolPath } : {} };
   const localConfig = createResourceLocalConfig(input.config, input.scope, repoPath, input.workspacePath);
   const manifest = await loadManifest();
   const scopeManifest = getManifestScope(manifest, input.scope, input.workspacePath);
@@ -1144,11 +1152,12 @@ async function executeCommand(
   }
 
   const slug = commandSlug(command, kind);
+  const tool = context.tool;
   if (action === 'install') {
-    return installDownloadedResource({ config, command, kind, slug, scope, workspacePath });
+    return installDownloadedResource({ config, command, kind, slug, scope, workspacePath, tool });
   }
 
-  await uninstallResource({ config, kind, slug, scope, workspacePath });
+  await uninstallResource({ config, kind, slug, scope, workspacePath, tool });
   return commandVersion(command, kind);
 }
 


### PR DESCRIPTION
## Summary

- Narrow `toolPaths` in `installDownloadedResource` and `uninstallResource` to only the current `context.tool`
- Prevents a sync command targeting one tool (e.g. codebuddy) from installing/uninstalling resources in all other tool directories (workbuddy, claude, etc.)

## Root Cause

`SkillsHandler.pullItem()` and `RulesHandler.pullAllRules()` iterate over all entries in `teamConfig.toolPaths` and install to every tool directory that exists on disk. When `installDownloadedResource` passed the full `teamConfig`, a skill/rule distributed to codebuddy would also land in `.workbuddy/skills/`, `.claude/skills/`, etc.

## Fix

Construct a scoped `teamConfig` with only the triggering tool's path before passing it to the resource handlers. The `tool` parameter is threaded from `executeCommand`'s `context.tool` (which comes from the `--tool` CLI flag on the hook).

## Test plan

- [x] Distribute a skill to codebuddy via ClawPro → verify it only appears in `.codebuddy/skills/`, not `.workbuddy/skills/`
- [x] Uninstall a skill from codebuddy → verify it's only removed from `.codebuddy/skills/`
- [x] Distribute a rule to workbuddy → verify it only appears in `.workbuddy/rules/`
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)