### PR TITLE
feat(votes): enforce adoption declaration at session stop

### DIFF
--- a/agents/teamai-recall.md
+++ b/agents/teamai-recall.md
@@ -135,6 +135,7 @@ Return your output in **this exact format** to the main conversation:
 - The trailing HTML comment **must** list every doc_id you returned —
   later phases (Phase 3 Stop hook) will parse this from the conversation
   transcript.
+- **不要自己输出带内容的 `teamai:referenced-doc-ids` 标记** —— 那是主对话的职责。你只需在返回末尾另起一行提示主对话：`👉 主对话：完成任务后请在最终回复末尾声明实际引用的 doc-id（从上面 recalled-doc-ids 列表中挑出真正用到的），方括号内只填用到的、没用到就留空。` 这样主对话是"剪枝"而非"凭记忆重建"，能显著提高声明率。
 
 ## Hard rules
 

--- a/src/__tests__/transcript-parser.test.ts
+++ b/src/__tests__/transcript-parser.test.ts
@@ -128,4 +128,104 @@ describe('parseTranscriptForVotes', () => {
     expect(result.referencedDocIds).toContain('doc-a');
     expect(result.referencedDocIds).toContain('doc-b');
   });
+
+  it('recalled-doc-ids comment in a tool_result (non-assistant) line is detected', async () => {
+    const filePath = path.join(tmpDir, 'transcript.jsonl');
+    writeLine(filePath, {
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [{
+          type: 'tool_result',
+          content: 'Some tool output here.<!-- teamai:recalled-doc-ids: [doc-a, doc-b] -->',
+        }],
+      },
+    });
+    writeLine(filePath, {
+      type: 'assistant',
+      message: {
+        content: [{
+          type: 'text',
+          text: 'Here is my answer with no referenced marker.',
+        }],
+      },
+    });
+
+    const result = await parseTranscriptForVotes(filePath);
+    expect(result.recalledDocIds).toContain('doc-a');
+    expect(result.recalledDocIds).toContain('doc-b');
+    expect(result.recalledDocIds).toHaveLength(2);
+    expect(result.referencedDocIds).toEqual([]);
+  });
+
+  it('referenced-doc-ids in a non-assistant line is NOT counted (assistant-only guard)', async () => {
+    const filePath = path.join(tmpDir, 'transcript.jsonl');
+    writeLine(filePath, {
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [{
+          type: 'tool_result',
+          content: 'Tool output.<!-- teamai:referenced-doc-ids: [doc-x] --><!-- teamai:recalled-doc-ids: [doc-y] -->',
+        }],
+      },
+    });
+
+    const result = await parseTranscriptForVotes(filePath);
+    expect(result.referencedDocIds).not.toContain('doc-x');
+    expect(result.referencedDocIds).toEqual([]);
+    expect(result.recalledDocIds).toContain('doc-y');
+  });
+
+  it('placeholder recalled-doc-ids are filtered', async () => {
+    const filePath = path.join(tmpDir, 'transcript.jsonl');
+    writeLine(filePath, {
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [{
+          type: 'tool_result',
+          content: 'Some output.<!-- teamai:recalled-doc-ids: [<id1>, <id2>, ...] -->',
+        }],
+      },
+    });
+    writeLine(filePath, {
+      type: 'assistant',
+      message: {
+        content: [{
+          type: 'text',
+          text: 'Here is my answer with no marker.',
+        }],
+      },
+    });
+
+    const result = await parseTranscriptForVotes(filePath);
+    expect(result.recalledDocIds).toHaveLength(0);
+  });
+
+  it('mixed real + placeholder recalled-doc-ids keeps only real', async () => {
+    const filePath = path.join(tmpDir, 'transcript.jsonl');
+    writeLine(filePath, {
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [{
+          type: 'tool_result',
+          content: 'Some output.<!-- teamai:recalled-doc-ids: [<id1>, real-doc-id] -->',
+        }],
+      },
+    });
+    writeLine(filePath, {
+      type: 'assistant',
+      message: {
+        content: [{
+          type: 'text',
+          text: 'Here is my answer with no marker.',
+        }],
+      },
+    });
+
+    const result = await parseTranscriptForVotes(filePath);
+    expect(result.recalledDocIds).toEqual(['real-doc-id']);
+  });
 });

--- a/src/builtin-rules.ts
+++ b/src/builtin-rules.ts
@@ -126,14 +126,17 @@ teamai recall "<关键词1> <关键词2> ..."
 
 从任务描述中提取 3-6 个高信号关键词进行检索。
 
-### 检索后要求
+### 检索后要求（用于评估知识被采纳情况，请务必执行）
 
-完成任务后，在最终回复中声明实际引用了哪些知识条目：
+teamai-recall subagent 的返回里已列出本次检索到的候选 doc-id（见其 recalled-doc-ids 列表）。
+你**不需要凭记忆重建列表**——只需在**最终回复末尾**追加下面这行，
+从候选里**保留你实际用到的**（照抄了命令、或概念上参考了，都算用到），删掉没用到的：
 
 \`\`\`
-<!-- teamai:referenced-doc-ids: [doc-id-1, doc-id-2] -->
+<!-- teamai:referenced-doc-ids: [你实际用到的-doc-id] -->
 \`\`\`
 
-如无相关命中则声明空列表：\`<!-- teamai:referenced-doc-ids: [] -->\`
+一个都没用到就留空：\`<!-- teamai:referenced-doc-ids: [] -->\`。
+若直接用 \`teamai recall\` 命令（未走 subagent），从召回结果的 File 路径推出 doc-id 自行填入。
 `;
 

--- a/src/hook-handlers.ts
+++ b/src/hook-handlers.ts
@@ -169,7 +169,7 @@ const contributeCheckHandler: HookHandler = {
 
 const votesSyncHandler: HookHandler = {
   name: 'votes-sync',
-  async execute(stdin) {
+  async execute(stdin, tool) {
     if (process.env.TEAMAI_RECALL_DISABLED === '1') return null;
 
     const transcriptPath = typeof stdin.transcript_path === 'string' ? stdin.transcript_path : null;
@@ -180,22 +180,74 @@ const votesSyncHandler: HookHandler = {
       const { incrementUpvoted, syncVotesToTeam } = await import('./votes.js');
       const { requireInit } = await import('./config.js');
 
-      // recalledDocIds are already counted by autoUpvote() at recall time;
-      // we only need referencedDocIds (adopted signal) from the transcript.
       const voteData = await parseTranscriptForVotes(transcriptPath);
-
       const { localConfig } = await requireInit();
-      const { VOTES_LOCAL_DIR } = await import('./types.js');
+      const { VOTES_LOCAL_DIR, TEAMAI_SESSIONS_DIR } = await import('./types.js');
       const votesDir = VOTES_LOCAL_DIR;
       const votePath = path.join(votesDir, `${localConfig.username}.yaml`);
 
+      // Record the adoptions the main conversation declared.
       if (voteData.referencedDocIds.length > 0) {
         await incrementUpvoted(votePath, voteData.referencedDocIds);
       }
-
       await syncVotesToTeam(localConfig.repo.localPath, localConfig.username, votesDir).catch(() => {
-        // Push failed — will retry next session via reportUsageToTeam
+        // Push failed — will retry next session
       });
+
+      // Enforcement: recall happened but nothing was declared → nudge the model
+      // once to declare which recalled docs it actually used. The nudge makes the
+      // model continue; on the next Stop the declaration is recorded above.
+      const sessionId = deriveSessionId(stdin, { includeCwd: true });
+      const recalled = voteData.recalledDocIds;
+      const declared = voteData.referencedDocIds;
+      let nudged = false;
+
+      if (recalled.length > 0 && declared.length === 0) {
+        const fsp = await import('node:fs/promises');
+        const safeId = sessionId.replace(/[^a-zA-Z0-9_.-]/g, '_');
+        const marker = path.join(TEAMAI_SESSIONS_DIR, `${safeId}-adoption-nudged`);
+        let already = false;
+        try { await fsp.access(marker); already = true; } catch { already = false; }
+        if (!already) {
+          try {
+            const { ensureDir } = await import('./utils/fs.js');
+            await ensureDir(TEAMAI_SESSIONS_DIR);
+            await fsp.writeFile(marker, '');
+            // Only nudge once we've persisted the marker, so a write failure
+            // degrades to "no nudge this Stop" rather than re-nudging every Stop.
+            nudged = true;
+          } catch {
+            // Could not persist the marker — skip the nudge this Stop; retry next.
+          }
+        }
+      }
+
+      // A/B measurement (opt-in): one line per Stop.
+      if (process.env.TEAMAI_ADOPTION_EVAL_LOG) {
+        try {
+          const { appendFile } = await import('node:fs/promises');
+          await appendFile(
+            process.env.TEAMAI_ADOPTION_EVAL_LOG,
+            JSON.stringify({
+              ts: new Date().toISOString(),
+              sessionId,
+              recalled: recalled.length,
+              declared: declared.length,
+              nudged,
+            }) + '\n',
+          );
+        } catch {
+          // best-effort; measurement only
+        }
+      }
+
+      if (nudged) {
+        const { formatStopHookOutput } = await import('./utils/hook-output.js');
+        const msg =
+          `你本次通过 teamai 召回了团队知识（候选 doc-id：${recalled.join(', ')}）。` +
+          `结束前请在回复末尾声明你实际用到的条目：<!-- teamai:referenced-doc-ids: [用到的doc-id] -->；没用到就留空 []。`;
+        return formatStopHookOutput(msg, tool ?? 'claude');
+      }
     } catch {
       // Non-critical — votes will sync on next pull
     }
@@ -257,8 +309,8 @@ export function buildHandlerRegistry(): HandlerRegistration[] {
 
     // ─── Stop ─────────────────────────────────────────
     { event: 'stop', matcher: '*', handler: updateHandler, timeoutMs: UPDATE_TIMEOUT_MS },
-    { event: 'stop', matcher: '*', handler: contributeCheckHandler, timeoutMs: CONTRIBUTE_CHECK_TIMEOUT_MS },
     { event: 'stop', matcher: '*', handler: votesSyncHandler, timeoutMs: VOTES_SYNC_TIMEOUT_MS },
+    { event: 'stop', matcher: '*', handler: contributeCheckHandler, timeoutMs: CONTRIBUTE_CHECK_TIMEOUT_MS },
     { event: 'stop', matcher: '*', handler: dashboardReportHandler, timeoutMs: DASHBOARD_TIMEOUT_MS },
     { event: 'stop', matcher: '*', handler: localAgentHandler, timeoutMs: LOCAL_AGENT_TIMEOUT_MS },
 

--- a/src/transcript-parser.ts
+++ b/src/transcript-parser.ts
@@ -30,7 +30,14 @@ export async function parseTranscriptForVotes(transcriptPath: string): Promise<T
 
   for await (const line of rl) {
     const trimmed = line.trim();
-    if (!trimmed || !trimmed.includes('"assistant"')) continue;
+    if (!trimmed) continue;
+
+    // The teamai-recall subagent emits `<!-- teamai:recalled-doc-ids: [...] -->`;
+    // in the subagent path it lands in the main transcript as a tool_result (not
+    // an assistant text block), so scan every raw line regardless of role.
+    extractRecalledDocIdsFromComment(trimmed, recalledSet);
+
+    if (!trimmed.includes('"assistant"')) continue;
 
     let entry: Record<string, unknown>;
     try {
@@ -60,6 +67,26 @@ export async function parseTranscriptForVotes(transcriptPath: string): Promise<T
   };
 }
 
+/**
+ * Reject placeholder-shaped tokens (e.g. `<id1>`, `<id2>`, `...`) that appear in
+ * documentation/agent example markers. Real doc-ids are kebab-case slugs and
+ * never contain angle brackets nor are a bare ellipsis.
+ */
+function isValidDocId(docId: string): boolean {
+  return docId.length > 0 && !/[<>]/.test(docId) && docId !== '...';
+}
+
+function extractRecalledDocIdsFromComment(text: string, out: Set<string>): void {
+  const pattern = /<!--\s*teamai:recalled-doc-ids:\s*\[([^\]]*)\]\s*-->/g;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(text)) !== null) {
+    for (const item of match[1].split(',')) {
+      const docId = item.trim().replace(/^['"]|['"]$/g, '');
+      if (isValidDocId(docId)) out.add(docId);
+    }
+  }
+}
+
 function extractRecalledDocIds(text: string, out: Set<string>): void {
   const START = '--- [teamai:recall:start] ---';
   const END = '--- [teamai:recall:end] ---';
@@ -80,7 +107,7 @@ function extractRecalledDocIds(text: string, out: Set<string>): void {
     while ((match = filePattern.exec(region)) !== null) {
       const filePath = match[1].trim();
       const docId = path.basename(filePath).replace(/\.md$/i, '');
-      out.add(docId);
+      if (isValidDocId(docId)) out.add(docId);
     }
 
     searchFrom = endIdx + END.length;
@@ -95,7 +122,7 @@ function extractReferencedDocIds(text: string, out: Set<string>): void {
     const raw = match[1];
     for (const item of raw.split(',')) {
       const docId = item.trim().replace(/^['"]|['"]$/g, '');
-      if (docId) out.add(docId);
+      if (isValidDocId(docId)) out.add(docId);
     }
   }
 }


### PR DESCRIPTION
## Summary

`upvoted_count` (knowledge adoption) is near-zero in production because it relied on the model spontaneously emitting a `referenced-doc-ids` declaration at session end — which it forgets in long sessions. A controlled A/B (`claude -p`, 6 tasks × 2 arms) showed **wording is not the bottleneck** (both old and new wording declared 100% of the time when the recall context is salient); the real cause is that the end-of-session bookkeeping step is simply skipped as sessions grow.

So this makes the declaration **enforced** rather than passive, while keeping the **main conversation as the judge** (the only entity that knows what it actually used, including concept-level adoption — no signature/heuristic guessing):

- When a session recalled knowledge (`recalled-doc-ids`) but declared nothing (`referenced-doc-ids` empty), the Stop hook nudges the model **once** via `additionalContext` to declare which recalled docs it actually used. The declaration is recorded on the next Stop; a per-session marker prevents re-nudging.
- Enforcement runs at Stop (after the task is done), so it does not interfere with problem-solving, and no heavy always-on rule is added to the context.

### Changes
- **transcript-parser**: detect the `teamai-recall` subagent's `<!-- teamai:recalled-doc-ids: [...] -->` across the whole transcript (it arrives as a `tool_result`, not assistant text); keep `referenced-doc-ids` assistant-only (pollution guard); filter placeholder ids like `<id1>`.
- **hook-handlers**: enforce declaration in `votesSyncHandler`; reorder `votes-sync` before `contribute-check` so the nudge wins the first Stop's output slot (contribute-check's hint then fires on the post-nudge second Stop).
- **builtin-rules / teamai-recall.md**: reword to "prune the recalled candidates" and forbid the subagent from emitting a filled `referenced-doc-ids` marker.
- Keeps `upvoted_count` (no schema change). Opt-in `TEAMAI_ADOPTION_EVAL_LOG` records `{recalled, declared, nudged}` per session for measurement.

## Test Plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — success
- [x] `npx vitest run` — 1676 passed; the 3 failures in `local-agent.test.ts` are pre-existing and unrelated (reproduce on the base ref with these changes stashed)
- [x] Unit tests added: recalled-doc-ids in a `tool_result` is detected; referenced-doc-ids in non-assistant lines is NOT counted; placeholder ids filtered
- [x] Hook-level e2e (real `hook-dispatch stop`): recall-without-declaration → single nudge + marker; repeat → no re-nudge (guard); declaration → `upvoted_count` recorded + synced
- [x] Real `claude` linchpin: a Stop-hook nudge makes the model emit a correctly-pruned `referenced-doc-ids` (both `additionalContext` and `decision:block` shapes work)
- [x] Full real-environment chain (isolated HOME, real `claude`, real `teamai-recall` subagent, real knowledge base): recall → subagent `recalled-doc-ids` reaches the main transcript → parser detects it → model declares the docs it used → Stop hook records `upvoted_count` only for declared docs (recalled-but-undeclared correctly not upvoted)

> Note: enforcement depends on the tool consuming Stop-hook `additionalContext`. Claude Code CLI: confirmed. Hosts that ignore it degrade to today's passive behavior (no worse than current).

🤖 Generated with [Claude Code](https://claude.com/claude-code)