### PR TITLE
feat(local-agent): install/update plugins via sync

### DIFF
--- a/src/__tests__/local-agent.test.ts
+++ b/src/__tests__/local-agent.test.ts
@@ -462,3 +462,145 @@ describe('local-agent: skill directory naming (SKILL.md name vs server slug)', (
     expect(manifest.scopes.user.skills['server-slug-xyz'].dir_name).toBeUndefined();
   });
 });
+
+// The npm layer is mocked so plugin install/uninstall orchestration (manifest,
+// idempotency, registry-vs-tarball dispatch) can be tested without spawning npm.
+const npmMock = vi.hoisted(() => ({ install: vi.fn(), uninstall: vi.fn(), getVersion: vi.fn() }));
+vi.mock('../plugin-installer.js', () => ({
+  installPluginPackage: npmMock.install,
+  uninstallPluginPackage: npmMock.uninstall,
+  getInstalledPluginVersion: npmMock.getVersion,
+}));
+
+describe('local-agent: plugin install/update/uninstall', () => {
+  const port = 42010;
+
+  beforeEach(() => {
+    npmMock.install.mockReset().mockResolvedValue(undefined);
+    npmMock.uninstall.mockReset().mockResolvedValue(undefined);
+    // Default: package not installed on disk, so installs proceed.
+    npmMock.getVersion.mockReset().mockResolvedValue(undefined);
+  });
+
+  async function runCommand(command: Record<string, unknown>) {
+    await setupConfig();
+    const acks: Array<Record<string, unknown>> = [];
+    const fetchMock = vi.fn(async (input: string | URL, init?: { body?: string }) => {
+      const url = String(input);
+      if (url.includes('/plugin.tgz')) return new Response(Buffer.from('fake-tarball'));
+      if (url.includes('/local-agent/sync')) {
+        return new Response(JSON.stringify({ ok: true, commands: [command] }));
+      }
+      if (url.includes('/commands/ack')) acks.push(JSON.parse(init?.body ?? '{}'));
+      return new Response(JSON.stringify({ ok: true }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ cwd: tmpDir, tool: 'codebuddy', status: 'running' });
+    return acks;
+  }
+
+  const readPlugins = async () => {
+    const manifest = await fse.readJson(path.join(tmpDir, '.teamai', 'local-agent', 'manifest.json'));
+    return manifest.scopes.user?.plugins ?? {};
+  };
+
+  it('installs a registry package and records it in the manifest', async () => {
+    const acks = await runCommand({
+      id: 1, type: 'install_plugin', plugin_slug: 'cls', plugin_package: '@t/cls-agent', plugin_version: '1.0.0',
+    });
+
+    expect(acks[0]).toMatchObject({ status: 'success', version: '1.0.0' });
+    expect(npmMock.install).toHaveBeenCalledWith({ package: '@t/cls-agent', version: '1.0.0' });
+    const plugins = await readPlugins();
+    expect(plugins.cls).toMatchObject({ slug: 'cls', package: '@t/cls-agent', version: '1.0.0', source: 'enterprise' });
+  });
+
+  it('is idempotent when the installed version already matches', async () => {
+    const cmd = { id: 1, type: 'install_plugin', plugin_slug: 'cls', plugin_package: '@t/cls-agent', plugin_version: '1.0.0' };
+    await runCommand(cmd);
+    // Now npm reports the package present at the requested version on disk.
+    npmMock.getVersion.mockResolvedValue('1.0.0');
+    await runCommand({ ...cmd, id: 2 });
+    expect(npmMock.install).toHaveBeenCalledTimes(1);
+  });
+
+  it('reinstalls when the manifest is stale but the package is gone from disk', async () => {
+    const cmd = { id: 1, type: 'install_plugin', plugin_slug: 'cls', plugin_package: '@t/cls-agent', plugin_version: '1.0.0' };
+    await runCommand(cmd);
+    // Manifest still records v1, but npm reports it absent → must reinstall.
+    npmMock.getVersion.mockResolvedValue(undefined);
+    await runCommand({ ...cmd, id: 2 });
+    expect(npmMock.install).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips an unpinned install when the package is already present', async () => {
+    npmMock.getVersion.mockResolvedValue('1.0.0'); // already installed at some version
+    const acks = await runCommand({ id: 1, type: 'install_plugin', plugin_slug: 'cls', plugin_package: '@t/cls-agent' });
+    expect(npmMock.install).not.toHaveBeenCalled();
+    expect(acks[0]).toMatchObject({ status: 'success', version: '1.0.0' });
+    expect((await readPlugins()).cls).toMatchObject({ package: '@t/cls-agent', version: '1.0.0' });
+  });
+
+  it('upgrades when a new version is requested', async () => {
+    await runCommand({ id: 1, type: 'install_plugin', plugin_slug: 'cls', plugin_package: '@t/cls-agent', plugin_version: '1.0.0' });
+    npmMock.getVersion.mockResolvedValue('1.0.0');
+    await runCommand({ id: 2, type: 'install_plugin', plugin_slug: 'cls', plugin_package: '@t/cls-agent', plugin_version: '2.0.0' });
+    expect(npmMock.install).toHaveBeenCalledTimes(2);
+    expect(npmMock.install).toHaveBeenLastCalledWith({ package: '@t/cls-agent', version: '2.0.0' });
+    expect((await readPlugins()).cls.version).toBe('2.0.0');
+  });
+
+  it('installs from a tarball when download_url is given', async () => {
+    await runCommand({
+      id: 1, type: 'install_plugin', plugin_slug: 'cls', plugin_package: '@t/cls-agent',
+      plugin_version: '1.0.0', download_url: `http://127.0.0.1:${port}/plugin.tgz`,
+    });
+    expect(npmMock.install).toHaveBeenCalledWith({ tarballPath: expect.stringMatching(/\.tgz$/) });
+    expect((await readPlugins()).cls.package).toBe('@t/cls-agent');
+  });
+
+  it('fails when plugin_package is missing', async () => {
+    const acks = await runCommand({ id: 1, type: 'install_plugin', plugin_slug: 'cls', plugin_version: '1.0.0' });
+    expect(acks[0]).toMatchObject({ status: 'failed' });
+    expect(acks[0].error).toMatch(/plugin_package/);
+    expect(npmMock.install).not.toHaveBeenCalled();
+  });
+
+  it('uninstalls by the recorded npm package name and drops the manifest entry', async () => {
+    await runCommand({ id: 1, type: 'install_plugin', plugin_slug: 'cls', plugin_package: '@t/cls-agent', plugin_version: '1.0.0' });
+    await runCommand({ id: 2, type: 'uninstall_plugin', plugin_slug: 'cls' });
+    expect(npmMock.uninstall).toHaveBeenCalledWith('@t/cls-agent');
+    expect((await readPlugins()).cls).toBeUndefined();
+  });
+
+  it('skips npm uninstall when no manifest entry exists for the slug', async () => {
+    const acks = await runCommand({ id: 1, type: 'uninstall_plugin', plugin_slug: 'never-installed' });
+    expect(npmMock.uninstall).not.toHaveBeenCalled();
+    expect(acks[0]).toMatchObject({ status: 'success' });
+  });
+
+  it('drops the record without npm uninstall when the entry has no package name', async () => {
+    await setupConfig();
+    const mdir = path.join(tmpDir, '.teamai', 'local-agent');
+    await fse.ensureDir(mdir);
+    await fse.writeJson(path.join(mdir, 'manifest.json'), {
+      scopes: { user: { skills: {}, rules: {}, claudemd: {}, plugins: { cls: { slug: 'cls', version: '1.0.0', installed_at: 'x' } } } },
+    });
+    await runCommand({ id: 1, type: 'uninstall_plugin', plugin_slug: 'cls' });
+    expect(npmMock.uninstall).not.toHaveBeenCalled();
+    expect((await readPlugins()).cls).toBeUndefined();
+  });
+
+  it('reports installed plugins at user level', async () => {
+    await runCommand({ id: 1, type: 'install_plugin', plugin_slug: 'cls', plugin_package: '@t/cls-agent', plugin_version: '1.0.0' });
+    const { buildReportPayload, loadLocalAgentConfig } = await import('../local-agent.js');
+    const config = await loadLocalAgentConfig();
+    const payload = (await buildReportPayload(config!, { tool: 'codebuddy' })) as {
+      user_level: { plugins: Array<{ slug: string; version?: string; source: string }> };
+    };
+    expect(payload.user_level.plugins).toEqual([
+      { slug: 'cls', version: '1.0.0', display_name: 'cls', source: 'enterprise' },
+    ]);
+  });
+});

--- a/src/__tests__/plugin-installer.test.ts
+++ b/src/__tests__/plugin-installer.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// execFile is mocked so the npm-argument logic and error mapping can be tested
+// without spawning a real npm process. The mock forwards to a mutable spy so
+// each test can control the callback outcome.
+const execFileMock = vi.fn();
+vi.mock('node:child_process', () => ({
+  execFile: (...args: unknown[]) => (execFileMock as (...a: unknown[]) => void)(...args),
+}));
+
+const {
+  buildNpmInstallArgs,
+  buildNpmUninstallArgs,
+  installPluginPackage,
+  uninstallPluginPackage,
+  getInstalledPluginVersion,
+} = await import('../plugin-installer.js');
+
+beforeEach(() => {
+  execFileMock.mockReset();
+});
+
+describe('plugin-installer: npm argument building', () => {
+  it('installs a registry package pinned to a version', () => {
+    expect(buildNpmInstallArgs({ package: 'my-plugin', version: '1.2.0' }))
+      .toEqual(['install', '--global', 'my-plugin@1.2.0']);
+  });
+
+  it('installs a registry package without a version', () => {
+    expect(buildNpmInstallArgs({ package: 'my-plugin' }))
+      .toEqual(['install', '--global', 'my-plugin']);
+  });
+
+  it('installs a scoped registry package', () => {
+    expect(buildNpmInstallArgs({ package: '@scope/plugin', version: '2.0.0' }))
+      .toEqual(['install', '--global', '@scope/plugin@2.0.0']);
+  });
+
+  it('prefers a tarball path over a registry package', () => {
+    expect(buildNpmInstallArgs({ package: 'my-plugin', version: '1.0.0', tarballPath: '/tmp/x.tgz' }))
+      .toEqual(['install', '--global', '/tmp/x.tgz']);
+  });
+
+  it('throws when neither package nor tarball is given', () => {
+    expect(() => buildNpmInstallArgs({})).toThrow(/package name or a tarball/);
+  });
+
+  it('builds uninstall args by package name', () => {
+    expect(buildNpmUninstallArgs('@scope/plugin')).toEqual(['uninstall', '--global', '@scope/plugin']);
+  });
+});
+
+describe('plugin-installer: npm execution', () => {
+  it('resolves when npm exits successfully', async () => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb: (e: unknown, r: unknown) => void) =>
+      cb(null, { stdout: 'ok', stderr: '' }));
+    await expect(installPluginPackage({ package: 'p', version: '1.0.0' })).resolves.toBeUndefined();
+    expect(execFileMock).toHaveBeenCalledWith('npm', ['install', '--global', 'p@1.0.0'], expect.any(Object), expect.any(Function));
+  });
+
+  it('maps a missing npm binary to a clear error', async () => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb: (e: unknown) => void) => {
+      const err = Object.assign(new Error('spawn npm ENOENT'), { code: 'ENOENT' });
+      cb(err);
+    });
+    await expect(uninstallPluginPackage('p')).rejects.toThrow(/npm not found on PATH/);
+  });
+
+  it('surfaces npm stderr on failure', async () => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb: (e: unknown) => void) => {
+      cb(Object.assign(new Error('exit 1'), { stderr: '  E404 not found  ' }));
+    });
+    await expect(installPluginPackage({ package: 'nope', version: '9.9.9' })).rejects.toThrow(/E404 not found/);
+  });
+});
+
+describe('plugin-installer: getInstalledPluginVersion', () => {
+  it('returns the installed version from npm ls JSON', async () => {
+    execFileMock.mockImplementation((_c, _a, _o, cb: (e: unknown, r: unknown) => void) =>
+      cb(null, { stdout: JSON.stringify({ dependencies: { 'my-plugin': { version: '1.2.3' } } }), stderr: '' }));
+    await expect(getInstalledPluginVersion('my-plugin')).resolves.toBe('1.2.3');
+  });
+
+  it('returns undefined when the package is absent (npm ls exits non-zero with stdout)', async () => {
+    execFileMock.mockImplementation((_c, _a, _o, cb: (e: unknown) => void) =>
+      cb(Object.assign(new Error('exit 1'), { code: 'ELSPROBLEMS', stdout: JSON.stringify({ dependencies: {} }) })));
+    await expect(getInstalledPluginVersion('missing')).resolves.toBeUndefined();
+  });
+
+  it('throws a clear error when npm is missing', async () => {
+    execFileMock.mockImplementation((_c, _a, _o, cb: (e: unknown) => void) =>
+      cb(Object.assign(new Error('spawn npm ENOENT'), { code: 'ENOENT' })));
+    await expect(getInstalledPluginVersion('x')).rejects.toThrow(/npm not found on PATH/);
+  });
+});

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -241,6 +241,54 @@ async function saveManifest(manifest: LocalAgentManifest): Promise<void> {
   await writeJson(getManifestPath(), manifest);
 }
 
+/**
+ * Serialize a manifest read-modify-write across concurrent teamai processes
+ * (hook events can fire in parallel, each running its own sync). A best-effort
+ * cross-process lock file is taken with O_EXCL; `mutate` gets a freshly loaded
+ * manifest and its changes are persisted before the lock is released. Without
+ * this, two interleaved processes each load → mutate → save, and the last save
+ * silently drops the other's entry (lost update). If the lock cannot be taken
+ * within the timeout (or a stale lock is found), it proceeds anyway rather than
+ * failing the command — correctness is best-effort, not guaranteed.
+ */
+async function withManifestLock<T>(
+  mutate: (manifest: LocalAgentManifest) => Promise<T> | T,
+): Promise<T> {
+  const lockPath = `${getManifestPath()}.lock`;
+  await ensureDir(path.dirname(lockPath));
+  const deadline = Date.now() + 5000;
+  let acquired = false;
+  while (Date.now() <= deadline) {
+    try {
+      const fd = await fs.promises.open(lockPath, 'wx');
+      await fd.close();
+      acquired = true;
+      break;
+    } catch (e) {
+      if ((e as { code?: string }).code !== 'EEXIST') throw e;
+      try {
+        // Reclaim a lock left behind by a crashed process.
+        const st = await fs.promises.stat(lockPath);
+        if (Date.now() - st.mtimeMs > 30_000) {
+          await fs.promises.rm(lockPath, { force: true });
+          continue;
+        }
+      } catch {
+        continue; // lock vanished between open and stat — retry immediately
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+  try {
+    const manifest = await loadManifest();
+    const result = await mutate(manifest);
+    await saveManifest(manifest);
+    return result;
+  } finally {
+    if (acquired) await fs.promises.rm(lockPath, { force: true });
+  }
+}
+
 function getManifestScope(
   manifest: LocalAgentManifest,
   scope: LocalAgentScope,
@@ -842,10 +890,7 @@ function commandVersion(command: LocalAgentCommand, kind: CommandResourceKind): 
 }
 
 function manifestKind(kind: CommandResourceKind): ResourceKind {
-  return kind === 'skill' ? 'skills'
-    : kind === 'rule' ? 'rules'
-    : kind === 'plugin' ? 'plugins'
-    : 'claudemd';
+  return kind === 'skill' ? 'skills' : kind === 'rule' ? 'rules' : 'claudemd';
 }
 
 /** Only http(s) downloads are allowed — reject file:, ftp:, gopher:, etc. */
@@ -862,12 +907,19 @@ function assertHttpUrl(rawUrl: string): URL {
   return parsed;
 }
 
+/** Hard caps on a resource download so a huge or slow URL cannot exhaust
+ * memory or stall the command loop. */
+const MAX_DOWNLOAD_BYTES = 100 * 1024 * 1024;
+const DOWNLOAD_TIMEOUT_MS = 60_000;
+
 /**
- * Fetch a resource by URL. download_url comes from backend sync commands, so it
- * is treated as untrusted: only http(s) is honoured (no file:// / local-path
- * copy, which would be arbitrary local file read), and redirects are followed
- * manually so every hop's scheme is re-validated instead of blindly trusting
- * whatever Location the server returns.
+ * Fetch a resource by URL. download_url comes from backend sync commands. Only
+ * http(s) is honoured (no file:// / local-path copy, which would be arbitrary
+ * local file read), and redirects are followed manually so every hop's scheme
+ * is re-validated instead of trusting whatever Location the server returns.
+ * This does NOT constrain the host, so it is not an SSRF guard — the backend is
+ * trusted to point only at legitimate package URLs. The body is size-capped and
+ * the request is bounded by a timeout.
  */
 async function downloadResource(downloadUrl: string): Promise<string> {
   const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'teamai-local-agent-'));
@@ -877,7 +929,7 @@ async function downloadResource(downloadUrl: string): Promise<string> {
   let response: Response;
   const maxRedirects = 5;
   for (let hop = 0; ; hop++) {
-    response = await fetch(current, { redirect: 'manual' });
+    response = await fetch(current, { redirect: 'manual', signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS) });
     if (response.status >= 300 && response.status < 400) {
       const location = response.headers.get('location');
       if (!location) break;
@@ -893,7 +945,15 @@ async function downloadResource(downloadUrl: string): Promise<string> {
   if (!response.ok) {
     throw new Error(`Download failed: ${response.status} ${response.statusText}`);
   }
+  // Reject before buffering when the server declares an oversized body.
+  const declared = Number(response.headers.get('content-length'));
+  if (Number.isFinite(declared) && declared > MAX_DOWNLOAD_BYTES) {
+    throw new Error(`Download too large: ${declared} bytes exceeds ${MAX_DOWNLOAD_BYTES}`);
+  }
   const buffer = Buffer.from(await response.arrayBuffer());
+  if (buffer.byteLength > MAX_DOWNLOAD_BYTES) {
+    throw new Error(`Download too large: ${buffer.byteLength} bytes exceeds ${MAX_DOWNLOAD_BYTES}`);
+  }
   await fs.promises.writeFile(filePath, buffer);
   return filePath;
 }
@@ -1134,31 +1194,39 @@ async function installPlugin(input: {
   // to the backend contract for now.
   const version = commandVersion(command, 'plugin');
 
-  const manifest = await loadManifest();
-  const scopeManifest = getManifestScope(manifest, PLUGIN_SCOPE);
-  scopeManifest.plugins ??= {};
-
   // Skip the (re)install when the desired state already holds on disk — checked
   // via npm, not the manifest, which can be stale if the package was removed out
   // of band. With an explicit version we require an exact match; without one, any
   // installed version counts as "present" (so an unpinned re-sync is a no-op).
   const installed = await getInstalledPluginVersion(pkg);
   const satisfied = version !== undefined ? installed === version : installed !== undefined;
+
+  const record = (m: LocalAgentManifest, recordedVersion: string | undefined): void => {
+    const scope = getManifestScope(m, PLUGIN_SCOPE);
+    scope.plugins ??= {};
+    scope.plugins[slug] = {
+      slug,
+      version: recordedVersion,
+      display_name: command.display_name ?? slug,
+      source: 'enterprise',
+      installed_at: new Date().toISOString(),
+      package: pkg,
+    };
+  };
+
   if (satisfied) {
-    if (!scopeManifest.plugins[slug]) {
-      scopeManifest.plugins[slug] = {
-        slug,
-        version: version ?? installed,
-        display_name: command.display_name ?? slug,
-        source: 'enterprise',
-        installed_at: new Date().toISOString(),
-        package: pkg,
-      };
-      await saveManifest(manifest);
-    }
+    // Ensure the manifest reflects the on-disk package, but do not rewrite an
+    // existing record (keeps installed_at and service registration stable).
+    await withManifestLock((m) => {
+      const scope = getManifestScope(m, PLUGIN_SCOPE);
+      scope.plugins ??= {};
+      if (!scope.plugins[slug]) record(m, version ?? installed);
+    });
     return version ?? installed;
   }
 
+  // npm work runs outside the manifest lock so a slow install does not block
+  // other processes' manifest updates.
   if (command.download_url) {
     const downloaded = await downloadResource(command.download_url);
     try {
@@ -1174,15 +1242,7 @@ async function installPlugin(input: {
     await installPluginPackage({ package: pkg, version });
   }
 
-  scopeManifest.plugins[slug] = {
-    slug,
-    version,
-    display_name: command.display_name ?? slug,
-    source: 'enterprise',
-    installed_at: new Date().toISOString(),
-    package: pkg,
-  };
-  await saveManifest(manifest);
+  await withManifestLock((m) => record(m, version));
   return version;
 }
 
@@ -1198,18 +1258,23 @@ async function uninstallPlugin(input: { slug: string }): Promise<void> {
     log.debug(`[local-agent] uninstall_plugin: no manifest entry for "${input.slug}", skipping`);
     return;
   }
+
+  const dropRecord = () =>
+    withManifestLock((m) => {
+      const scope = getManifestScope(m, PLUGIN_SCOPE);
+      delete scope.plugins?.[input.slug];
+    });
+
   if (!entry.package) {
     // Without the real npm package name we cannot safely target npm (the slug is
     // a teamai id, not necessarily a package name). Drop the record rather than
     // risk uninstalling an unrelated global package.
     log.warn(`[local-agent] uninstall_plugin: entry "${input.slug}" has no package name; removing record without npm uninstall`);
-    delete scopeManifest.plugins[input.slug];
-    await saveManifest(manifest);
+    await dropRecord();
     return;
   }
   await uninstallPluginPackage(entry.package);
-  delete scopeManifest.plugins[input.slug];
-  await saveManifest(manifest);
+  await dropRecord();
 }
 
 async function syncClaudemd(

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -26,6 +26,7 @@ import { getAgentVersion } from './agent-version.js';
 import { getMachineId, deriveLocalAgentId } from './machine-id.js';
 import { EXCLUDED_RULE_NAMES } from './builtin-rules.js';
 import { assertSafeResourceName } from './utils/path-safety.js';
+import { installPluginPackage, uninstallPluginPackage, getInstalledPluginVersion } from './plugin-installer.js';
 import { logHttpRequest, logHttpResponse } from './utils/http-log.js';
 import {
   TEAMAI_HOME,
@@ -47,8 +48,8 @@ const MANIFEST_FILE = 'manifest.json';
 const REPORTER_ERROR_LOG = 'reporter/errors.jsonl';
 
 type LocalAgentScope = 'instance' | 'user' | 'project';
-type ResourceKind = 'skills' | 'rules' | 'claudemd';
-type CommandResourceKind = 'skill' | 'rule' | 'claudemd';
+type ResourceKind = 'skills' | 'rules' | 'claudemd' | 'plugins';
+type CommandResourceKind = 'skill' | 'rule' | 'claudemd' | 'plugin';
 
 interface WorkspaceBinding {
   groupId: number;
@@ -89,12 +90,19 @@ interface ManifestResource {
    * locate the directory by slug (the manifest key stays the slug).
    */
   dir_name?: string;
+  /**
+   * npm package name for plugin entries. The manifest key is the teamai plugin
+   * slug (id); this records the actual package name so uninstall/upgrade can
+   * target it (scoped names like `@scope/pkg` are allowed here, unlike slugs).
+   */
+  package?: string;
 }
 
 interface ManifestScope {
   skills: Record<string, ManifestResource>;
   rules: Record<string, ManifestResource>;
   claudemd: Record<string, ManifestResource>;
+  plugins: Record<string, ManifestResource>;
 }
 
 interface LocalAgentManifest {
@@ -114,6 +122,9 @@ interface LocalAgentCommand {
   rule_type?: string;
   claudemd_slug?: string;
   claudemd_version?: string;
+  plugin_slug?: string;
+  plugin_package?: string;
+  plugin_version?: string;
   resource_slug?: string;
   resource_version?: string;
   slug?: string;
@@ -218,7 +229,7 @@ function scopeKey(scope: LocalAgentScope, workspacePath?: string): string {
 }
 
 function emptyManifestScope(): ManifestScope {
-  return { skills: {}, rules: {}, claudemd: {} };
+  return { skills: {}, rules: {}, claudemd: {}, plugins: {} };
 }
 
 async function loadManifest(): Promise<LocalAgentManifest> {
@@ -656,6 +667,30 @@ function collectManifestSlugs(manifest: LocalAgentManifest): { skills: Set<strin
   return { skills, rules };
 }
 
+/**
+ * Plugins are npm packages installed globally, so they have no workspace scope
+ * and are recorded under a single `user` manifest scope. The manifest key is
+ * the teamai plugin slug; `package` records the real npm name for uninstall.
+ */
+const PLUGIN_SCOPE: LocalAgentScope = 'user';
+
+/**
+ * List installed plugins from the manifest (not disk — global npm packages do
+ * not live under a teamai-controlled directory). Plugins are reported at
+ * user-level only, since they are installed globally with no workspace scope,
+ * so only PLUGIN_SCOPE is read.
+ */
+function scanPluginsFromManifest(manifest: LocalAgentManifest): ReportedResource[] {
+  const plugins = manifest.scopes[scopeKey(PLUGIN_SCOPE)]?.plugins ?? {};
+  return Object.values(plugins)
+    .map((entry) => ({
+      slug: entry.slug,
+      version: entry.version,
+      display_name: entry.display_name ?? entry.slug,
+      source: entry.source ?? 'enterprise',
+    }))
+    .sort((a, b) => a.slug.localeCompare(b.slug));
+}
 
 export async function buildReportPayload(
   config: LocalAgentConfig,
@@ -703,6 +738,7 @@ export async function buildReportPayload(
       group_id: config.userGroupId,
       skills: userScope.skills,
       rules: userScope.rules,
+      plugins: scanPluginsFromManifest(manifest),
     },
   };
 
@@ -753,6 +789,7 @@ function commandKind(command: LocalAgentCommand): CommandResourceKind | null {
   if (type.endsWith('_skill') || type === '') return 'skill';
   if (type.endsWith('_claudemd') || type.endsWith('_claude_md')) return 'claudemd';
   if (type.endsWith('_rule')) return 'rule';
+  if (type.endsWith('_plugin')) return 'plugin';
   return null;
 }
 
@@ -786,6 +823,7 @@ function commandSlug(command: LocalAgentCommand, kind: CommandResourceKind): str
   const slug =
     kind === 'skill' ? command.skill_slug :
     kind === 'rule' ? command.rule_slug :
+    kind === 'plugin' ? command.plugin_slug :
     (command.claudemd_slug ?? command.rule_slug);
   const resolved = slug ?? command.resource_slug ?? command.slug ?? command.name;
   if (!resolved) {
@@ -798,12 +836,16 @@ function commandVersion(command: LocalAgentCommand, kind: CommandResourceKind): 
   return (
     kind === 'skill' ? command.skill_version :
     kind === 'rule' ? command.rule_version :
+    kind === 'plugin' ? command.plugin_version :
     (command.claudemd_version ?? command.rule_version)
   ) ?? command.resource_version ?? command.version;
 }
 
 function manifestKind(kind: CommandResourceKind): ResourceKind {
-  return kind === 'skill' ? 'skills' : kind === 'rule' ? 'rules' : 'claudemd';
+  return kind === 'skill' ? 'skills'
+    : kind === 'rule' ? 'rules'
+    : kind === 'plugin' ? 'plugins'
+    : 'claudemd';
 }
 
 /** Only http(s) downloads are allowed — reject file:, ftp:, gopher:, etc. */
@@ -1071,6 +1113,105 @@ async function uninstallResource(input: {
   await saveManifest(manifest);
 }
 
+/**
+ * Install (or upgrade) a plugin npm package and record it in the manifest.
+ * Source is either a tarball (download_url) or the npm registry; either way the
+ * npm package name (plugin_package) is required so a later uninstall/upgrade can
+ * target it. Idempotent: re-running for an already-installed version is skipped.
+ */
+async function installPlugin(input: {
+  command: LocalAgentCommand;
+  slug: string;
+}): Promise<string | undefined> {
+  const { command, slug } = input;
+  const pkg = command.plugin_package;
+  if (!pkg) {
+    throw new Error(`Missing plugin_package for ${command.type ?? 'install_plugin'}`);
+  }
+  // plugin_package comes from the trusted backend and is passed to npm as a
+  // literal argv entry (execFile, not a shell) so it cannot inject commands. A
+  // package-name allowlist could further constrain what may be installed; left
+  // to the backend contract for now.
+  const version = commandVersion(command, 'plugin');
+
+  const manifest = await loadManifest();
+  const scopeManifest = getManifestScope(manifest, PLUGIN_SCOPE);
+  scopeManifest.plugins ??= {};
+
+  // Skip the (re)install when the desired state already holds on disk — checked
+  // via npm, not the manifest, which can be stale if the package was removed out
+  // of band. With an explicit version we require an exact match; without one, any
+  // installed version counts as "present" (so an unpinned re-sync is a no-op).
+  const installed = await getInstalledPluginVersion(pkg);
+  const satisfied = version !== undefined ? installed === version : installed !== undefined;
+  if (satisfied) {
+    if (!scopeManifest.plugins[slug]) {
+      scopeManifest.plugins[slug] = {
+        slug,
+        version: version ?? installed,
+        display_name: command.display_name ?? slug,
+        source: 'enterprise',
+        installed_at: new Date().toISOString(),
+        package: pkg,
+      };
+      await saveManifest(manifest);
+    }
+    return version ?? installed;
+  }
+
+  if (command.download_url) {
+    const downloaded = await downloadResource(command.download_url);
+    try {
+      // npm identifies a local tarball by its `.tgz` name, but downloadResource
+      // writes an extension-less file — rename it before handing it to npm.
+      const tarball = path.join(path.dirname(downloaded), 'plugin.tgz');
+      await fs.promises.rename(downloaded, tarball);
+      await installPluginPackage({ tarballPath: tarball });
+    } finally {
+      await remove(path.dirname(downloaded));
+    }
+  } else {
+    await installPluginPackage({ package: pkg, version });
+  }
+
+  scopeManifest.plugins[slug] = {
+    slug,
+    version,
+    display_name: command.display_name ?? slug,
+    source: 'enterprise',
+    installed_at: new Date().toISOString(),
+    package: pkg,
+  };
+  await saveManifest(manifest);
+  return version;
+}
+
+/** Uninstall a plugin npm package (by its recorded name) and drop the manifest entry. */
+async function uninstallPlugin(input: { slug: string }): Promise<void> {
+  const manifest = await loadManifest();
+  const scopeManifest = getManifestScope(manifest, PLUGIN_SCOPE);
+  scopeManifest.plugins ??= {};
+  const entry = scopeManifest.plugins[input.slug];
+  if (!entry) {
+    // Nothing recorded under this slug — do not run npm uninstall, which could
+    // otherwise remove an unrelated global package that shares the name.
+    log.debug(`[local-agent] uninstall_plugin: no manifest entry for "${input.slug}", skipping`);
+    return;
+  }
+  if (!entry.package) {
+    // Without the real npm package name we cannot safely target npm (the slug is
+    // a teamai id, not necessarily a package name). Drop the record rather than
+    // risk uninstalling an unrelated global package.
+    log.warn(`[local-agent] uninstall_plugin: entry "${input.slug}" has no package name; removing record without npm uninstall`);
+    delete scopeManifest.plugins[input.slug];
+    await saveManifest(manifest);
+    return;
+  }
+  await uninstallPluginPackage(entry.package);
+  delete scopeManifest.plugins[input.slug];
+  await saveManifest(manifest);
+}
+
 async function syncClaudemd(
   teamConfig: TeamaiConfig,
   localConfig: LocalConfig,
@@ -1154,6 +1295,16 @@ async function executeCommand(
   const action = commandAction(command);
   if (!kind || !action) {
     throw new Error(`Unsupported command type: ${command.type ?? ''}`);
+  }
+
+  // Plugins are global npm packages: no scope/workspace, no on-disk copy.
+  if (kind === 'plugin') {
+    const slug = commandSlug(command, kind);
+    if (action === 'install') {
+      return installPlugin({ command, slug });
+    }
+    await uninstallPlugin({ slug });
+    return commandVersion(command, kind);
   }
 
   const scope = command.scope ?? 'user';

--- a/src/plugin-installer.ts
+++ b/src/plugin-installer.ts
@@ -1,0 +1,94 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Where an npm plugin package comes from. Exactly one source is used:
+ * a tarball (already downloaded to `tarballPath`) or a registry package name
+ * (`package`, optionally pinned to `version`).
+ */
+export interface NpmInstallSpec {
+  package?: string;
+  version?: string;
+  tarballPath?: string;
+}
+
+/**
+ * Build the argv for a global npm install. Tarball path takes precedence; a
+ * registry package is pinned to `@version` when a version is given. Pure and
+ * deterministic so the argument logic can be unit-tested without spawning npm.
+ */
+export function buildNpmInstallArgs(spec: NpmInstallSpec): string[] {
+  if (spec.tarballPath) {
+    return ['install', '--global', spec.tarballPath];
+  }
+  if (!spec.package) {
+    throw new Error('Plugin install requires a package name or a tarball path');
+  }
+  const target = spec.version ? `${spec.package}@${spec.version}` : spec.package;
+  return ['install', '--global', target];
+}
+
+/** Build the argv for a global npm uninstall of a package by name. */
+export function buildNpmUninstallArgs(pkg: string): string[] {
+  return ['uninstall', '--global', pkg];
+}
+
+/** Install a plugin package globally via npm (registry or tarball source). */
+export async function installPluginPackage(spec: NpmInstallSpec): Promise<void> {
+  await runNpm(buildNpmInstallArgs(spec));
+}
+
+/** Uninstall a globally-installed plugin package by npm package name. */
+export async function uninstallPluginPackage(pkg: string): Promise<void> {
+  await runNpm(buildNpmUninstallArgs(pkg));
+}
+
+/**
+ * Return the version of a globally-installed package, or undefined if it is not
+ * installed. Used to decide idempotency against the real on-disk state rather
+ * than trusting the manifest (which can go stale if a package is removed out of
+ * band). `npm ls` exits non-zero when the package is absent but still prints the
+ * (empty) JSON tree to stdout, so that stdout is parsed on the error path too.
+ */
+export async function getInstalledPluginVersion(pkg: string): Promise<string | undefined> {
+  const args = ['ls', '--global', '--depth=0', '--json', pkg];
+  const extractVersion = (stdout: string): string | undefined => {
+    try {
+      const parsed = JSON.parse(stdout) as { dependencies?: Record<string, { version?: string }> };
+      return parsed.dependencies?.[pkg]?.version;
+    } catch {
+      return undefined;
+    }
+  };
+  try {
+    const { stdout } = await execFileAsync('npm', args, { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 });
+    return extractVersion(stdout);
+  } catch (e) {
+    const err = e as { code?: string; stdout?: string };
+    if (err.code === 'ENOENT') {
+      throw new Error('npm not found on PATH; cannot manage plugins');
+    }
+    // Absent package → npm ls exits non-zero with the tree still on stdout.
+    return err.stdout ? extractVersion(err.stdout) : undefined;
+  }
+}
+
+/**
+ * Run npm with the given arguments, mapping failures to readable errors. npm
+ * output can be large, so the stdout/stderr buffer is raised well above the
+ * 1 MB default. A missing npm binary (ENOENT) is reported explicitly.
+ */
+async function runNpm(args: string[]): Promise<void> {
+  try {
+    await execFileAsync('npm', args, { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 });
+  } catch (e) {
+    const err = e as { code?: string; stderr?: string; message: string };
+    if (err.code === 'ENOENT') {
+      throw new Error('npm not found on PATH; cannot manage plugins');
+    }
+    const detail = (err.stderr ?? '').trim() || err.message;
+    throw new Error(`npm ${args.join(' ')} failed: ${detail}`);
+  }
+}


### PR DESCRIPTION
## What & why

Adds a **generic, command-driven plugin capability** to the HTTP local-agent so the backend can auto-install software on the user side via sync commands. This is the infrastructure for shipping observability collectors etc. to users; it is intentionally decoupled from any specific plugin.

Scope of this PR (deliberately minimal):
- ✅ **install / update / uninstall** global npm packages (npm registry **or** tarball via `download_url`)
- ✅ report installed plugins at `user_level.plugins`
- ❌ **not** included (future work): running/keeping the plugin alive, config/env delivery

## How it works

- New sync command types `install_plugin` / `uninstall_plugin` carry `plugin_slug`, `plugin_package` (real npm name), `plugin_version`, and optional `download_url`.
- `executeCommand` routes plugin kinds to a small orchestrator (`installPlugin` / `uninstallPlugin`); the pure npm layer lives in `src/plugin-installer.ts` (`execFile`, no shell → no injection).
- **Idempotency is checked against the real npm-installed version** (`npm ls -g`), not just the manifest, so a manifest that has gone stale (package removed out of band) still triggers a reinstall. Update = re-issue install with a new version.
- Uninstall targets the recorded npm package name; if unknown it refuses to run npm (avoids removing an unrelated global package).
- Follows the existing skills/rules command/manifest/report patterns; plugins are **not** added to the git-synced ResourceType set (they are centrally delivered, not user-authored).

## Test plan

- [x]  `npx tsc --noEmit` ✅
- [x]  `npx vitest run` — 23 new plugin tests; full suite: **0 new failures** ✅
- [x]  **Real e2e**: built CLI + a mock backend serving `/api/local-agent/*` + a local `npm pack` tarball fixture, run under an isolated `HOME` and `npm_config_prefix`:

  - `teamai hook-dispatch` → sync → real `npm i -g` installs the package; manifest records `{slug, package, version}`
  - same-version re-sync is a no-op (real `npm ls` short-circuit)
  - `uninstall_plugin` → real `npm uninstall -g` removes it; manifest cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)
