### PR TITLE
fix(uninstall): remove CLI built-in resources (recall agent/rule, built-in skills)

### DIFF
--- a/src/__tests__/uninstall.test.ts
+++ b/src/__tests__/uninstall.test.ts
@@ -68,6 +68,7 @@ function makeTeamConfig(overrides?: Partial<TeamaiConfig>): TeamaiConfig {
         rules: '.claude/rules',
         settings: '.claude/settings.json',
         claudemd: '.claude/CLAUDE.md',
+        agents: '.claude/agents',
       },
     },
     ...overrides,
@@ -107,6 +108,15 @@ async function setupFixture(tmpDir: string) {
   // Tool dirs: synced rule
   await fse.ensureDir(path.join(homeDir, '.claude', 'rules'));
   await fse.writeFile(path.join(homeDir, '.claude', 'rules', 'team-rule.md'), '# Team Rule');
+
+  // Tool dirs: CLI built-in resources (deployed by the CLI, not the team repo)
+  await fse.writeFile(path.join(homeDir, '.claude', 'rules', 'teamai-recall.md'), '# Recall Rule');
+  await fse.ensureDir(path.join(homeDir, '.claude', 'agents'));
+  await fse.writeFile(path.join(homeDir, '.claude', 'agents', 'teamai-recall.md'), '# Recall Agent');
+  await fse.ensureDir(path.join(homeDir, '.claude', 'skills', 'teamai-share-learnings'));
+  await fse.writeFile(path.join(homeDir, '.claude', 'skills', 'teamai-share-learnings', 'SKILL.md'), '# Share Learnings');
+  await fse.ensureDir(path.join(homeDir, '.claude', 'skills', 'team-wiki-codebase'));
+  await fse.writeFile(path.join(homeDir, '.claude', 'skills', 'team-wiki-codebase', 'SKILL.md'), '# Wiki Codebase');
 
   // Settings.json with hooks
   await fse.writeJson(path.join(homeDir, '.claude', 'settings.json'), {
@@ -420,6 +430,27 @@ describe('uninstall', () => {
     expect(await fse.pathExists(path.join(homeDir, '.claude', 'skills', 'team-skill'))).toBe(false);
     expect(await fse.pathExists(path.join(homeDir, '.claude', 'skills', 'ns-skill'))).toBe(false);
     // User skill preserved
+    expect(await fse.pathExists(path.join(homeDir, '.claude', 'skills', 'my-own-skill'))).toBe(true);
+  });
+
+  it('移除 CLI built-in 资源（recall agent/rule + built-in skills）', async () => {
+    const { homeDir, repoPath } = await setupFixture(tmpDir);
+    vi.stubEnv('HOME', homeDir);
+    vi.stubEnv('SHELL', '/bin/zsh');
+
+    const teamConfig = makeTeamConfig();
+    const localConfig = makeLocalConfig(homeDir, repoPath);
+    mockAutoDetectInit.mockResolvedValue({ localConfig, teamConfig });
+
+    await uninstall({ force: true });
+
+    // Built-in recall agent + rule removed
+    expect(await fse.pathExists(path.join(homeDir, '.claude', 'agents', 'teamai-recall.md'))).toBe(false);
+    expect(await fse.pathExists(path.join(homeDir, '.claude', 'rules', 'teamai-recall.md'))).toBe(false);
+    // Built-in skills removed
+    expect(await fse.pathExists(path.join(homeDir, '.claude', 'skills', 'teamai-share-learnings'))).toBe(false);
+    expect(await fse.pathExists(path.join(homeDir, '.claude', 'skills', 'team-wiki-codebase'))).toBe(false);
+    // User's own skill still preserved
     expect(await fse.pathExists(path.join(homeDir, '.claude', 'skills', 'my-own-skill'))).toBe(true);
   });
 

--- a/src/uninstall.ts
+++ b/src/uninstall.ts
@@ -21,7 +21,9 @@ import {
   type LocalConfig,
   type Scope,
 } from './types.js';
-import { EXCLUDED_RULE_NAMES } from './builtin-rules.js';
+import { BUILTIN_RULE_NAMES } from './builtin-rules.js';
+import { BUILTIN_AGENT_NAMES } from './builtin-agents.js';
+import { BUILTIN_SKILL_NAMES } from './builtin-skills.js';
 import {
   pathExists,
   readFileSafe,
@@ -49,8 +51,10 @@ interface RemovalPlan {
   claudeMdFiles: string[];
   /** Skill directories synced from team repo. */
   skillDirs: string[];
-  /** Rule .md files synced from team repo. */
+  /** Rule .md files synced from team repo (plus CLI built-in rules). */
   ruleFiles: string[];
+  /** Built-in agent .md files deployed by the CLI (e.g. teamai-recall). */
+  agentFiles: string[];
   /** Shell profile path containing env block (null if none). */
   shellProfile: string | null;
   /** Docs directory (null if doesn't exist). */
@@ -143,6 +147,7 @@ async function buildRemovalPlan(
     claudeMdFiles: [],
     skillDirs: [],
     ruleFiles: [],
+    agentFiles: [],
     shellProfile: null,
     docsDir: null,
     teamaiHome,
@@ -151,10 +156,16 @@ async function buildRemovalPlan(
     scope: localConfig.scope,
   };
 
-  // Discover team repo resource names for targeted removal
+  // Discover team repo resource names for targeted removal. CLI built-in
+  // resources (recall agent/rule, share-learnings skill, …) are deployed by
+  // the CLI itself rather than synced from the team repo, so fold their names
+  // in explicitly — otherwise uninstall leaks them (they match neither the
+  // team-repo set nor a user-authored resource).
   const repoPath = localConfig.repo.localPath;
   const teamSkillNames = await collectTeamSkillNames(repoPath);
+  for (const name of BUILTIN_SKILL_NAMES) teamSkillNames.add(name);
   const teamRuleNames = await collectTeamRuleNames(repoPath);
+  for (const name of BUILTIN_RULE_NAMES) teamRuleNames.add(name);
 
   // Also include resources installed by local-agent (HTTP distribution)
   const localAgentManifestPath = path.join(
@@ -211,7 +222,8 @@ async function buildRemovalPlan(
       }
     }
 
-    // (d) Rules — only those matching team repo, excluding built-in
+    // (d) Rules — team-synced rules plus CLI built-in rules (teamRuleNames
+    // now includes BUILTIN_RULE_NAMES). User-authored rules are left alone.
     if (toolPath.rules) {
       const rulesDir = path.join(baseDir, toolPath.rules);
       if (await pathExists(rulesDir)) {
@@ -219,9 +231,22 @@ async function buildRemovalPlan(
         for (const file of files) {
           if (!file.endsWith('.md')) continue;
           const ruleName = file.replace(/\.md$/, '');
-          if (EXCLUDED_RULE_NAMES.has(ruleName)) continue;
           if (teamRuleNames.has(ruleName)) {
             plan.ruleFiles.push(path.join(rulesDir, file));
+          }
+        }
+      }
+    }
+
+    // (d2) Built-in agents — CLI-deployed subagents (e.g. teamai-recall).
+    // Not synced from the team repo, so match by BUILTIN_AGENT_NAMES.
+    if (toolPath.agents) {
+      const agentsDir = path.join(baseDir, toolPath.agents);
+      if (await pathExists(agentsDir)) {
+        for (const name of BUILTIN_AGENT_NAMES) {
+          const agentFile = path.join(agentsDir, `${name}.md`);
+          if (await pathExists(agentFile)) {
+            plan.agentFiles.push(agentFile);
           }
         }
       }
@@ -265,6 +290,7 @@ function isPlanEmpty(plan: RemovalPlan): boolean {
     plan.claudeMdFiles.length === 0 &&
     plan.skillDirs.length === 0 &&
     plan.ruleFiles.length === 0 &&
+    plan.agentFiles.length === 0 &&
     plan.shellProfile === null &&
     plan.docsDir === null &&
     !plan.teamaiHomeExists
@@ -309,6 +335,11 @@ function printSummary(plan: RemovalPlan): void {
 
   if (plan.ruleFiles.length > 0) {
     console.log(`   Rules (${plan.ruleFiles.length} 个文件)`);
+    console.log('');
+  }
+
+  if (plan.agentFiles.length > 0) {
+    console.log(`   Agents (${plan.agentFiles.length} 个文件)`);
     console.log('');
   }
 
@@ -402,6 +433,18 @@ async function executeRemoval(plan: RemovalPlan): Promise<void> {
   }
   if (plan.ruleFiles.length > 0) {
     log.success(`移除了 ${plan.ruleFiles.length} 个 rule 文件`);
+  }
+
+  // (d2) Remove built-in agent files (e.g. teamai-recall)
+  for (const agentFile of plan.agentFiles) {
+    try {
+      await remove(agentFile);
+    } catch (e) {
+      log.warn(`移除 agent 失败 ${agentFile}: ${(e as Error).message}`);
+    }
+  }
+  if (plan.agentFiles.length > 0) {
+    log.success(`移除了 ${plan.agentFiles.length} 个 agent 文件`);
   }
 
   // (e) Clean shell profile env block


### PR DESCRIPTION
## Problem

`teamai uninstall` claims to "Remove all teamai-managed resources and hooks from this machine", but it only removes resources **synced from the team repo**. CLI **built-in** resources — deployed by the CLI itself, not the team repo — are leaked on every uninstall:

| Resource | Why it leaked |
|----------|---------------|
| built-in agent `teamai-recall.md` | uninstall had **no agent-removal logic at all** |
| built-in rule `teamai-recall.md` | skipped by `EXCLUDED_RULE_NAMES` **and** absent from the team repo → matched by neither branch |
| built-in skills `teamai-share-learnings`, `team-wiki-codebase` | not in the team repo → never matched |

Combined with recall being disabled by default (which makes the redeploy path skip these files too), they become zombies: **neither updated on CLI upgrade nor removable via uninstall** — the user has to `rm` them by hand.

## Fix

Surgical change within the existing plan → summary → execute flow in `src/uninstall.ts`:

- Fold `BUILTIN_SKILL_NAMES` and `BUILTIN_RULE_NAMES` into the removal-matching sets (`teamSkillNames` / `teamRuleNames`), so built-in skills/rules are matched for removal.
- Drop the `EXCLUDED_RULE_NAMES` skip in the rule pass (built-in rules are now intentionally included; `EXCLUDED_RULE_NAMES` is still used by push to exclude them from team-repo push — untouched).
- Add a dedicated pass `(d2)` that removes files matching `BUILTIN_AGENT_NAMES` from each tool's `agents/` dir.
- Wire the new `agentFiles` into `RemovalPlan`, `isPlanEmpty`, `printSummary`, and `executeRemoval`.

User-authored skills/rules are still preserved (matched by name, not blanket-deleted).

## Test Plan

- [x] `npx tsc --noEmit` — passes
- [x] `npx vitest run src/__tests__/uninstall.test.ts` — 14 passed, incl. new case `移除 CLI built-in 资源（recall agent/rule + built-in skills）`
- [x] Full suite: 1679 passed (1 unrelated pre-existing failure in `import-repo-merge.test.ts`, fails identically on clean `main`)
- [x] **Real CLI E2E**: built `dist/`, ran `node dist/index.js uninstall --force` against an inited HAI install:
  - summary showed `Agents (8 个文件)`; log `移除了 8 个 agent 文件`
  - **8 recall files** (agent + rule across `.claude`/`.cursor`/`.codex`/`.codebuddy`) → all removed ✅
  - built-in skill dirs (`teamai-share-learnings`, `team-wiki-codebase`) → all removed ✅
  - user-authored skills (`dragon-doctor`, `tencent-meeting-mcp`) → preserved ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)