### PR TITLE
feat(local-agent): get-config-driven plugin lifecycle (command reconcile)

### DIFF
--- a/src/__tests__/plugin-lifecycle.test.ts
+++ b/src/__tests__/plugin-lifecycle.test.ts
@@ -1,0 +1,412 @@
+import { describe, it, expect } from 'vitest';
+import {
+  reconcilePlugins,
+  teardownAllPlugins,
+  parseGetConfig,
+  substituteVars,
+  unresolvedPlaceholders,
+  type PluginDescriptor,
+  type PluginState,
+  type ReconcileDeps,
+} from '../plugin-lifecycle.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeDescriptor(overrides: Partial<PluginDescriptor> = {}): PluginDescriptor {
+  return {
+    slug: 'cls-codebuddy',
+    version: '1.0.0',
+    installCmd: 'npm install -g cls-plugin@1.0.0',
+    uninstallCmd: 'npm uninstall -g cls-plugin',
+    runCmd: 'cls-codebuddy setup',
+    ...overrides,
+  };
+}
+
+/** Build a fake ReconcileDeps backed by an in-memory map plus a call-order log. */
+function makeDeps(
+  initial: Record<string, PluginState> = {},
+  opts: { nowMs?: number } = {},
+): ReconcileDeps & { calls: string[]; map: Record<string, PluginState>; nowMs: number } {
+  let nowMs = opts.nowMs ?? 0;
+  const map: Record<string, PluginState> = { ...initial };
+  const calls: string[] = [];
+
+  return {
+    calls,
+    map,
+    get nowMs() {
+      return nowMs;
+    },
+    set nowMs(v: number) {
+      nowMs = v;
+    },
+
+    async readPlugins() {
+      return { ...map };
+    },
+    async mutatePlugins(fn) {
+      fn(map);
+    },
+    async execCommand(cmd) {
+      calls.push(`exec:${cmd}`);
+    },
+    now() {
+      return nowMs;
+    },
+    log: { debug() {}, warn() {} },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. Fresh install
+// ---------------------------------------------------------------------------
+
+describe('reconcilePlugins – fresh install', () => {
+  it('calls install then run in order and marks ready', async () => {
+    const deps = makeDeps();
+    const d = makeDescriptor();
+
+    await reconcilePlugins([d], deps);
+
+    expect(deps.calls).toEqual([
+      `exec:${d.installCmd}`,
+      `exec:${d.runCmd}`,
+    ]);
+    expect(deps.map[d.slug]).toMatchObject({ ready: true, version: '1.0.0' });
+    expect(deps.map[d.slug].lastError).toBeUndefined();
+    expect(deps.map[d.slug].lastAttemptAt).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Install failure + cooldown + retry
+// ---------------------------------------------------------------------------
+
+describe('reconcilePlugins – install failure and cooldown', () => {
+  it('records lastError on failure, skips on cooldown, retries after cooldown expires', async () => {
+    const deps = makeDeps();
+    deps.execCommand = async (cmd: string) => {
+      deps.calls.push(`exec:${cmd}`);
+      throw new Error('npm install failed');
+    };
+    const d = makeDescriptor();
+
+    // First attempt: fails
+    await reconcilePlugins([d], deps);
+    expect(deps.map[d.slug]).toMatchObject({ ready: false, lastError: 'npm install failed' });
+    expect(deps.map[d.slug].lastAttemptAt).toBe(new Date(0).toISOString());
+    const firstExecCount = deps.calls.filter((c) => c.startsWith('exec:')).length;
+    expect(firstExecCount).toBe(1);
+
+    // Second attempt immediately: should be in cooldown → exec NOT called again
+    await reconcilePlugins([d], deps);
+    const execCountAfterCooldown = deps.calls.filter((c) => c.startsWith('exec:')).length;
+    expect(execCountAfterCooldown).toBe(1); // still 1, not retried
+
+    // Advance time past cooldown (11 minutes)
+    deps.nowMs = 11 * 60 * 1000;
+
+    // Make execCommand succeed now
+    deps.execCommand = async (cmd: string) => {
+      deps.calls.push(`exec:${cmd}`);
+    };
+    await reconcilePlugins([d], deps);
+    const execCountAfterRetry = deps.calls.filter((c) => c.startsWith('exec:')).length;
+    // install + run = 2 more execs
+    expect(execCountAfterRetry).toBe(3);
+    expect(deps.map[d.slug]).toMatchObject({ ready: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Version change
+// ---------------------------------------------------------------------------
+
+describe('reconcilePlugins – version update', () => {
+  it('runs updateCmd then runCmd in order and updates manifest version', async () => {
+    const existing: PluginState = {
+      slug: 'cls-codebuddy',
+      version: '1.0.0',
+      ready: true,
+      uninstallCmd: 'npm uninstall -g cls-plugin',
+    };
+    const deps = makeDeps({ 'cls-codebuddy': existing });
+    const d = makeDescriptor({ version: '2.0.0', updateCmd: 'npm install -g cls-plugin@2.0.0' });
+
+    await reconcilePlugins([d], deps);
+
+    const execIdx = (cmd: string) => deps.calls.indexOf(`exec:${cmd}`);
+    expect(execIdx(d.updateCmd!)).toBeGreaterThanOrEqual(0);
+    expect(execIdx(d.runCmd)).toBeGreaterThanOrEqual(0);
+    expect(execIdx(d.updateCmd!)).toBeLessThan(execIdx(d.runCmd));
+    expect(deps.map[d.slug].version).toBe('2.0.0');
+    expect(deps.map[d.slug].ready).toBe(true);
+  });
+
+  it('falls back to installCmd when updateCmd is absent', async () => {
+    const existing: PluginState = {
+      slug: 'cls-codebuddy',
+      version: '1.0.0',
+      ready: true,
+      uninstallCmd: 'npm uninstall -g cls-plugin',
+    };
+    const deps = makeDeps({ 'cls-codebuddy': existing });
+    const d = makeDescriptor({ version: '2.0.0', updateCmd: undefined });
+
+    await reconcilePlugins([d], deps);
+
+    expect(deps.calls).toContain(`exec:${d.installCmd}`);
+    expect(deps.map[d.slug].version).toBe('2.0.0');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Steady state – same version → no-op
+// ---------------------------------------------------------------------------
+
+describe('reconcilePlugins – steady state no-op', () => {
+  it('issues zero commands when version is unchanged and plugin is ready', async () => {
+    const existing: PluginState = {
+      slug: 'cls-codebuddy',
+      version: '1.0.0',
+      ready: true,
+      uninstallCmd: 'npm uninstall -g cls-plugin',
+    };
+    const deps = makeDeps({ 'cls-codebuddy': existing });
+    const d = makeDescriptor();
+
+    await reconcilePlugins([d], deps);
+
+    expect(deps.calls).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4a. No-version steady state → no-op when already ready
+// ---------------------------------------------------------------------------
+
+describe('reconcilePlugins – no version, already ready → no-op', () => {
+  it('issues zero commands when desired has no version and plugin is already ready', async () => {
+    const existing: PluginState = {
+      slug: 'cls',
+      version: undefined,
+      ready: true,
+      uninstallCmd: 'cls-codebuddy uninstall-all',
+    };
+    const deps = makeDeps({ cls: existing });
+    const d = makeDescriptor({ slug: 'cls', version: undefined, uninstallCmd: 'cls-codebuddy uninstall-all' });
+
+    await reconcilePlugins([d], deps);
+
+    expect(deps.calls).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Plugin removed from desired → execCommand(uninstallCmd) + delete, no deregister
+// ---------------------------------------------------------------------------
+
+describe('reconcilePlugins – plugin disappears from desired', () => {
+  it('calls execCommand(uninstallCmd) then deletes entry; no deregister call', async () => {
+    const existing: PluginState = {
+      slug: 'cls-codebuddy',
+      version: '1.0.0',
+      ready: true,
+      uninstallCmd: 'npm uninstall -g cls-plugin',
+    };
+    const deps = makeDeps({ 'cls-codebuddy': existing });
+
+    // desired is empty
+    await reconcilePlugins([], deps);
+
+    expect(deps.calls).toEqual([`exec:${existing.uninstallCmd}`]);
+    expect(deps.map['cls-codebuddy']).toBeUndefined();
+    // No deregister call
+    expect(deps.calls.some((c) => c.startsWith('deregister:'))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. teardownAllPlugins
+// ---------------------------------------------------------------------------
+
+describe('teardownAllPlugins', () => {
+  it('uninstalls all plugins and empties the map; no deregister', async () => {
+    const map: Record<string, PluginState> = {
+      'plugin-a': {
+        slug: 'plugin-a',
+        version: '1.0.0',
+        ready: true,
+        uninstallCmd: 'npm uninstall -g plugin-a',
+      },
+      'plugin-b': {
+        slug: 'plugin-b',
+        version: '2.0.0',
+        ready: true,
+        uninstallCmd: 'npm uninstall -g plugin-b',
+      },
+    };
+    const deps = makeDeps(map);
+
+    await teardownAllPlugins(deps);
+
+    expect(deps.map).toEqual({});
+    expect(deps.calls).toContain('exec:npm uninstall -g plugin-a');
+    expect(deps.calls).toContain('exec:npm uninstall -g plugin-b');
+    expect(deps.calls.some((c) => c.startsWith('deregister:'))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. parseGetConfig
+// ---------------------------------------------------------------------------
+
+describe('parseGetConfig', () => {
+  it('parses real response structure: cls section with commands + vars', () => {
+    const resp = {
+      cls: {
+        endpoint: 'ap-guangzhou.cls.tencentcs.com',
+        topic_id: 'f7e11f3b-xxxx',
+        secret_id: 'AKIDxxxx',
+        secret_key: 'sk-xxxx',
+        user_id: 37,
+        user_name: 'admin123',
+        install_cmd: 'npm install -g tencentcloud-cls-sdk-codebuddy-test --registry https://mirrors.tencentyun.com/npm/',
+        update_cmd: 'npm install -g tencentcloud-cls-sdk-codebuddy-test --registry https://mirrors.tencentyun.com/npm/',
+        uninstall_cmd: 'cls-codebuddy uninstall-all',
+        run_cmd: 'cls-codebuddy setup --endpoint ${endpoint} --topic-id ${topic_id} --secret-id ${secret_id} --secret-key ${secret_key} --service-name ${local_agent_id} --user-name ${user_name} --user-id ${user_id}',
+      },
+    };
+
+    const result = parseGetConfig(resp);
+
+    expect(result.plugins).toHaveLength(1);
+    expect(result.plugins[0]).toMatchObject({
+      slug: 'cls',
+      installCmd: 'npm install -g tencentcloud-cls-sdk-codebuddy-test --registry https://mirrors.tencentyun.com/npm/',
+      updateCmd: 'npm install -g tencentcloud-cls-sdk-codebuddy-test --registry https://mirrors.tencentyun.com/npm/',
+      uninstallCmd: 'cls-codebuddy uninstall-all',
+      runCmd: 'cls-codebuddy setup --endpoint ${endpoint} --topic-id ${topic_id} --secret-id ${secret_id} --secret-key ${secret_key} --service-name ${local_agent_id} --user-name ${user_name} --user-id ${user_id}',
+    });
+    expect(result.plugins[0].version).toBeUndefined();
+    expect(result.vars).toEqual({
+      endpoint: 'ap-guangzhou.cls.tencentcs.com',
+      topic_id: 'f7e11f3b-xxxx',
+      secret_id: 'AKIDxxxx',
+      secret_key: 'sk-xxxx',
+      user_id: '37',
+      user_name: 'admin123',
+    });
+  });
+
+  it('returns 0 plugins when install_cmd is missing', () => {
+    const resp = {
+      cls: {
+        uninstall_cmd: 'cls-codebuddy uninstall-all',
+        run_cmd: 'cls-codebuddy setup',
+        // install_cmd intentionally absent
+      },
+    };
+    expect(parseGetConfig(resp).plugins).toHaveLength(0);
+  });
+
+  it('returns 0 plugins when run_cmd is missing', () => {
+    const resp = {
+      cls: {
+        install_cmd: 'npm install -g cls-sdk',
+        uninstall_cmd: 'cls-codebuddy uninstall-all',
+        // run_cmd intentionally absent
+      },
+    };
+    expect(parseGetConfig(resp).plugins).toHaveLength(0);
+  });
+
+  it('returns 0 plugins when uninstall_cmd is missing', () => {
+    const resp = {
+      cls: {
+        install_cmd: 'npm install -g cls-sdk',
+        run_cmd: 'cls-codebuddy setup',
+        // uninstall_cmd intentionally absent
+      },
+    };
+    expect(parseGetConfig(resp).plugins).toHaveLength(0);
+  });
+
+  it('handles null and non-object inputs without throwing', () => {
+    expect(parseGetConfig(null)).toEqual({ vars: {}, plugins: [] });
+    expect(parseGetConfig(undefined)).toEqual({ vars: {}, plugins: [] });
+    expect(parseGetConfig('string')).toEqual({ vars: {}, plugins: [] });
+  });
+
+  it('converts user_id number to string in vars', () => {
+    const resp = {
+      cls: {
+        user_id: 37,
+        user_name: 'admin123',
+        install_cmd: 'npm install -g x',
+        uninstall_cmd: 'x uninstall',
+        run_cmd: 'x setup',
+      },
+    };
+    const { vars } = parseGetConfig(resp);
+    expect(vars['user_id']).toBe('37');
+    expect(vars['user_name']).toBe('admin123');
+  });
+
+  it('skips non-object section values', () => {
+    const resp = { cls: 'not-an-object', other: 42 };
+    expect(parseGetConfig(resp).plugins).toHaveLength(0);
+    expect(parseGetConfig(resp).vars).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. substituteVars
+// ---------------------------------------------------------------------------
+
+describe('substituteVars', () => {
+  it('replaces known placeholders', () => {
+    const vars = { endpoint: 'https://cls.example.com', local_agent_id: 'codebuddy-abc123' };
+    expect(substituteVars('setup --endpoint ${endpoint} --name ${local_agent_id}', vars)).toBe(
+      'setup --endpoint https://cls.example.com --name codebuddy-abc123',
+    );
+  });
+
+  it('leaves unknown placeholders untouched', () => {
+    expect(substituteVars('cmd --secret ${secret_key} --x ${unknown}', { secret_key: 'abc' })).toBe(
+      'cmd --secret abc --x ${unknown}',
+    );
+  });
+
+  it('returns cmd unchanged when no placeholders', () => {
+    expect(substituteVars('npm install -g cls', {})).toBe('npm install -g cls');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. unresolvedPlaceholders
+// ---------------------------------------------------------------------------
+
+describe('unresolvedPlaceholders', () => {
+  it('returns names of remaining placeholders after partial substitution', () => {
+    const partial = substituteVars(
+      'cls setup --endpoint ${endpoint} --secret ${secret_key} --user ${user_id}',
+      { endpoint: 'https://cls.example.com' },
+    );
+    expect(unresolvedPlaceholders(partial)).toEqual(expect.arrayContaining(['secret_key', 'user_id']));
+    expect(unresolvedPlaceholders(partial)).toHaveLength(2);
+  });
+
+  it('returns empty array when all placeholders are resolved', () => {
+    const vars = { endpoint: 'https://cls.example.com', local_agent_id: 'codebuddy-abc123' };
+    const resolved = substituteVars('setup --endpoint ${endpoint} --name ${local_agent_id}', vars);
+    expect(unresolvedPlaceholders(resolved)).toHaveLength(0);
+  });
+
+  it('deduplicates repeated placeholder names', () => {
+    expect(unresolvedPlaceholders('${key} and ${key} again')).toEqual(['key']);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -347,6 +347,14 @@ sourceCmd
   });
 
 sourceCmd
+  .command('reconcile-plugins', { hidden: true })
+  .description('Run plugin reconcile worker (called internally by session_start hook)')
+  .action(async () => {
+    const { runPluginReconcileWorker } = await import('./local-agent.js');
+    await runPluginReconcileWorker();
+  });
+
+sourceCmd
   .command('list')
   .description('List all configured sources')
   .action(async () => {

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -426,11 +426,14 @@ export async function fetchUserGroups(config: LocalAgentConfig): Promise<LocalAg
   return response.groups ?? [];
 }
 
-/** Mask secret values (CLI flags / key=value) so they don't reach logs. */
+/** Mask secret values (CLI flags / key=value / bearer tokens) so they don't reach logs. */
 function redactSecrets(s: string): string {
+  // Secret-bearing identifiers, matched case-insensitively in flag and key=value forms.
+  const names = 'secret[_-]?(?:key|id)|api[_-]?key|access[_-]?token|token|password|passwd|pwd';
   return s
-    .replace(/(--secret-(?:key|id)[= ]+)\S+/gi, '$1***')
-    .replace(/(secret[_-]?(?:key|id)"?\s*[:=]\s*"?)[^"\s,}]+/gi, '$1***');
+    .replace(new RegExp(`(--(?:${names})[= ]+)\\S+`, 'gi'), '$1***')
+    .replace(new RegExp(`((?:${names})"?\\s*[:=]\\s*"?)[^"\\s,}]+`, 'gi'), '$1***')
+    .replace(/(bearer\s+)[\w.\-]+/gi, '$1***');
 }
 
 /** Execute a shell command string with a timeout. Rejects on non-zero exit or timeout. */
@@ -470,7 +473,15 @@ function buildReconcileDeps(config: LocalAgentConfig, tag: string): ReconcileDep
     mutatePlugins: (fn) => withPluginStateLock(fn),
     execCommand: (cmd, t) => execPluginCommand(cmd, t),
     now: () => Date.now(),
-    log: { debug: (msg) => log.debug(`${tag} ${msg}`), warn: (msg) => log.warn(`${tag} ${msg}`) },
+    log: {
+      debug: (msg) => log.debug(`${tag} ${msg}`),
+      // The reconcile worker runs detached (stdio: 'ignore'), so console-only log.warn
+      // output is discarded. Mirror warnings to debug.log so failures are traceable.
+      warn: (msg) => {
+        log.warn(`${tag} ${msg}`);
+        log.debug(`${tag} WARN: ${msg}`);
+      },
+    },
   };
 }
 
@@ -521,6 +532,8 @@ export async function runPluginReconcileWorker(): Promise<void> {
     try {
       const resp = await fetchPluginConfig(config, tag);
       const { vars, plugins } = parseGetConfig(resp);
+      const declaredSlugs = plugins.length ? ` [${plugins.map((p) => p.slug).join(', ')}]` : '';
+      log.debug(`${tag} get-config: ${plugins.length} plugin(s) declared${declaredSlugs}`);
       const laid = process.env.TEAMAI_PLUGIN_LOCAL_AGENT_ID;
       if (!laid) log.debug(tag + ' no local_agent_id in env; plugins needing it will be skipped');
       const allVars = { ...vars, ...(laid ? { local_agent_id: laid } : {}) };
@@ -541,11 +554,13 @@ export async function runPluginReconcileWorker(): Promise<void> {
         ])];
         if (missing.length) {
           log.warn(`${tag} plugin ${p.slug}: unresolved placeholders [${missing.join(',')}], skipping`);
+          log.debug(`${tag} WARN: plugin ${p.slug}: unresolved placeholders [${missing.join(',')}], skipping`);
           continue;
         }
         resolved.push(rp);
       }
       await reconcilePlugins(resolved, buildReconcileDeps(config, tag));
+      log.debug(`${tag} reconcile complete (${resolved.length} plugin(s) processed)`);
       await writeJson(statePath, { lastPullAt: Date.now() });
     } catch (e) {
       const prev = (await readJson<{ lastPullAt?: number; lastFailAt?: number }>(statePath)) ?? {};

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -27,6 +27,7 @@ import { getMachineId, deriveLocalAgentId } from './machine-id.js';
 import { EXCLUDED_RULE_NAMES } from './builtin-rules.js';
 import { assertSafeResourceName } from './utils/path-safety.js';
 import { logHttpRequest, logHttpResponse } from './utils/http-log.js';
+import { reconcilePlugins, teardownAllPlugins, parseGetConfig, substituteVars, unresolvedPlaceholders, type ReconcileDeps, type PluginState } from './plugin-lifecycle.js';
 import {
   TEAMAI_HOME,
   TEAMAI_TOKEN_PATH,
@@ -230,6 +231,46 @@ async function saveManifest(manifest: LocalAgentManifest): Promise<void> {
   await writeJson(getManifestPath(), manifest);
 }
 
+function getPluginStatePath(): string {
+  return path.join(getLocalAgentHome(), 'plugins.json');
+}
+
+async function readPluginState(): Promise<Record<string, PluginState>> {
+  return (await readJson<Record<string, PluginState>>(getPluginStatePath())) ?? {};
+}
+
+/**
+ * Atomically mutate the plugin-state file under an exclusive lock. If the lock
+ * cannot be acquired within the timeout, throws (the caller skips this cycle
+ * rather than writing without the lock — reconcile is throttled, so skipping is safe).
+ */
+async function withPluginStateLock(mutate: (m: Record<string, PluginState>) => void): Promise<void> {
+  const statePath = getPluginStatePath();
+  const lockPath = `${statePath}.lock`;
+  await ensureDir(path.dirname(lockPath));
+  const deadline = Date.now() + 5000;
+  let acquired = false;
+  while (Date.now() <= deadline) {
+    try { const fd = await fs.promises.open(lockPath, 'wx'); await fd.close(); acquired = true; break; }
+    catch (e) {
+      if ((e as { code?: string }).code !== 'EEXIST') throw e;
+      try {
+        const st = await fs.promises.stat(lockPath);
+        if (Date.now() - st.mtimeMs > 30_000) { await fs.promises.rm(lockPath, { force: true }); continue; }
+      } catch { /* lock vanished */ }
+      await new Promise((r) => setTimeout(r, 50));
+    }
+  }
+  if (!acquired) throw new Error('could not acquire plugin-state lock');
+  try {
+    const m = await readPluginState();
+    mutate(m);
+    await writeJson(statePath, m);
+  } finally {
+    await fs.promises.rm(lockPath, { force: true });
+  }
+}
+
 function getManifestScope(
   manifest: LocalAgentManifest,
   scope: LocalAgentScope,
@@ -332,6 +373,7 @@ async function localAgentFetch<T>(
   tag: string,
   route: string,
   init?: RequestInit,
+  opts?: { redactResponseLog?: boolean },
 ): Promise<T> {
   const method = init?.method ?? 'GET';
   const url = `${config.endpoint}${route}`;
@@ -351,7 +393,7 @@ async function localAgentFetch<T>(
       body = text;
     }
   }
-  logHttpResponse(tag, method, url, response.status, response.statusText, body);
+  logHttpResponse(tag, method, url, response.status, response.statusText, opts?.redactResponseLog ? '<redacted>' : body);
   if (!response.ok) {
     const message = typeof body === 'object' && body && 'error' in body
       ? String((body as { error: unknown }).error)
@@ -382,6 +424,137 @@ export async function fetchUserGroups(config: LocalAgentConfig): Promise<LocalAg
     { method: 'GET' },
   );
   return response.groups ?? [];
+}
+
+/** Mask secret values (CLI flags / key=value) so they don't reach logs. */
+function redactSecrets(s: string): string {
+  return s
+    .replace(/(--secret-(?:key|id)[= ]+)\S+/gi, '$1***')
+    .replace(/(secret[_-]?(?:key|id)"?\s*[:=]\s*"?)[^"\s,}]+/gi, '$1***');
+}
+
+/** Execute a shell command string with a timeout. Rejects on non-zero exit or timeout. */
+async function execPluginCommand(cmd: string, timeoutMs: number): Promise<void> {
+  const { spawn } = await import('node:child_process');
+  await new Promise<void>((resolve, reject) => {
+    const child = process.platform === 'win32'
+      ? spawn('cmd', ['/c', cmd], { windowsHide: true, stdio: ['ignore', 'ignore', 'pipe'] })
+      : spawn('/bin/sh', ['-lc', cmd], { stdio: ['ignore', 'ignore', 'pipe'] });
+    let stderr = '';
+    child.stderr?.on('data', (d) => { stderr += d.toString(); if (stderr.length > 8192) stderr = stderr.slice(-8192); });
+    const timer = setTimeout(() => { child.kill('SIGKILL'); reject(new Error(`command timed out after ${timeoutMs}ms`)); }, timeoutMs);
+    child.on('error', (e) => { clearTimeout(timer); reject(e); });
+    child.on('close', (code) => { clearTimeout(timer); code === 0 ? resolve() : reject(new Error(`command failed (exit ${code})${stderr ? ' :: ' + redactSecrets(stderr.slice(0, 200).trim()) : ''}`)); });
+  });
+}
+
+/**
+ * Fetch backend plugin config.
+ * Route = /api/local-agent/get-config → final URL: <endpoint>/api/local-agent/get-config.
+ * localAgentFetch builds `url = config.endpoint + route`, matching report/sync pattern.
+ */
+async function fetchPluginConfig(config: LocalAgentConfig, tag: string): Promise<unknown> {
+  return localAgentFetch<unknown>(config, tag, '/api/local-agent/get-config', { method: 'GET' }, { redactResponseLog: true });
+}
+
+const PLUGIN_PULL_INTERVAL_MS = 12 * 60 * 60 * 1000;
+const PLUGIN_FAIL_BACKOFF_MS = 60 * 60 * 1000;
+
+function getPluginPullStatePath(): string {
+  return path.join(getLocalAgentHome(), 'plugin-pull.json');
+}
+
+function buildReconcileDeps(config: LocalAgentConfig, tag: string): ReconcileDeps {
+  return {
+    readPlugins: () => readPluginState(),
+    mutatePlugins: (fn) => withPluginStateLock(fn),
+    execCommand: (cmd, t) => execPluginCommand(cmd, t),
+    now: () => Date.now(),
+    log: { debug: (msg) => log.debug(`${tag} ${msg}`), warn: (msg) => log.warn(`${tag} ${msg}`) },
+  };
+}
+
+/** On session start, throttle-check and spawn a detached worker for plugin reconcile. Never blocks. */
+async function maybeReconcilePlugins(context: LocalAgentContext): Promise<void> {
+  try {
+    const state = (await readJson<{ lastPullAt?: number; lastFailAt?: number }>(getPluginPullStatePath())) ?? {};
+    const now = Date.now();
+    if (state.lastPullAt && now - state.lastPullAt < PLUGIN_PULL_INTERVAL_MS) return;
+    if (state.lastFailAt && now - state.lastFailAt < PLUGIN_FAIL_BACKOFF_MS) return;
+    const tool = context.tool ?? 'workbuddy';
+    const localAgentId = `${tool}-${resolveLocalAgentId(context)}`;
+    const { spawn } = await import('node:child_process');
+    if (!process.argv[1]) { log.debug('[local-agent] plugin reconcile: no CLI entrypoint (argv[1]), skipping'); return; }
+    const child = spawn(process.execPath, [process.argv[1], 'source', 'reconcile-plugins'],
+      { detached: true, stdio: 'ignore', env: { ...process.env, TEAMAI_PLUGIN_LOCAL_AGENT_ID: localAgentId } });
+    child.unref();
+  } catch (e) { log.debug(`[local-agent] plugin reconcile spawn skipped: ${(e as Error).message}`); }
+}
+
+/** Detached worker: pull get-config and reconcile plugins once, guarded by a reconcile lock. */
+export async function runPluginReconcileWorker(): Promise<void> {
+  const config = await loadLocalAgentConfig();
+  if (!config) return;
+  const lockPath = path.join(getLocalAgentHome(), 'plugin-reconcile.lock');
+  await ensureDir(path.dirname(lockPath));
+  let acquired = false;
+  try {
+    try {
+      const fd = await fs.promises.open(lockPath, 'wx');
+      await fd.close();
+      acquired = true;
+    } catch (e) {
+      if ((e as { code?: string }).code !== 'EEXIST') throw e;
+      try {
+        const st = await fs.promises.stat(lockPath);
+        if (Date.now() - st.mtimeMs > 30 * 60 * 1000) {
+          await fs.promises.rm(lockPath, { force: true });
+          const fd = await fs.promises.open(lockPath, 'wx');
+          await fd.close();
+          acquired = true;
+        }
+      } catch { /* ignore */ }
+      if (!acquired) return;
+    }
+    const tag = '[local-agent] [plugin-reconcile]';
+    const statePath = getPluginPullStatePath();
+    try {
+      const resp = await fetchPluginConfig(config, tag);
+      const { vars, plugins } = parseGetConfig(resp);
+      const laid = process.env.TEAMAI_PLUGIN_LOCAL_AGENT_ID;
+      if (!laid) log.debug(tag + ' no local_agent_id in env; plugins needing it will be skipped');
+      const allVars = { ...vars, ...(laid ? { local_agent_id: laid } : {}) };
+      const resolved: typeof plugins = [];
+      for (const p of plugins) {
+        const rp = {
+          ...p,
+          installCmd: substituteVars(p.installCmd, allVars),
+          updateCmd: p.updateCmd ? substituteVars(p.updateCmd, allVars) : undefined,
+          uninstallCmd: substituteVars(p.uninstallCmd, allVars),
+          runCmd: substituteVars(p.runCmd, allVars),
+        };
+        const missing = [...new Set([
+          ...unresolvedPlaceholders(rp.installCmd),
+          ...unresolvedPlaceholders(rp.runCmd),
+          ...unresolvedPlaceholders(rp.uninstallCmd),
+          ...(rp.updateCmd ? unresolvedPlaceholders(rp.updateCmd) : []),
+        ])];
+        if (missing.length) {
+          log.warn(`${tag} plugin ${p.slug}: unresolved placeholders [${missing.join(',')}], skipping`);
+          continue;
+        }
+        resolved.push(rp);
+      }
+      await reconcilePlugins(resolved, buildReconcileDeps(config, tag));
+      await writeJson(statePath, { lastPullAt: Date.now() });
+    } catch (e) {
+      const prev = (await readJson<{ lastPullAt?: number; lastFailAt?: number }>(statePath)) ?? {};
+      await writeJson(statePath, { ...prev, lastFailAt: Date.now() });
+      log.debug(`${tag} reconcile failed: ${(e as Error).message}`);
+    }
+  } finally {
+    if (acquired) await fs.promises.rm(lockPath, { force: true });
+  }
 }
 
 async function askViaTty(prompt: string): Promise<string | null> {
@@ -1224,6 +1397,10 @@ export async function reportAndSyncLocalAgent(context: LocalAgentContext): Promi
   const tag = localAgentTag(context);
   log.debug(`${tag} run: endpoint=${config.endpoint}`);
 
+  if (context.event?.type === 'session_start') {
+    await maybeReconcilePlugins(context);
+  }
+
   try {
     const reportPayload = await buildReportPayload(config, context);
     await localAgentFetch(config, tag, '/api/local-agent/report', {
@@ -1390,6 +1567,11 @@ export async function removeLocalAgentHttp(): Promise<void> {
     log.info('No HTTP source configured — nothing to remove.');
     return;
   }
+
+  // Tear down installed plugins before removing teamai's local-agent state.
+  try {
+    await teardownAllPlugins(buildReconcileDeps(config, '[local-agent] [uninstall]'));
+  } catch (e) { log.warn(`[local-agent] plugin teardown failed: ${(e as Error).message}`); }
 
   const kinds: CommandResourceKind[] = ['skill', 'rule', 'claudemd'];
   const manifest = await loadManifest();

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -436,7 +436,14 @@ function redactSecrets(s: string): string {
     .replace(/(bearer\s+)[\w.\-]+/gi, '$1***');
 }
 
-/** Execute a shell command string with a timeout. Rejects on non-zero exit or timeout. */
+/**
+ * Execute a shell command string with a timeout.
+ *
+ * Completion is gated on the process 'exit' event, NOT 'close': a setup command that
+ * daemonizes and leaves the inherited stderr pipe open in a background process would never
+ * emit 'close', producing a false timeout even though the command itself finished.
+ * Rejects on non-zero exit, termination by signal, or timeout.
+ */
 async function execPluginCommand(cmd: string, timeoutMs: number): Promise<void> {
   const { spawn } = await import('node:child_process');
   await new Promise<void>((resolve, reject) => {
@@ -444,10 +451,38 @@ async function execPluginCommand(cmd: string, timeoutMs: number): Promise<void> 
       ? spawn('cmd', ['/c', cmd], { windowsHide: true, stdio: ['ignore', 'ignore', 'pipe'] })
       : spawn('/bin/sh', ['-lc', cmd], { stdio: ['ignore', 'ignore', 'pipe'] });
     let stderr = '';
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout>;
     child.stderr?.on('data', (d) => { stderr += d.toString(); if (stderr.length > 8192) stderr = stderr.slice(-8192); });
-    const timer = setTimeout(() => { child.kill('SIGKILL'); reject(new Error(`command timed out after ${timeoutMs}ms`)); }, timeoutMs);
-    child.on('error', (e) => { clearTimeout(timer); reject(e); });
-    child.on('close', (code) => { clearTimeout(timer); code === 0 ? resolve() : reject(new Error(`command failed (exit ${code})${stderr ? ' :: ' + redactSecrets(stderr.slice(0, 200).trim()) : ''}`)); });
+    const detachStderr = (): void => {
+      // Drain and unref the stderr pipe without closing it: a daemonized child may still hold
+      // the write end, and closing our read end would send it SIGPIPE. Unref-ing lets this
+      // worker process exit without waiting on — or killing — the daemon.
+      child.stderr?.removeAllListeners('data');
+      child.stderr?.resume();
+      (child.stderr as unknown as { unref?: () => void } | undefined)?.unref?.();
+    };
+    const finish = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      detachStderr();
+      child.unref();
+      fn();
+    };
+    timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      finish(() => reject(new Error(`command timed out after ${timeoutMs}ms`)));
+    }, timeoutMs);
+    child.on('error', (e) => finish(() => reject(e)));
+    child.on('exit', (code, signal) =>
+      finish(() => {
+        if (signal) return reject(new Error(`command killed by ${signal}`));
+        if (code === 0) return resolve();
+        const tail = stderr ? ' :: ' + redactSecrets(stderr.slice(0, 200).trim()) : '';
+        reject(new Error(`command failed (exit ${code})${tail}`));
+      }),
+    );
   });
 }
 

--- a/src/plugin-lifecycle.ts
+++ b/src/plugin-lifecycle.ts
@@ -109,18 +109,22 @@ export async function reconcilePlugins(
           deps.log.debug(`plugin ${d.slug}: in failure cooldown, skip`);
           continue;
         }
+        deps.log.debug(`plugin ${d.slug}: installing${d.version ? ' version ' + d.version : ''}`);
         await deps.execCommand(d.installCmd, INSTALL_TIMEOUT_MS);
         await deps.execCommand(d.runCmd, RUN_TIMEOUT_MS);
         await deps.mutatePlugins((m) => {
           m[d.slug] = makeReadyState(d, deps);
         });
+        deps.log.debug(`plugin ${d.slug}: installed and setup complete`);
       } else if (d.version !== undefined && e.version !== d.version) {
         // Version changed → update
+        deps.log.debug(`plugin ${d.slug}: updating ${e.version ?? '(unknown)'} -> ${d.version}`);
         await deps.execCommand(d.updateCmd ?? d.installCmd, UPDATE_TIMEOUT_MS);
         await deps.execCommand(d.runCmd, RUN_TIMEOUT_MS);
         await deps.mutatePlugins((m) => {
           m[d.slug] = makeReadyState(d, deps);
         });
+        deps.log.debug(`plugin ${d.slug}: updated to version ${d.version}`);
       }
       // else: steady state — plugin self-manages, teamai is no-op
     } catch (err) {
@@ -150,10 +154,12 @@ export async function reconcilePlugins(
     if (desiredSlugs.has(slug)) continue;
     const e = local[slug];
     try {
+      deps.log.debug(`plugin ${slug}: uninstalling (removed from desired list)`);
       await deps.execCommand(e.uninstallCmd, UNINSTALL_TIMEOUT_MS);
       await deps.mutatePlugins((m) => {
         delete m[slug];
       });
+      deps.log.debug(`plugin ${slug}: uninstalled`);
     } catch (err) {
       deps.log.warn(`plugin ${slug} uninstall failed: ${(err as Error).message}`);
     }
@@ -170,10 +176,12 @@ export async function teardownAllPlugins(deps: ReconcileDeps): Promise<void> {
   const plugins = await deps.readPlugins();
   for (const [slug, state] of Object.entries(plugins)) {
     try {
+      deps.log.debug(`plugin ${slug}: tearing down`);
       await deps.execCommand(state.uninstallCmd, UNINSTALL_TIMEOUT_MS);
       await deps.mutatePlugins((m) => {
         delete m[slug];
       });
+      deps.log.debug(`plugin ${slug}: torn down`);
     } catch (err) {
       deps.log.warn(`plugin ${slug} teardown failed: ${(err as Error).message}`);
     }

--- a/src/plugin-lifecycle.ts
+++ b/src/plugin-lifecycle.ts
@@ -1,0 +1,232 @@
+/** Plugin lifecycle reconciliation engine. All I/O is injected via `ReconcileDeps` for pure-logic testing. */
+
+// ---------------------------------------------------------------------------
+// Domain types
+// ---------------------------------------------------------------------------
+
+/** Desired plugin state delivered by the backend get-config response. */
+export interface PluginDescriptor {
+  slug: string;
+  version?: string;
+  /** Install package + inject hooks. Does not start the daemon. */
+  installCmd: string;
+  /** Falls back to `installCmd` when absent. */
+  updateCmd?: string;
+  uninstallCmd: string;
+  /** Setup command; plugin daemonizes itself and registers autostart. */
+  runCmd: string;
+}
+
+/** Persisted plugin state in the local manifest. */
+export interface PluginState {
+  slug: string;
+  version?: string;
+  /** true = installed and setup completed; false = partial/failed. */
+  ready: boolean;
+  installedAt?: string;
+  /** Required: needed by uninstall when the plugin is removed from desired list. */
+  uninstallCmd: string;
+  /** ISO timestamp of last failed attempt; used for failure cooldown. */
+  lastAttemptAt?: string;
+  lastError?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Injected dependencies
+// ---------------------------------------------------------------------------
+
+/** All external effects are injected so the reconciler can be unit-tested in isolation. */
+export interface ReconcileDeps {
+  /** Read the current plugin manifest (slug -> PluginState). */
+  readPlugins(): Promise<Record<string, PluginState>>;
+  /**
+   * Atomically mutate the plugin manifest. The caller holds a cross-process
+   * lock around load → fn(map) → save.
+   */
+  mutatePlugins(fn: (map: Record<string, PluginState>) => void): Promise<void>;
+  /**
+   * Execute a shell command string. Rejects on non-zero exit or timeout.
+   * Callers must ensure the command string contains no secret material.
+   */
+  execCommand(cmd: string, timeoutMs: number): Promise<void>;
+  /** Return current epoch milliseconds. Injected so tests can control time. */
+  now(): number;
+  log: { debug(msg: string): void; warn(msg: string): void };
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const INSTALL_TIMEOUT_MS = 5 * 60 * 1000;
+const UPDATE_TIMEOUT_MS = 5 * 60 * 1000;
+const UNINSTALL_TIMEOUT_MS = 5 * 60 * 1000;
+/** Setup daemonizes quickly; allow 1 minute. */
+const RUN_TIMEOUT_MS = 60 * 1000;
+const FAILURE_COOLDOWN_MS = 10 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+function makeReadyState(d: PluginDescriptor, deps: ReconcileDeps): PluginState {
+  return {
+    slug: d.slug,
+    version: d.version,
+    ready: true,
+    installedAt: new Date(deps.now()).toISOString(),
+    uninstallCmd: d.uninstallCmd,
+    lastAttemptAt: undefined,
+    lastError: undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Core exports
+// ---------------------------------------------------------------------------
+
+/**
+ * Reconcile desired plugin state against local manifest.
+ *
+ * Phase A: for each desired plugin, install/update as needed; plugin self-daemonizes via runCmd.
+ * Phase B: for each locally-known plugin absent from desired, uninstall it.
+ * Each plugin is handled independently; one failure does not block others.
+ */
+export async function reconcilePlugins(
+  desired: PluginDescriptor[],
+  deps: ReconcileDeps,
+): Promise<void> {
+  const local = await deps.readPlugins();
+  const desiredSlugs = new Set(desired.map((d) => d.slug));
+
+  // Phase A: install / update / steady-state
+  for (const d of desired) {
+    const e = local[d.slug];
+    try {
+      if (!e || !e.ready) {
+        // Not installed or previous attempt failed → try install (subject to cooldown)
+        if (e?.lastAttemptAt && deps.now() - Date.parse(e.lastAttemptAt) < FAILURE_COOLDOWN_MS) {
+          deps.log.debug(`plugin ${d.slug}: in failure cooldown, skip`);
+          continue;
+        }
+        await deps.execCommand(d.installCmd, INSTALL_TIMEOUT_MS);
+        await deps.execCommand(d.runCmd, RUN_TIMEOUT_MS);
+        await deps.mutatePlugins((m) => {
+          m[d.slug] = makeReadyState(d, deps);
+        });
+      } else if (d.version !== undefined && e.version !== d.version) {
+        // Version changed → update
+        await deps.execCommand(d.updateCmd ?? d.installCmd, UPDATE_TIMEOUT_MS);
+        await deps.execCommand(d.runCmd, RUN_TIMEOUT_MS);
+        await deps.mutatePlugins((m) => {
+          m[d.slug] = makeReadyState(d, deps);
+        });
+      }
+      // else: steady state — plugin self-manages, teamai is no-op
+    } catch (err) {
+      const msg = (err as Error).message;
+      deps.log.warn(`plugin ${d.slug} reconcile failed: ${msg}`);
+      await deps.mutatePlugins((m) => {
+        const prev = m[d.slug];
+        const base: PluginState = prev ?? {
+          slug: d.slug,
+          version: d.version,
+          ready: false,
+          uninstallCmd: d.uninstallCmd,
+        };
+        // Preserve ready=true if the plugin was already healthy (transient error)
+        if (!prev || !prev.ready) {
+          base.ready = false;
+        }
+        base.lastAttemptAt = new Date(deps.now()).toISOString();
+        base.lastError = msg;
+        m[d.slug] = base;
+      });
+    }
+  }
+
+  // Phase B: remove plugins that are no longer in desired list
+  for (const slug of Object.keys(local)) {
+    if (desiredSlugs.has(slug)) continue;
+    const e = local[slug];
+    try {
+      await deps.execCommand(e.uninstallCmd, UNINSTALL_TIMEOUT_MS);
+      await deps.mutatePlugins((m) => {
+        delete m[slug];
+      });
+    } catch (err) {
+      deps.log.warn(`plugin ${slug} uninstall failed: ${(err as Error).message}`);
+    }
+  }
+}
+
+/**
+ * Tear down all locally-tracked plugins.
+ *
+ * Called when uninstalling teamai itself. Each plugin is handled independently;
+ * a failure only warns and continues.
+ */
+export async function teardownAllPlugins(deps: ReconcileDeps): Promise<void> {
+  const plugins = await deps.readPlugins();
+  for (const [slug, state] of Object.entries(plugins)) {
+    try {
+      await deps.execCommand(state.uninstallCmd, UNINSTALL_TIMEOUT_MS);
+      await deps.mutatePlugins((m) => {
+        delete m[slug];
+      });
+    } catch (err) {
+      deps.log.warn(`plugin ${slug} teardown failed: ${(err as Error).message}`);
+    }
+  }
+}
+
+/**
+ * Parse a raw get-config response into structured plugin descriptors and substitution vars.
+ *
+ * New contract: iterate over each top-level key; if the value is an object that contains
+ * non-empty `install_cmd`, `run_cmd`, and `uninstall_cmd` strings, it is a plugin whose
+ * slug equals that key. Substitution vars (endpoint, topic_id, etc.) are extracted from
+ * the same section.
+ */
+export function parseGetConfig(resp: unknown): { vars: Record<string, string>; plugins: PluginDescriptor[] } {
+  const vars: Record<string, string> = {};
+  const plugins: PluginDescriptor[] = [];
+  if (!resp || typeof resp !== 'object') return { vars, plugins };
+  for (const [key, section] of Object.entries(resp as Record<string, unknown>)) {
+    if (!section || typeof section !== 'object') continue;
+    const s = section as Record<string, unknown>;
+    const isStr = (v: unknown): v is string => typeof v === 'string' && v.length > 0;
+    if (!isStr(s['install_cmd']) || !isStr(s['run_cmd']) || !isStr(s['uninstall_cmd'])) continue;
+    // substitution vars: scalar fields referenced by ${...} in run_cmd
+    for (const f of ['endpoint', 'topic_id', 'secret_id', 'secret_key', 'user_name'] as const) {
+      if (isStr(s[f])) vars[f] = s[f] as string;
+    }
+    if (typeof s['user_id'] === 'number') vars['user_id'] = String(s['user_id']);
+    else if (isStr(s['user_id'])) vars['user_id'] = s['user_id'] as string;
+    plugins.push({
+      slug: key,
+      version: isStr(s['version']) ? (s['version'] as string) : undefined,
+      installCmd: s['install_cmd'] as string,
+      updateCmd: isStr(s['update_cmd']) ? (s['update_cmd'] as string) : undefined,
+      uninstallCmd: s['uninstall_cmd'] as string,
+      runCmd: s['run_cmd'] as string,
+    });
+  }
+  return { vars, plugins };
+}
+
+/** Replace ${key} occurrences in cmd with vars[key]. Unknown keys are left untouched. */
+export function substituteVars(cmd: string, vars: Record<string, string>): string {
+  return cmd.replace(/\$\{([a-zA-Z_][a-zA-Z0-9_]*)\}/g, (match, key: string) =>
+    key in vars ? vars[key] : match
+  );
+}
+
+/** Return the list of unresolved ${...} placeholder names remaining in cmd. */
+export function unresolvedPlaceholders(cmd: string): string[] {
+  const found = new Set<string>();
+  for (const match of cmd.matchAll(/\$\{([a-zA-Z_][a-zA-Z0-9_]*)\}/g)) {
+    found.add(match[1]);
+  }
+  return [...found];
+}


### PR DESCRIPTION
## Summary

Adds a **get-config-driven plugin lifecycle** for local agents. teamai reconciles the set of local plugins declared by the backend at `GET /api/local-agent/get-config` (no `sync` involvement) and runs their declared shell commands idempotently. The first target plugin is the CLS observability collector for CodeBuddy.

The plugin **self-manages its own daemon + autostart** (e.g. `cls-codebuddy setup` daemonizes and registers a user systemd service), so teamai does **not** do OS-service keep-alive — it just runs the declared commands at the right time.

## What it does

Per plugin, the reconcile engine compares the desired state (get-config) against the local manifest:

| state | action |
|---|---|
| not installed / previous attempt failed | `install_cmd` → `run_cmd` |
| target version changed | `update_cmd` → `run_cmd` |
| steady (same version) | no-op |
| disappeared from desired list | `uninstall_cmd` |

- **Idempotency** by `(slug, version)`; **failure cooldown** (10 min) so a failing install isn't retried every session.
- **Placeholder substitution**: `run_cmd` templates like `${endpoint}/${topic_id}/${secret_id}/${secret_key}/${user_name}/${user_id}` are filled from the get-config `cls` section, and `${local_agent_id}` = `<tool>-<derived id>`. Plugins with unresolved placeholders are skipped.
- **Trigger**: on the `session_start` hook, throttled (12 h after success / 1 h backoff after failure), a **detached** worker (never blocks the hook) pulls get-config and reconciles under a cross-process lock. Also exposed as a hidden `source reconcile-plugins` command.
- **Uninstall integration**: `source remove-http` tears down all installed plugins.

## Security

- No secrets persisted in the manifest (only `slug`/`version`/`uninstall_cmd`).
- Command strings are omitted from error/log messages (`run_cmd` carries `--secret-key`).
- Residual (inherent to the plugin's CLI-arg interface): secrets are briefly visible in `ps` while `run_cmd` runs.

## Files

- `src/plugin-lifecycle.ts` (new) — dependency-injected reconcile engine (`reconcilePlugins` / `teardownAllPlugins` / `parseGetConfig` / `substituteVars` / `unresolvedPlaceholders`).
- `src/local-agent.ts` — manifest `plugins` scope, cross-process manifest lock, shell command executor with timeout, get-config fetch, detached reconcile worker, session_start trigger, uninstall teardown.
- `src/index.ts` — hidden `source reconcile-plugins` command.

## Rollout safety

The backend `get-config` endpoint isn't deployed yet; until it is, the session-start pull fails fast and backs off (1 h) — the feature is effectively a no-op with no impact on existing behavior.

## Test Plan

- [x] `npx tsc --noEmit` clean; `npm run build` succeeds.
- [x] 20 unit tests for `plugin-lifecycle` (reconcile paths, cooldown, disappear→uninstall, substituteVars/unresolvedPlaceholders, parseGetConfig). Full suite green except 3 pre-existing skill-dir-naming failures that also fail on `main` (environment-dependent).
- [x] Linux end-to-end via the built CLI against a mock get-config: placeholder substitution → **real** `npm install -g tencentcloud-cls-sdk-codebuddy(-test)` → `cls-codebuddy setup` (daemon running, hooks injected, endpoint/topic/service-name correctly substituted, self-registered systemd autostart); idempotent no-op; disappear → uninstall. (CLS data delivery not verifiable from here — the collector credentials are write-only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
