### PR TITLE
feat(uninstall): tear down local-agent plugins on uninstall

### DIFF
--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -1642,6 +1642,25 @@ function parseScopeKey(key: string): { scope: LocalAgentScope; workspacePath?: s
 }
 
 /**
+ * Run each installed plugin's uninstall_cmd (stop daemons, deregister autostart,
+ * remove packages) using the persisted plugin manifest. No-op when no HTTP source
+ * is configured.
+ *
+ * Best-effort: failures are logged, never thrown, so teardown of the rest of teamai
+ * is never blocked. Must run BEFORE ~/.teamai is deleted — it reads the plugin
+ * manifest and endpoint config from ~/.teamai/local-agent/.
+ */
+export async function teardownLocalAgentPlugins(): Promise<void> {
+  try {
+    const config = await loadLocalAgentConfig();
+    if (!config) return;
+    await teardownAllPlugins(buildReconcileDeps(config, '[local-agent] [uninstall]'));
+  } catch (e) {
+    log.warn(`[local-agent] plugin teardown failed: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+/**
  * Tear down the HTTP local-agent bypass: uninstall every resource recorded in the
  * manifest (skills/rules/claudemd, across all scopes) from the AI tool dirs, then
  * remove the whole ~/.teamai/local-agent/ directory (config + manifest).

--- a/src/uninstall.ts
+++ b/src/uninstall.ts
@@ -364,6 +364,20 @@ function printSummary(plan: RemovalPlan): void {
 
 // ─── Execution ─────────────────────────────────────────
 
+/**
+ * Stop and uninstall local-agent plugins (best-effort) before ~/.teamai is deleted.
+ * Dynamic import mirrors source.ts — keeps local-agent's heavy dependency graph out
+ * of uninstall's static import chain.
+ */
+async function teardownPlugins(): Promise<void> {
+  try {
+    const { teardownLocalAgentPlugins } = await import('./local-agent.js');
+    await teardownLocalAgentPlugins();
+  } catch (e) {
+    log.warn(`plugin teardown failed: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
 async function executeRemoval(plan: RemovalPlan): Promise<void> {
   // (a) Remove hooks from tool settings (built-in A + team B via the manifest)
   for (const { path: settingsPath, tool } of plan.hookFiles) {
@@ -478,6 +492,8 @@ async function executeRemoval(plan: RemovalPlan): Promise<void> {
 
   // (g) Remove ~/.teamai/ directory (last — earlier steps read from it)
   if (plan.teamaiHomeExists) {
+    // Tear down plugins first: their manifest/config live under ~/.teamai/local-agent.
+    await teardownPlugins();
     try {
       await remove(plan.teamaiHome);
       log.success(`移除 ${plan.teamaiHome}/`);
@@ -560,6 +576,7 @@ export async function uninstall(opts: UninstallOptions): Promise<void> {
     }
 
     try {
+      await teardownPlugins();
       await remove(home);
       log.success(`移除 ${home}/`);
       log.success('teamai 卸载完成');


### PR DESCRIPTION
## Problem

`teamai uninstall` removes synced skills/rules/hooks/docs and the `~/.teamai` directory, but it never touched **local-agent plugins**. Their npm packages, running daemons, and OS autostart registrations survived a full uninstall — only `teamai remove-http` tore plugins down (via `teardownAllPlugins` in `removeLocalAgentHttp`).

Result: after `teamai uninstall`, a plugin such as the CLS/CodeBuddy collector keeps running and stays registered for autostart.

## Change

- **`src/local-agent.ts`**: new exported `teardownLocalAgentPlugins()` — loads the local-agent config (no-op when no HTTP source is configured) and runs each installed plugin's persisted `uninstall_cmd` via the existing reconcile deps. Fully best-effort: any failure (including a bad dynamic import or a throwing teardown) is logged, never thrown, so it can never block the rest of the uninstall.
- **`src/uninstall.ts`**: new `teardownPlugins()` wrapper (dynamic import, mirroring `source.ts`, to keep local-agent's heavy dependency graph out of uninstall's static chain). Invoked **before `~/.teamai` is deleted** on both paths:
  - full-plan path — `executeRemoval` step (g), before `remove(plan.teamaiHome)`;
  - minimal fallback path — before `remove(home)`.

Timing matters: the plugin manifest and endpoint config live under `~/.teamai/local-agent/`, so teardown must precede the directory removal.

Note: whether the daemon is actually stopped / autostart deregistered depends on the plugin's own `uninstall_cmd` content (delivered by the backend get-config). This PR guarantees teamai *invokes* that command on `uninstall`; a bare `npm uninstall -g …` that doesn't stop its daemon is a backend-config concern, not a teamai one.

## Test Plan

- [x] `npx tsc --noEmit` — passes
- [x] `npm run build` — passes
- [x] E2E (temp `HOME`): plugin with `ready:true` + observable `uninstall_cmd` → `teamai uninstall --force` executes the command (marker created) and removes `~/.teamai`
- [x] E2E negative: config present but no `plugins.json` → uninstall exits 0, removes `~/.teamai`, no throw
- [x] `npx vitest run` — no new failures (3 pre-existing skill-rename failures in `local-agent.test.ts` also fail on clean `main`, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)