### PR TITLE
docs: simplify README and supplement usage-guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
 [![npm downloads](https://img.shields.io/npm/dm/teamai-cli.svg)](https://www.npmjs.com/package/teamai-cli)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
+[![Discord](https://img.shields.io/discord/1234567890?label=Discord&logo=discord)](https://discord.gg/gervEZm58g)
+
+💬 **User Discussion:** [Discord](https://discord.gg/gervEZm58g) | 🛠 **Developer Chat:** [Discord](https://discord.gg/DeHHxPnfZF)
+
 Make every AI coding agent work by the same harness.
 
 Git-native management of skills, rules, and docs across 20+ AI tools — for you or your whole team.
@@ -21,23 +25,14 @@ Git-native management of skills, rules, and docs across 20+ AI tools — for you
 
 > 📚 **Provider notes:** [docs/providers.md](docs/providers.md) — GitHub / TGit differences and auth setup.
 
-Questions or suggestions are welcome — please open a PR or an Issue and help build this project together.
-
 ## Install
 
 ```bash
 npm install -g teamai-cli
+npm install -g @tencent/teamai-cli --registry=http://r.tnpm.oa.com  # Tencent internal
 ```
 
-<details>
-<summary>Tencent internal users: install <code>@tencent/teamai-cli</code> via tnpm</summary>
-
-```bash
-npm install -g @tencent/teamai-cli --registry=http://r.tnpm.oa.com
-```
-
-The two packages share identical source code; `@tencent/teamai-cli` is just the internal mirror of the public `teamai-cli`.
-</details>
+Prerequisites: Node.js 20+. To update: `npm update -g teamai-cli`
 
 ## Quick Start
 
@@ -57,89 +52,43 @@ teamai init --repo yourteam/yourproject --scope user --role hai_dev --force
 
 ### Admins
 
-First create the shared-experience repo on your git host (GitHub by default; TGit also supported) and grant write access to every team member.
-
-- **GitHub:** create with `gh repo create yourorg/yourproject --private` or via the UI. Then use Settings → Collaborators to add members, and set `master`/`main` as the default branch.
-- **TGit (Tencent Gongfeng):** create on [git.woa.com](https://git.woa.com/) and grant master permissions in bulk via user groups.
+Create a shared-experience repo on your git host (GitHub or TGit), grant write access to team members, then have them run `teamai init --repo <org>/<repo>`.
 
 The CLI picks a provider automatically from the repo URL:
 
 - `yourorg/yourrepo` or `https://github.com/yourorg/yourrepo` → GitHub
 - `https://git.woa.com/yourteam/yourrepo` → TGit
 
-### Read-only consumers (HTTP team repo, no git)
+### Read-only consumers (HTTP mode)
 
-Some users or agents only need to *consume* a team's skills/rules — no git clone, no push. Onboard them over plain HTTP with just an API key:
+For users who only consume skills/rules without git access:
 
 ```bash
 teamai init --http https://your-team-host/api --token <api-key>
 ```
 
-- **Read-only:** `push` / `contribute` / `remove` are disabled for HTTP repos.
-- The API key is stored `0600` (never written to config, never committed); `TEAMAI_API_TOKEN` is also honored.
-- No git clone: skills/rules/CLAUDE.md are delivered per-session over the report/sync/ack lifecycle. Hooks and status reporting are wired at init time.
-
-#### Agent status reporting
-
-Once initialized, supported agents (CodeBuddy / WorkBuddy) report their installed-skill state on session start and pull down server-managed skill install / update / uninstall commands, driven by the existing hook dispatch (`session-start` → report + sync, `prompt-submit` → sync). Failed deliveries are buffered to an offline queue and retried next time.
-
-> **Privacy.** The install path and machine id are only hashed *locally* to derive a stable `local_agent_id` — neither is ever uploaded.
-
-<details>
-<summary><b>HTTP contract</b> (for backend implementers) — what the <code>--http</code> endpoint must serve</summary>
-
-The value you pass to `--http <baseUrl>` is the base; every endpoint is relative to it and authenticated with `Authorization: Bearer <api-key>`.
-
-| Endpoint | Method | Purpose | Path |
-|----------|--------|---------|------|
-| `{baseUrl}/api/local-agent/report` | POST | Session start: upsert agent + installed skills | default, configurable |
-| `{baseUrl}/api/local-agent/sync` | POST | Report status + return pending skill commands | default, configurable |
-| `{baseUrl}/api/local-agent/commands/ack` | POST | Ack one command (`{ id, status, error }`) | default, configurable |
-
-`POST /api/local-agent/sync` returns pending commands that install/update/uninstall skills:
-
-```json
-{
-  "ok": true,
-  "commands": [{ "id": 1, "type": "install_skill", "skill_slug": "x", "skill_version": "1.0.0", "download_url": "https://signed-url/..." }]
-}
-```
-
-- A skill `download_url` is fetched **directly** — it carries its own signed auth in the query string, so no `Bearer` header is sent. It must resolve to a `.zip` whose root is either `<slug>/SKILL.md …` or a flat `SKILL.md …`.
-
-**Configurable paths.** The three reporter paths are defaults you can override. The JSON shapes above are the contract. Knobs (env vars):
-
-| Variable | Effect |
-|----------|--------|
-| `TEAMAI_API_TOKEN` | API key (alternative to `--token`) |
-| `TEAMAI_REPORT_ENDPOINT` | Reporter base URL (defaults to the `--http` URL) |
-| `TEAMAI_REPORT_PATHS` | JSON `{ "report", "sync", "ack" }` to override the three reporter paths |
-| `TEAMAI_REPORT_AGENTS` | Comma-separated agents that report (default `workbuddy,codebuddy`) |
-| `TEAMAI_SKILL_DOWNLOAD_HOSTS` | Comma-separated host allowlist for skill `download_url` (empty = allow all) |
-| `TEAMAI_BIND_PROMPT_ENABLED` | Set to `1` to enable the org-binding prompt (TTY prompt + injected hook hint). Off by default; `teamai bind-project` works regardless |
-
-</details>
+- Read-only: `push` / `contribute` / `remove` are disabled for HTTP repos.
+- API key stored `0600`; `TEAMAI_API_TOKEN` env var also honored.
+- No git clone needed — skills/rules are delivered per-session over the report/sync/ack lifecycle.
+- Supported agents report installed-skill state on session start and pull down server-managed install/update/uninstall commands automatically.
 
 ## Commands
 
 | Command | Description |
 |---------|-------------|
-| `teamai init` | Initialize (OAuth login, link repo, register member, inject hooks) |
-| `teamai push` | Push local resources to a branch and open a Merge Request |
+| `teamai init` | Initialize: OAuth login, link repo, register member, inject hooks |
 | `teamai pull` | Pull team resources and inject into local AI tools |
+| `teamai push` | Push local resources to a branch and open a Merge Request |
 | `teamai status` | Show local vs team repo diff |
-| `teamai recall <query>` | Search the team knowledge base (BM25 + graph-boost) |
-| `teamai recall enable/disable/status` | Toggle or check recall state (controls auto-recall hooks + subagent deployment) |
-| `teamai import --dir <path>` | Extract code knowledge graph from a local directory |
-| `teamai import --from-repo <url>` | Import a repo's code knowledge graph (`teamwiki/`) |
-| `teamai import --from-org <org>` | Batch import all repos under an organization |
-| `teamai import --from-repo-list <yaml>` | Batch import repos from a whitelist |
-| `teamai import --from-mr <url>` | Extract learning from a merged MR/PR |
-| `teamai import --from-iwiki <id>` | Import iWiki documents as learnings |
-| `teamai codebase --lint` | Knowledge graph health check |
 | `teamai contribute` | Share session experience to team repo |
+| `teamai recall <query>` | Search the team knowledge base (BM25 + graph-boost) |
+| `teamai recall enable/disable/status` | Toggle or check recall state |
+| `teamai import` | Import knowledge (`--dir`, `--from-repo`, `--from-org`, `--from-repo-list`, `--from-mr`, `--from-iwiki`) |
+| `teamai codebase --lint` | Knowledge graph health check |
+| `teamai ci extract-mr --url <url>` | CI: extract knowledge from MR, post comments, write after merge |
 | `teamai members` | List team members |
 | `teamai roles` | Manage team roles and namespaces |
+| `teamai source` | Manage cross-team skill subscriptions |
 | `teamai remove <type> <name>` | Remove a resource and open MR |
 | `teamai digest` | Generate weekly team usage digest |
 | `teamai doctor` | Diagnose configuration issues |
@@ -147,436 +96,138 @@ The value you pass to `--http <baseUrl>` is the base; every endpoint is relative
 
 Global options: `--dry-run`, `--verbose`
 
-Import options: `--incremental`, `--skip-enrich` (skip AI calls, only extract + graph)
-
-<details>
-<summary>More commands (management, CI, analytics)</summary>
-
-| Command | Description |
-|---------|-------------|
-| `teamai list [type]` | List resources (skills\|rules\|docs\|env\|wiki) |
-| `teamai skill [show <name>]` | Inspect skill metadata and contributors |
-| `teamai source` | Manage cross-team skill subscriptions |
-| `teamai tags` | Manage tag-based resource filtering |
-| `teamai env` | Manage team environment variables |
-| `teamai hooks` | Manage AI-tool hooks |
-| `teamai cache --gc` | Garbage-collect clone cache |
-| `teamai ci extract-mr --url <url>` | CI: extract knowledge from MR, post comments, write after merge |
-
-</details>
-
 ## How It Works
 
 ```
-Member A                             Member B
-  create skill / write rules           same
-    │                                     │
-    ▼                                     ▼
-  teamai push                        teamai push
-    │                                     │
-    ▼                                     ▼
-  create branch + MR                 create branch + MR
-    │                                     │
-    └──────► team git repo ◄─────────────┘
-                  │         ▲
-                  │         │ reviewer approves + merges MR
-                  ▼
-             SessionStart hook → teamai pull
-             auto-synced to every member's local
+teamai push → create branch + MR → reviewer approves + merges
+                                         ↓
+              SessionStart hook → teamai pull → synced to local AI tools
 ```
 
-- `teamai push` creates a dedicated branch (`teamai/push/<user>/<timestamp>`), pushes it, then opens a Merge Request and assigns reviewers automatically.
-- `teamai init` lets you configure default reviewers (stored in the `reviewers` field of `teamai.yaml`).
-- `teamai init` injects hooks tailored to each tool's format (`SessionStart`, `Stop`, `PostToolUse`, `UserPromptSubmit`, etc.). During sessions the hooks run `teamai pull`, `teamai update`, tracking, dashboard updates, and so on (supports Claude Code, Codex, Claude Code Internal, Codex Internal, Cursor, CodeBuddy IDE, OpenClaw, WorkBuddy).
-- Skills sync to `~/.claude/skills/`, `~/.codex/skills/`, `~/.codex-internal/skills/`, `~/.claude-internal/skills/`, `~/.cursor/skills/`, `~/.codebuddy/skills/`.
-- Rules sync to each tool's rules directory and are merged into `CLAUDE.md` via marker comments (supported for claude, claude-internal, codebuddy).
-- Knowledge syncs to `~/.teamai/docs/`.
-- Learnings sync to `~/.teamai/learnings/` and back the recall index (shared team-wide, not partitioned by role).
-- Culture syncs the team culture file (`culture.md`): its frontmatter and body are compiled and injected into every AI tool's `CLAUDE.md`.
+TeamAI stores skills, rules, docs, and learnings in a shared git repo. Members push changes via `teamai push`, which opens a Merge Request for review. Once merged, `teamai pull` (triggered automatically on session start via hooks) syncs the latest resources into every member's local AI tools.
+
+Skills sync to `~/.claude/skills/`, `~/.codex/skills/`, `~/.cursor/skills/`, `~/.codebuddy/skills/`, etc.
 
 ## Role-scoped Skills
 
-When the team resource repo enables role-scoped directories, skills are organized under role namespaces. During `teamai init`, the CLI asks you to pick a `primaryRole` and optional `additionalRoles` and writes them to your local `config.yaml`.
-
-Remote repo layout convention:
-
-```text
-manifest/roles.yaml            # role definitions
-skills/<namespace>/<skill>/    # skills organized by namespace
-rules/                         # global, not role-scoped
-```
-
-- `teamai pull` reads `manifest/roles.yaml` and only syncs skills under `primaryRole + additionalRoles` namespaces (unioned with tag-filter results).
-- Skills install flat from `skills/<namespace>/<skill-name>/` into `<tool>/skills/<skill-name>/` — the namespace layout is invisible to users.
-- If two activated namespaces contain a skill with the same name, `pull` fails outright to prevent silent overrides.
-- Skills outside both activated namespaces and tag-filter results are cleaned up automatically.
-- `rules/`, `docs/`, `learnings/` keep their original behavior and are not role-scoped (learnings are shared team-wide).
-
-Example config:
+Skills are organized under role namespaces. During `teamai init`, you pick a `primaryRole` and optional `additionalRoles`. `teamai pull` only syncs skills matching your activated namespaces.
 
 ```yaml
+# ~/.teamai/config.yaml
 primaryRole: hai
 additionalRoles:
   - pm
-resourceProfileVersion: 1
 ```
 
-This syncs every skill from `skills/common/`, `skills/hai/`, and `skills/pm/`.
+This syncs skills from `skills/common/`, `skills/hai/`, and `skills/pm/`.
 
-## Role-scoped Pushing
-
-In a role-scoped repo, when you push a new skill the CLI auto-detects available namespaces and prompts:
-
-```bash
-# Interactive namespace selection (recommended)
-teamai push
-# Output:
-# Which namespace should new skills be pushed to?
-#   1. common
-#   2. hai
-#   3. pm
-# Choose namespace [1-3] (default: 1 = common):
-
-# Explicit target namespace
-teamai push --role pm
-```
-
-- With a `primaryRole`, the list expands from `manifest/roles.yaml`.
-- Without a `primaryRole`, namespaces are discovered by scanning the team repo's directory structure.
-- When only one namespace exists, it's selected automatically — no prompt.
-- `--role <id>` temporarily overrides the target namespace.
-- Modifying an existing skill keeps its original namespace — no reselection needed.
-
-On push, the CLI checks `SKILL.md`'s YAML frontmatter (`name`/`description`) and auto-fills anything missing, so you don't have to maintain it by hand.
-
-## Team Culture
-
-Create `culture.md` at the root of the team repo. Use YAML frontmatter for company/team info and the body for cultural guidelines:
-
-```markdown
----
-company:
-  name: Acme Corp
-  mission: Build great things
-  values:
-    - Innovation
-    - Integrity
-team:
-  name: Platform
-  mission: Enable developers
-  goals:
-    - Ship v2.0
-    - Improve test coverage
----
-
-## Coding Guidelines
-
-- Every PR needs at least one reviewer approval
-- Direct pushes to master are forbidden
-- Test coverage must stay above 80%
-```
-
-`teamai pull` compiles `culture.md` into structured content and injects it into every AI tool's `CLAUDE.md` (between `<!-- [teamai:culture:start] -->` and `<!-- [teamai:culture:end] -->`). AI coding assistants pick up the team culture on every session.
-
-## Cross-team Skill Subscription
-
-Use `teamai source` to subscribe to other teams' public skill repos. Their skills sync automatically on `pull`:
-
-```bash
-# Add a subscription source
-teamai source add https://github.com/other-team/teamai-public.git --name other-team
-
-# List subscribed sources
-teamai source list
-
-# Browse skills from a source
-teamai source browse other-team
-
-# Remove a subscription (and clean up its skills)
-teamai source remove other-team
-```
-
-Subscribed skills sync to your local machine on `teamai pull` and coexist with your own team's skills.
-
-### HTTP source (report/sync/ack)
-
-The subscriptions above are **git** sources. You can additionally attach a single **HTTP** source that uses the report/sync/ack lifecycle — the same one an `init --http` consumer gets — **alongside your existing git main repo**, without changing it:
-
-```bash
-# Attach an HTTP source (git main repo stays untouched)
-teamai source add-http https://your-team-host/api --token <api-key>
-
-# See it listed under "HTTP source"
-teamai source list
-
-# Detach it (uninstalls its resources, clears its config)
-teamai source remove-http
-```
-
-The HTTP source reports status and pulls down skills/rules/CLAUDE.md commands on each AI session, driven by the `hook-dispatch` hook that `teamai init` already installs. Users who never run `add-http` are unaffected.
-
-Only one HTTP source is supported, and it is meant for **git-based** main repos: if your main repo is itself an HTTP backend (`init --http`), it already owns the HTTP config, so `add-http` is rejected.
-
-## Scope
-
-TeamAI supports two scopes that can coexist:
-
-| Dimension | User Scope (default) | Project Scope |
-|-----------|---------------------|---------------|
-| **Install location** | under `~/` (e.g. `~/.claude/skills/`) | under the project (e.g. `<project>/.claude/skills/`) |
-| **Config file** | `~/.teamai/config.yaml` | `<project>/.teamai/config.yaml` |
-| **Use case** | general team norms, cross-project skills | project-specific skills and rules |
-| **Init** | `teamai init --repo <group>/<repo>` | `cd <project> && teamai init --repo <group>/<repo> --scope project` |
-
-**Dual-scope cooperation:**
-- `teamai pull` pulls user and project scopes sequentially; they don't conflict.
-- `teamai contribute --scope user/project` lets you pick which repo to push to.
-- `teamai recall` merges knowledge bases from both scopes into a single ranking and tags each result with its origin `[user]` / `[project]`.
-- The `scope` field in the remote `teamai.yaml` locks the repo's type; member init must match.
-
-## Automatic Experience Sharing
-
-When an AI coding session ends, the Stop hook evaluates session value and prompts you to share:
-
-```
-AI coding session (ongoing...)
-    │
-    ▼  PostToolUse hook continuously tracks tool calls and skill usage
-    │
-    ▼  session ends (Stop hook fires)
-    │
-    ├─ Smart scoring: tool-call count + tool diversity + skill usage + error retries + session duration
-    │  (extracted from dashboard events.jsonl, one-shot, out of 100)
-    │
-    ├─ Score < 35 → stay silent (too few or too uniform calls, not worth summarizing)
-    │
-    ▼  Score ≥ 35
-    │
-    AI: "This session was productive — consider running /teamai-share-learnings to share."
-    │
-    ▼  user accepts
-    │
-    /teamai-share-learnings (AI sub-agent)
-    ├─ AI summarizes the session's lessons
-    ├─ Generates a Markdown document
-    └─ teamai contribute --file <path> → pushes directly to the team repo's learnings/
-```
-
-- `/teamai-share-learnings` is a built-in CLI skill, deployed locally by `teamai pull/init`.
-- Each session is prompted at most once (de-duplicated); you can always ignore it.
-- The document lands directly in `learnings/` and is visible to teammates on their next `pull`.
+When pushing, the CLI auto-detects available namespaces and prompts you to pick one (or use `teamai push --role pm` to specify directly).
 
 ## Team Knowledge Recall
 
-`teamai recall` implements the "read" side of the knowledge flywheel — the AI can search across accumulated team experience docs:
-
-```
-contribute (write) → pull (sync + index) → recall (search) → upvote (vote) → better ranking
-```
+`teamai recall` searches across accumulated team knowledge:
 
 ```bash
-$ teamai recall "fuse port"
-[1/2] MR review caught a FUSE port-conflict bug ★1 [user]
-Author: jeffyxu | Score: 18.5 | Tags: troubleshooting, fuse, k8s
+$ teamai recall "port conflict"
+[1/2] MR review caught a port-conflict bug ★1 [user]
+Author: member-a | Score: 18.5 | Tags: troubleshooting, networking
 
-[2/2] FUSE deployment configuration best practices [project]
-Author: alice | Score: 12.0 | Tags: fuse, deploy
+[2/2] Deployment configuration best practices [project]
+Author: member-b | Score: 12.0 | Tags: deploy, config
 ```
 
-- **Dual-scope merged search:** automatically merges user and project scope knowledge bases, each result tagged with its origin.
-- Hybrid CJK + English search (Intl.Segmenter + CJK bigrams).
-- Searches implicitly upvote matched docs; good docs naturally float up over time.
-- Votes are written to each scope's own repo, so attribution stays correct.
-
-`teamai recall` results carry a `[<type>]` tag so callers can quickly tell which knowledge bucket a hit came from. The shared search index covers four categories:
-
-| Type | Source | Notes |
-|------|--------|-------|
-| `[learnings]` | `~/.teamai/learnings/*.md` | session experience documents |
-| `[docs]` | team repo `docs/**/*.md` | shared project knowledge |
-| `[rules]` | team repo `rules/**/*.md` | coding rules and conventions |
-| `[skills]` | team repo `skills/<name>/SKILL.md` | reusable AI skills |
-
-The index is rebuilt automatically on every `teamai pull`. Indexes built by older versions (no `version` field or missing `type`) are detected and rebuilt transparently on first use.
-
-### Recall Enable / Disable
-
-Recall is controlled at two levels — team admin sets the default, individual users can override:
-
-| Layer | File | Field | Effect |
-|-------|------|-------|--------|
-| Team default | `teamai.yaml` | `sharing.recall.enabled` | `true` / `false` (default: `false`) |
-| User override | `~/.teamai/config.yaml` | `recallEnabled` | `true` / `false` — wins over team default |
-| Env var | shell | `TEAMAI_RECALL_DISABLED=1` | Force-disable all recall hooks (quick kill-switch) |
+- Hybrid CJK + English search with BM25 + graph-boost ranking.
+- Dual-scope (user + project) merged results, tagged with origin.
+- Implicit upvoting: searches boost matched docs; good docs float up over time.
 
 ```bash
-teamai recall enable     # enable recall + deploy subagent & rules
-teamai recall disable    # disable recall + remove subagent & rules
-teamai recall status     # show effective state (team default + user override)
+teamai recall enable     # enable recall + deploy subagent
+teamai recall disable    # disable recall + remove subagent
+teamai recall status     # show effective state
 ```
 
-When recall is disabled, `teamai pull` skips deploying the recall subagent, recall rules block, and TodoWrite reminder hook. The `teamai recall <query>` manual search command still works regardless of this setting.
+## Codebase Knowledge Graph
 
-### Codebase Knowledge Graph (teamwiki/)
-
-`teamai codebase --extract` (or `teamai import --from-repo`) parses your source repos and writes a structured knowledge graph under `teamwiki/`:
-
-```
-teamwiki/
-├── router.md               # Navigation hub — lists every imported repo
-├── index.md                # Global index (auto-generated, with timestamp)
-├── hot.md                  # Active working memory (reserved for Phase 4)
-├── source-manifest.json    # Per-file hash manifest for incremental extraction
-├── .indices/
-│   └── graph-index.json    # Knowledge graph: nodes + edges (JSON)
-├── evidence/
-│   └── code/
-│       └── <project>/      # One directory per imported repo
-│           ├── index.md    # Project summary (fact count + page list)
-│           ├── component.md  # Functions / classes / components
-│           ├── interface.md  # Interface and type definitions
-│           ├── config.md   # Config keys (env vars, TOML keys, etc.)
-│           ├── error.md    # Error-handling patterns
-│           └── relation-<dir>.md  # Import relationships grouped by top-level dir
-└── gaps/
-    └── detected.md         # Detected knowledge gaps (IMPL_MISSING, LOW_CONNECTIVITY, …)
-```
-
-**graph-index.json** stores the extracted graph. A real example: 11 HAI team repos → **2 218 nodes, 852 edges**.
-
-| Field | Description |
-|-------|-------------|
-| `nodes[].kind` | `component` (function/class) or `config` (config key) |
-| `edges[].relation` | `imports` — cross-file and cross-repo dependency |
-
-Cross-repo edges are detected automatically by PascalCase label matching.
-
-`teamai recall` uses this graph for **BM25 + graph-boost** retrieval: keyword hits are re-ranked by graph proximity, so you get structurally relevant results, not just textual matches.
-
-### TodoWrite reminder hook
-
-`teamai pull` registers a PostToolUse hook on the `TodoWrite` tool. The first time a session writes a TODO list, the hook injects a one-time reminder asking the agent to invoke `teamai-recall` if it has not already done so. Per-session deduplication uses `~/.teamai/sessions/<sid>-todowrite-hint.json` (24 h TTL).
-
-To disable the reminder globally, set:
+`teamai import` parses source repos into a structured graph under `teamwiki/`, enabling structurally-aware retrieval:
 
 ```bash
-export TEAMAI_RECALL_DISABLED=1
+teamai import --from-repo https://github.com/org/repo
+teamai import --from-org myorg              # batch import all repos
+teamai codebase --lint                      # health check
 ```
 
-The same env var also disables `teamai recall`'s quality tracking (used by contribute-check's knowledge-gap detection).
+The graph stores components, interfaces, configs, and cross-repo import edges. `teamai recall` uses it for graph-boosted re-ranking.
 
-### `agents` resource type
+## Automatic Experience Sharing
 
-The team repo can ship custom subagent definitions under a flat `agents/` directory (one `*.md` file per agent). They follow the same push / pull / remove semantics as `rules`:
+When a session ends, the Stop hook evaluates session value (tool diversity, skill usage, error handling, duration). If the score is high enough, the AI suggests:
 
-```text
-team-repo/
-  agents/
-    code-reviewer.md      # team-authored subagent
-    .removed              # tombstone (auto-managed by `teamai remove agents <name>`)
+```
+建议运行 /teamai-share-learnings 总结本次 session 的经验并分享给团队。
 ```
 
-`teamai pull` copies them into every Tier-1 tool's `agents/` directory (e.g. `~/.claude/agents/`). The CLI built-in `teamai-recall.md` is deployed alongside team agents and is **excluded** from `teamai push` (it is CLI-managed, not team-managed).
+The `/teamai-share-learnings` skill summarizes the session and pushes a learning document directly to the team repo. Each session is prompted at most once.
 
-### `hooks` resource type (team-declared hooks)
+## Team Hooks
 
-Beyond the built-in operational hooks the CLI injects, a team can declare its **own** hooks once in the repo and have `teamai pull` adapt and deliver them to every AI tool (Claude Code, CodeBuddy, Cursor, …). Declare them in `hooks/hooks.yaml`:
+Declare custom hooks in `hooks/hooks.yaml` and `teamai pull` delivers them to every AI tool:
 
 ```yaml
 hooks:
-  - id: block-secret            # unique, ^[a-z0-9-]+$ — used for the marker + manifest
-    description: 提交前扫描密钥     # written into the hook description
-    event: PreToolUse           # Claude PascalCase event name (the cross-tool lingua franca)
-    matcher: Bash               # optional tool matcher
+  - id: block-secret
+    description: Scan for secrets before commit
+    event: PreToolUse
+    matcher: Bash
     command: 'bash -lc "~/.teamai/team-scripts/scan-secret.sh" || true'
-    timeout: 15                 # optional, seconds
-    tools: [claude, cursor]     # optional; default = all hook-capable tools
-
-# Optional: tune the CLI's own built-in hooks (whitelisted fields only)
-builtin:
-  disabled: [Hook dispatch post-tool-use TodoWrite]   # drop a built-in hook
-  overrides:
-    Hook dispatch stop: { timeout: 20 }               # only `timeout` may be overridden
+    tools: [claude, cursor]
 ```
-
-- `teamai pull` reconciles built-in (A) + team (B) hooks into each tool on every session start (it bypasses the "already synced" fast-path, so new/changed hooks self-heal automatically).
-- Team hooks are isolated from built-in hooks by a `[teamai:hook:<id>]` marker and tracked in `~/.teamai/managed-hooks.json`, so removing one from `hooks.yaml` cleanly removes it from every tool on the next pull — built-in hooks are never disturbed.
-- Disk format is unchanged and byte-identical for built-in hooks, so upgrading the CLI is a zero-diff, zero-regression operation for already-installed machines.
-
-Audit, force-apply, or strip the effective hooks:
 
 ```bash
-teamai hooks list      # list effective built-in (A) + team (B) hooks
-teamai hooks inject    # force-reconcile A + B into all tools
-teamai hooks remove    # remove all teamai-managed hooks (A + B)
+teamai hooks list      # list effective hooks
+teamai hooks inject    # force-reconcile into all tools
+teamai hooks remove    # remove all teamai-managed hooks
 ```
 
-> **Security.** Team hooks are arbitrary shell commands that run automatically on session events — treat the repo's write access as an execution surface (governed by MR review, same as `env.yaml`). Guards:
-> - Commands are printed for transparency when applied (unless `--silent`).
-> - `sharing.hooks.autoApply: false` (in `teamai.yaml`) holds team hooks during `pull` and only hints — the user must run `teamai hooks inject` to consent.
-> - `sharing.hooks.requireTeamScripts: true` rejects any team hook whose command is not under `~/.teamai/team-scripts/`.
-> - Set `TEAMAI_HOOKS_DISABLED=1` to veto all team hooks locally (built-in hooks still apply).
+## Cross-team Skill Subscription
 
-## Update
+### Git source
+
+Subscribe to other teams' public skill repos:
 
 ```bash
-teamai update              # auto-detect and upgrade to latest
-npm update -g teamai-cli   # or trigger an npm upgrade manually
+teamai source add https://github.com/other-team/teamai-public.git --name other-team
+teamai source list
+teamai source browse other-team    # browse available skills
+teamai source remove other-team
 ```
 
-`teamai update` picks the registry based on the installed package name:
+Subscribed skills sync automatically on `teamai pull`.
 
-- `teamai-cli` → public npm (`https://registry.npmjs.org`)
-- `@tencent/teamai-cli` → internal tnpm (`http://r.tnpm.oa.com`)
+### HTTP source
 
-To override the registry manually, set `TEAMAI_NPM_REGISTRY=<url>`.
+Attach an HTTP source alongside your existing git main repo — useful for server-managed skill delivery without changing the main repo:
 
-### Auto-update Control
+```bash
+teamai source add-http https://your-team-host/api --token <api-key>
+teamai source list            # shows under "HTTP source"
+teamai source remove-http     # detach and uninstall its resources
+```
 
-Auto-update runs on the Stop hook at the end of a session. It can be controlled at two layers:
-
-| Layer | File | Field | Allowed values |
-|-------|------|-------|----------------|
-| Team default | `teamai.yaml` | `autoUpdate` | `true` (default) / `false` |
-| User override | `~/.teamai/config.yaml` | `updatePolicy` | `auto` / `prompt` / `skip` |
-
-The user-level `updatePolicy` always wins over the team-level `autoUpdate`.
+The HTTP source reports agent status and pulls down skill commands on each session via hook dispatch. Only one HTTP source is supported per installation.
 
 ## CI Integration
 
-TeamAI can integrate into your CI pipeline to automatically extract knowledge from every MR/PR:
-
-```
-MR opened/updated → CI extracts learning + codebase suggestions → posts as comments
-    → Reviewer rejects unwanted suggestions (GitHub 👎 / TGit ☝️)
-    → MR merged → CI writes approved items to team knowledge repo
-```
-
-### Quick Start
+`teamai ci extract-mr` plugs into CI to extract learnings from every MR:
 
 ```bash
-# Comment mode: post suggestions to MR (run on PR open/update)
+# Post suggestions as comments (on PR open/update)
 teamai ci extract-mr --url "$MR_URL" --mode comment --individual-comments
 
-# Write mode: write approved items to knowledge repo (run after merge)
-teamai ci extract-mr --url "$MR_URL" --mode write --team-repo ./team-repo --individual-comments
+# Write approved items after merge
+teamai ci extract-mr --url "$MR_URL" --mode write --team-repo ./team-repo
 ```
 
-### CI Templates
-
-Ready-to-use templates in `examples/ci/`:
-
-| File | Platform |
-|------|----------|
-| `github-actions-mr-extract.yml` | GitHub Actions |
-| `coding-ci-mr-extract.yaml` | Coding CI (TGit + ZhiYan QCI) |
-
-### Reject Interaction
-
-| Platform | How to reject | Default |
-|----------|--------------|---------|
-| GitHub | Add 👎 reaction to the suggestion comment | Write all |
-| TGit | Add ☝️ emoji to the suggestion note | Write all |
+Ready-to-use templates: `examples/ci/github-actions-mr-extract.yml` (GitHub Actions), `examples/ci/coding-ci-mr-extract.yaml` (Coding CI).
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,6 +11,10 @@
 [![npm downloads](https://img.shields.io/npm/dm/teamai-cli.svg)](https://www.npmjs.com/package/teamai-cli)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
+[![Discord](https://img.shields.io/discord/1234567890?label=Discord&logo=discord)](https://discord.gg/gervEZm58g)
+
+💬 **用户讨论：** [Discord](https://discord.gg/gervEZm58g) | 🛠 **开发者交流：** [Discord](https://discord.gg/DeHHxPnfZF)
+
 让每个 AI 编程助手都按同一套标准工作。
 
 通过 Git 统一管理 skills、rules、docs，驾驭 20+ 种 AI 工具——一个人也能用，团队用更强。
@@ -21,562 +25,208 @@
 
 > 📚 **Provider 说明**：[docs/providers.md](docs/providers.md) — GitHub / TGit 差异与认证配置。
 
-如有问题或建议，欢迎提交 PR 或 Issue，一起共建这个项目。
-
 ## 安装
 
 ```bash
 npm install -g teamai-cli
+npm install -g @tencent/teamai-cli --registry=http://r.tnpm.oa.com  # 腾讯内部
 ```
 
-<details>
-<summary>腾讯内部用户：通过 tnpm 安装 <code>@tencent/teamai-cli</code></summary>
-
-```bash
-npm install -g @tencent/teamai-cli --registry=http://r.tnpm.oa.com
-```
-
-两个包的代码内容一致，`@tencent/teamai-cli` 只是公网 `teamai-cli` 的内网镜像。
-</details>
+前置要求：Node.js 20+。更新：`npm update -g teamai-cli`
 
 ## 快速开始
 
 ### 团队成员
 
 ```bash
-# 用户级初始化（默认，资源安装到 ~/）
+# 用户级初始化（默认，资源安装到 ~/ 下）
 teamai init --repo yourteam/yourproject
 
 # 项目级初始化（资源安装到项目目录下）
 cd /path/to/my-project
 teamai init --repo yourteam/yourproject --scope project
 
-# 非交互模式（适合 CI/CD 或 AI agent 自动化）
+# 非交互模式（适用于 CI/CD 或 AI 自动化场景）
 teamai init --repo yourteam/yourproject --scope user --role hai_dev --force
 ```
 
 ### 管理员
 
-先在 git 托管平台上创建好团队共享经验的仓库（默认 GitHub；TGit 也支持），并把所有团队成员加入到该仓库的 write 权限。
+在 Git 托管平台（GitHub 或 TGit）创建共享经验仓库，授予团队成员写权限，然后让他们运行 `teamai init --repo <org>/<repo>`。
 
-- **GitHub**：用 `gh repo create yourorg/yourproject --private` 创建，或在 UI 上建。然后用 Settings → Collaborators 把成员加进来，并把 master/main 设置为默认分支。
-- **TGit（腾讯工蜂）**：在 [git.woa.com](https://git.woa.com/) 上创建，通过 user group 批量添加 master 权限。
-
-CLI 会根据用户传入的 repo URL 自动选择 provider：
+CLI 自动根据仓库 URL 选择 provider：
 
 - `yourorg/yourrepo` 或 `https://github.com/yourorg/yourrepo` → GitHub
 - `https://git.woa.com/yourteam/yourrepo` → TGit
 
-### 只读消费者（HTTP 团队仓库，免 git）
+### 只读消费者（HTTP 模式）
 
-有些用户或 agent 只需要*消费*团队的 skills/rules——不需要 git clone，也不需要 push。用一个 API key 即可通过纯 HTTP 接入：
+仅消费 skills/rules、无需 git 访问的用户：
 
 ```bash
 teamai init --http https://your-team-host/api --token <api-key>
 ```
 
-- **只读**：HTTP 仓库下 `push` / `contribute` / `remove` 均被禁用。
-- API key 以 `0600` 权限保存（不写入 config，也不会被提交）；同时支持 `TEAMAI_API_TOKEN` 环境变量。
-- 无需 git clone：skills/rules/CLAUDE.md 在每次会话时通过 report/sync/ack 生命周期交付。hooks 与状态上报在 init 时即接线完成。
+- 只读模式：`push` / `contribute` / `remove` 不可用。
+- 无需 git clone——skills/rules 通过 report/sync/ack 生命周期按 session 下发。
+- 支持的 agent 在 session 启动时自动上报已安装 skill 状态，并拉取服务端管理的安装/更新/卸载指令。
 
-#### Agent 状态上报
-
-初始化后，受支持的 agent（CodeBuddy / WorkBuddy）会在 session 启动时上报本地已安装 skill 的状态，并拉取服务端下发的 skill 安装 / 更新 / 卸载命令，全部挂在既有 hook dispatch 上（`session-start` → report + sync，`prompt-submit` → sync）。下发失败会进离线队列，下次重试。
-
-> **隐私**：install path 和 machine id 仅在*本地*哈希以派生稳定的 `local_agent_id`，二者都不会上报。
-
-<details>
-<summary><b>HTTP 契约</b>（面向后端实现者）—— <code>--http</code> 端点需要提供哪些接口</summary>
-
-`--http <baseUrl>` 传入的是基础地址，所有端点都相对于它，并统一用 `Authorization: Bearer <api-key>` 鉴权。
-
-| 端点 | 方法 | 用途 | 路径 |
-|------|------|------|------|
-| `{baseUrl}/api/local-agent/report` | POST | session 启动：upsert agent + 已装 skill | 默认，可配置 |
-| `{baseUrl}/api/local-agent/sync` | POST | 上报状态 + 返回待执行的 skill 命令 | 默认，可配置 |
-| `{baseUrl}/api/local-agent/commands/ack` | POST | 回执单条命令（`{ id, status, error }`） | 默认，可配置 |
-
-`POST /api/local-agent/sync` 返回负责 skill 安装/更新/卸载的待执行命令：
-
-```json
-{
-  "ok": true,
-  "commands": [{ "id": 1, "type": "install_skill", "skill_slug": "x", "skill_version": "1.0.0", "download_url": "https://signed-url/..." }]
-}
-```
-
-- skill 的 `download_url` 是**直连**拉取——它在 query string 里自带签名鉴权，因此不附带 `Bearer` 头。它必须指向一个 `.zip`，其根目录为 `<slug>/SKILL.md …` 或扁平的 `SKILL.md …`。
-
-**可配置路径**：reporter 三个路径是可覆盖的默认值;上面的 JSON 结构是契约。可调项（环境变量）：
-
-| 变量 | 作用 |
-|------|------|
-| `TEAMAI_API_TOKEN` | API key（`--token` 的替代） |
-| `TEAMAI_REPORT_ENDPOINT` | reporter 基础 URL（默认 = `--http` 地址） |
-| `TEAMAI_REPORT_PATHS` | JSON `{ "report", "sync", "ack" }`，覆盖 reporter 三个路径 |
-| `TEAMAI_REPORT_AGENTS` | 参与上报的 agent，逗号分隔（默认 `workbuddy,codebuddy`） |
-| `TEAMAI_SKILL_DOWNLOAD_HOSTS` | skill `download_url` 的 host 白名单，逗号分隔（空 = 全部放行） |
-| `TEAMAI_BIND_PROMPT_ENABLED` | 设为 `1` 开启组织绑定提示（TTY 交互提示 + 注入的 hook 提示）。默认关闭；`teamai bind-project` 手动命令不受影响 |
-
-</details>
-
-## 命令
+## 命令一览
 
 | 命令 | 说明 |
 |------|------|
-| `teamai init` | 初始化（OAuth 登录、关联仓库、注册成员、注入 hooks） |
-| `teamai push` | 推送本地资源到独立分支并创建 MR |
+| `teamai init` | 初始化：OAuth 登录、关联仓库、注册成员、注入 hooks |
 | `teamai pull` | 拉取团队资源并注入到本地 AI 工具 |
-| `teamai status` | 查看本地 vs 团队仓库差异 |
-| `teamai recall <query>` | 搜索团队知识库（BM25 + 图谱加权） |
-| `teamai recall enable/disable/status` | 开启/关闭/查看 recall 状态（控制 auto-recall hooks 和 subagent 部署） |
-| `teamai import --dir <path>` | 从本地目录提取代码知识图谱 |
-| `teamai import --from-repo <url>` | 导入仓库代码知识图谱（`teamwiki/`） |
-| `teamai import --from-org <org>` | 批量导入组织下所有仓库 |
-| `teamai import --from-repo-list <yaml>` | 按白名单批量导入 |
-| `teamai import --from-mr <url>` | 从已合并 MR 提取 learning |
-| `teamai import --from-iwiki <id>` | 从 iWiki 导入文档为 learnings |
-| `teamai codebase --lint` | 知识图谱健康度检查 |
-| `teamai contribute` | 分享本次 session 经验到团队仓库 |
-| `teamai members` | 列出团队成员 |
+| `teamai push` | 推送本地资源到分支并创建合并请求 |
+| `teamai status` | 显示本地与团队仓库的差异 |
+| `teamai contribute` | 将 session 经验分享到团队仓库 |
+| `teamai recall <query>` | 搜索团队知识库（BM25 + 图谱增强） |
+| `teamai recall enable/disable/status` | 开关或查看 recall 状态 |
+| `teamai import` | 导入知识（`--dir`、`--from-repo`、`--from-org`、`--from-repo-list`、`--from-mr`、`--from-iwiki`） |
+| `teamai codebase --lint` | 知识图谱健康检查 |
+| `teamai ci extract-mr --url <url>` | CI：从 MR 提取知识、发评论、合并后写入 |
+| `teamai members` | 查看团队成员 |
 | `teamai roles` | 管理团队角色和命名空间 |
+| `teamai source` | 管理跨团队 skill 订阅 |
 | `teamai remove <type> <name>` | 删除资源并创建 MR |
-| `teamai digest` | 生成团队使用周报 |
+| `teamai digest` | 生成团队周报 |
 | `teamai doctor` | 诊断配置问题 |
-| `teamai uninstall` | 卸载所有 teamai 资源和 hooks |
+| `teamai uninstall` | 移除所有 teamai 资源和 hooks |
 
 全局选项：`--dry-run`、`--verbose`
-
-Import 选项：`--incremental`、`--skip-enrich`（跳过 AI 调用，仅做代码提取 + 图谱构建）
-
-<details>
-<summary>更多命令（管理、CI、分析）</summary>
-
-| 命令 | 说明 |
-|------|------|
-| `teamai list [type]` | 列出资源（skills\|rules\|docs\|env\|wiki） |
-| `teamai skill [show <name>]` | 查看 skill 元数据和贡献者 |
-| `teamai source` | 管理跨团队 skill 订阅 |
-| `teamai tags` | 管理基于标签的资源过滤 |
-| `teamai env` | 管理团队环境变量 |
-| `teamai hooks` | 管理 AI 工具 hooks |
-| `teamai cache --gc` | 回收 clone 缓存 |
-| `teamai ci extract-mr --url <url>` | CI：从 MR 提取知识，发布评论，合并后写入团队仓库 |
-
-</details>
 
 ## 工作原理
 
 ```
-成员 A                               成员 B
-  创建 skill / 写规则                   同上
-    │                                     │
-    ▼                                     ▼
-  teamai push                        teamai push
-    │                                     │
-    ▼                                     ▼
-  创建分支 + MR                       创建分支 + MR
-    │                                     │
-    └──────► 团队git仓库 ◄──────────────┘
-                  │         ▲
-                  │         │ reviewer 审批合并 MR
-                  ▼
-             SessionStart hook → teamai pull
-             自动拉取到所有成员本地
+teamai push → 创建分支 + MR → reviewer 审批合并
+                                    ↓
+           SessionStart hook → teamai pull → 同步到本地 AI 工具
 ```
 
-- `teamai push` 会创建独立分支（`teamai/push/<user>/<timestamp>`），推送后自动创建 Merge Request 并指派 reviewers
-- `teamai init` 初始化时可配置默认 reviewers（记录在 `teamai.yaml` 的 `reviewers` 字段）
-- `teamai init` 会自动注入与各工具格式对齐的 hooks（含 `SessionStart`、`Stop`、`PostToolUse`、`UserPromptSubmit` 等），会话中会执行 `teamai pull`、`teamai update`、追踪与仪表盘等（支持 Claude Code、Codex、Claude Code Internal、Codex Internal、Cursor、CodeBuddy IDE、OpenClaw、WorkBuddy）
-- Skills 同步到 `~/.claude/skills/`、`~/.codex/skills/`、`~/.codex-internal/skills/`、`~/.claude-internal/skills/`、`~/.cursor/skills/`、`~/.codebuddy/skills/`
-- Rules 同步到各工具的 rules 目录，并通过标记注释合并到 `CLAUDE.md`（支持 claude、claude-internal、codebuddy）
-- Knowledge 同步到 `~/.teamai/docs/`
-- Learnings 同步到 `~/.teamai/learnings/`，并基于该目录构建 recall 索引（全团队共享，不按角色拆分）
-- Culture 同步团队文化文件（`culture.md`），编译 frontmatter 和 body 后注入到各 AI 工具的 `CLAUDE.md`
+TeamAI 将 skills、rules、docs 和 learnings 存储在共享 Git 仓库中。成员通过 `teamai push` 提交变更并创建合并请求供审核。合并后，`teamai pull`（通过 hooks 在 session 启动时自动触发）将最新资源同步到每位成员的本地 AI 工具。
+
+Skills 同步到 `~/.claude/skills/`、`~/.codex/skills/`、`~/.cursor/skills/`、`~/.codebuddy/skills/` 等目录。
 
 ## 角色化 Skills
 
-当团队资源仓库启用角色化目录后，Skills 按角色 namespace 组织，CLI 在 `teamai init` 时要求选择 `primaryRole` 和可选的 `additionalRoles`，并写入本地 `config.yaml`。
-
-远端仓库目录约定：
-
-```text
-manifest/roles.yaml        # 角色定义
-skills/<namespace>/<skill>/   # 按 namespace 组织的 skills
-rules/                     # 全局，不做角色拆分
-```
-
-- `teamai pull` 读取 `manifest/roles.yaml`，只同步 `primaryRole + additionalRoles` 对应 namespace 中的 skills（同时保留 tag 过滤的并集）。
-- Skills 从 `skills/<namespace>/<skill-name>/` 拍平安装到本地 `<tool>/skills/<skill-name>/`，用户无感知 namespace 结构。
-- 如果激活 namespace 中出现同名 skill，`pull` 会直接失败，避免隐式覆盖。
-- 不在激活 namespace 中、也不在 tag 过滤结果中的 skills 会被自动清理。
-- `rules/`、`docs/`、`learnings/` 仍然保持原有逻辑，不做角色拆分（learnings 全团队共享）。
-
-配置示例：
+Skills 按角色命名空间组织。`teamai init` 时选择 `primaryRole` 和可选的 `additionalRoles`，`teamai pull` 仅同步匹配的命名空间。
 
 ```yaml
+# ~/.teamai/config.yaml
 primaryRole: hai
 additionalRoles:
   - pm
-resourceProfileVersion: 1
 ```
 
-这会同步 `skills/common/`、`skills/hai/`、`skills/pm/` 三个 namespace 中的所有 skills。
+以上配置会同步 `skills/common/`、`skills/hai/`、`skills/pm/` 下的所有 skills。
 
-## 角色化推送
+推送时，CLI 自动检测可用命名空间并提示选择（或使用 `teamai push --role pm` 直接指定）。
 
-角色化仓库下，推送新 skill 时 CLI 会自动检测可用的命名空间并提供交互式选择：
+## 团队知识检索
+
+`teamai recall` 搜索团队积累的知识：
 
 ```bash
-# 交互式选择命名空间（推荐）
-teamai push
-# 输出：
-# Which namespace should new skills be pushed to?
-#   1. common
-#   2. hai
-#   3. pm
-# Choose namespace [1-3] (default: 1 = common):
+$ teamai recall "port conflict"
+[1/2] MR review caught a port-conflict bug ★1 [user]
+Author: member-a | Score: 18.5 | Tags: troubleshooting, networking
 
-# 显式指定目标 namespace
-teamai push --role pm
+[2/2] Deployment configuration best practices [project]
+Author: member-b | Score: 12.0 | Tags: deploy, config
 ```
 
-- 有 `primaryRole` 时，从 `manifest/roles.yaml` 展开可用 namespace 列表
-- 无 `primaryRole` 时，自动扫描团队仓库目录结构中的 namespace
-- 单一命名空间时自动选中，无需交互
-- `--role <id>` 可临时覆盖目标 namespace
-- 修改已有 skill 时自动保持原 namespace，无需重新选择
-
-推送时 CLI 会自动检查 `SKILL.md` 的 YAML frontmatter（`name`/`description`），缺失则自动补全，无需手动维护。
-
-## 团队文化（Culture）
-
-在团队仓库根目录创建 `culture.md`，用 YAML frontmatter 定义公司和团队信息，body 部分写团队文化指引：
-
-```markdown
----
-company:
-  name: Acme Corp
-  mission: Build great things
-  values:
-    - Innovation
-    - Integrity
-team:
-  name: Platform
-  mission: Enable developers
-  goals:
-    - Ship v2.0
-    - Improve test coverage
----
-
-## 编码准则
-
-- 所有 PR 必须有至少一个 reviewer 审批
-- 禁止直接 push master
-- 测试覆盖率不低于 80%
-```
-
-`teamai pull` 时会自动将 culture.md 编译为结构化内容，注入到各 AI 工具的 `CLAUDE.md` 中（`<!-- [teamai:culture:start] -->` / `<!-- [teamai:culture:end] -->` 标记之间）。AI 编码助手在每次会话中都能感知团队文化。
-
-## 跨团队 Skill 订阅
-
-通过 `teamai source` 订阅其他团队的公共 skill 仓库，pull 时自动同步订阅源的 skills：
+- 中英文混合搜索，BM25 + 图谱增强排名。
+- 双 scope（用户 + 项目）合并结果，标注来源。
+- 隐式投票：搜索自动提升匹配文档权重，优质文档自然上浮。
 
 ```bash
-# 添加订阅源
-teamai source add https://git.woa.com/other-team/teamai-public.git --name other-team
-
-# 查看已订阅的源
-teamai source list
-
-# 浏览订阅源的 skills
-teamai source browse other-team
-
-# 移除订阅（同时清理其 skills）
-teamai source remove other-team
+teamai recall enable     # 启用 recall + 部署 subagent
+teamai recall disable    # 禁用 recall + 移除 subagent
+teamai recall status     # 查看生效状态
 ```
 
-订阅源的 skills 在 `teamai pull` 时自动同步到本地，与团队自有 skills 共存。
+## 代码知识图谱
 
-### HTTP source（report/sync/ack）
-
-上面的订阅源是 **git** 源。你还可以在**不改动现有 git 主仓**的前提下，额外挂一个 **HTTP** 源，它走 report/sync/ack 生命周期——与 `init --http` 消费者所用的完全相同：
+`teamai import` 将源码仓库解析为 `teamwiki/` 下的结构化图谱，实现结构感知的检索：
 
 ```bash
-# 挂一个 HTTP 源（git 主仓保持不变）
-teamai source add-http https://your-team-host/api --token <api-key>
-
-# 在 "HTTP source" 分区查看
-teamai source list
-
-# 移除（卸载其资源并清空配置）
-teamai source remove-http
+teamai import --from-repo https://github.com/org/repo
+teamai import --from-org myorg              # 批量导入所有仓库
+teamai codebase --lint                      # 健康检查
 ```
 
-HTTP 源在每次 AI 会话时上报状态并拉取 skills/rules/CLAUDE.md 指令命令，由 `teamai init` 已安装的 `hook-dispatch` hook 驱动。从不执行 `add-http` 的用户不受任何影响。
+图谱存储组件、接口、配置和跨仓库依赖边。`teamai recall` 利用图谱进行增强排名。
 
-仅支持一个 HTTP 源，且面向 **git 主仓**用户：若你的主仓本身就是 HTTP 后端（`init --http`），它已占用 HTTP 配置，此时 `add-http` 会被拒绝。
+## 自动经验沉淀
 
-## Scope（作用域）
-
-TeamAI 支持两种 scope，可以共存：
-
-| 维度 | User Scope（默认） | Project Scope |
-|------|-------------------|---------------|
-| **资源安装位置** | `~/` 下（如 `~/.claude/skills/`） | 项目目录下（如 `<project>/.claude/skills/`） |
-| **配置文件** | `~/.teamai/config.yaml` | `<project>/.teamai/config.yaml` |
-| **适用场景** | 通用团队规范、跨项目技能 | 项目特定的技能和规则 |
-| **初始化** | `teamai init --repo <group>/<repo>` | `cd <project> && teamai init --repo <group>/<repo> --scope project` |
-
-**双 scope 协同：**
-- `teamai pull` 会依次拉取 user + project 两个 scope 的资源，互不冲突
-- `teamai contribute --scope user/project` 可显式选择推送到哪个仓库
-- `teamai recall` 自动合并两个 scope 的知识库，统一搜索排序，结果标注来源 `[user]`/`[project]`
-- 远端 `teamai.yaml` 的 `scope` 字段锁定仓库类型，成员 init 时必须匹配
-
-## 经验自动分享
-
-当一次 AI coding session 结束时，系统会通过 Stop hook 智能评估 session 价值并提示分享：
+Session 结束时，Stop hook 对 session 价值评分（工具多样性、skill 使用、错误处理、时长）。达标后 AI 会建议：
 
 ```
-AI coding session (持续工作中...)
-    │
-    ▼  PostToolUse hook 持续追踪工具调用和 skill 使用
-    │
-    ▼  会话结束（Stop hook 触发）
-    │
-    ├─ 智能评分：工具调用数量 + 工具多样性 + skill 使用 + 错误重试 + session 时长
-    │  （从 dashboard events.jsonl 提取，一次性评估，满分 100）
-    │
-    ├─ 分数 < 35 → 不打扰（工具调用少或缺乏多样性，没有总结价值）
-    │
-    ▼  分数 ≥ 35
-    │
-    AI 提示："本次 session 内容丰富，建议运行 /teamai-share-learnings 分享经验"
-    │
-    ▼  用户同意
-    │
-    /teamai-share-learnings (AI sub-agent)
-    ├─ AI 总结本次 session 的经验
-    ├─ 生成 Markdown 文档
-    └─ teamai contribute --file <path> → 直接 push 到团队仓库 learnings/
+建议运行 /teamai-share-learnings 总结本次 session 的经验并分享给团队。
 ```
 
-- `/teamai-share-learnings` 是 CLI 内置 skill，随 `teamai pull/init` 自动部署到本地
-- 每个 session 最多提示一次（去重），用户可以忽略
-- 文档直接 push 到 `learnings/` 目录，团队成员下次 pull 时可见
+`/teamai-share-learnings` skill 自动总结 session 经验并推送到团队仓库。每个 session 最多提示一次。
 
-## 团队知识回忆
+## 团队 Hooks
 
-`teamai recall` 实现知识飞轮的"读出路径"——AI 可以自动搜索团队积累的经验文档：
-
-```
-contribute(写入) → pull(同步+索引) → recall(搜索) → upvote(投票) → 排序优化
-```
-
-```bash
-$ teamai recall "fuse 端口"
-[1/2] MR 审查发现 FUSE 端口冲突 Bug ★1 [user]
-Author: jeffyxu | Score: 18.5 | Tags: troubleshooting, fuse, k8s
-
-[2/2] FUSE 部署配置最佳实践 [project]
-Author: alice | Score: 12.0 | Tags: fuse, deploy
-```
-
-- **双 scope 合并搜索**：自动合并 user 和 project scope 的知识库，结果标注来源
-- Hybrid 中英文搜索（Intl.Segmenter + CJK bigrams）
-- 搜索自动投票，好文档自然浮到顶部
-- 投票按 scope 分别写入各自的 repo，归属正确
-
-`teamai recall` 的输出会给每条命中前置 `[<type>]` 标签，方便调用方快速判断知识来源。共享检索索引覆盖四类内容：
-
-| 类型 | 源路径 | 说明 |
-|------|--------|------|
-| `[learnings]` | `~/.teamai/learnings/*.md` | session 经验文档 |
-| `[docs]` | 团队仓库 `docs/**/*.md` | 共享项目知识 |
-| `[rules]` | 团队仓库 `rules/**/*.md` | 编码规则和约定 |
-| `[skills]` | 团队仓库 `skills/<name>/SKILL.md` | 可复用 AI skill |
-
-索引在每次 `teamai pull` 时自动重建。旧版索引（无 `version` 字段或缺少 `type`）会在首次使用时被自动检测并重建，对调用方透明
-
-### 开启 / 关闭 Recall
-
-Recall 功能通过两级配置控制——管理员设置团队默认值，成员可在本地覆盖：
-
-| 层级 | 配置文件 | 字段 | 说明 |
-|------|----------|------|------|
-| 团队默认 | `teamai.yaml` | `sharing.recall.enabled` | `true` / `false`（默认 `false`） |
-| 用户覆盖 | `~/.teamai/config.yaml` | `recallEnabled` | `true` / `false`，优先级高于团队默认 |
-| 环境变量 | shell | `TEAMAI_RECALL_DISABLED=1` | 强制禁用所有 recall hooks（应急开关） |
-
-```bash
-teamai recall enable     # 开启 recall，部署 subagent 和 rules
-teamai recall disable    # 关闭 recall，移除 subagent 和 rules
-teamai recall status     # 查看当前生效状态（团队默认 + 用户覆盖）
-```
-
-关闭后，`teamai pull` 将跳过部署 recall subagent、recall rules 注入块和 TodoWrite 提醒 hook。手动执行 `teamai recall <query>` 搜索不受此开关影响。
-
-### 代码库知识图谱（teamwiki/）
-
-`teamai codebase --extract`（或 `teamai import --from-repo`）解析源码仓库，将结构化知识图谱写入 `teamwiki/` 目录：
-
-```
-teamwiki/
-├── router.md               # 导航枢纽，列出所有已导入仓库
-├── index.md                # 全局索引（自动生成，含时间戳）
-├── hot.md                  # 活跃工作记忆（Phase 4 hot/cold 预留）
-├── source-manifest.json    # 源文件哈希清单（增量提取用）
-├── .indices/
-│   └── graph-index.json    # 知识图谱：nodes + edges（JSON 格式）
-├── evidence/
-│   └── code/
-│       └── <project>/      # 每个导入的仓库一个目录
-│           ├── index.md    # 项目摘要（facts 总数 + 页面列表）
-│           ├── component.md  # 函数 / 类 / 组件
-│           ├── interface.md  # 接口和类型定义
-│           ├── config.md   # 配置项（环境变量、TOML key 等）
-│           ├── error.md    # 错误处理模式
-│           └── relation-<dir>.md  # 按顶级目录分组的 import 依赖关系
-└── gaps/
-    └── detected.md         # 知识缺口检测结果（IMPL_MISSING / LOW_CONNECTIVITY / …）
-```
-
-**graph-index.json** 存储提取出的知识图谱。真实数据参考：HAI 团队 11 个仓库 → **2 218 个节点，852 条边**。
-
-| 字段 | 说明 |
-|------|------|
-| `nodes[].kind` | `component`（函数/类）或 `config`（配置项） |
-| `edges[].relation` | `imports` —— 跨文件或跨仓库依赖关系 |
-
-跨仓 edge 通过 PascalCase 标签匹配自动检测，无需手动配置。
-
-`teamai recall` 利用此图谱进行 **BM25 + graph-boost** 检索：关键词命中后按图结构邻近度重排序，结果兼具文本相关性和结构相关性。
-
-### TodoWrite 提醒 hook
-
-`teamai pull` 会在 `TodoWrite` 工具上注册一个 PostToolUse hook。当 session 第一次写 TODO 列表时，hook 会注入一次性提醒，要求 agent 在尚未调用 `teamai-recall` 时先调用一次。session 级去重通过 `~/.teamai/sessions/<sid>-todowrite-hint.json` 实现（TTL 24 小时）
-
-如果要全局关闭该提醒，请设置：
-
-```bash
-export TEAMAI_RECALL_DISABLED=1
-```
-
-该环境变量同时也会关闭 `teamai recall` 的召回质量记录（用于 contribute-check 知识空白检测）
-
-### `agents` 资源类型
-
-团队仓库可以在扁平的 `agents/` 目录下放置自定义 subagent 定义（每个 agent 一个 `*.md`），push / pull / remove 语义与 `rules` 保持一致：
-
-```text
-team-repo/
-  agents/
-    code-reviewer.md      # 团队作者编写的 subagent
-    .removed              # tombstone（由 `teamai remove agents <name>` 自动管理）
-```
-
-`teamai pull` 会把它们复制到每个 Tier-1 工具的 `agents/` 目录（例如 `~/.claude/agents/`）。CLI 内置的 `teamai-recall.md` 会与团队 agents 一起部署，并在 `teamai push` 时被自动排除（由 CLI 管理，不归团队仓库）
-
-### `hooks` 资源类型（团队自定义 hooks）
-
-除了 CLI 内置的运维 hooks，团队还可以在仓库里**声明一次自己的 hooks**，由 `teamai pull` 自动适配下发到各 AI 工具（Claude Code、CodeBuddy、Cursor……）。在 `hooks/hooks.yaml` 中声明：
+在 `hooks/hooks.yaml` 中声明自定义 hooks，`teamai pull` 自动分发到所有 AI 工具：
 
 ```yaml
 hooks:
-  - id: block-secret            # 唯一，^[a-z0-9-]+$，用于 marker 与清单索引
-    description: 提交前扫描密钥     # 写进 hook 的 description
-    event: PreToolUse           # Claude 规范事件名（跨工具中立语言）
-    matcher: Bash               # 可选，工具 matcher
+  - id: block-secret
+    description: 提交前扫描密钥
+    event: PreToolUse
+    matcher: Bash
     command: 'bash -lc "~/.teamai/team-scripts/scan-secret.sh" || true'
-    timeout: 15                 # 可选，秒
-    tools: [claude, cursor]     # 可选，缺省 = 所有支持 hooks 的工具
-
-# 可选：有限度地调整 CLI 自身的内置 hooks（仅白名单字段）
-builtin:
-  disabled: [Hook dispatch post-tool-use TodoWrite]   # 关闭某条内置 hook
-  overrides:
-    Hook dispatch stop: { timeout: 20 }               # 仅允许覆盖 timeout
+    tools: [claude, cursor]
 ```
-
-- `teamai pull` 每次会话开始都会把内置（A）+ 团队（B）hooks 对齐注入到各工具（绕过「已同步」快路径，新增/变更的 hook 自动自愈生效）。
-- 团队 hooks 通过 `[teamai:hook:<id>]` marker 与内置 hooks 隔离，并记录在 `~/.teamai/managed-hooks.json` 中；从 `hooks.yaml` 删除某条后，下次 pull 会从所有工具干净移除，且**绝不误伤内置 hooks**。
-- 写到磁盘的内容对内置 hooks **逐字节不变**，老机器升级 CLI 是零 diff、零回归。
-
-审计、强制注入或清除当前生效的 hooks：
 
 ```bash
-teamai hooks list      # 列出生效的内置（A）+ 团队（B）hooks
-teamai hooks inject    # 强制对齐注入 A + B
-teamai hooks remove    # 移除所有 teamai 托管的 hooks（A + B）
+teamai hooks list      # 查看生效的 hooks
+teamai hooks inject    # 强制重新注入到所有工具
+teamai hooks remove    # 移除所有 teamai 管理的 hooks
 ```
 
-> **安全提示**：团队 hooks 是会随会话事件自动执行的任意 shell 命令——请把仓库写权限视为一个执行面（同 `env.yaml`，受 MR review 治理）。护栏：
-> - 注入时逐条打印将执行的命令（`--silent` 时静默）。
-> - `teamai.yaml` 中 `sharing.hooks.autoApply: false`：`pull` 时只提示、不自动应用，需用户手动 `teamai hooks inject` 同意。
-> - `sharing.hooks.requireTeamScripts: true`：拒绝命令不在 `~/.teamai/team-scripts/` 下的团队 hook。
-> - 设置 `TEAMAI_HOOKS_DISABLED=1` 可在本机否决所有团队 hooks（内置 hooks 仍生效）。
+## 跨团队 Skill 订阅
 
-## 更新
+### Git 源
+
+订阅其他团队的公开 skill 仓库：
 
 ```bash
-teamai update        # 自动检测并升级到最新版
-npm update -g teamai-cli   # 或手动触发 npm 升级
+teamai source add https://github.com/other-team/teamai-public.git --name other-team
+teamai source list
+teamai source browse other-team    # 浏览可用 skills
+teamai source remove other-team
 ```
 
-`teamai update` 会根据当前安装的包名自动选择 registry：
+订阅的 skills 在 `teamai pull` 时自动同步。
 
-- `teamai-cli` → 公网 npm (`https://registry.npmjs.org`)
-- `@tencent/teamai-cli` → 内网 tnpm (`http://r.tnpm.oa.com`)
+### HTTP 源
 
-如需手动覆盖 registry，可以设置环境变量 `TEAMAI_NPM_REGISTRY=<url>`。
+在已有 git 主仓的基础上附加 HTTP 源——适用于服务端管理的 skill 下发，无需修改主仓：
 
-### 自动更新控制
+```bash
+teamai source add-http https://your-team-host/api --token <api-key>
+teamai source list            # 在 "HTTP source" 下显示
+teamai source remove-http     # 解绑并卸载其资源
+```
 
-自动更新通过 Stop hook 在会话结束时执行，可在两个层级控制：
-
-| 配置层级 | 文件 | 字段 | 可选值 |
-|---------|------|------|-------|
-| 团队默认 | `teamai.yaml` | `autoUpdate` | `true`（默认）/ `false` |
-| 用户覆盖 | `~/.teamai/config.yaml` | `updatePolicy` | `auto` / `prompt` / `skip` |
-
-用户级 `updatePolicy` 始终优先于团队级 `autoUpdate`。
+HTTP 源通过 hook dispatch 在每次 session 中上报状态并拉取 skill 指令。每个安装仅支持一个 HTTP 源。
 
 ## CI 集成
 
-TeamAI 可以集成到 CI 流水线中，从每次 MR/PR 自动提取知识：
-
-```
-MR 创建/更新 → CI 提取 learning + codebase 建议 → 以评论形式发布
-    → Reviewer 拒绝不需要的建议（GitHub 👎 / TGit ☝️）
-    → MR 合并 → CI 将已通过的条目写入团队知识仓库
-```
-
-### 快速开始
+`teamai ci extract-mr` 接入 CI，从每个 MR 自动提取知识：
 
 ```bash
-# Comment 模式：将建议发布到 MR（在 PR 打开/更新时运行）
+# 以评论形式发布建议（PR 打开/更新时）
 teamai ci extract-mr --url "$MR_URL" --mode comment --individual-comments
 
-# Write 模式：将已通过的条目写入知识仓库（在合并后运行）
-teamai ci extract-mr --url "$MR_URL" --mode write --team-repo ./team-repo --individual-comments
+# 合并后写入知识库
+teamai ci extract-mr --url "$MR_URL" --mode write --team-repo ./team-repo
 ```
 
-### CI 模板
-
-`examples/ci/` 目录下提供了开箱即用的模板：
-
-| 文件 | 平台 |
-|------|------|
-| `github-actions-mr-extract.yml` | GitHub Actions |
-| `coding-ci-mr-extract.yaml` | Coding CI（TGit + 智研 QCI） |
-
-### 拒绝交互
-
-| 平台 | 拒绝方式 | 默认行为 |
-|------|---------|---------|
-| GitHub | 对建议评论添加 👎 reaction | 全部写入 |
-| TGit | 对建议 note 添加 ☝️ emoji | 全部写入 |
+开箱即用模板：`examples/ci/github-actions-mr-extract.yml`（GitHub Actions）、`examples/ci/coding-ci-mr-extract.yaml`（Coding CI）。
 
 ## 许可证
 
@@ -584,4 +234,4 @@ teamai ci extract-mr --url "$MR_URL" --mode write --team-repo ./team-repo --indi
 
 ## 贡献
 
-欢迎 PR！请先阅读 [CONTRIBUTING.md](.github/CONTRIBUTING.md)。
+欢迎提交 PR！请先阅读 [CONTRIBUTING.md](.github/CONTRIBUTING.md)。

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -180,6 +180,19 @@ cd /path/to/my-project
 teamai init --repo <group>/TeamAi-<team> --scope project
 ```
 
+**HTTP 模式（只读消费者）：**
+
+无需 git 访问、仅消费 skills/rules 的用户或 agent：
+
+```bash
+teamai init --http https://your-team-host/api --token <api-key>
+```
+
+- 只读模式：`push` / `contribute` / `remove` 不可用。
+- 无需 git clone——skills/rules 通过 report/sync/ack 生命周期按 session 下发。
+- 支持的 agent 在 session 启动时自动上报已安装 skill 状态，并拉取服务端管理的安装/更新/卸载指令。
+- API key 存储为 `0600` 权限，也可通过 `TEAMAI_API_TOKEN` 环境变量传入。
+
 **验证：**
 
 ```bash
@@ -523,6 +536,74 @@ cat ~/.claude/CLAUDE.md
 
 ## 进阶功能
 
+### HTTP 契约（面向后端实现者）
+
+使用 `teamai init --http <baseUrl>` 时，端点需要提供以下接口（`Authorization: Bearer <api-key>` 鉴权）：
+
+| 端点 | 方法 | 用途 |
+|------|------|------|
+| `{baseUrl}/api/local-agent/report` | POST | session 启动：upsert agent + 已装 skill |
+| `{baseUrl}/api/local-agent/sync` | POST | 上报状态 + 返回待执行的 skill 命令 |
+| `{baseUrl}/api/local-agent/commands/ack` | POST | 回执单条命令（`{ id, status, error }`） |
+
+`POST /api/local-agent/sync` 返回待执行命令：
+
+```json
+{
+  "ok": true,
+  "commands": [{ "id": 1, "type": "install_skill", "skill_slug": "x", "skill_version": "1.0.0", "download_url": "https://signed-url/..." }]
+}
+```
+
+可配置环境变量：
+
+| 变量 | 作用 |
+|------|------|
+| `TEAMAI_API_TOKEN` | API key（`--token` 的替代） |
+| `TEAMAI_REPORT_ENDPOINT` | reporter 基础 URL（默认 = `--http` 地址） |
+| `TEAMAI_REPORT_PATHS` | JSON `{ "report", "sync", "ack" }`，覆盖三个路径 |
+| `TEAMAI_REPORT_AGENTS` | 参与上报的 agent，逗号分隔（默认 `workbuddy,codebuddy`） |
+| `TEAMAI_SKILL_DOWNLOAD_HOSTS` | skill `download_url` host 白名单（空 = 全部放行） |
+
+> **隐私**：install path 和 machine id 仅在本地哈希以派生 `local_agent_id`，不会上报。
+
+### 代码知识图谱
+
+`teamai import` 将源码仓库解析为结构化知识图谱（存储在团队仓库的 `teamwiki/` 目录下），实现结构感知的知识检索：
+
+```bash
+# 从本地目录提取
+teamai import --dir /path/to/project
+
+# 从远程仓库导入
+teamai import --from-repo https://github.com/org/repo
+
+# 批量导入组织下所有仓库
+teamai import --from-org myorg
+
+# 从白名单批量导入
+teamai import --from-repo-list repos.yaml
+
+# 从已合并的 MR/PR 提取经验
+teamai import --from-mr https://github.com/org/repo/pull/123
+
+# 从 iWiki 导入文档
+teamai import --from-iwiki 12345
+
+# 增量模式（跳过未变更文件）
+teamai import --from-repo https://github.com/org/repo --incremental
+
+# 仅提取结构，跳过 AI 增强
+teamai import --from-repo https://github.com/org/repo --skip-enrich
+```
+
+图谱存储组件、接口、配置和跨仓库依赖关系。`teamai recall` 利用图谱进行 BM25 + graph-boost 增强排名。
+
+```bash
+# 图谱健康检查
+teamai codebase --lint
+```
+
 ### Dashboard
 
 ```bash
@@ -575,6 +656,53 @@ teamai hooks inject    # 重新注入
 teamai hooks remove    # 移除
 ```
 
+### 团队 Hooks 声明
+
+团队可在仓库 `hooks/hooks.yaml` 中声明自定义 hooks，`teamai pull` 自动分发到所有成员的 AI 工具：
+
+```yaml
+hooks:
+  - id: block-secret
+    description: 提交前扫描密钥
+    event: PreToolUse
+    matcher: Bash
+    command: 'bash -lc "~/.teamai/team-scripts/scan-secret.sh" || true'
+    timeout: 15
+    tools: [claude, cursor]
+
+builtin:
+  disabled: [Hook dispatch post-tool-use TodoWrite]
+  overrides:
+    Hook dispatch stop: { timeout: 20 }
+```
+
+| 字段 | 说明 |
+|------|------|
+| `id` | 唯一标识，`^[a-z0-9-]+$` |
+| `event` | Claude PascalCase 事件名（跨工具通用） |
+| `matcher` | 可选，工具 matcher |
+| `tools` | 可选，目标工具列表（默认 = 所有 hook 支持的工具） |
+| `builtin.disabled` | 禁用的内置 hook 列表 |
+| `builtin.overrides` | 仅可覆盖内置 hook 的 `timeout` |
+
+安全治理：
+- `sharing.hooks.autoApply: false`（`teamai.yaml`）：pull 时仅提示，需手动 `teamai hooks inject` 确认
+- `sharing.hooks.requireTeamScripts: true`：拒绝 command 不在 `~/.teamai/team-scripts/` 下的 hook
+- `TEAMAI_HOOKS_DISABLED=1`：本地禁用所有团队 hooks（内置 hooks 不受影响）
+
+### Agents 资源类型
+
+团队仓库可在 `agents/` 目录下维护自定义 subagent 定义（每个 agent 一个 `*.md` 文件）：
+
+```text
+team-repo/
+  agents/
+    code-reviewer.md      # 团队自定义 subagent
+    .removed              # tombstone（由 teamai remove agents <name> 自动管理）
+```
+
+`teamai pull` 会将它们复制到每个 Tier-1 工具的 `agents/` 目录（如 `~/.claude/agents/`）。CLI 内置的 `teamai-recall.md` 与团队 agents 并列部署，但不会被 `teamai push` 上传。
+
 ### 其他
 
 ```bash
@@ -585,6 +713,38 @@ teamai remove skills <name>   # 删除资源
 teamai remove rules <name>
 teamai remove wiki <name>
 ```
+
+自动更新在 Stop hook 中执行，可通过两层控制：
+
+| 层级 | 文件 | 字段 | 值 |
+|------|------|------|------|
+| 团队默认 | `teamai.yaml` | `autoUpdate` | `true`（默认）/ `false` |
+| 用户覆盖 | `~/.teamai/config.yaml` | `updatePolicy` | `auto` / `prompt` / `skip` |
+
+用户级 `updatePolicy` 始终优先于团队级 `autoUpdate`。
+
+### CI 集成
+
+`teamai ci extract-mr` 接入 CI 流水线，从每个 MR/PR 自动提取知识：
+
+```bash
+# 评论模式：以评论形式发布建议（在 PR 打开/更新时运行）
+teamai ci extract-mr --url "$MR_URL" --mode comment --individual-comments
+
+# 写入模式：合并后将审批通过的建议写入知识库
+teamai ci extract-mr --url "$MR_URL" --mode write --team-repo ./team-repo --individual-comments
+```
+
+工作流程：
+
+1. MR 打开/更新 → CI 触发 `--mode comment`，提取知识建议并发布为 MR 评论
+2. Reviewer 审查评论，对不需要的建议添加拒绝标记（GitHub 👎 / TGit ☝️）
+3. MR 合并 → CI 触发 `--mode write`，将未被拒绝的建议写入团队知识仓库
+
+开箱即用模板：
+
+- `examples/ci/github-actions-mr-extract.yml`（GitHub Actions）
+- `examples/ci/coding-ci-mr-extract.yaml`（Coding CI / TGit）
 
 ### 跨团队 Skill 订阅
 
@@ -605,6 +765,23 @@ teamai source remove other-team
 ```
 
 订阅源的 skills 在 `teamai pull` 时自动同步到本地，与团队自有 skills 共存。配置存储在本地 `config.yaml` 的 `sources` 字段中。
+
+#### HTTP 源
+
+除了 git 订阅源，还可以在已有 git 主仓的基础上附加一个 HTTP 源——适用于服务端管理的 skill 下发：
+
+```bash
+# 附加 HTTP 源（git 主仓不受影响）
+teamai source add-http https://your-team-host/api --token <api-key>
+
+# 查看（在 "HTTP source" 下显示）
+teamai source list
+
+# 解绑并卸载其资源
+teamai source remove-http
+```
+
+HTTP 源通过 hook dispatch 在每次 session 中上报状态并拉取 skill 指令。每个安装仅支持一个 HTTP 源。若主仓本身已是 HTTP 模式（`init --http`），则 `add-http` 不可用（主仓已占用 HTTP 配置）。
 
 ---
 


### PR DESCRIPTION
## Summary
- Trim README (EN + ZH) from 586 → ~234 lines — focused on getting new users started
- Remove HTTP contract tables, JSON schema, directory trees, CI YAML templates from README
- Retain: Quick Start (member/admin/HTTP mode), commands table, feature overviews with usage examples, doc links
- Supplement docs/usage-guide.md (+90 lines) with previously undocumented features:
  - HTTP mode initialization (`teamai init --http`)
  - Code knowledge graph (`teamai import` full suite + `codebase --lint`)
  - CI integration (`teamai ci extract-mr` workflow)
  - HTTP source subscription (`teamai source add-http / remove-http`)

## Test plan
- [x] Both READMEs render correctly (checked structure, badges, code blocks)
- [x] EN and ZH READMEs stay in sync (same section count, same structure)
- [x] usage-guide.md new sections use consistent formatting with existing content
- [ ] Visual check: render on GitHub after push

🤖 Generated with [Claude Code](https://claude.com/claude-code)