### PR TITLE
fix(import): prevent duplicate MRs from metadata-only diffs

### DIFF
--- a/src/__tests__/git.test.ts
+++ b/src/__tests__/git.test.ts
@@ -15,6 +15,7 @@ const mockGit = {
   revparse: vi.fn().mockResolvedValue('main'),
   reset: vi.fn(),
   merge: vi.fn(),
+  diff: vi.fn().mockResolvedValue('+some real content change\n'),
 };
 
 vi.mock('simple-git', () => ({
@@ -45,7 +46,7 @@ vi.mock('../utils/logger.js', () => ({
   },
 }));
 
-import { generateBranchName, pushRepoBranch, checkoutMaster, pushRepoDirectly, initRepo, configureGitUser, getHeadRev, resetToCleanMaster } from '../utils/git.js';
+import { generateBranchName, pushRepoBranch, checkoutMaster, pushRepoDirectly, initRepo, configureGitUser, getHeadRev, resetToCleanMaster, isMetadataOnlyDiff } from '../utils/git.js';
 import fse from 'fs-extra';
 
 describe('generateBranchName', () => {
@@ -110,6 +111,26 @@ describe('pushRepoBranch', () => {
     expect(mockGit.deleteLocalBranch).toHaveBeenCalledWith('teamai/push/test/456', true);
     expect(mockGit.commit).not.toHaveBeenCalled();
     expect(mockGit.push).not.toHaveBeenCalled();
+  });
+
+  it('should return false and clean up when diff is metadata-only (timestamps)', async () => {
+    mockGit.status.mockResolvedValue({ staged: ['codebase.md'] });
+    mockGit.diff.mockResolvedValue(
+      '-lastUpdated: 2026-07-16T10:00:00.000Z\n+lastUpdated: 2026-07-16T10:05:00.000Z\n',
+    );
+    mockGit.revparse.mockImplementation(async (args: any) => {
+      const a = Array.isArray(args) ? args : [args];
+      if (a[0] === '--abbrev-ref' && a[1] === 'origin/HEAD') return 'origin/master';
+      return '';
+    });
+
+    const result = await pushRepoBranch('/repo', 'msg', ['file.txt'], 'teamai/push/test/789');
+
+    expect(result).toBe(false);
+    expect(mockGit.diff).toHaveBeenCalledWith(['--cached', '--unified=0']);
+    expect(mockGit.checkout).toHaveBeenCalledWith('master');
+    expect(mockGit.deleteLocalBranch).toHaveBeenCalledWith('teamai/push/test/789', true);
+    expect(mockGit.commit).not.toHaveBeenCalled();
   });
 });
 
@@ -328,5 +349,59 @@ describe('resetToCleanMaster', () => {
     await resetToCleanMaster(mockGit as any);
 
     expect(mockGit.checkout).toHaveBeenCalledWith('main');
+  });
+});
+
+describe('isMetadataOnlyDiff', () => {
+  it('should return true for empty diff', () => {
+    expect(isMetadataOnlyDiff('')).toBe(true);
+    expect(isMetadataOnlyDiff('  \n  ')).toBe(true);
+  });
+
+  it('should return true for timestamp-only changes', () => {
+    const diff = [
+      '--- a/teamwiki/source-manifest.json',
+      '+++ b/teamwiki/source-manifest.json',
+      '-  "lastScan": "2026-07-16T10:00:00.000Z",',
+      '+  "lastScan": "2026-07-16T10:05:00.000Z",',
+    ].join('\n');
+    expect(isMetadataOnlyDiff(diff)).toBe(true);
+  });
+
+  it('should return true for mixed metadata patterns', () => {
+    const diff = [
+      '-lastUpdated: 2026-07-16T10:00:00.000Z',
+      '+lastUpdated: 2026-07-16T10:05:00.000Z',
+      '-  "lastScan": "2026-07-16T10:00:00.000Z",',
+      '+  "lastScan": "2026-07-16T10:05:00.000Z",',
+      '-syncedAt: 2026-07-16T10:00:00.000Z',
+      '+syncedAt: 2026-07-16T10:05:00.000Z',
+    ].join('\n');
+    expect(isMetadataOnlyDiff(diff)).toBe(true);
+  });
+
+  it('should return false when real content changes are present', () => {
+    const diff = [
+      '-lastUpdated: 2026-07-16T10:00:00.000Z',
+      '+lastUpdated: 2026-07-16T10:05:00.000Z',
+      '-## Old Section',
+      '+## New Section with real changes',
+    ].join('\n');
+    expect(isMetadataOnlyDiff(diff)).toBe(false);
+  });
+
+  it('should return false for purely content changes', () => {
+    const diff = '+export function newFeature() { return 42; }\n';
+    expect(isMetadataOnlyDiff(diff)).toBe(false);
+  });
+
+  it('should ignore diff header lines (--- and +++)', () => {
+    const diff = [
+      '--- a/file.md',
+      '+++ b/file.md',
+      '-lastUpdated: old',
+      '+lastUpdated: new',
+    ].join('\n');
+    expect(isMetadataOnlyDiff(diff)).toBe(true);
   });
 });

--- a/src/__tests__/import-repo-incremental.test.ts
+++ b/src/__tests__/import-repo-incremental.test.ts
@@ -29,6 +29,10 @@ vi.mock('../utils/prompt.js', () => ({
     askConfirmation: vi.fn().mockResolvedValue(true),
 }));
 
+vi.mock('../config.js', () => ({
+    autoDetectInit: vi.fn().mockRejectedValue(new Error('no config in test')),
+}));
+
 // ─── Imports (after mocks) ───────────────────────────────
 
 import { importFromRepo } from '../import-repo.js';

--- a/src/__tests__/import-repo-list.test.ts
+++ b/src/__tests__/import-repo-list.test.ts
@@ -27,6 +27,10 @@ vi.mock('../domains/store.js', () => ({
     }),
 }));
 
+vi.mock('../config.js', () => ({
+    autoDetectInit: vi.fn().mockRejectedValue(new Error('no config in test')),
+}));
+
 // ─── Imports（after mocks）──────────────────────────────
 
 import { importFromRepoList } from '../import-repo-list.js';

--- a/src/__tests__/import-repo-merge.test.ts
+++ b/src/__tests__/import-repo-merge.test.ts
@@ -35,6 +35,10 @@ vi.mock('../codebase-extract.js', () => ({
     extractCodebase: vi.fn(),
 }));
 
+vi.mock('../config.js', () => ({
+    autoDetectInit: vi.fn().mockRejectedValue(new Error('no config in test')),
+}));
+
 // ─── Imports (after mocks) ──────────────────────────────
 
 import { importFromRepo } from '../import-repo.js';

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -190,8 +190,37 @@ export async function autoPushViaMR(
 }
 
 /**
+ * Check whether a unified diff contains only metadata/timestamp changes.
+ * If ALL added/removed lines match known timestamp patterns, the diff is
+ * metadata-only and should not trigger a new MR.
+ */
+export function isMetadataOnlyDiff(diff: string): boolean {
+  if (!diff.trim()) return true;
+
+  const METADATA_PATTERNS = [
+    /^\s*"?lastUpdated"?\s*[:=]/i,
+    /^\s*"?lastScan"?\s*[:=]/i,
+    /^\s*"?syncedAt"?\s*[:=]/i,
+    /^\s*"?generatedAt"?\s*[:=]/i,
+    /^\s*"?updatedAt"?\s*[:=]/i,
+  ];
+
+  const lines = diff.split('\n');
+  for (const line of lines) {
+    if (!line.startsWith('+') && !line.startsWith('-')) continue;
+    if (line.startsWith('---') || line.startsWith('+++')) continue;
+    const content = line.slice(1);
+    if (!content.trim()) continue;
+    const isMetadata = METADATA_PATTERNS.some(pat => pat.test(content));
+    if (!isMetadata) return false;
+  }
+
+  return true;
+}
+
+/**
  * Create a new branch, commit files, and push the branch to remote.
- * Returns false if there are no changes to commit.
+ * Returns false if there are no changes to commit (or only metadata changes).
  * Leaves the local repo on the new branch after pushing so that
  * the provider's createPullRequest (which may internally push HEAD)
  * sees the correct branch.
@@ -214,6 +243,16 @@ export async function pushRepoBranch(
   if (status.staged.length === 0) {
     const defaultBranch = await getDefaultBranch(localPath);
     log.debug(`Nothing to commit, switching back to ${defaultBranch}`);
+    await git.checkout(defaultBranch);
+    await git.deleteLocalBranch(branchName, true);
+    return false;
+  }
+
+  // Second gate: skip if all staged changes are metadata-only (timestamps)
+  const diffOutput = await git.diff(['--cached', '--unified=0']);
+  if (isMetadataOnlyDiff(diffOutput)) {
+    const defaultBranch = await getDefaultBranch(localPath);
+    log.debug(`Only metadata/timestamp changes detected, switching back to ${defaultBranch}`);
     await git.checkout(defaultBranch);
     await git.deleteLocalBranch(branchName, true);
     return false;


### PR DESCRIPTION
## Summary

- Add `isMetadataOnlyDiff()` guard in `pushRepoBranch` — when all staged changes are just timestamp fields (`lastUpdated`, `lastScan`, `syncedAt`), skip branch creation and MR creation entirely
- Fix test isolation: mock `config.js` in import-repo tests to prevent leaking writes to the real team-repo when `~/.teamai/config.yaml` exists

## Root Cause

`teamai import --from-repo` generates files with timestamp fields that change every run. This causes `git diff` to always report changes, so every execution creates a new MR — even when the actual codebase content hasn't changed. On the HyperAI/teamai TGit repo, this produced 17+ duplicate "Import codebase knowledge" MRs.

## Test plan

- [x] `npx tsc --noEmit` — no type errors
- [x] `npx vitest run src/__tests__/git.test.ts` — 26 tests pass (including new metadata-only diff tests)
- [x] `npx vitest run src/__tests__/import-repo-merge.test.ts` — 3 tests pass (previously 1 failed due to missing config mock)
- [x] `npx vitest run src/__tests__/import-repo-incremental.test.ts` — passes with config isolation
- [x] `npm run build` — build success

🤖 Generated with [Claude Code](https://claude.com/claude-code)