### PR TITLE
feat(privacy): add secret-redaction utility, scrub dashboard stopped-output

### DIFF
--- a/src/__tests__/dashboard-collector.test.ts
+++ b/src/__tests__/dashboard-collector.test.ts
@@ -280,6 +280,17 @@ describe('readLastAssistantOutput', () => {
     const output = await readLastAssistantOutput(transcriptPath);
     expect(output).toBe('Valid response');
   });
+
+  it('redacts secrets in the assistant output before returning', async () => {
+    const transcriptPath = path.join(tmpDir, 'secret.jsonl');
+    const text = 'Here is the token ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 use it';
+    const line = JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text }] } });
+    fs.writeFileSync(transcriptPath, line + '\n');
+
+    const output = await readLastAssistantOutput(transcriptPath);
+    expect(output).not.toContain('ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789');
+    expect(output).toContain('<REDACTED:gh_tok>');
+  });
 });
 
 // ─── JSONL persistence ──────────────────────────────────

--- a/src/__tests__/redact.test.ts
+++ b/src/__tests__/redact.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import { redact, collectEnvSecrets, redactWithEnv } from '../utils/redact.js';
+
+describe('redact', () => {
+  it('returns empty and non-secret text unchanged', () => {
+    expect(redact('')).toBe('');
+    expect(redact('just a normal sentence with no secrets')).toBe(
+      'just a normal sentence with no secrets',
+    );
+  });
+
+  describe('layer 1: literal env-value masking', () => {
+    it('masks a known secret value with its label', () => {
+      const out = redact('curl -H "auth: abcd1234efgh5678"', {
+        envSecrets: { MY_TOKEN: 'abcd1234efgh5678' },
+      });
+      expect(out).toBe('curl -H "auth: <REDACTED:MY_TOKEN>"');
+    });
+
+    it('masks longer values before shorter overlapping ones', () => {
+      const out = redact('value is abcdef123456789', {
+        envSecrets: { SHORT: 'abcdef12', LONG: 'abcdef123456789' },
+      });
+      // The long value should win; no leftover fragment of the short one.
+      expect(out).toBe('value is <REDACTED:LONG>');
+    });
+
+    it('replaces every occurrence of a value', () => {
+      const out = redact('sekret9999 ... sekret9999', {
+        envSecrets: { K: 'sekret9999' },
+      });
+      expect(out).toBe('<REDACTED:K> ... <REDACTED:K>');
+    });
+  });
+
+  describe('layer 2: secret-shape patterns', () => {
+    it('masks an Anthropic key without double-tagging as openai', () => {
+      const out = redact('key=sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAA');
+      expect(out).toContain('<REDACTED:anthropic>');
+      expect(out).not.toContain('sk-ant-');
+      expect(out).not.toContain('<REDACTED:openai>');
+    });
+
+    it('masks an OpenAI key', () => {
+      const out = redact('OPENAI=sk-proj-ABCDEFGHIJKLMNOPQRSTUVWX');
+      expect(out).toContain('<REDACTED:openai>');
+      expect(out).not.toContain('sk-proj-ABCDEFGH');
+    });
+
+    it('masks GitHub tokens and PATs', () => {
+      expect(redact('ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789')).toContain('<REDACTED:gh_tok>');
+      expect(redact('github_pat_ABCDEFGHIJKLMNOPQRSTUV_wxyz0123456789')).toContain(
+        '<REDACTED:gh_pat>',
+      );
+    });
+
+    it('masks AWS access key ids', () => {
+      expect(redact('id AKIAIOSFODNN7EXAMPLE done')).toBe('id <REDACTED:aws> done');
+    });
+
+    it('masks JWTs', () => {
+      const jwt =
+        'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV';
+      expect(redact(`token ${jwt}`)).toContain('<REDACTED:jwt>');
+    });
+
+    it('masks a PEM private-key block including its body', () => {
+      const pem =
+        '-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA\nsecretbody\n-----END RSA PRIVATE KEY-----';
+      const out = redact(`before\n${pem}\nafter`);
+      expect(out).toBe('before\n<REDACTED:pem>\nafter');
+    });
+
+    it('masks Google API keys', () => {
+      // AIza followed by exactly 35 chars.
+      expect(redact('AIza' + 'B'.repeat(35))).toBe('<REDACTED:google>');
+    });
+
+    it('masks assorted vendor tokens via the provider pattern', () => {
+      expect(redact('glpat-ABCDEFGHIJKLMNOPQRST')).toContain('<REDACTED:provider>');
+      expect(redact('hf_ABCDEFGHIJKLMNOPQRSTUVWX')).toContain('<REDACTED:provider>');
+    });
+  });
+
+  describe('layer 2: structural patterns keep surrounding context', () => {
+    it('masks key=value but keeps the key', () => {
+      const out = redact('password = hunter2SuperLongValue99');
+      expect(out).toBe('password = <REDACTED:kv>');
+    });
+
+    it('masks bearer tokens but keeps the scheme', () => {
+      const out = redact('Authorization: Bearer abcdefghijklmnopqrstuvwx');
+      expect(out).toBe('Authorization: Bearer <REDACTED:authz>');
+    });
+
+    it('masks only the password in a connection string', () => {
+      const out = redact('postgres://admin:s3cr3tPassword@db.example.com:5432/app');
+      expect(out).toBe('postgres://admin:<REDACTED:conn>@db.example.com:5432/app');
+    });
+  });
+
+  it('can disable the pattern layer', () => {
+    const out = redact('ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789', { patterns: false });
+    expect(out).toBe('ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789');
+  });
+
+  it('does not touch ordinary short values that merely look key-ish', () => {
+    // Too short to trip the KV pattern's 16-char minimum.
+    expect(redact('key=abc')).toBe('key=abc');
+  });
+});
+
+describe('collectEnvSecrets', () => {
+  it('selects secret-looking keys with long-enough values', () => {
+    const secrets = collectEnvSecrets({
+      MY_TOKEN: 'abcdefghij',
+      DB_PASSWORD: 'longpassword',
+      SERVICE_PAT: 'patvalue1234',
+      PATH: '/usr/bin:/bin',
+      HOME: '/root',
+    });
+    expect(secrets).toEqual({
+      MY_TOKEN: 'abcdefghij',
+      DB_PASSWORD: 'longpassword',
+      SERVICE_PAT: 'patvalue1234',
+    });
+  });
+
+  it('ignores secret-looking keys whose values are too short', () => {
+    expect(collectEnvSecrets({ API_KEY: 'short' })).toEqual({});
+  });
+
+  it('ignores non-secret keys', () => {
+    expect(collectEnvSecrets({ EDITOR: 'vim-with-a-long-config' })).toEqual({});
+  });
+});
+
+describe('redactWithEnv', () => {
+  it('composes env collection with pattern redaction', () => {
+    const out = redactWithEnv('token=abcdefghij and ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345', {
+      SOME_TOKEN: 'abcdefghij',
+    } as NodeJS.ProcessEnv);
+    expect(out).toContain('<REDACTED:SOME_TOKEN>');
+    expect(out).toContain('<REDACTED:gh_tok>');
+  });
+});

--- a/src/dashboard-collector.ts
+++ b/src/dashboard-collector.ts
@@ -6,6 +6,7 @@ import { deriveSessionId } from './utils/session-id.js';
 import { ensureDir } from './utils/fs.js';
 import { resolveMonitorPid } from './pid-monitor.js';
 import { normalizeToolName } from './utils/tool-names.js';
+import { redactWithEnv } from './utils/redact.js';
 import {
   DASHBOARD_EVENTS_PATH,
   DASHBOARD_EVENTS_DIR,
@@ -103,7 +104,10 @@ export async function readLastAssistantOutput(transcriptPath: string): Promise<s
         }
       }
 
-      return lastAssistantText.slice(0, STOPPED_OUTPUT_MAX_CHARS);
+      // Scrub secrets before this text is persisted to events.jsonl and rendered
+      // in the dashboard. Redact first, then slice, so a placeholder (not a raw
+      // token fragment) is what lands near the length boundary.
+      return redactWithEnv(lastAssistantText).slice(0, STOPPED_OUTPUT_MAX_CHARS);
     } finally {
       await fh.close();
     }

--- a/src/utils/redact.ts
+++ b/src/utils/redact.ts
@@ -1,0 +1,139 @@
+/**
+ * Best-effort secret scrubbing for text that may be persisted or shared.
+ *
+ * TeamAI's privacy posture is "counts only, no prompt text": aggregated numbers
+ * are pushed to the team repo, but raw session content is never uploaded, partly
+ * because there was no way to guarantee a leaked token wouldn't ride along.
+ * This utility is the missing primitive — a deterministic, dependency-free
+ * scrubber that lets callers redact free-form text before it leaves the machine.
+ *
+ * Two layers, applied in order (ported from the claude-cloud-sync sync hook):
+ *   1. Literal masking of known secret *values* (e.g. env vars that look like
+ *      credentials). This is 100% precise for values already in the environment.
+ *   2. Regex fallback for common secret *shapes* — vendor token prefixes, PEM
+ *      private-key blocks, JWTs, `key=value` pairs, `Authorization: Bearer`
+ *      headers, and connection-string passwords. This catches secrets pasted
+ *      into a conversation that never touched the environment.
+ *
+ * This is defense-in-depth, not a guarantee: it will not catch every possible
+ * secret. Callers should still gate content upload behind explicit opt-in.
+ * Run it *after* any analytics extraction so metrics are computed on the
+ * original text and remain unaffected by redaction.
+ *
+ * Why a vendored function rather than a dependency: this runs on the hook hot
+ * path (every session event cold-starts the CLI), and teamai-cli keeps a small
+ * dependency surface and a Node 20 floor. The mature options don't fit that
+ * baseline — external scanners (gitleaks, trufflehog) are separate binaries,
+ * and Node-native linters (secretlint) are dev-time, file-oriented, and require
+ * a newer runtime. Those tools use the same regex catalog this file does; here
+ * it's inlined without the framework weight. A heavier external scanner is best
+ * layered on top as an *optional, opt-in deep pass*, not as the always-on floor.
+ */
+
+const PLACEHOLDER = (label: string): string => `<REDACTED:${label}>`;
+
+/** Env var name fragments that mark a value as likely-secret. */
+const SECRET_KEY_HINTS = ['TOKEN', 'SECRET', 'KEY', 'PASSWORD', 'PASSWD', '_PAT', 'CREDENTIAL'];
+
+/** Minimum length before an env value is worth masking (avoids masking `KEY=1`). */
+const MIN_ENV_VALUE_LENGTH = 8;
+
+/**
+ * (label, regex) pairs matched and replaced wholesale. Order matters: more
+ * specific prefixes (e.g. `sk-ant-`) run before broader ones (e.g. `sk-`).
+ */
+const SECRET_PATTERNS: ReadonlyArray<readonly [string, RegExp]> = [
+  ['pem', /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----/g],
+  ['anthropic', /\bsk-ant-[A-Za-z0-9_-]{20,}/g],
+  ['openai', /\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}/g],
+  ['gh_pat', /\bgithub_pat_[A-Za-z0-9_]{22,}/g],
+  ['gh_tok', /\bgh[pousr]_[A-Za-z0-9]{20,}/g],
+  ['aws', /\b(?:AKIA|ASIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA)[0-9A-Z]{16}\b/g],
+  ['slack', /\bxox[baprs]-[A-Za-z0-9-]{10,}/g],
+  ['slackhook', /https:\/\/hooks\.slack\.com\/services\/[A-Za-z0-9/]{20,}/g],
+  ['google', /\bAIza[0-9A-Za-z_-]{35}\b/g],
+  ['gcp_oauth', /\bya29\.[0-9A-Za-z_-]{20,}/g],
+  ['stripe', /\b[rs]k_(?:live|test)_[A-Za-z0-9]{16,}/g],
+  ['jwt', /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/g],
+  ['sendgrid', /\bSG\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}/g],
+  ['provider', /\b(?:xai-|gsk_|pplx-|sk-or-v1-|hf_|dop_v1_|glpat-|npm_|shpat_|tfp_|nvapi-|r8_)[A-Za-z0-9_-]{16,}/g],
+];
+
+/** `key=value` / `key: value` — mask only the value, keep the key for readability. */
+const KV_PATTERN =
+  /(secret|token|api[_-]?key|access[_-]?key|client[_-]?secret|password|passwd|auth[_-]?token|private[_-]?key)(["']?\s*[:=]\s*["']?)([A-Za-z0-9._\-/+=]{16,})/gi;
+
+/** `Authorization: Bearer <token>` — keep the scheme, mask the token. */
+const BEARER_PATTERN = /\b(bearer\s+)([A-Za-z0-9._-]{16,})/gi;
+
+/** `proto://user:PASSWORD@host` — mask only the password segment. */
+const CONNECTION_STRING_PATTERN = /([a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^\s:/@]+:)([^\s/@]{6,})(@)/g;
+
+export interface RedactOptions {
+  /**
+   * Literal secret values to mask, keyed by the label shown in the placeholder
+   * (typically the source env var name). Use {@link collectEnvSecrets} to build
+   * this from `process.env`.
+   */
+  envSecrets?: Record<string, string>;
+  /** Apply the built-in secret-shape patterns. Default: `true`. */
+  patterns?: boolean;
+}
+
+/**
+ * Scan an environment map for values that look like credentials, keyed by var
+ * name. Kept separate from {@link redact} so redaction stays a pure function of
+ * its inputs (and so the env scan can be unit-tested with a fake env).
+ */
+export function collectEnvSecrets(env: NodeJS.ProcessEnv = process.env): Record<string, string> {
+  const secrets: Record<string, string> = {};
+  for (const [name, value] of Object.entries(env)) {
+    if (typeof value !== 'string' || value.length < MIN_ENV_VALUE_LENGTH) continue;
+    const upper = name.toUpperCase();
+    if (SECRET_KEY_HINTS.some((hint) => upper.includes(hint))) {
+      secrets[name] = value;
+    }
+  }
+  return secrets;
+}
+
+/**
+ * Redact likely secrets from `text`. Returns the input unchanged when it is
+ * empty or contains nothing that looks secret.
+ */
+export function redact(text: string, options: RedactOptions = {}): string {
+  if (!text) return text;
+  let out = text;
+
+  // Layer 1: literal env-value masking. Longest values first so a value that
+  // contains a shorter one is masked before the shorter match can fire.
+  const envSecrets = options.envSecrets ?? {};
+  const entries = Object.entries(envSecrets).sort((a, b) => b[1].length - a[1].length);
+  for (const [label, value] of entries) {
+    if (value && out.includes(value)) {
+      out = out.split(value).join(PLACEHOLDER(label));
+    }
+  }
+
+  // Layer 2: secret-shape regexes.
+  if (options.patterns !== false) {
+    for (const [label, pattern] of SECRET_PATTERNS) {
+      out = out.replace(pattern, () => PLACEHOLDER(label));
+    }
+    out = out.replace(KV_PATTERN, (_m, key: string, sep: string) => key + sep + PLACEHOLDER('kv'));
+    out = out.replace(BEARER_PATTERN, (_m, scheme: string) => scheme + PLACEHOLDER('authz'));
+    out = out.replace(CONNECTION_STRING_PATTERN, (_m, prefix: string, _pw: string, at: string) =>
+      prefix + PLACEHOLDER('conn') + at,
+    );
+  }
+
+  return out;
+}
+
+/**
+ * Convenience wrapper: redact using both the built-in patterns and secrets
+ * discovered in the current environment.
+ */
+export function redactWithEnv(text: string, env: NodeJS.ProcessEnv = process.env): string {
+  return redact(text, { envSecrets: collectEnvSecrets(env) });
+}


### PR DESCRIPTION
## Summary

Adds a small, dependency-free secret-redaction utility (`src/utils/redact.ts`) and wires it into the one place TeamAI currently persists raw assistant text — the dashboard's `stoppedOutput` — so a token pasted into a conversation can no longer land in `~/.teamai/dashboard/events.jsonl` (or the rendered dashboard). This is the missing primitive behind the "counts only, no prompt text" posture: with deterministic scrubbing available, later features can safely persist richer session content behind explicit opt-in.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing behavior to change)
- [ ] Documentation only
- [ ] Refactor / internal cleanup

## What it does

`redact(text, options)` scrubs likely secrets in two layers, applied in order:

1. **Literal masking** of known secret *values* (e.g. credential-shaped env vars via `collectEnvSecrets()`) — 100% precise for values already in the environment. Longest values are masked first so an overlapping shorter one leaves no fragment.
2. **Regex fallback** for common secret *shapes* — vendor token prefixes (`sk-ant-`, `sk-`, `ghp_`, `github_pat_`, AWS `AKIA…`, Slack, Google, Stripe, and a provider catalog), PEM private-key blocks, JWTs, `key=value` pairs, `Authorization: Bearer` headers, and connection-string passwords. This catches secrets pasted into a conversation that never touched the environment.

Structural patterns keep surrounding context (`password = <REDACTED:kv>`, `Authorization: Bearer <REDACTED:authz>`, `postgres://admin:<REDACTED:conn>@host`). Redaction runs *after* any analytics extraction, so metrics are unaffected.

### Why vendored rather than a dependency

This runs on the hook hot path (every session event cold-starts the CLI), and the project keeps a small dependency surface and a Node 20 floor. The mature options don't fit that baseline: external scanners (gitleaks, trufflehog) are separate binaries; Node-native linters (secretlint) are dev-time, file-oriented, and require a newer runtime. Those tools use the same regex catalog inlined here, without the framework weight. A heavier external scanner is best layered later as an *optional, opt-in deep pass* — not the always-on floor.

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` passes — 139 files, 1729 tests
- [x] Added/updated tests for the change — 21 unit tests in `redact.test.ts`; a regression test in `dashboard-collector.test.ts` asserting a `ghp_…` token in the last assistant message is masked
- [x] `npm run build` succeeds
- [x] Real-CLI E2E: piped a `Stop` event with a fake `ghp_…` token through `node dist/index.js hook-dispatch stop --tool claude`; the resulting `events.jsonl` `stoppedOutput` read `GH_TOKEN=<REDACTED:gh_tok>` and the raw token was absent.

## Notes for Reviewers

- New behavior is limited to `readLastAssistantOutput()`; everything else is a pure, standalone utility with no callers yet, so blast radius is small.
- No user-facing CLI/README strings change, so no `README.zh-CN.md` update is needed.
- The utility is intentionally best-effort (documented as such) and meant as a reusable building block for privacy-safe session persistence.
