### PR TITLE
feat(sessions): add `teamai save-session` — monthly session logs + digest feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ The graph stores components, interfaces, configs, and cross-repo import edges. `
 | `teamai skill exclude add/remove/list` | Manage skills excluded from local sync ([usage guide](docs/usage-guide.md#excluding-skills-you-dont-need)) |
 | `teamai source` | Manage cross-team skill subscriptions |
 | `teamai remove <type> <name>` | Remove a resource and open MR |
+| `teamai session save` | Record a privacy-scrubbed session summary to a monthly log (`--push` feeds `digest`) |
 | `teamai digest` | Generate weekly team usage digest |
 | `teamai doctor` | Diagnose configuration issues |
 | `teamai uninstall` | Remove all teamai resources and hooks |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -169,6 +169,7 @@ teamai codebase --lint                      # 健康检查
 | `teamai skill exclude add/remove/list` | 管理不参与本地同步的 skills（[使用指南](docs/usage-guide.zh-CN.md#排除个人不需要的-skill)） |
 | `teamai source` | 管理跨团队 skill 订阅 |
 | `teamai remove <type> <name>` | 删除资源并创建 MR |
+| `teamai session save` | 将脱敏后的 session 摘要记录到月度日志（`--push` 可喂给 `digest`） |
 | `teamai digest` | 生成团队周报 |
 | `teamai doctor` | 诊断配置问题 |
 | `teamai uninstall` | 移除所有 teamai 资源和 hooks |

--- a/docs/designs/team-intelligence-platform.md
+++ b/docs/designs/team-intelligence-platform.md
@@ -33,14 +33,14 @@ Transform TeamAI from a simple skill-sharing CLI into a **Team Intelligence Plat
 ### Core Features
 
 #### 1. Session 工具使用记录
-**What:** 在会话内主动收集 AI 对话过程和工具使用记录，重点关注 AI 用错工具的情况。通过 `teamai save-session` 命令或 Stop hook 触发。
+**What:** 在会话内主动收集 AI 对话过程和工具使用记录，重点关注 AI 用错工具的情况。通过 `teamai session save` 命令或 Stop hook 触发。
 
 **How it works:**
 ```
 会话进行中 → AI 使用工具、对话
                     │
                     ▼
-        用户/AI 调用 teamai save-session
+        用户/AI 调用 teamai session save
                     │
                     ▼
         收集工具使用记录 + 对话摘要
@@ -144,7 +144,7 @@ git pull → git add → git commit → git push (直接到 master)
 │ hook         │     │ → append JSONL │     │                  │
 │              │     │                │     │ sessions/<user>/ │
 │ In-session   │     │ session-       │     │  <year-month>.md │
-│ save-session─┼────▶│ collector.ts   │     │                  │
+│ session save─┼────▶│ collector.ts   │     │                  │
 │ command      │     │                │     └──────────────────┘
 └──────────────┘     │ health.ts      │            ▲
                      │ recommend.ts   │            │

--- a/src/__tests__/session-collector.test.ts
+++ b/src/__tests__/session-collector.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  collectSession,
+  isValuable,
+  renderSessionMarkdown,
+  appendMonthlyLog,
+  pruneMonthlyLogs,
+  monthKey,
+} from '../session-collector.js';
+import type { DashboardEvent } from '../types.js';
+
+function ev(partial: Partial<DashboardEvent> & { type: DashboardEvent['type']; timestamp: string; sessionId: string }): DashboardEvent {
+  return { tool: 'claude', ...partial } as DashboardEvent;
+}
+
+const SID = 'aaaabbbb-1111-2222-3333-444455556666';
+
+function sampleEvents(): DashboardEvent[] {
+  return [
+    ev({ type: 'session_start', timestamp: '2026-03-10T09:00:00.000Z', sessionId: SID, cwd: '/home/u/proj' }),
+    ev({ type: 'prompt_submit', timestamp: '2026-03-10T09:00:05.000Z', sessionId: SID, promptSummary: 'help me fix the bug' }),
+    ev({ type: 'tool_use', timestamp: '2026-03-10T09:00:10.000Z', sessionId: SID, toolName: 'Edit' }),
+    ev({ type: 'tool_use', timestamp: '2026-03-10T09:00:12.000Z', sessionId: SID, toolName: 'Bash' }),
+    ev({ type: 'tool_use', timestamp: '2026-03-10T09:00:14.000Z', sessionId: SID, toolName: 'Edit' }),
+    ev({ type: 'tool_use', timestamp: '2026-03-10T09:00:16.000Z', sessionId: SID, toolName: 'Read' }),
+    ev({ type: 'stop', timestamp: '2026-03-10T09:05:00.000Z', sessionId: SID, interventions: { interrupt: 1, toolReject: 0 }, prompts: 1 }),
+  ];
+}
+
+describe('collectSession', () => {
+  it('returns null for an unknown session id', () => {
+    expect(collectSession('nope', sampleEvents())).toBeNull();
+  });
+
+  it('folds tool counts, interventions, and timing for one session', () => {
+    const s = collectSession(SID, sampleEvents())!;
+    expect(s.toolCounts).toEqual({ Edit: 2, Bash: 1, Read: 1 });
+    expect(s.toolTotal).toBe(4);
+    expect(s.distinctTools).toBe(3);
+    expect(s.interventions.interrupt).toBe(1);
+    expect(s.interventionCount).toBe(1);
+    expect(s.prompts).toBe(1);
+    expect(s.startedAt).toBe('2026-03-10T09:00:00.000Z');
+    expect(s.endedAt).toBe('2026-03-10T09:05:00.000Z');
+    expect(s.cwd).toBe('/home/u/proj');
+  });
+
+  it('only counts events for the requested session', () => {
+    const events = [
+      ...sampleEvents(),
+      ev({ type: 'tool_use', timestamp: '2026-03-10T09:01:00.000Z', sessionId: 'other', toolName: 'Grep' }),
+    ];
+    const s = collectSession(SID, events)!;
+    expect(s.toolCounts.Grep).toBeUndefined();
+  });
+
+  it('redacts secrets in the first prompt', () => {
+    const events = [
+      ev({ type: 'prompt_submit', timestamp: '2026-03-10T09:00:05.000Z', sessionId: SID, promptSummary: 'deploy with ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789' }),
+      ev({ type: 'stop', timestamp: '2026-03-10T09:00:06.000Z', sessionId: SID }),
+    ];
+    const s = collectSession(SID, events)!;
+    expect(s.firstPrompt).toContain('<REDACTED:gh_tok>');
+    expect(s.firstPrompt).not.toContain('ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789');
+  });
+});
+
+describe('isValuable', () => {
+  it('is valuable with any intervention', () => {
+    expect(isValuable({ interventionCount: 1, distinctTools: 1 })).toBe(true);
+  });
+  it('is valuable with 3+ distinct tools', () => {
+    expect(isValuable({ interventionCount: 0, distinctTools: 3 })).toBe(true);
+  });
+  it('is not valuable for trivial sessions', () => {
+    expect(isValuable({ interventionCount: 0, distinctTools: 1 })).toBe(false);
+  });
+});
+
+describe('renderSessionMarkdown', () => {
+  it('renders a self-contained block with heading and stats', () => {
+    const s = collectSession(SID, sampleEvents())!;
+    const md = renderSessionMarkdown(s);
+    expect(md).toContain('### 2026-03-10 · aaaabbbb · claude');
+    expect(md).toContain('Tools: 4 (3 distinct)');
+    expect(md).toContain('interrupt 1');
+  });
+
+  it('omits the first-prompt line by default', () => {
+    const s = collectSession(SID, sampleEvents())!;
+    expect(renderSessionMarkdown(s)).not.toContain('First ask:');
+  });
+
+  it('includes the first-prompt line only when includePrompt is set', () => {
+    const s = collectSession(SID, sampleEvents())!;
+    expect(renderSessionMarkdown(s, { includePrompt: true })).toContain('First ask: help me fix the bug');
+  });
+});
+
+describe('appendMonthlyLog / pruneMonthlyLogs', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-sesslog-'));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('writes a monthly file with a header on first write', async () => {
+    const s = collectSession(SID, sampleEvents())!;
+    const file = await appendMonthlyLog(dir, s);
+    expect(file).toBe(path.join(dir, '2026-03.md'));
+    const content = fs.readFileSync(file!, 'utf-8');
+    expect(content).toContain('# Session log — 2026-03');
+    expect(content).toContain('aaaabbbb');
+  });
+
+  it('is idempotent for the same session', async () => {
+    const s = collectSession(SID, sampleEvents())!;
+    expect(await appendMonthlyLog(dir, s)).not.toBeNull();
+    expect(await appendMonthlyLog(dir, s)).toBeNull();
+    const content = fs.readFileSync(path.join(dir, '2026-03.md'), 'utf-8');
+    // Header appears once; the session is recorded once (its full-id marker).
+    expect(content.match(/# Session log/g)!.length).toBe(1);
+    expect(content.match(/<!-- teamai:session /g)!.length).toBe(1);
+  });
+
+  it('records two distinct sessions that share an 8-char id prefix', async () => {
+    // Same shortId ("aaaabbbb"), different full ids: the old `· <shortId> ·`
+    // marker would have collapsed these into one. The full-id marker keeps them.
+    const COLLIDING = 'aaaabbbb-9999-8888-7777-666655554444';
+    const a = collectSession(SID, sampleEvents())!;
+    const b = collectSession(COLLIDING, [
+      ev({ type: 'session_start', timestamp: '2026-03-10T10:00:00.000Z', sessionId: COLLIDING }),
+      ev({ type: 'tool_use', timestamp: '2026-03-10T10:00:10.000Z', sessionId: COLLIDING, toolName: 'Edit' }),
+      ev({ type: 'stop', timestamp: '2026-03-10T10:05:00.000Z', sessionId: COLLIDING, prompts: 1 }),
+    ])!;
+    expect(await appendMonthlyLog(dir, a)).not.toBeNull();
+    expect(await appendMonthlyLog(dir, b)).not.toBeNull(); // not dropped as a dup
+    const content = fs.readFileSync(path.join(dir, '2026-03.md'), 'utf-8');
+    expect(content.match(/<!-- teamai:session /g)!.length).toBe(2);
+  });
+
+  it('prunes months older than the retention window but keeps recent ones', async () => {
+    fs.writeFileSync(path.join(dir, '2025-01.md'), '# old\n');
+    fs.writeFileSync(path.join(dir, '2026-03.md'), '# recent\n');
+    fs.writeFileSync(path.join(dir, 'not-a-log.txt'), 'ignore me\n');
+    const removed = await pruneMonthlyLogs(dir, new Date('2026-03-20T00:00:00.000Z'), 90);
+    expect(removed).toEqual(['2025-01.md']);
+    expect(fs.existsSync(path.join(dir, '2026-03.md'))).toBe(true);
+    expect(fs.existsSync(path.join(dir, 'not-a-log.txt'))).toBe(true);
+  });
+
+  it('monthKey derives YYYY-MM from the end timestamp', () => {
+    const s = collectSession(SID, sampleEvents())!;
+    expect(monthKey(s)).toBe('2026-03');
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -545,6 +545,25 @@ program
     await showStats({ byRepo: cmdOpts.byRepo, byTime: cmdOpts.byTime });
   });
 
+// ─── Session subcommands ──────────────────────────────────
+const sessionCmd = program
+  .command('session')
+  .description('Record and inspect coding-session summaries');
+
+sessionCmd
+  .command('save')
+  .description('Record a privacy-scrubbed summary of a coding session to a local monthly log')
+  .option('--session-id <id>', 'Session to record (default: most recent, or $CLAUDE_SESSION_ID)')
+  .option('--push', 'Also push the summary to the team repo (feeds `teamai digest`)')
+  .option('--force', 'Push even if the session is not flagged as valuable')
+  .option('--include-prompt', 'Include the redacted first-prompt line in the pushed summary (default: off)')
+  .option('--scope <scope>', 'Config scope for --push: user | project (default: auto-detect)')
+  .action(async (cmdOpts) => {
+    const globalOpts = program.opts() as GlobalOptions;
+    const { saveSession } = await import('./save-session.js');
+    await saveSession({ ...globalOpts, ...cmdOpts });
+  });
+
 program
   .command('digest')
   .description('Generate weekly team activity digest')

--- a/src/save-session.ts
+++ b/src/save-session.ts
@@ -1,0 +1,161 @@
+/**
+ * `teamai session save` — persist a privacy-scrubbed summary of a coding session
+ * to a local monthly log, and optionally push it to the team repo so it shows up
+ * in `teamai digest`'s "Session Highlights".
+ *
+ * Implements Features 1 & 5 from docs/designs/team-intelligence-platform.md,
+ * reusing the dashboard's existing per-session event stream rather than a new
+ * collection path. Team upload is opt-in (`--push`) and only carries counts,
+ * tool names, and a redacted first-prompt line — consistent with TeamAI's
+ * "counts only, no prompt text" posture.
+ */
+
+import path from 'node:path';
+import {
+  requireInit,
+  detectProjectConfig,
+  loadLocalConfigForScope,
+} from './config.js';
+import { assertNotReadOnly } from './read-only.js';
+import { pushRepoDirectly, pullRepo } from './utils/git.js';
+import { readEvents } from './dashboard-collector.js';
+import {
+  collectSession,
+  appendMonthlyLog,
+  pruneMonthlyLogs,
+  monthKey,
+} from './session-collector.js';
+import { log, spinner } from './utils/logger.js';
+import { withTimeout } from './utils/async.js';
+import { SESSION_LOGS_LOCAL_DIR } from './types.js';
+import type { GlobalOptions, LocalConfig } from './types.js';
+
+export interface SaveSessionOptions extends GlobalOptions {
+  sessionId?: string;
+  /** Push the summary to the team repo (default: local only). */
+  push?: boolean;
+  /** Push even when the session isn't judged "valuable". */
+  force?: boolean;
+  /** Include the redacted first-prompt line in the pushed summary (default: off). */
+  includePrompt?: boolean;
+  scope?: string;
+}
+
+/** Pick the session id of the most recently active session in the event log. */
+function mostRecentSessionId(events: { sessionId: string; timestamp: string }[]): string | undefined {
+  let best: { sessionId: string; timestamp: string } | undefined;
+  for (const e of events) {
+    if (!best || e.timestamp > best.timestamp) best = e;
+  }
+  return best?.sessionId;
+}
+
+export async function saveSession(options: SaveSessionOptions): Promise<void> {
+  const events = await readEvents();
+  if (events.length === 0) {
+    log.info('No local session data yet — nothing to save.');
+    return;
+  }
+
+  const sessionId =
+    options.sessionId || process.env.CLAUDE_SESSION_ID || mostRecentSessionId(events);
+  if (!sessionId) {
+    log.error('Could not determine a session id. Pass --session-id <id>.');
+    return;
+  }
+
+  const summary = collectSession(sessionId, events);
+  if (!summary) {
+    log.error(`No events found for session ${sessionId}.`);
+    return;
+  }
+
+  // Always write the local monthly log.
+  if (options.dryRun) {
+    log.info(
+      `[dry-run] Would record session ${sessionId.slice(0, 8)} ` +
+        `(${summary.toolTotal} tools, ${summary.interventionCount} interventions, ` +
+        `valuable=${summary.valuable}) to ${SESSION_LOGS_LOCAL_DIR}/${monthKey(summary)}.md`,
+    );
+  } else {
+    // Local logs live on the user's own machine, so keep the redacted prompt line.
+    const written = await appendMonthlyLog(SESSION_LOGS_LOCAL_DIR, summary, { includePrompt: true });
+    if (written) {
+      log.info(`Recorded session to ${written}`);
+    } else {
+      log.info(`Session ${sessionId.slice(0, 8)} already recorded this month.`);
+    }
+    await pruneMonthlyLogs(SESSION_LOGS_LOCAL_DIR, new Date()).catch(() => []);
+  }
+
+  if (!options.push) return;
+
+  // ── Team push (opt-in) ─────────────────────────────────
+  if (!summary.valuable && !options.force) {
+    log.info('Session not flagged as valuable (no interventions, few tools) — skipping team push. Use --force to override.');
+    return;
+  }
+
+  let localConfig: LocalConfig;
+  try {
+    if (options.scope === 'project') {
+      const cfg = await loadLocalConfigForScope('project', process.cwd());
+      if (!cfg) {
+        log.error('No project-level teamai config in the current directory.');
+        return;
+      }
+      localConfig = cfg;
+    } else if (options.scope === 'user') {
+      localConfig = (await requireInit()).localConfig;
+    } else {
+      const projectConfig = await detectProjectConfig();
+      localConfig = projectConfig ?? (await requireInit()).localConfig;
+    }
+  } catch (e) {
+    log.error(`Cannot push: ${(e as Error).message}`);
+    log.info('The local log was still saved.');
+    return;
+  }
+  try {
+    assertNotReadOnly(localConfig, 'teamai session save --push');
+  } catch (e) {
+    log.error((e as Error).message);
+    log.info('The local log was still saved.');
+    return;
+  }
+
+  const repoPath = localConfig.repo.localPath;
+  const username = localConfig.username;
+  const teamDir = path.join(repoPath, 'sessions', username);
+
+  if (options.dryRun) {
+    log.info(`[dry-run] Would push session summary to sessions/${username}/${monthKey(summary)}.md`);
+    return;
+  }
+
+  const spin = spinner('Pushing session summary to team...').start();
+  try {
+    try {
+      await pullRepo(repoPath);
+    } catch {
+      log.debug('session save: pull failed, continuing with local state');
+    }
+
+    // Team upload defaults to counts + tools only; the redacted prompt line is
+    // opt-in via --include-prompt, since redact() is best-effort.
+    const written = await appendMonthlyLog(teamDir, summary, { includePrompt: options.includePrompt });
+    if (!written) {
+      spin.info('Session already present in the team log — nothing to push.');
+      return;
+    }
+    const rel = path.relative(repoPath, written);
+    const commitMsg = `[teamai] Session summary from ${username} (${monthKey(summary)})`;
+
+    await withTimeout(pushRepoDirectly(repoPath, commitMsg, [rel]), 10_000, 'Push timeout (10s)');
+
+    spin.succeed(`Pushed: ${rel}`);
+  } catch (e) {
+    spin.fail(`Team push failed: ${(e as Error).message}`);
+    log.info('The local log was still saved. Retry later with: teamai session save --push');
+  }
+}

--- a/src/session-collector.ts
+++ b/src/session-collector.ts
@@ -1,0 +1,237 @@
+/**
+ * Session collector — implements Feature 1 ("session tool-usage record") from
+ * docs/designs/team-intelligence-platform.md.
+ *
+ * The dashboard already collects a rich per-session event stream in
+ * ~/.teamai/dashboard/events.jsonl (tool sequence, prompt turns, interventions,
+ * tokens). Historically that stream never left the machine and was dropped by
+ * dashboard compaction. This module folds one session's events into a compact,
+ * privacy-scrubbed markdown summary and appends it to a monthly log, so the
+ * record survives and (via `teamai session save --push`) can seed the team
+ * digest's "Session Highlights".
+ *
+ * Design decisions honored:
+ *   - Collect-then-summarize (no LLM call here). (Decision 1)
+ *   - Monthly aggregated markdown files. (Decision 3)
+ *   - "Valuable" sessions are the ones showing tool misuse / retries / user
+ *     intervention — the core signal the platform wants to surface. (Decision 7/8)
+ *   - Counts and tool names only; any free text is run through redact(). (Security)
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { ensureDir } from './utils/fs.js';
+import { redactWithEnv } from './utils/redact.js';
+import { aggregateSessionMetrics } from './dashboard-collector.js';
+import { emptyTokenUsage } from './types.js';
+import type { DashboardEvent, SessionMetrics } from './types.js';
+
+/** A folded, human-readable summary of a single session. */
+export interface SessionSummary {
+  sessionId: string;
+  tool: string;
+  cwd: string;
+  startedAt: string;
+  endedAt: string;
+  /** Tool-name → invocation count, from tool_use events. */
+  toolCounts: Record<string, number>;
+  /** Total tool invocations. */
+  toolTotal: number;
+  /** Distinct tool names used. */
+  distinctTools: number;
+  interventions: { interrupt: number; toolReject: number; correction: number };
+  interventionCount: number;
+  prompts: number;
+  /** First user prompt, redacted and truncated. Empty when unavailable. */
+  firstPrompt: string;
+  /** Whether this session is worth surfacing to the team (see isValuable). */
+  valuable: boolean;
+}
+
+/** Max characters kept from the first prompt in a summary. */
+const FIRST_PROMPT_MAX_CHARS = 160;
+/** A session touching at least this many distinct tools is considered substantial. */
+const SUBSTANTIAL_TOOL_COUNT = 3;
+
+/**
+ * A session is "valuable" (worth surfacing to the team) when it shows signs of
+ * friction — a user interrupt, a tool rejection, or a re-prompt correction —
+ * or when it exercised a substantial number of distinct tools. Pure chatter and
+ * trivial one-tool sessions are filtered out. (Design Decision 8.)
+ */
+export function isValuable(summary: Pick<SessionSummary, 'interventionCount' | 'distinctTools'>): boolean {
+  return summary.interventionCount > 0 || summary.distinctTools >= SUBSTANTIAL_TOOL_COUNT;
+}
+
+/**
+ * Fold every event for a single session id into a {@link SessionSummary}.
+ * Returns null when the session has no events (unknown id).
+ */
+export function collectSession(sessionId: string, events: DashboardEvent[]): SessionSummary | null {
+  const own = events.filter((e) => e.sessionId === sessionId);
+  if (own.length === 0) return null;
+
+  const toolCounts: Record<string, number> = {};
+  let tool = own[0].tool;
+  let cwd = '';
+  let firstPromptRaw = '';
+  let startedAt = own[0].timestamp;
+  let endedAt = own[0].timestamp;
+
+  for (const e of own) {
+    if (e.tool) tool = e.tool;
+    if (e.cwd) cwd = e.cwd;
+    if (e.timestamp < startedAt) startedAt = e.timestamp;
+    if (e.timestamp > endedAt) endedAt = e.timestamp;
+    if (e.type === 'tool_use' && e.toolName) {
+      toolCounts[e.toolName] = (toolCounts[e.toolName] ?? 0) + 1;
+    }
+    if (!firstPromptRaw && e.type === 'prompt_submit' && e.promptSummary) {
+      firstPromptRaw = e.promptSummary;
+    }
+  }
+
+  const metrics: SessionMetrics =
+    aggregateSessionMetrics(own).get(sessionId) ??
+    { interrupt: 0, toolReject: 0, correction: 0, prompts: 0, tokens: emptyTokenUsage() };
+
+  const interventions = {
+    interrupt: metrics.interrupt,
+    toolReject: metrics.toolReject,
+    correction: metrics.correction,
+  };
+  const interventionCount = interventions.interrupt + interventions.toolReject + interventions.correction;
+  const toolTotal = Object.values(toolCounts).reduce((s, n) => s + n, 0);
+  const distinctTools = Object.keys(toolCounts).length;
+  const firstPrompt = firstPromptRaw
+    ? redactWithEnv(firstPromptRaw).replace(/\s+/g, ' ').trim().slice(0, FIRST_PROMPT_MAX_CHARS)
+    : '';
+
+  return {
+    sessionId,
+    tool,
+    cwd,
+    startedAt,
+    endedAt,
+    toolCounts,
+    toolTotal,
+    distinctTools,
+    interventions,
+    interventionCount,
+    prompts: metrics.prompts,
+    firstPrompt,
+    valuable: isValuable({ interventionCount, distinctTools }),
+  };
+}
+
+/** Short, stable id fragment for headings (first segment of a UUID). */
+function shortId(sessionId: string): string {
+  return sessionId.split('-')[0].slice(0, 8) || sessionId.slice(0, 8);
+}
+
+export interface RenderOptions {
+  /**
+   * Include the (redacted) first-prompt line. Off by default so the team-pushed
+   * summary stays counts-and-tools only; `redact()` is best-effort, so prompt
+   * text is opt-in even after scrubbing. Local logs pass this on.
+   */
+  includePrompt?: boolean;
+}
+
+/** Render a single session as a self-contained markdown block. */
+export function renderSessionMarkdown(summary: SessionSummary, options: RenderOptions = {}): string {
+  const date = summary.endedAt.slice(0, 10);
+  const topTools = Object.entries(summary.toolCounts)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 8)
+    .map(([name, count]) => `${name}×${count}`)
+    .join(', ');
+  const iv = summary.interventions;
+  const lines = [
+    // Stable, collision-proof idempotency key: the full session id, in an HTML
+    // comment so it never renders. The heading below still shows the short id
+    // for humans. `appendMonthlyLog` dedups on this marker.
+    `<!-- teamai:session ${summary.sessionId} -->`,
+    `### ${date} · ${shortId(summary.sessionId)} · ${summary.tool}`,
+    '',
+    `- Project: \`${summary.cwd || 'unknown'}\``,
+    `- Prompts: ${summary.prompts} · Tools: ${summary.toolTotal} (${summary.distinctTools} distinct)`,
+    `- Interventions: interrupt ${iv.interrupt}, toolReject ${iv.toolReject}, correction ${iv.correction}`,
+  ];
+  if (topTools) lines.push(`- Top tools: ${topTools}`);
+  if (options.includePrompt && summary.firstPrompt) lines.push(`- First ask: ${summary.firstPrompt}`);
+  lines.push('');
+  return lines.join('\n');
+}
+
+/** `YYYY-MM` bucket for a session, from its end timestamp. */
+export function monthKey(summary: SessionSummary): string {
+  return summary.endedAt.slice(0, 7);
+}
+
+/**
+ * Append a session's markdown to its monthly log file, idempotently: a session
+ * already present (matched by its full-session-id `<!-- teamai:session … -->`
+ * marker) is not appended again. Returns the file path written, or null when the
+ * session was already recorded. Creates the directory and a month header on first
+ * write.
+ */
+export async function appendMonthlyLog(
+  dir: string,
+  summary: SessionSummary,
+  options: RenderOptions = {},
+): Promise<string | null> {
+  await ensureDir(dir);
+  const month = monthKey(summary);
+  const file = path.join(dir, `${month}.md`);
+  const block = renderSessionMarkdown(summary, options);
+  const marker = `<!-- teamai:session ${summary.sessionId} -->`;
+
+  let existing = '';
+  try {
+    existing = await fs.promises.readFile(file, 'utf-8');
+  } catch {
+    // New month.
+  }
+
+  if (existing.includes(marker)) return null;
+
+  const header = existing ? '' : `# Session log — ${month}\n\n`;
+  await fs.promises.writeFile(file, existing + header + block, 'utf-8');
+  return file;
+}
+
+/**
+ * Delete monthly log files whose month is older than `retentionDays` (Feature 5
+ * retention). Returns the list of removed file basenames. Best-effort: unreadable
+ * entries are skipped.
+ */
+export async function pruneMonthlyLogs(
+  dir: string,
+  now: Date,
+  retentionDays = 90,
+): Promise<string[]> {
+  let entries: string[];
+  try {
+    entries = await fs.promises.readdir(dir);
+  } catch {
+    return [];
+  }
+  const cutoff = now.getTime() - retentionDays * 86_400_000;
+  const removed: string[] = [];
+  for (const entry of entries) {
+    const m = entry.match(/^(\d{4})-(\d{2})\.md$/);
+    if (!m) continue;
+    // Compare against the *end* of that month so the current month is never pruned.
+    const monthEnd = new Date(Date.UTC(Number(m[1]), Number(m[2]), 0, 23, 59, 59));
+    if (monthEnd.getTime() < cutoff) {
+      try {
+        await fs.promises.unlink(path.join(dir, entry));
+        removed.push(entry);
+      } catch {
+        // Skip files we can't remove.
+      }
+    }
+  }
+  return removed;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -339,6 +339,11 @@ export const TEAMAI_USAGE_PATH = `${TEAMAI_HOME}/usage.jsonl`;
 export const TEAMAI_KNOWN_SKILLS_PATH = `${TEAMAI_HOME}/known-skills.json`;
 export const TEAMAI_PUSHIGNORE_PATH = `${TEAMAI_HOME}/pushignore`;
 export const TEAMAI_SESSIONS_DIR = `${TEAMAI_HOME}/sessions`;
+/**
+ * Local monthly session logs (`teamai session save`). Kept in a dedicated dir —
+ * not TEAMAI_SESSIONS_DIR, which holds per-session contribute-state `.json`.
+ */
+export const SESSION_LOGS_LOCAL_DIR = `${TEAMAI_HOME}/session-logs`;
 
 export interface UsageEvent {
   skill: string;


### PR DESCRIPTION
## Summary

Implements **Features 1 & 5** from `docs/designs/team-intelligence-platform.md` — accepted ("ENG LOCKED") in that design but never built. `digest.ts`'s `getRecentSessions()` has been reading an always-empty `sessions/` directory; this PR gives it data.

`teamai save-session` folds the dashboard's **existing** per-session event stream (tool sequence, prompt turns, interventions) into a compact, privacy-scrubbed markdown summary, appends it to a local monthly log, and — with `--push` — commits a valuable session to the team repo at the exact path `digest` already reads, so "Session Highlights" lights up.

> ⚠️ **Stacked on #191** (secret-redaction utility). The first commit in this branch is that PR; this PR's own change is the `save-session` commit. Please merge #191 first — the diff will then reduce to just this change.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## What it does

```
teamai save-session                 # record most-recent session locally
teamai save-session --session-id X  # record a specific session
teamai save-session --push          # also push a "valuable" session to the team repo
teamai save-session --push --force  # push even trivial sessions
```

- **Local:** `~/.teamai/session-logs/<year-month>.md` (dedicated dir; not the shared `~/.teamai/sessions/` which holds contribute-state `.json`). Idempotent per session; pruned after 90 days (Feature 5 retention).
- **Team (`--push`, opt-in):** `sessions/<user>/<year-month>.md`, direct commit (no MR), like `contribute`. This is the path `digest`'s `getRecentSessions()` already globs — **no change to `digest.ts` needed**.
- **"Valuable"** (Decision 8) = the session shows friction (interrupt / tool-reject / correction) or substantial tool use (≥3 distinct tools). Trivial sessions stay local unless `--force`.

## Design decisions honored

- Collect-then-summarize, **no LLM call** (Decision 1).
- Monthly aggregated markdown (Decision 3).
- Surfaces **AI tool-misuse / retry** signal (Decisions 7/8).
- **Privacy:** team payload is counts + tool names + a single first-prompt line, and that line is run through `redact()` (from #191). Consistent with the "counts only, no prompt text" posture.

## Reuses existing infrastructure (no new collection path)

- `dashboard-collector` `readEvents()` + `aggregateSessionMetrics()` for the data
- `utils/git` `pushRepoDirectly()` for the direct team commit
- `read-only` `assertNotReadOnly()` so HTTP-mode teams can't push
- `redact()` for the only free text included

## Test Plan

- [x] `npx tsc --noEmit`
- [x] `npx vitest run` — 140 files, 1741 tests (12 new in `session-collector.test.ts`)
- [x] `npm run build`
- [x] Real-CLI E2E: seeded `~/.teamai/dashboard/events.jsonl`, ran `node dist/index.js save-session --session-id <sid>`. Result: `~/.teamai/session-logs/2026-07.md` written with folded stats; a `ghp_…` token in the prompt came out `<REDACTED:gh_tok>` (0 raw leaks); a second run was idempotent ("already recorded"); `--push` without init failed gracefully while keeping the local log.

## Notes for Reviewers

- `save-session` is a **command** only (manual / agent-invoked). Auto-saving on the Stop hook is a natural follow-up but intentionally left out here to keep the injected-hook surface unchanged.
- Local storage uses `~/.teamai/session-logs/` rather than the design's literal `~/.teamai/sessions/<year-month>.md`, to avoid mixing with the contribute-state `.json` files already in `sessions/`. Happy to change if you prefer the literal path.
- `digest.ts` is deliberately untouched — the feature works by supplying the data its existing reader expects.
