### PR TITLE
feat(stats): add `--by-repo` and `--by-time` breakdowns to `teamai stats`

### DIFF
--- a/src/__tests__/session-analytics.test.ts
+++ b/src/__tests__/session-analytics.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { canonicalRepo, attributeRepo } from '../utils/repo-attribution.js';
+import { attributeByRepo, timeAnalytics, renderHourSparkline } from '../session-analytics.js';
+import type { DashboardEvent, TokenUsage } from '../types.js';
+
+function ev(p: Partial<DashboardEvent> & { type: DashboardEvent['type']; timestamp: string; sessionId: string }): DashboardEvent {
+  return { tool: 'claude', ...p } as DashboardEvent;
+}
+function tok(input: number, output: number): TokenUsage {
+  return { input, output, cacheRead: 0, cacheCreation: 0 };
+}
+
+describe('canonicalRepo', () => {
+  it('drops host and keeps owner/repo across platforms', () => {
+    expect(canonicalRepo('github.com/Eyre921/new-api')).toBe('Eyre921/new-api');
+    expect(canonicalRepo('cnb.cool/Eyre921/new-api')).toBe('Eyre921/new-api');
+    expect(canonicalRepo('https://github.com/Tencent/teamai-cli.git')).toBe('Tencent/teamai-cli');
+    expect(canonicalRepo('git@github.com:Tencent/teamai-cli.git')).toBe('Tencent/teamai-cli');
+  });
+  it('handles the legacy owner_repo underscore form', () => {
+    expect(canonicalRepo('Eyre921_new-api')).toBe('Eyre921/new-api');
+  });
+  it('returns null when no owner can be derived', () => {
+    expect(canonicalRepo('new-api')).toBeNull();
+  });
+});
+
+describe('attributeRepo', () => {
+  it('uses the project directory name for filesystem paths', () => {
+    expect(attributeRepo('/home/u/new-api')).toBe('new-api');
+    expect(attributeRepo('/opt/teamai-cli/')).toBe('teamai-cli');
+  });
+  it('canonicalizes remote-form cwds to owner/repo', () => {
+    expect(attributeRepo('github.com/Tencent/teamai-cli')).toBe('Tencent/teamai-cli');
+  });
+  it('maps home/root/ops/empty dirs to no_repo', () => {
+    expect(attributeRepo('/home')).toBe('no_repo');
+    expect(attributeRepo('/root')).toBe('no_repo');
+    expect(attributeRepo('/opt')).toBe('no_repo');
+    expect(attributeRepo('')).toBe('no_repo');
+    expect(attributeRepo(undefined)).toBe('no_repo');
+  });
+});
+
+describe('attributeByRepo', () => {
+  const events: DashboardEvent[] = [
+    // Session A in /home/u/alpha: 2 tools, 1 prompt, tokens 100/50
+    ev({ type: 'session_start', timestamp: '2026-07-01T10:00:00.000Z', sessionId: 'A', cwd: '/home/u/alpha' }),
+    ev({ type: 'prompt_submit', timestamp: '2026-07-01T10:00:01.000Z', sessionId: 'A', cwd: '/home/u/alpha', promptSummary: 'hi' }),
+    ev({ type: 'tool_use', timestamp: '2026-07-01T10:00:02.000Z', sessionId: 'A', cwd: '/home/u/alpha', toolName: 'Edit' }),
+    ev({ type: 'tool_use', timestamp: '2026-07-01T10:00:03.000Z', sessionId: 'A', cwd: '/home/u/alpha', toolName: 'Bash' }),
+    ev({ type: 'stop', timestamp: '2026-07-01T10:00:10.000Z', sessionId: 'A', cwd: '/home/u/alpha', tokens: tok(100, 50), prompts: 1, interventions: { interrupt: 1, toolReject: 0 } }),
+    // Session B also in /home/u/alpha: 1 tool
+    ev({ type: 'tool_use', timestamp: '2026-07-01T11:00:00.000Z', sessionId: 'B', cwd: '/home/u/alpha', toolName: 'Read' }),
+    ev({ type: 'stop', timestamp: '2026-07-01T11:00:05.000Z', sessionId: 'B', cwd: '/home/u/alpha', tokens: tok(10, 5), prompts: 0 }),
+    // Session C in /home/u/beta: 1 tool
+    ev({ type: 'tool_use', timestamp: '2026-07-01T12:00:00.000Z', sessionId: 'C', cwd: '/home/u/beta', toolName: 'Grep' }),
+  ];
+
+  it('groups sessions by repo and rolls up totals', () => {
+    const repos = attributeByRepo(events);
+    const alpha = repos.find((r) => r.repo === 'alpha')!;
+    const beta = repos.find((r) => r.repo === 'beta')!;
+    expect(alpha.sessions).toBe(2);
+    expect(alpha.tools).toBe(3); // Edit + Bash + Read
+    expect(alpha.prompts).toBe(1);
+    expect(alpha.interventions).toBe(1);
+    expect(alpha.tokens.input).toBe(110);
+    expect(beta.sessions).toBe(1);
+    expect(beta.tools).toBe(1);
+  });
+
+  it('sorts repos by total tokens then sessions (alpha before beta)', () => {
+    const repos = attributeByRepo(events);
+    expect(repos[0].repo).toBe('alpha');
+  });
+});
+
+describe('timeAnalytics', () => {
+  const events: DashboardEvent[] = [
+    ev({ type: 'prompt_submit', timestamp: '2026-07-01T02:00:00.000Z', sessionId: 'A' }),
+    ev({ type: 'tool_use', timestamp: '2026-07-01T02:02:00.000Z', sessionId: 'A' }), // +2min (active)
+    ev({ type: 'tool_use', timestamp: '2026-07-01T02:30:00.000Z', sessionId: 'A' }), // +28min (idle, not counted)
+    ev({ type: 'prompt_submit', timestamp: '2026-07-01T14:00:00.000Z', sessionId: 'B' }),
+  ];
+
+  it('counts active minutes only for sub-idle gaps', () => {
+    const ta = timeAnalytics(events);
+    expect(ta.activeMinutes).toBe(2);
+    expect(ta.totalEvents).toBe(4);
+  });
+
+  it('byHour sums to total and peakHour is the argmax (TZ-independent checks)', () => {
+    const ta = timeAnalytics(events);
+    expect(ta.byHour.reduce((a, b) => a + b, 0)).toBe(4);
+    const max = Math.max(...ta.byHour);
+    expect(ta.byHour[ta.peakHour]).toBe(max);
+  });
+
+  it('night-owl ratio matches the local-hour split of the same timestamps', () => {
+    const ta = timeAnalytics(events);
+    const expectedNight = events.filter((e) => new Date(e.timestamp).getHours() < 6).length / events.length;
+    expect(ta.nightOwlRatio).toBeCloseTo(expectedNight, 5);
+  });
+
+  it('returns empty analytics for no events', () => {
+    const ta = timeAnalytics([]);
+    expect(ta).toEqual({ byHour: new Array(24).fill(0), peakHour: -1, nightOwlRatio: 0, activeMinutes: 0, totalEvents: 0 });
+  });
+});
+
+describe('renderHourSparkline', () => {
+  it('renders 24 characters', () => {
+    const spark = renderHourSparkline(new Array(24).fill(0).map((_, i) => i));
+    expect(spark.length).toBe(24);
+  });
+
+  it('renders all-zero input as 24 dots (idle is distinct from low activity)', () => {
+    expect(renderHourSparkline(new Array(24).fill(0))).toBe('·'.repeat(24));
+  });
+
+  it('renders a single peak as a full bar and empty hours as dots', () => {
+    const byHour = new Array(24).fill(0);
+    byHour[9] = 42;
+    const spark = renderHourSparkline(byHour);
+    expect(spark[9]).toBe('█');
+    expect(spark[0]).toBe('·');
+    expect(spark.replace(/[·█]/g, '')).toBe(''); // only dots and the one full bar
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -538,9 +538,11 @@ program
 program
   .command('stats')
   .description('Show local skill usage statistics')
-  .action(async () => {
+  .option('--by-repo', 'Break usage down per repository')
+  .option('--by-time', 'Show activity by hour of day')
+  .action(async (cmdOpts) => {
     const { showStats } = await import('./stats.js');
-    await showStats();
+    await showStats({ byRepo: cmdOpts.byRepo, byTime: cmdOpts.byTime });
   });
 
 program

--- a/src/session-analytics.ts
+++ b/src/session-analytics.ts
@@ -1,0 +1,147 @@
+/**
+ * Derived session analytics for `teamai stats` — per-repo breakdown and
+ * time-of-day patterns, computed from the local dashboard event stream.
+ *
+ * Ports the shape of claude-cloud-sync's stats.json analytics (by_repo,
+ * timeline_by_hour, active_minutes, night-owl ratio), adapted to the data
+ * teamai-cli already collects: attribution is at session granularity (one cwd
+ * per session) rather than the sync's per-turn cost splitting.
+ */
+
+import { aggregateSessionMetrics } from './dashboard-collector.js';
+import { emptyTokenUsage, addTokenUsage, totalTokens } from './types.js';
+import { attributeRepo } from './utils/repo-attribution.js';
+import type { DashboardEvent, TokenUsage } from './types.js';
+
+export interface RepoStat {
+  repo: string;
+  sessions: number;
+  prompts: number;
+  tools: number;
+  interventions: number;
+  tokens: TokenUsage;
+}
+
+/**
+ * Roll usage up per repo. Each session is attributed to the project of its cwd;
+ * its prompts/interventions/tokens (from aggregateSessionMetrics) and tool count
+ * are added to that repo's totals. Sorted by total tokens, then session count.
+ */
+export function attributeByRepo(events: DashboardEvent[]): RepoStat[] {
+  const sessionCwd = new Map<string, string>();
+  const sessionTools = new Map<string, number>();
+  const sessionIds = new Set<string>();
+
+  for (const e of events) {
+    sessionIds.add(e.sessionId);
+    if (e.cwd) sessionCwd.set(e.sessionId, e.cwd);
+    if (e.type === 'tool_use') {
+      sessionTools.set(e.sessionId, (sessionTools.get(e.sessionId) ?? 0) + 1);
+    }
+  }
+
+  const metrics = aggregateSessionMetrics(events);
+  const byRepo = new Map<string, RepoStat>();
+
+  for (const sid of sessionIds) {
+    const repo = attributeRepo(sessionCwd.get(sid));
+    let r = byRepo.get(repo);
+    if (!r) {
+      r = { repo, sessions: 0, prompts: 0, tools: 0, interventions: 0, tokens: emptyTokenUsage() };
+      byRepo.set(repo, r);
+    }
+    r.sessions += 1;
+    r.tools += sessionTools.get(sid) ?? 0;
+    const m = metrics.get(sid);
+    if (m) {
+      r.prompts += m.prompts;
+      r.interventions += m.interrupt + m.toolReject + m.correction;
+      r.tokens = addTokenUsage(r.tokens, m.tokens);
+    }
+  }
+
+  return Array.from(byRepo.values()).sort(
+    (a, b) => totalTokens(b.tokens) - totalTokens(a.tokens) || b.sessions - a.sessions,
+  );
+}
+
+export interface TimeAnalytics {
+  /** Activity-event counts indexed by local hour of day (0–23). */
+  byHour: number[];
+  /** Hour of day with the most activity (0–23); -1 when there is no data. */
+  peakHour: number;
+  /** Share of activity between 00:00 and 05:59 local time (0–1). */
+  nightOwlRatio: number;
+  /** Sum, across sessions, of consecutive event gaps under the idle threshold. */
+  activeMinutes: number;
+  /** Total activity events considered. */
+  totalEvents: number;
+}
+
+/** Gaps shorter than this count as continuous active time (matches dashboard idle). */
+const ACTIVE_GAP_MS = 5 * 60_000;
+
+/**
+ * Compute time-of-day activity patterns and active minutes from the event
+ * stream. Hours use the local timezone of the machine running the command.
+ */
+export function timeAnalytics(events: DashboardEvent[]): TimeAnalytics {
+  const byHour = new Array(24).fill(0) as number[];
+  let nightOwl = 0;
+  let total = 0;
+
+  // Per-session sorted timestamps for active-minute accumulation.
+  const perSession = new Map<string, number[]>();
+
+  for (const e of events) {
+    const t = new Date(e.timestamp);
+    const ms = t.getTime();
+    if (Number.isNaN(ms)) continue;
+    const hour = t.getHours();
+    byHour[hour] += 1;
+    if (hour < 6) nightOwl += 1;
+    total += 1;
+    const arr = perSession.get(e.sessionId);
+    if (arr) arr.push(ms);
+    else perSession.set(e.sessionId, [ms]);
+  }
+
+  let activeMs = 0;
+  for (const times of perSession.values()) {
+    times.sort((a, b) => a - b);
+    for (let i = 1; i < times.length; i++) {
+      const gap = times[i] - times[i - 1];
+      if (gap > 0 && gap < ACTIVE_GAP_MS) activeMs += gap;
+    }
+  }
+
+  let peakHour = -1;
+  let peakCount = -1;
+  for (let h = 0; h < 24; h++) {
+    if (byHour[h] > peakCount) {
+      peakCount = byHour[h];
+      peakHour = h;
+    }
+  }
+
+  return {
+    byHour,
+    peakHour: total > 0 ? peakHour : -1,
+    nightOwlRatio: total > 0 ? nightOwl / total : 0,
+    activeMinutes: Math.round(activeMs / 60_000),
+    totalEvents: total,
+  };
+}
+
+/**
+ * Render a compact 24-hour sparkline for a byHour histogram. Empty hours render
+ * as `·` so idle hours are visually distinct from low-but-nonzero activity
+ * (which is at least `▁`).
+ */
+export function renderHourSparkline(byHour: number[]): string {
+  const bars = '▁▂▃▄▅▆▇█';
+  const max = Math.max(...byHour, 1);
+  return byHour
+    .map((c) => (c === 0 ? '·' : bars[Math.min(bars.length - 1, Math.round((c / max) * (bars.length - 1)))]))
+    .join('');
+}

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -5,6 +5,7 @@ import { readFileSafe } from './utils/fs.js';
 import { loadLocalConfig, detectProjectConfig } from './config.js';
 import { readEvents, aggregateSessionMetrics } from './dashboard-collector.js';
 import { totalTokens, addTokenUsage, emptyTokenUsage } from './types.js';
+import { attributeByRepo, timeAnalytics, renderHourSparkline } from './session-analytics.js';
 import { formatTokenCount } from './digest.js';
 import type { UsageEvent, UserStats, TokenUsage, SessionMetrics } from './types.js';
 
@@ -149,11 +150,18 @@ function mergeDashboardAndReported(
   return merged;
 }
 
+export interface ShowStatsOptions {
+  /** Add a per-repo usage breakdown. */
+  byRepo?: boolean;
+  /** Add a time-of-day activity breakdown. */
+  byTime?: boolean;
+}
+
 /**
  * CLI: Show skill usage and session/token statistics.
  * Merges local unreported events with reported team stats for a complete view.
  */
-export async function showStats(): Promise<void> {
+export async function showStats(options: ShowStatsOptions = {}): Promise<void> {
   const events = await readUsageEvents();
   const localStats = aggregateUsage(events);
   const reported = await loadReportedStats();
@@ -224,6 +232,43 @@ export async function showStats(): Promise<void> {
       if (dashboard.interrupt > 0) console.log(`    Interrupts:       ${dashboard.interrupt}`);
       if (dashboard.toolReject > 0) console.log(`    Tool rejects:     ${dashboard.toolReject}`);
       if (dashboard.correction > 0) console.log(`    Corrections:      ${dashboard.correction}`);
+    }
+  }
+
+  // ─── Per-repo breakdown (--by-repo) ───
+  if (options.byRepo) {
+    const repos = attributeByRepo(dashboardEvents);
+    if (repos.length > 0) {
+      console.log('');
+      console.log('By Repo:');
+      console.log('');
+      const TOP_N = 15;
+      const maxLen = Math.max(...repos.slice(0, TOP_N).map((r) => r.repo.length), 4);
+      for (const r of repos.slice(0, TOP_N)) {
+        const name = r.repo.padEnd(maxLen);
+        const tok = totalTokens(r.tokens);
+        const parts = [`${r.sessions} sess`, `${r.prompts} turns`, `${r.tools} tools`];
+        if (tok > 0) parts.push(`${formatTokenCount(tok)} tok`);
+        if (r.interventions > 0) parts.push(`${r.interventions} intv`);
+        console.log(`  ${name}  ${parts.join(', ')}`);
+      }
+      if (repos.length > TOP_N) {
+        console.log(`  … and ${repos.length - TOP_N} more`);
+      }
+    }
+  }
+
+  // ─── Time-of-day patterns (--by-time) ───
+  if (options.byTime) {
+    const ta = timeAnalytics(dashboardEvents);
+    if (ta.totalEvents > 0) {
+      console.log('');
+      console.log('Activity by Hour (local time):');
+      console.log('');
+      console.log(`  00h ${renderHourSparkline(ta.byHour)} 23h`);
+      console.log(`  Peak hour:    ${String(ta.peakHour).padStart(2, '0')}:00`);
+      console.log(`  Active time:  ${ta.activeMinutes} min`);
+      console.log(`  Night owl:    ${(ta.nightOwlRatio * 100).toFixed(0)}% of activity before 6am`);
     }
   }
 }

--- a/src/utils/repo-attribution.ts
+++ b/src/utils/repo-attribution.ts
@@ -1,0 +1,61 @@
+/**
+ * Attribute a session's working directory to a stable repo label, so usage can
+ * be broken down per project.
+ *
+ * The dashboard event stream records a `cwd` per session but no git remote, so
+ * attribution here is by the working directory's project folder (session-level),
+ * not the per-turn remote resolution claude-cloud-sync does device-side. The
+ * remote-form canonicalization below is ported from that project's repo_canon so
+ * that, if a remote-qualified identity ever does show up, `github.com/o/r` and
+ * `cnb.cool/o/r` collapse to the same platform-independent `owner/repo`.
+ */
+
+/** Leaf directory names that aren't projects — attributed to 'no_repo'. */
+const NON_REPO_LEAVES = new Set([
+  'home', 'root', 'users', 'user', 'tmp', 'workspace', 'srv', 'mnt', 'data', 'opt',
+]);
+
+/**
+ * Canonicalize a *remote-form* repo identity (a git URL, `host/owner/repo`, or
+ * the legacy `owner_repo` underscore form) into a platform-independent
+ * `owner/repo`, dropping the host and any `.git` suffix. Returns null when no
+ * owner can be derived (e.g. a bare name).
+ */
+export function canonicalRepo(identity: string): string | null {
+  let s = identity.trim().replace(/\.git$/i, '');
+  s = s.replace(/^[a-z][a-z0-9+.-]*:\/\//i, ''); // proto://
+  s = s.replace(/^git@([^:]+):/i, '$1/'); // git@host:owner/repo → host/owner/repo
+  const segs = s.split('/').filter(Boolean);
+  if (segs.length >= 2) {
+    return `${segs[segs.length - 2]}/${segs[segs.length - 1]}`;
+  }
+  // Legacy owner_repo (remote '/' replaced by '_').
+  const only = segs[0] ?? '';
+  if (only.includes('_')) {
+    const idx = only.indexOf('_');
+    return `${only.slice(0, idx)}/${only.slice(idx + 1)}`;
+  }
+  return null;
+}
+
+/**
+ * Map a session's `cwd` to a repo label:
+ *  - a remote-form cwd (URL / host-qualified) → canonicalRepo (`owner/repo`)
+ *  - a filesystem path → the project directory name (its basename)
+ *  - home/root/ops dirs or an empty cwd → 'no_repo'
+ */
+export function attributeRepo(cwd: string | undefined): string {
+  if (!cwd || !cwd.trim()) return 'no_repo';
+  const raw = cwd.trim();
+
+  if (/:\/\//.test(raw) || /^git@/.test(raw) || /^[^/\s]+\.[^/\s]+\//.test(raw)) {
+    const c = canonicalRepo(raw);
+    if (c) return c;
+  }
+
+  const segs = raw.replace(/\/+$/, '').split('/').filter(Boolean);
+  if (segs.length === 0) return 'no_repo';
+  const leaf = segs[segs.length - 1];
+  if (NON_REPO_LEAVES.has(leaf.toLowerCase())) return 'no_repo';
+  return leaf;
+}


### PR DESCRIPTION
## Summary

`teamai stats` reported tokens / turns / interventions as a single lump. This adds two optional breakdowns over the **same** local dashboard event stream — no new data collection:

```
teamai stats --by-repo   # per-project: sessions / turns / tools / tokens / interventions
teamai stats --by-time   # 24h activity sparkline, peak hour, active minutes, night-owl %
```

Ports the shape of claude-cloud-sync's `stats.json` analytics (`by_repo`, `timeline_by_hour`, `active_minutes`, night-owl ratio) to the data teamai-cli already has.

> ⚠️ **Stacked on #191 and #192.** This PR's own change is the final commit; please merge those first — the diff will then reduce to just the stats change.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Details

- **Attribution granularity:** per session (one cwd per session), not the sync's per-turn cost splitting — that's what the event stream carries. Honest about the trade-off.
- **`utils/repo-attribution.ts`** — `attributeRepo(cwd)` maps a working directory to a project label (basename), and `canonicalRepo()` ports `repo_canon` so a remote-form `github.com/o/r` and `cnb.cool/o/r` collapse to the same platform-independent `owner/repo`. Today a filesystem cwd degrades to its basename; the canonicalization is future-proof for when a git remote is captured.
- **`session-analytics.ts`** — `attributeByRepo()` and `timeAnalytics()` are pure folds; `timeAnalytics` uses the machine's local timezone for hour-of-day.
- Default `teamai stats` output is unchanged; the new sections appear only with the flags.

## Test Plan

- [x] `npx tsc --noEmit`
- [x] `npx vitest run` — 141 files, 1754 tests (13 new in `session-analytics.test.ts`)
- [x] `npm run build`
- [x] Real-CLI E2E: seeded `~/.teamai/dashboard/events.jsonl` across two repos and two hours; `node dist/index.js stats --by-repo --by-time` printed a per-repo table (`alpha 150 tok / beta 15 tok`, sorted) and an hourly sparkline (peak `02:00`, active `4 min`, night-owl `67%`) — all matching the seed.

## Notes for Reviewers

- `no_repo` is used for home/root/ops cwds; the per-repo table includes it when present.
- Timezone: hours are local to the machine running `stats` (the sync fixed this to Beijing time; local felt more appropriate for a per-user CLI). Easy to make configurable if preferred.
