### PR TITLE
feat(skills): add per-user skill exclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ teamai init --http https://your-team-host/api --token <api-key>
 | `teamai ci extract-mr --url <url>` | CI: extract knowledge from MR, post comments, write after merge |
 | `teamai members` | List team members |
 | `teamai roles` | Manage team roles and namespaces |
+| `teamai skill exclude add/remove/list` | Manage skills excluded from local sync ([usage guide](docs/usage-guide.md#排除个人不需要的-skill)) |
 | `teamai source` | Manage cross-team skill subscriptions |
 | `teamai remove <type> <name>` | Remove a resource and open MR |
 | `teamai digest` | Generate weekly team usage digest |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -87,6 +87,7 @@ teamai init --http https://your-team-host/api --token <api-key>
 | `teamai ci extract-mr --url <url>` | CI：从 MR 提取知识、发评论、合并后写入 |
 | `teamai members` | 查看团队成员 |
 | `teamai roles` | 管理团队角色和命名空间 |
+| `teamai skill exclude add/remove/list` | 管理不参与本地同步的 skills（[使用指南](docs/usage-guide.md#排除个人不需要的-skill)） |
 | `teamai source` | 管理跨团队 skill 订阅 |
 | `teamai remove <type> <name>` | 删除资源并创建 MR |
 | `teamai digest` | 生成团队周报 |

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -226,6 +226,28 @@ teamai pull --dry-run    # 试运行，不实际修改
 
 启用角色化 skills 后，`pull` 的 skills 同步来源会变成 `skills/<namespace>/` 中的内容，按 `primaryRole + additionalRoles` 展开对应的 namespace，拍平安装到本地各 AI 工具 skills 目录。`rules/`、`docs/`、`learnings/` 仍然保持原有全局同步逻辑。
 
+### 排除个人不需要的 Skill
+
+如果团队共享的某个 skill 不适合你，可以只在本地将它排除，无需修改团队仓库，也不会影响其他成员：
+
+```bash
+teamai skill exclude add using-superpowers
+teamai pull                    # 从本地 AI 工具中删除
+teamai skill exclude list
+
+teamai skill exclude remove using-superpowers
+teamai pull                    # 重新同步
+```
+
+排除列表保存在当前 user 或 project scope 的 `config.yaml` 中：
+
+```yaml
+excludedSkills:
+  - using-superpowers
+```
+
+排除规则在角色和标签过滤之后生效。执行 `teamai pull` 时，被排除的 skill 不会同步，并且会清理由之前 pull 安装的副本。
+
 ### 推送本地资源
 
 ```bash

--- a/src/__tests__/e2e/e2e.test.ts
+++ b/src/__tests__/e2e/e2e.test.ts
@@ -135,6 +135,68 @@ describe('tags CLI', () => {
   });
 });
 
+// ─── Skill exclusion CLI (isolated local config) ─────────
+
+describe('skill exclude CLI', () => {
+  it('add/list/remove updates config and invalidates the pull cache', async () => {
+    const os = await import('node:os');
+    const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-exclude-e2e-'));
+    const teamaiHome = path.join(sandbox, '.teamai');
+    const repoPath = path.join(sandbox, 'team-repo');
+
+    try {
+      fs.mkdirSync(teamaiHome, { recursive: true });
+      fs.mkdirSync(repoPath, { recursive: true });
+      fs.writeFileSync(
+        path.join(repoPath, 'teamai.yaml'),
+        [
+          'team: exclude-e2e',
+          'description: isolated CLI test',
+          'repo: local/exclude-e2e',
+          'provider: github',
+          'reviewers: []',
+        ].join('\n'),
+      );
+      fs.writeFileSync(
+        path.join(teamaiHome, 'config.yaml'),
+        [
+          'repo:',
+          `  localPath: ${repoPath}`,
+          '  remote: local/exclude-e2e',
+          'username: e2e',
+          'scope: user',
+        ].join('\n'),
+      );
+      fs.writeFileSync(
+        path.join(teamaiHome, 'state.json'),
+        JSON.stringify({ lastPullRev: 'abc1234' }),
+      );
+
+      const env = { HOME: sandbox };
+      const add = await runCLIWithEnv(['skill', 'exclude', 'add', 'b-skill', 'a-skill'], env, '', sandbox);
+      expect(add.code, add.output).toBe(0);
+      expect(add.output).toContain('Excluded: b-skill, a-skill');
+
+      const savedConfig = fs.readFileSync(path.join(teamaiHome, 'config.yaml'), 'utf-8');
+      expect(savedConfig).toMatch(/excludedSkills:\n\s+- a-skill\n\s+- b-skill/);
+      const invalidatedState = JSON.parse(fs.readFileSync(path.join(teamaiHome, 'state.json'), 'utf-8'));
+      expect(invalidatedState.lastPullRev).toBeNull();
+
+      const list = await runCLIWithEnv(['skill', 'exclude', 'list'], env, '', sandbox);
+      expect(list.code, list.output).toBe(0);
+      expect(list.output).toContain('a-skill');
+      expect(list.output).toContain('b-skill');
+
+      const remove = await runCLIWithEnv(['skill', 'exclude', 'remove', 'a-skill', 'b-skill'], env, '', sandbox);
+      expect(remove.code, remove.output).toBe(0);
+      const finalConfig = fs.readFileSync(path.join(teamaiHome, 'config.yaml'), 'utf-8');
+      expect(finalConfig).not.toContain('excludedSkills');
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+});
+
 // ─── Source-code sanity checks (migrated from test/e2e.mjs) ──
 
 describe('source code checks', () => {

--- a/src/__tests__/exclude.test.ts
+++ b/src/__tests__/exclude.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../config.js', () => ({
+  detectProjectConfig: vi.fn(),
+  loadStateForScope: vi.fn(),
+  requireInit: vi.fn(),
+  saveLocalConfig: vi.fn(),
+  saveLocalConfigForScope: vi.fn(),
+  saveStateForScope: vi.fn(),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  log: {
+    dim: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+import {
+  detectProjectConfig,
+  loadStateForScope,
+  requireInit,
+  saveLocalConfig,
+  saveLocalConfigForScope,
+  saveStateForScope,
+} from '../config.js';
+import { excludeAdd, excludeRemove } from '../exclude.js';
+import type { LocalConfig } from '../types.js';
+
+const userConfig: LocalConfig = {
+  repo: { localPath: '/tmp/team-repo', remote: 'owner/repo' },
+  username: 'tester',
+  scope: 'user',
+  additionalRoles: [],
+};
+
+describe('skill exclude commands', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(detectProjectConfig).mockResolvedValue(null);
+    vi.mocked(requireInit).mockResolvedValue({
+      localConfig: userConfig,
+      teamConfig: {} as never,
+    });
+    vi.mocked(loadStateForScope).mockResolvedValue({
+      lastPull: '2026-07-17T00:00:00.000Z',
+      lastPullRev: 'abc1234',
+      lastPush: null,
+      pushedRules: [],
+      pushedSkills: [],
+      pushedEnvVars: [],
+      lastUpdateCheck: null,
+      availableUpdate: null,
+    });
+  });
+
+  it('adds sorted exclusions and invalidates the pull revision cache', async () => {
+    await excludeAdd(['z-skill', 'a-skill'], {});
+
+    expect(saveLocalConfig).toHaveBeenCalledWith(expect.objectContaining({
+      excludedSkills: ['a-skill', 'z-skill'],
+    }));
+    expect(saveStateForScope).toHaveBeenCalledWith(
+      expect.objectContaining({ lastPullRev: null }),
+      'user',
+      undefined,
+    );
+  });
+
+  it('removes exclusions in project scope and invalidates that scope only', async () => {
+    const projectConfig: LocalConfig = {
+      ...userConfig,
+      scope: 'project',
+      projectRoot: '/tmp/project',
+      excludedSkills: ['a-skill', 'b-skill'],
+    };
+    vi.mocked(detectProjectConfig).mockResolvedValue(projectConfig);
+
+    await excludeRemove(['a-skill'], {});
+
+    expect(saveLocalConfigForScope).toHaveBeenCalledWith(
+      expect.objectContaining({ excludedSkills: ['b-skill'] }),
+      'project',
+      '/tmp/project',
+    );
+    expect(saveStateForScope).toHaveBeenCalledWith(
+      expect.objectContaining({ lastPullRev: null }),
+      'project',
+      '/tmp/project',
+    );
+    expect(saveLocalConfig).not.toHaveBeenCalled();
+  });
+
+  it('does not rewrite config or state when the exclusion is unchanged', async () => {
+    vi.mocked(requireInit).mockResolvedValue({
+      localConfig: { ...userConfig, excludedSkills: ['a-skill'] },
+      teamConfig: {} as never,
+    });
+
+    await excludeAdd(['a-skill'], {});
+
+    expect(saveLocalConfig).not.toHaveBeenCalled();
+    expect(saveStateForScope).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/pull-exclude.test.ts
+++ b/src/__tests__/pull-exclude.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fse from 'fs-extra';
+import os from 'node:os';
+import path from 'node:path';
+
+vi.mock('../config.js', () => ({
+  detectProjectConfig: vi.fn().mockResolvedValue(null),
+  loadLocalConfigForScope: vi.fn(),
+  loadStateForScope: vi.fn().mockResolvedValue({ lastPull: null, lastPullRev: null }),
+  loadTeamConfig: vi.fn(),
+  requireInit: vi.fn(),
+  saveStateForScope: vi.fn(),
+}));
+
+vi.mock('../utils/git.js', () => ({
+  getHeadRev: vi.fn().mockResolvedValue('abc1234'),
+  pullRepo: vi.fn().mockResolvedValue('already up to date'),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  log: {
+    debug: vi.fn(), error: vi.fn(), info: vi.fn(), success: vi.fn(), warn: vi.fn(), dim: vi.fn(),
+  },
+  spinner: vi.fn(() => ({
+    fail: vi.fn().mockReturnThis(), info: vi.fn().mockReturnThis(),
+    start: vi.fn().mockReturnThis(), stop: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(), warn: vi.fn().mockReturnThis(),
+  })),
+}));
+
+vi.mock('../roles.js', () => ({
+  loadRolesManifest: vi.fn().mockResolvedValue({
+    version: 1,
+    roles: [{
+      id: 'dev',
+      name: 'Dev',
+      description: '',
+      resources: { knowledge: ['common'], skills: ['common'], learnings: ['common'] },
+    }],
+    defaults: { shareTarget: 'primary-role' },
+  }),
+  resolveRoleResourceNamespaces: vi.fn(() => ({
+    knowledge: ['common'], skills: ['common'], learnings: ['common'],
+  })),
+}));
+
+import { detectProjectConfig, loadLocalConfigForScope, loadTeamConfig } from '../config.js';
+import { pull } from '../pull.js';
+import type { LocalConfig, TeamaiConfig } from '../types.js';
+
+describe('pull with excluded skills', () => {
+  let tempDir: string;
+  let homeDir: string;
+  let repoPath: string;
+
+  beforeEach(async () => {
+    tempDir = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-pull-exclude-'));
+    homeDir = path.join(tempDir, 'home');
+    repoPath = path.join(tempDir, 'team-repo');
+    vi.stubEnv('HOME', homeDir);
+
+    await fse.ensureDir(path.join(repoPath, 'skills', 'common', 'excluded-skill'));
+    await fse.writeFile(
+      path.join(repoPath, 'skills', 'common', 'excluded-skill', 'SKILL.md'),
+      '---\nname: excluded-skill\ndescription: excluded\n---\n',
+    );
+    await fse.ensureDir(path.join(repoPath, 'skills', 'common', 'kept-skill'));
+    await fse.writeFile(
+      path.join(repoPath, 'skills', 'common', 'kept-skill', 'SKILL.md'),
+      '---\nname: kept-skill\ndescription: kept\n---\n',
+    );
+    await fse.ensureDir(path.join(repoPath, 'manifest'));
+    await fse.writeFile(path.join(repoPath, 'manifest', 'roles.yaml'), 'version: 1\n');
+    await fse.ensureDir(path.join(homeDir, '.claude', 'skills'));
+
+    const localConfig: LocalConfig = {
+      repo: { localPath: repoPath, remote: 'owner/repo' },
+      username: 'tester',
+      scope: 'user',
+      primaryRole: 'dev',
+      additionalRoles: [],
+      excludedSkills: ['excluded-skill'],
+    };
+    const teamConfig: TeamaiConfig = {
+      team: 'test',
+      description: '',
+      repo: 'owner/repo',
+      provider: 'github',
+      reviewers: [],
+      sharing: {
+        skills: {}, rules: { enforced: [] }, docs: { localDir: '' }, env: { injectShellProfile: true },
+      },
+      toolPaths: { claude: { skills: '.claude/skills', rules: '.claude/rules' } },
+    };
+
+    vi.mocked(detectProjectConfig).mockResolvedValue(null);
+    vi.mocked(loadLocalConfigForScope).mockResolvedValue(localConfig);
+    vi.mocked(loadTeamConfig).mockResolvedValue(teamConfig);
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+    await fse.remove(tempDir);
+  });
+
+  it('does not install an excluded skill and still installs allowed skills', async () => {
+    await pull({ force: true });
+
+    expect(await fse.pathExists(path.join(homeDir, '.claude', 'skills', 'excluded-skill'))).toBe(false);
+    expect(await fse.pathExists(path.join(homeDir, '.claude', 'skills', 'kept-skill'))).toBe(true);
+  });
+
+  it('removes a previously installed excluded skill', async () => {
+    const installed = path.join(homeDir, '.claude', 'skills', 'excluded-skill');
+    await fse.ensureDir(installed);
+    await fse.writeFile(path.join(installed, 'SKILL.md'), '# stale copy');
+
+    await pull({ force: true });
+
+    expect(await fse.pathExists(installed)).toBe(false);
+  });
+});

--- a/src/exclude.ts
+++ b/src/exclude.ts
@@ -1,0 +1,82 @@
+import {
+  detectProjectConfig,
+  loadStateForScope,
+  requireInit,
+  saveLocalConfig,
+  saveLocalConfigForScope,
+  saveStateForScope,
+} from './config.js';
+import { log } from './utils/logger.js';
+import type { GlobalOptions, LocalConfig } from './types.js';
+
+async function resolveExcludeScope(): Promise<LocalConfig> {
+  const projectConfig = await detectProjectConfig();
+  return projectConfig ?? (await requireInit()).localConfig;
+}
+
+async function saveExcludeScopeConfig(localConfig: LocalConfig): Promise<void> {
+  if (localConfig.scope === 'project') {
+    await saveLocalConfigForScope(localConfig, 'project', localConfig.projectRoot);
+  } else {
+    await saveLocalConfig(localConfig);
+  }
+
+  // A changed exclude list must bypass pull's unchanged-revision fast path so
+  // excluded skills are removed, or newly included skills are restored.
+  try {
+    const state = await loadStateForScope(localConfig.scope, localConfig.projectRoot);
+    state.lastPullRev = null;
+    await saveStateForScope(state, localConfig.scope, localConfig.projectRoot);
+  } catch {
+    // Missing/corrupt state is non-critical: the next pull performs a full sync.
+  }
+}
+
+export async function excludeList(_options: GlobalOptions): Promise<void> {
+  const config = await resolveExcludeScope();
+  const excludedSkills = config.excludedSkills ?? [];
+  if (excludedSkills.length === 0) {
+    log.info('No excluded skills. (pull syncs all role skills)');
+    return;
+  }
+
+  log.info(`Excluded skills (${excludedSkills.length}):`);
+  for (const skill of excludedSkills) log.dim(`  ${skill}`);
+}
+
+export async function excludeAdd(skills: string[], _options: GlobalOptions): Promise<void> {
+  const config = await resolveExcludeScope();
+  const existing = new Set(config.excludedSkills ?? []);
+  const added = skills.filter((skill) => {
+    if (existing.has(skill)) return false;
+    existing.add(skill);
+    return true;
+  });
+
+  if (added.length === 0) {
+    log.info('Already excluded.');
+    return;
+  }
+
+  await saveExcludeScopeConfig({ ...config, excludedSkills: [...existing].sort() });
+  log.success(`Excluded: ${added.join(', ')}`);
+  log.dim('Run `teamai pull` to remove them from local AI tools.');
+}
+
+export async function excludeRemove(skills: string[], _options: GlobalOptions): Promise<void> {
+  const config = await resolveExcludeScope();
+  const existing = new Set(config.excludedSkills ?? []);
+  const removed = skills.filter((skill) => existing.delete(skill));
+
+  if (removed.length === 0) {
+    log.info('None of those skills were excluded.');
+    return;
+  }
+
+  await saveExcludeScopeConfig({
+    ...config,
+    excludedSkills: existing.size > 0 ? [...existing].sort() : undefined,
+  });
+  log.success(`Removed from exclude list: ${removed.join(', ')}`);
+  log.dim('Run `teamai pull` to sync them again.');
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,42 @@ skillCmd
     await skillShow(name, { ...globalOpts, ...cmdOpts });
   });
 
+const excludeCmd = skillCmd
+  .command('exclude')
+  .description('Manage per-user skill exclusion (skip sync without affecting team repo)')
+  .action(async () => {
+    const globalOpts = program.opts() as GlobalOptions;
+    const { excludeList } = await import('./exclude.js');
+    await excludeList(globalOpts);
+  });
+
+excludeCmd
+  .command('list')
+  .description('List excluded skills')
+  .action(async () => {
+    const globalOpts = program.opts() as GlobalOptions;
+    const { excludeList } = await import('./exclude.js');
+    await excludeList(globalOpts);
+  });
+
+excludeCmd
+  .command('add <skills...>')
+  .description('Add skill(s) to the exclude list')
+  .action(async (skills: string[]) => {
+    const globalOpts = program.opts() as GlobalOptions;
+    const { excludeAdd } = await import('./exclude.js');
+    await excludeAdd(skills, globalOpts);
+  });
+
+excludeCmd
+  .command('remove <skills...>')
+  .description('Remove skill(s) from the exclude list')
+  .action(async (skills: string[]) => {
+    const globalOpts = program.opts() as GlobalOptions;
+    const { excludeRemove } = await import('./exclude.js');
+    await excludeRemove(skills, globalOpts);
+  });
+
 const membersCmd = program
   .command('members')
   .description('Manage team members')

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -338,6 +338,7 @@ async function pullForScope(
   // Load tags config for filtering
   const tagsConfig = await loadTagsConfig(localConfig.repo.localPath);
   const subscribedTags = localConfig.subscribedTags;
+  const excludedSkills = new Set(localConfig.excludedSkills ?? []);
 
   // Step 2: Sync each resource type
   const resourceTypes: ResourceType[] = ['skills', 'rules', 'docs', 'env', 'agents'];
@@ -396,6 +397,9 @@ async function pullForScope(
         if (!merged.has(item.name)) merged.set(item.name, item);
       }
       items = [...merged.values()];
+      if (excludedSkills.size > 0) {
+        items = items.filter((item) => !excludedSkills.has(item.name));
+      }
       desiredSkillNames = new Set(items.map((i) => i.name));
       knownRepoSkillNames = new Set(allTeamSkills.map((i) => i.name));
     } else {
@@ -530,6 +534,23 @@ async function pullForScope(
         const skillDir = path.join(skillsDir, dir);
         await remove(skillDir);
         log.debug(`Removed excluded skill ${dir} from ${tool}`);
+      }
+
+      // Old releases could leave namespace-nested copies behind. Pull now
+      // installs skills flat, but remove an excluded nested copy as well.
+      if (excludedSkills.size > 0) {
+        for (const namespace of localDirs) {
+          const namespaceDir = path.join(skillsDir, namespace);
+          // A top-level skill is not a namespace; never traverse into it.
+          if (await pathExists(path.join(namespaceDir, 'SKILL.md'))) continue;
+          for (const skillName of await listDirs(namespaceDir)) {
+            if (!excludedSkills.has(skillName) || BUILTIN_SKILL_NAMES.has(skillName)) continue;
+            const nestedSkillDir = path.join(namespaceDir, skillName);
+            if (!await pathExists(path.join(nestedSkillDir, 'SKILL.md'))) continue;
+            await remove(nestedSkillDir);
+            log.debug(`Removed excluded skill ${namespace}/${skillName} from ${tool}`);
+          }
+        }
       }
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -181,6 +181,8 @@ export const LocalConfigSchema = z.object({
   projectRoot: z.string().optional(),
   /** Tags the user has subscribed to. If empty/undefined, pull all resources. */
   subscribedTags: z.array(z.string()).optional(),
+  /** Skills to exclude from local sync (per-user, does not affect team repo). */
+  excludedSkills: z.array(z.string()).optional(),
   /** User-level override for recall feature. When set, takes precedence over team config. */
   recallEnabled: z.boolean().optional(),
   /** When set, only inject hooks into these agents. Additive across multiple init --agent runs. */


### PR DESCRIPTION
## Summary

Adds per-user and per-project skill exclusions through `teamai skill exclude add/remove/list`. Excluded skills are filtered during pull and previously installed flat or legacy namespace-nested copies are cleaned up without changing the team repository.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing behavior to change)
- [ ] Documentation only
- [ ] Refactor / internal cleanup

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` passes — 141 files, 1741 tests
- [x] Added/updated tests for the change
- [x] Isolated CLI E2E covers `skill exclude add/list/remove`

## Related Issues

Based on TGit MR !203.

## Notes for Reviewers

Review found and fixed an unchanged-revision cache bug in the original implementation: after changing the exclusion list, `teamai pull` could return early and fail to remove or restore skills. This version invalidates `state.lastPullRev` whenever exclusions change, matching role-change behavior. Nested cleanup also verifies `SKILL.md` before deleting a directory.
