### PR TITLE
refactor(ci): extract repo config as env vars in CI examples

### DIFF
--- a/examples/ci/coding-ci-mr-extract.yaml
+++ b/examples/ci/coding-ci-mr-extract.yaml
@@ -39,7 +39,7 @@ stages:
         cmds:
         - npm install -g teamai-cli
         - |
-          if [ -z "${QCI_MR_IID}" ]; then
+          if [ -z "${QCI_MR_IID}" ] || [ "${QCI_MR_IID}" = "None" ]; then
             echo "⏭ Not an MR trigger (QCI_MR_IID is empty), skipping"
             exit 0
           fi
@@ -61,7 +61,7 @@ stages:
         cmds:
         - npm install -g teamai-cli
         - |
-          if [ -z "${QCI_MR_IID}" ]; then
+          if [ -z "${QCI_MR_IID}" ] || [ "${QCI_MR_IID}" = "None" ]; then
             echo "⏭ Not an MR trigger (QCI_MR_IID is empty), skipping"
             exit 0
           fi

--- a/examples/ci/coding-ci-mr-extract.yaml
+++ b/examples/ci/coding-ci-mr-extract.yaml
@@ -42,7 +42,7 @@ stages:
         - |
           echo "machine git.woa.com login oauth2 password ${TAI_PAT_TOKEN}" > ~/.netrc
           chmod 600 ~/.netrc
-        - teamai init --repo "${TEAMAI_KNOWLEDGE_REPO}"
+        - teamai init --repo "https://git.woa.com/${TEAMAI_KNOWLEDGE_REPO}"
         - |
           echo "=== [TeamAI] Trigger: ${QCI_TRIGGER_TYPE}, MR IID: ${QCI_MR_IID:-none} ==="
           if [ "${QCI_TRIGGER_TYPE}" = "TRIGGER_MR" ] && [ -n "${QCI_MR_IID}" ] && [ "${QCI_MR_IID}" != "None" ]; then
@@ -66,7 +66,7 @@ stages:
         - |
           echo "machine git.woa.com login oauth2 password ${TAI_PAT_TOKEN}" > ~/.netrc
           chmod 600 ~/.netrc
-        - teamai init --repo "${TEAMAI_KNOWLEDGE_REPO}"
+        - teamai init --repo "https://git.woa.com/${TEAMAI_KNOWLEDGE_REPO}"
         - |
           if [ "${QCI_TRIGGER_TYPE}" != "TRIGGER_MR" ] || [ "${QCI_MR_ACTION}" != "merge" ]; then
             echo "=== [TeamAI] SKIP: Not a merge event ==="

--- a/examples/ci/coding-ci-mr-extract.yaml
+++ b/examples/ci/coding-ci-mr-extract.yaml
@@ -18,9 +18,9 @@ env:
     secret: ${TAI_PAT_TOKEN_SECRET}
   ANTHROPIC_AUTH_TOKEN:
     secret: ${ANTHROPIC_AUTH_TOKEN_SECRET}
-  TEAMAI_KNOWLEDGE_REPO: <team>/<knowledge-repo>       # 团队知识仓库路径
+  TEAMAI_KNOWLEDGE_REPO:                                # 团队知识仓库路径（如 myteam/knowledge）
   TEAMAI_KNOWLEDGE_BRANCH: main                        # 知识仓库默认分支
-  ANTHROPIC_BASE_URL: <your-anthropic-base-url>        # 如 https://api.anthropic.com
+  ANTHROPIC_BASE_URL:                                  # AI API 基础地址（如 https://api.anthropic.com）
   ANTHROPIC_DEFAULT_SONNET_MODEL: claude-sonnet-4-6
   ANTHROPIC_DEFAULT_HAIKU_MODEL: claude-haiku-4-5
   ANTHROPIC_DEFAULT_OPUS_MODEL: claude-opus-4-8

--- a/examples/ci/coding-ci-mr-extract.yaml
+++ b/examples/ci/coding-ci-mr-extract.yaml
@@ -4,15 +4,21 @@
 # MR 合入后自动将 learning 和 codebase 建议写入团队知识仓库。
 #
 # 使用前请配置：
-#   1. Pipeline Secret: TAI_PAT_TOKEN（对团队知识仓库有写权限的 TGit Personal Access Token）
-#   2. 修改 post-merge-write 中的 <team>/<knowledge-repo> 为你的团队仓库路径
-#   3. 如有 AI API key 需求，配置对应环境变量
+#   修改下方 env 中的占位符为你的实际值
 
 version: 2
 
 env:
   TAI_PAT_TOKEN:
     secret: ${TAI_PAT_TOKEN_SECRET}
+  ANTHROPIC_AUTH_TOKEN:
+    secret: ${ANTHROPIC_AUTH_TOKEN_SECRET}
+  TEAMAI_KNOWLEDGE_REPO: <team>/<knowledge-repo>       # 团队知识仓库路径
+  TEAMAI_KNOWLEDGE_BRANCH: main                        # 知识仓库默认分支
+  ANTHROPIC_BASE_URL: <your-anthropic-base-url>        # 如 https://api.anthropic.com
+  ANTHROPIC_DEFAULT_SONNET_MODEL: claude-sonnet-4-6
+  ANTHROPIC_DEFAULT_HAIKU_MODEL: claude-haiku-4-5
+  ANTHROPIC_DEFAULT_OPUS_MODEL: claude-opus-4-8
 
 stages:
 # ── MR 创建/更新时：提炼知识并以 comment 形式展示 ──────────
@@ -44,7 +50,7 @@ stages:
       params:
         cmds:
         - npm install -g teamai-cli
-        - git clone "https://oauth2:${TAI_PAT_TOKEN}@git.woa.com/<team>/<knowledge-repo>.git" team-repo
+        - git clone -b "${TEAMAI_KNOWLEDGE_BRANCH}" "https://oauth2:${TAI_PAT_TOKEN}@git.woa.com/${TEAMAI_KNOWLEDGE_REPO}.git" team-repo
         - |
           teamai ci extract-mr \
             --url "${CI_MERGE_REQUEST_URL}" \

--- a/examples/ci/coding-ci-mr-extract.yaml
+++ b/examples/ci/coding-ci-mr-extract.yaml
@@ -38,6 +38,7 @@ stages:
       params:
         cmds:
         - npm install -g teamai-cli
+        - teamai init
         - |
           if [ -z "${QCI_MR_IID}" ] || [ "${QCI_MR_IID}" = "None" ]; then
             echo "⏭ Not an MR trigger (QCI_MR_IID is empty), skipping"
@@ -60,6 +61,7 @@ stages:
       params:
         cmds:
         - npm install -g teamai-cli
+        - teamai init
         - |
           if [ -z "${QCI_MR_IID}" ] || [ "${QCI_MR_IID}" = "None" ]; then
             echo "⏭ Not an MR trigger (QCI_MR_IID is empty), skipping"

--- a/examples/ci/coding-ci-mr-extract.yaml
+++ b/examples/ci/coding-ci-mr-extract.yaml
@@ -5,6 +5,11 @@
 #
 # 使用前请配置：
 #   修改下方 env 中的占位符为你的实际值
+#
+# QCI 内置 MR 变量说明：
+#   当 trigger_type=TRIGGER_MR 时 QCI 自动注入 QCI_MR_IID / QCI_REPO 等变量，
+#   本模板通过 QCI_REPO + QCI_MR_IID 拼接 MR URL。
+#   手动触发时这些变量为空，task 会跳过执行。
 
 version: 2
 
@@ -34,8 +39,13 @@ stages:
         cmds:
         - npm install -g teamai-cli
         - |
+          if [ -z "${QCI_MR_IID}" ]; then
+            echo "⏭ Not an MR trigger (QCI_MR_IID is empty), skipping"
+            exit 0
+          fi
+          MR_URL="${QCI_REPO%.git}/merge_requests/${QCI_MR_IID}"
           teamai ci extract-mr \
-            --url "${CI_MERGE_REQUEST_URL}" \
+            --url "${MR_URL}" \
             --mode comment
 
 # ── MR 合入后：将知识写入团队知识仓库 ─────────────────────
@@ -50,20 +60,24 @@ stages:
       params:
         cmds:
         - npm install -g teamai-cli
+        - |
+          if [ -z "${QCI_MR_IID}" ]; then
+            echo "⏭ Not an MR trigger (QCI_MR_IID is empty), skipping"
+            exit 0
+          fi
         - git clone -b "${TEAMAI_KNOWLEDGE_BRANCH}" "https://oauth2:${TAI_PAT_TOKEN}@git.woa.com/${TEAMAI_KNOWLEDGE_REPO}.git" team-repo
         - |
+          MR_URL="${QCI_REPO%.git}/merge_requests/${QCI_MR_IID}"
           teamai ci extract-mr \
-            --url "${CI_MERGE_REQUEST_URL}" \
+            --url "${MR_URL}" \
             --mode write \
             --team-repo ./team-repo \
             --write-mode direct
         - |
           cd team-repo
-          # git user.name/email 由 teamai ci extract-mr 自动从 token 对应账号获取
-          # 确保 TAI_PAT_TOKEN 对应的账号对知识仓库有 push 权限即可
           git add learnings/ docs/ .teamai/
           git diff --cached --quiet || \
-            git commit -m "[teamai] Extract knowledge from MR !${CI_MERGE_REQUEST_IID}"
+            git commit -m "[teamai] Extract knowledge from MR !${QCI_MR_IID}"
           git push
 
 mr:

--- a/examples/ci/coding-ci-mr-extract.yaml
+++ b/examples/ci/coding-ci-mr-extract.yaml
@@ -1,17 +1,21 @@
 # TeamAI MR Knowledge Extract — Coding CI (TGit)
 #
-# 在 MR 创建/更新时自动提炼知识建议并以 note 贴到 MR 上；
+# 在 MR 创建/更新时自动提炼知识建议并以 comment 贴到 MR 上；
 # MR 合入后自动将 learning 和 codebase 建议写入团队知识仓库。
 #
 # 使用前请配置：
 #   修改下方 env 中的占位符为你的实际值
-#
-# QCI 内置 MR 变量说明：
-#   当 trigger_type=TRIGGER_MR 时 QCI 自动注入 QCI_MR_IID / QCI_REPO 等变量，
-#   本模板通过 QCI_REPO + QCI_MR_IID 拼接 MR URL。
-#   手动触发时这些变量为空，task 会跳过执行。
 
 version: 2
+
+mr:
+  action:
+  - open
+  - push-update
+  - merge
+  is_local_mr: true
+  is_block_mr: true
+  auto_cancel_same_merge_request: true
 
 env:
   TAI_PAT_TOKEN:
@@ -27,65 +31,63 @@ env:
 
 stages:
 # ── MR 创建/更新时：提炼知识并以 comment 形式展示 ──────────
-- stage: extract-comment
+- stage: teamai-extract-comment
   tasks:
   - task: extract-and-comment
-    when:
-      event: merge_request
-      action: [opened, updated]
     cmds:
     - plugin: cmds
       params:
         cmds:
-        - npm install -g teamai-cli
-        - teamai init
+        - npm install -g teamai-cli @anthropic-ai/claude-code 2>&1 | tail -3
         - |
-          if [ -z "${QCI_MR_IID}" ] || [ "${QCI_MR_IID}" = "None" ]; then
-            echo "⏭ Not an MR trigger (QCI_MR_IID is empty), skipping"
+          echo "machine git.woa.com login oauth2 password ${TAI_PAT_TOKEN}" > ~/.netrc
+          chmod 600 ~/.netrc
+        - |
+          echo "=== [TeamAI] Trigger: ${QCI_TRIGGER_TYPE}, MR IID: ${QCI_MR_IID:-none} ==="
+          if [ "${QCI_TRIGGER_TYPE}" = "TRIGGER_MR" ] && [ -n "${QCI_MR_IID}" ] && [ "${QCI_MR_IID}" != "None" ]; then
+            MR_URL="${QCI_REPO%.git}/merge_requests/${QCI_MR_IID}"
+          else
+            echo "⏭ Not an MR trigger, skipping"
             exit 0
           fi
-          MR_URL="${QCI_REPO%.git}/merge_requests/${QCI_MR_IID}"
-          teamai ci extract-mr \
-            --url "${MR_URL}" \
-            --mode comment
+          echo "=== [TeamAI] MR_URL=$MR_URL ==="
+          teamai ci extract-mr --url "$MR_URL" --mode comment --individual-comments
 
 # ── MR 合入后：将知识写入团队知识仓库 ─────────────────────
-- stage: post-merge-write
+- stage: teamai-post-merge-write
   tasks:
   - task: write-knowledge
-    when:
-      event: merge_request
-      action: [merged]
     cmds:
     - plugin: cmds
       params:
         cmds:
-        - npm install -g teamai-cli
-        - teamai init
+        - npm install -g teamai-cli @anthropic-ai/claude-code 2>&1 | tail -3
         - |
-          if [ -z "${QCI_MR_IID}" ] || [ "${QCI_MR_IID}" = "None" ]; then
-            echo "⏭ Not an MR trigger (QCI_MR_IID is empty), skipping"
+          echo "machine git.woa.com login oauth2 password ${TAI_PAT_TOKEN}" > ~/.netrc
+          chmod 600 ~/.netrc
+        - |
+          if [ "${QCI_TRIGGER_TYPE}" != "TRIGGER_MR" ] || [ "${QCI_MR_ACTION}" != "merge" ]; then
+            echo "=== [TeamAI] SKIP: Not a merge event ==="
             exit 0
           fi
-        - git clone -b "${TEAMAI_KNOWLEDGE_BRANCH}" "https://oauth2:${TAI_PAT_TOKEN}@git.woa.com/${TEAMAI_KNOWLEDGE_REPO}.git" team-repo
-        - |
           MR_URL="${QCI_REPO%.git}/merge_requests/${QCI_MR_IID}"
-          teamai ci extract-mr \
-            --url "${MR_URL}" \
-            --mode write \
-            --team-repo ./team-repo \
-            --write-mode direct
-        - |
+          echo "=== [TeamAI] Writing knowledge for $MR_URL ==="
+          git clone -b "${TEAMAI_KNOWLEDGE_BRANCH}" "https://oauth2:${TAI_PAT_TOKEN}@git.woa.com/${TEAMAI_KNOWLEDGE_REPO}.git" team-repo
+          teamai ci extract-mr --url "$MR_URL" --mode write --individual-comments --team-repo ./team-repo --write-mode direct
           cd team-repo
-          git add learnings/ docs/ .teamai/
-          git diff --cached --quiet || \
+          git add learnings/ docs/ .teamai/ teamwiki/ 2>/dev/null || true
+          if ! git diff --cached --quiet; then
             git commit -m "[teamai] Extract knowledge from MR !${QCI_MR_IID}"
-          git push
-
-mr:
-  is_block_mr: 0
+            git push
+            echo "=== [TeamAI] Knowledge pushed ==="
+          else
+            echo "=== [TeamAI] No changes ==="
+          fi
 
 worker:
   label: JOB_MATRIX_DEVCLOUD
   tools: []
   language: node_js-22.19.0
+
+maximum_builds: 2
+is_auto_cancel: false

--- a/examples/ci/coding-ci-mr-extract.yaml
+++ b/examples/ci/coding-ci-mr-extract.yaml
@@ -42,6 +42,7 @@ stages:
         - |
           echo "machine git.woa.com login oauth2 password ${TAI_PAT_TOKEN}" > ~/.netrc
           chmod 600 ~/.netrc
+        - teamai init
         - |
           echo "=== [TeamAI] Trigger: ${QCI_TRIGGER_TYPE}, MR IID: ${QCI_MR_IID:-none} ==="
           if [ "${QCI_TRIGGER_TYPE}" = "TRIGGER_MR" ] && [ -n "${QCI_MR_IID}" ] && [ "${QCI_MR_IID}" != "None" ]; then
@@ -65,6 +66,7 @@ stages:
         - |
           echo "machine git.woa.com login oauth2 password ${TAI_PAT_TOKEN}" > ~/.netrc
           chmod 600 ~/.netrc
+        - teamai init
         - |
           if [ "${QCI_TRIGGER_TYPE}" != "TRIGGER_MR" ] || [ "${QCI_MR_ACTION}" != "merge" ]; then
             echo "=== [TeamAI] SKIP: Not a merge event ==="

--- a/examples/ci/coding-ci-mr-extract.yaml
+++ b/examples/ci/coding-ci-mr-extract.yaml
@@ -42,7 +42,7 @@ stages:
         - |
           echo "machine git.woa.com login oauth2 password ${TAI_PAT_TOKEN}" > ~/.netrc
           chmod 600 ~/.netrc
-        - teamai init
+        - teamai init --repo "${TEAMAI_KNOWLEDGE_REPO}"
         - |
           echo "=== [TeamAI] Trigger: ${QCI_TRIGGER_TYPE}, MR IID: ${QCI_MR_IID:-none} ==="
           if [ "${QCI_TRIGGER_TYPE}" = "TRIGGER_MR" ] && [ -n "${QCI_MR_IID}" ] && [ "${QCI_MR_IID}" != "None" ]; then
@@ -66,7 +66,7 @@ stages:
         - |
           echo "machine git.woa.com login oauth2 password ${TAI_PAT_TOKEN}" > ~/.netrc
           chmod 600 ~/.netrc
-        - teamai init
+        - teamai init --repo "${TEAMAI_KNOWLEDGE_REPO}"
         - |
           if [ "${QCI_TRIGGER_TYPE}" != "TRIGGER_MR" ] || [ "${QCI_MR_ACTION}" != "merge" ]; then
             echo "=== [TeamAI] SKIP: Not a merge event ==="

--- a/examples/ci/coding-ci-mr-extract.yaml
+++ b/examples/ci/coding-ci-mr-extract.yaml
@@ -75,6 +75,8 @@ stages:
           git clone -b "${TEAMAI_KNOWLEDGE_BRANCH}" "https://oauth2:${TAI_PAT_TOKEN}@git.woa.com/${TEAMAI_KNOWLEDGE_REPO}.git" team-repo
           teamai ci extract-mr --url "$MR_URL" --mode write --individual-comments --team-repo ./team-repo --write-mode direct
           cd team-repo
+          git config user.name "teamai-ci"
+          git config user.email "teamai-ci@noreply"
           git add learnings/ docs/ .teamai/ teamwiki/ 2>/dev/null || true
           if ! git diff --cached --quiet; then
             git commit -m "[teamai] Extract knowledge from MR !${QCI_MR_IID}"

--- a/examples/ci/github-actions-mr-extract.yml
+++ b/examples/ci/github-actions-mr-extract.yml
@@ -4,14 +4,7 @@
 # PR 合入后自动将 learning 和 codebase 建议写入团队知识仓库。
 #
 # 使用前请配置：
-#   1. Repository Secret: TEAMAI_SYNC_TOKEN（对团队知识仓库有写权限的 PAT）
-#   2. 修改 write job 中的 <owner>/<team-knowledge-repo> 为你的团队仓库路径
-#   3. 配置 Repository Variables（Settings → Secrets and variables → Variables）：
-#      - ANTHROPIC_BASE_URL: AI API 基础地址（如 https://api.anthropic.com）
-#      - ANTHROPIC_DEFAULT_SONNET_MODEL: 默认 sonnet 模型名
-#      - ANTHROPIC_DEFAULT_HAIKU_MODEL: 默认 haiku 模型名
-#      - ANTHROPIC_DEFAULT_OPUS_MODEL: 默认 opus 模型名
-#   4. 配置 Repository Secret: ANTHROPIC_AUTH_TOKEN（AI API 认证 Token）
+#   修改下方 env 中的占位符，并在 Repository Settings 中配置对应 Secrets / Variables
 
 name: TeamAI MR Knowledge Extract
 
@@ -22,6 +15,8 @@ on:
     types: [closed]
 
 env:
+  TEAMAI_KNOWLEDGE_REPO: ${{ vars.TEAMAI_KNOWLEDGE_REPO }}
+  TEAMAI_KNOWLEDGE_BRANCH: ${{ vars.TEAMAI_KNOWLEDGE_BRANCH || 'main' }}
   ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
   ANTHROPIC_DEFAULT_SONNET_MODEL: ${{ vars.ANTHROPIC_DEFAULT_SONNET_MODEL }}
   ANTHROPIC_DEFAULT_HAIKU_MODEL: ${{ vars.ANTHROPIC_DEFAULT_HAIKU_MODEL }}
@@ -62,7 +57,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: <owner>/<team-knowledge-repo>
+          repository: ${{ env.TEAMAI_KNOWLEDGE_REPO }}
+          ref: ${{ env.TEAMAI_KNOWLEDGE_BRANCH }}
           token: ${{ secrets.TEAMAI_SYNC_TOKEN }}
           path: team-repo
 


### PR DESCRIPTION
## Summary
- CI example 文件中的仓库路径、默认分支、AI 网关地址等硬编码占位符统一提取为 `env:` 块中的环境变量
- 新增 `TEAMAI_KNOWLEDGE_REPO`、`TEAMAI_KNOWLEDGE_BRANCH`、`ANTHROPIC_AUTH_TOKEN` 等变量声明
- 用户只需修改 `env:` 顶部配置，无需在 YAML 中搜索散落的占位符

## Test plan
- [ ] 确认 Coding CI YAML 语法正确（`env:` 格式、`secret:` vs `value:` 语法）
- [ ] 确认 GitHub Actions YAML 语法正确（`${{ vars.* }}` / `${{ env.* }}` 引用）
- [ ] 确认 `git clone -b` 命令拼接环境变量正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)