### PR TITLE
docs: restructure README into Harness distribution & knowledge base

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,66 +11,144 @@
 [![npm downloads](https://img.shields.io/npm/dm/teamai-cli.svg)](https://www.npmjs.com/package/teamai-cli)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-[![Discord](https://img.shields.io/discord/1234567890?label=Discord&logo=discord)](https://discord.gg/gervEZm58g)
-
-💬 **User Discussion:** [Discord](https://discord.gg/gervEZm58g) | 🛠 **Developer Chat:** [Discord](https://discord.gg/DeHHxPnfZF)
+[![User Chat](https://img.shields.io/badge/User_Chat-Discord-5865F2?logo=discord&logoColor=white)](https://discord.gg/gervEZm58g)
+[![Developer Chat](https://img.shields.io/badge/Developer_Chat-Discord-5865F2?logo=discord&logoColor=white)](https://discord.gg/DeHHxPnfZF)
 
 Make every AI coding agent work by the same harness.
 
-Git-native management of skills, rules, and docs across 20+ AI tools — for you or your whole team.
+Git-native management of skills, rules, and docs across Claude Code / Codex / CodeBuddy / WorkBuddy and more.
 
-**Supports:** Claude Code, Codex, Cursor, CodeBuddy IDE, as well as Gemini CLI, Windsurf, Trae, Aider, Amp, OpenClaw, and 20+ other AI coding tools (skills sync).
+For you or your whole team.
 
-> 📖 **Full usage guide:** [docs/usage-guide.md](docs/usage-guide.md) — covers everything from team creation to day-to-day use.
+## Quick Start
 
-> 📚 **Provider notes:** [docs/providers.md](docs/providers.md) — GitHub / TGit differences and auth setup.
-
-## Install
+### Install
 
 ```bash
 npm install -g teamai-cli
-npm install -g @tencent/teamai-cli --registry=http://r.tnpm.oa.com  # Tencent internal
 ```
 
-Prerequisites: Node.js 20+. To update: `npm update -g teamai-cli`
+### Team admin / solo user
 
-## Quick Start
+Create a shared-experience repo on your git host (GitHub or TGit), **grant write access to team members**, then have them run `teamai init --repo https://github.com/yourorg/yourrepo`.
+
+> Solo use needs no separate repo setup: `teamai init` checks the target repo and creates it automatically if it doesn't exist.
 
 ### Team members
 
 ```bash
 # User-scope init (default, resources installed under ~/)
-teamai init --repo yourteam/yourproject
+teamai init --repo https://github.com/yourorg/yourrepo
 
 # Project-scope init (resources installed under the project directory)
 cd /path/to/my-project
-teamai init --repo yourteam/yourproject --scope project
-
-# Non-interactive mode (for CI/CD or AI-agent automation)
-teamai init --repo yourteam/yourproject --scope user --role hai_dev --force
+teamai init --repo https://github.com/yourorg/yourrepo --scope project
 ```
 
-### Admins
+Once initialized, every AI session automatically pulls the latest skills / rules and other Harness updates published by admins — no manual sync needed.
 
-Create a shared-experience repo on your git host (GitHub or TGit), grant write access to team members, then have them run `teamai init --repo <org>/<repo>`.
+> **Full usage guide:** [docs/usage-guide.md](docs/usage-guide.md) — covers everything from team creation to day-to-day use.
 
-The CLI picks a provider automatically from the repo URL:
+## Harness Management & Distribution
 
-- `yourorg/yourrepo` or `https://github.com/yourorg/yourrepo` → GitHub
-- `https://git.woa.com/yourteam/yourrepo` → TGit
+TeamAI keeps skills, rules, docs, and hooks in a shared git repo and distributes them to every member's local AI tools through a "push → review & merge → pull" flow — with support for subscribing to other teams' Harness.
 
-### Read-only consumers (HTTP mode)
+### How It Works
 
-For users who only consume skills/rules without git access:
+```
+teamai push → create branch + MR → reviewer approves + merges
+                                         ↓
+              SessionStart hook → teamai pull → synced to local AI tools
+```
+
+Members push changes via `teamai push`, which opens a Merge Request for review. Once merged, `teamai pull` (triggered automatically on session start via the SessionStart hook) syncs the latest resources locally. Skills sync to `~/.claude/skills/`, `~/.codex/skills/`, `~/.cursor/skills/`, `~/.codebuddy/skills/`, etc.
+
+### Team Hooks
+
+Declare custom hooks in `hooks/hooks.yaml` and `teamai pull` delivers them to every AI tool:
+
+```yaml
+hooks:
+  - id: block-secret
+    description: Scan for secrets before commit
+    event: PreToolUse
+    matcher: Bash
+    command: 'bash -lc "~/.teamai/team-scripts/scan-secret.sh" || true'
+    tools: [claude, cursor]
+```
 
 ```bash
-teamai init --http https://your-team-host/api --token <api-key>
+teamai hooks list      # list effective hooks
+teamai hooks inject    # force-reconcile into all tools
+teamai hooks remove    # remove all teamai-managed hooks
 ```
 
-- Read-only: `push` / `contribute` / `remove` are disabled for HTTP repos.
-- API key stored `0600`; `TEAMAI_API_TOKEN` env var also honored.
-- No git clone needed — skills/rules are delivered per-session over the report/sync/ack lifecycle.
-- Supported agents report installed-skill state on session start and pull down server-managed install/update/uninstall commands automatically.
+### Cross-team Skill Subscription
+
+Subscribe to other teams' public skill repos:
+
+```bash
+teamai source add https://github.com/other-team/teamai-public.git --name other-team
+teamai source list
+teamai source browse other-team    # browse available skills
+teamai source remove other-team
+```
+
+Subscribed skills sync automatically on `teamai pull`.
+
+## Knowledge Base
+
+Beyond distributing the Harness, TeamAI organizes accumulated team experience and code structure into a searchable knowledge base that the AI recalls automatically when needed.
+
+### Automatic Experience Sharing
+
+When a session ends, the Stop hook evaluates session value (tool diversity, skill usage, error handling, duration). If the score is high enough, the AI suggests:
+
+```
+建议运行 /teamai-share-learnings 总结本次 session 的经验并分享给团队。
+```
+
+The `/teamai-share-learnings` skill summarizes the session and pushes a learning document directly to the team repo. Each session is prompted at most once.
+
+### Team Knowledge Recall
+
+Let the AI automatically search accumulated team knowledge before a task. This feature is **off by default** and must be enabled explicitly — teams can set `sharing.recall.enabled: true` in `teamai.yaml` as the default, and members can override locally:
+
+```bash
+teamai recall enable     # on: deploy the teamai-recall subagent + inject guidance rules
+teamai recall disable    # off: remove the subagent and rules
+teamai recall status     # show effective state (team default + user override)
+```
+
+**Search runs via a subagent**: once enabled, `teamai pull` deploys the built-in `teamai-recall` subagent into each AI tool's `agents/` directory. The AI invokes it before a task — the subagent extracts keywords, runs the search, reads the matched source files, and returns a structured summary of team knowledge. Under the hood it shells out to the `teamai recall` command, which you can also run manually:
+
+```bash
+$ teamai recall "port conflict"
+[1/2] MR review caught a port-conflict bug ★1 [user]
+Author: member-a | Score: 18.5 | Tags: troubleshooting, networking
+
+[2/2] Deployment configuration best practices [project]
+Author: member-b | Score: 12.0 | Tags: deploy, config
+```
+
+**Coverage spans two parts:**
+
+- **Shared search index** (`search-index.json`): four categories — learnings (session experience), docs (team docs), rules (coding rules), and skills (each `SKILL.md`) — sourced from the corresponding team-repo directories, (re)built on `teamai pull` / `teamai contribute`.
+- **Codebase knowledge graph** (`teamwiki/`): produced by `teamai import`, queried live at search time.
+
+Ranking uses BM25 + graph-boost, merges dual-scope (user + project) results tagged with origin, and implicitly upvotes matched docs so good content floats up over time.
+
+### Codebase Knowledge Graph
+
+`teamai import` parses source repos into a structured graph under `teamwiki/`, enabling structurally-aware retrieval:
+
+```bash
+teamai import --from-repo https://github.com/org/repo
+teamai import --from-org myorg              # batch import all repos
+teamai codebase --lint                      # health check
+```
+
+The graph stores components, interfaces, configs, and cross-repo import edges. `teamai recall` uses it for graph-boosted re-ranking.
 
 ## Commands
 
@@ -95,139 +173,6 @@ teamai init --http https://your-team-host/api --token <api-key>
 | `teamai uninstall` | Remove all teamai resources and hooks |
 
 Global options: `--dry-run`, `--verbose`
-
-## How It Works
-
-```
-teamai push → create branch + MR → reviewer approves + merges
-                                         ↓
-              SessionStart hook → teamai pull → synced to local AI tools
-```
-
-TeamAI stores skills, rules, docs, and learnings in a shared git repo. Members push changes via `teamai push`, which opens a Merge Request for review. Once merged, `teamai pull` (triggered automatically on session start via hooks) syncs the latest resources into every member's local AI tools.
-
-Skills sync to `~/.claude/skills/`, `~/.codex/skills/`, `~/.cursor/skills/`, `~/.codebuddy/skills/`, etc.
-
-## Role-scoped Skills
-
-Skills are organized under role namespaces. During `teamai init`, you pick a `primaryRole` and optional `additionalRoles`. `teamai pull` only syncs skills matching your activated namespaces.
-
-```yaml
-# ~/.teamai/config.yaml
-primaryRole: hai
-additionalRoles:
-  - pm
-```
-
-This syncs skills from `skills/common/`, `skills/hai/`, and `skills/pm/`.
-
-When pushing, the CLI auto-detects available namespaces and prompts you to pick one (or use `teamai push --role pm` to specify directly).
-
-## Team Knowledge Recall
-
-`teamai recall` searches across accumulated team knowledge:
-
-```bash
-$ teamai recall "port conflict"
-[1/2] MR review caught a port-conflict bug ★1 [user]
-Author: member-a | Score: 18.5 | Tags: troubleshooting, networking
-
-[2/2] Deployment configuration best practices [project]
-Author: member-b | Score: 12.0 | Tags: deploy, config
-```
-
-- Hybrid CJK + English search with BM25 + graph-boost ranking.
-- Dual-scope (user + project) merged results, tagged with origin.
-- Implicit upvoting: searches boost matched docs; good docs float up over time.
-
-```bash
-teamai recall enable     # enable recall + deploy subagent
-teamai recall disable    # disable recall + remove subagent
-teamai recall status     # show effective state
-```
-
-## Codebase Knowledge Graph
-
-`teamai import` parses source repos into a structured graph under `teamwiki/`, enabling structurally-aware retrieval:
-
-```bash
-teamai import --from-repo https://github.com/org/repo
-teamai import --from-org myorg              # batch import all repos
-teamai codebase --lint                      # health check
-```
-
-The graph stores components, interfaces, configs, and cross-repo import edges. `teamai recall` uses it for graph-boosted re-ranking.
-
-## Automatic Experience Sharing
-
-When a session ends, the Stop hook evaluates session value (tool diversity, skill usage, error handling, duration). If the score is high enough, the AI suggests:
-
-```
-建议运行 /teamai-share-learnings 总结本次 session 的经验并分享给团队。
-```
-
-The `/teamai-share-learnings` skill summarizes the session and pushes a learning document directly to the team repo. Each session is prompted at most once.
-
-## Team Hooks
-
-Declare custom hooks in `hooks/hooks.yaml` and `teamai pull` delivers them to every AI tool:
-
-```yaml
-hooks:
-  - id: block-secret
-    description: Scan for secrets before commit
-    event: PreToolUse
-    matcher: Bash
-    command: 'bash -lc "~/.teamai/team-scripts/scan-secret.sh" || true'
-    tools: [claude, cursor]
-```
-
-```bash
-teamai hooks list      # list effective hooks
-teamai hooks inject    # force-reconcile into all tools
-teamai hooks remove    # remove all teamai-managed hooks
-```
-
-## Cross-team Skill Subscription
-
-### Git source
-
-Subscribe to other teams' public skill repos:
-
-```bash
-teamai source add https://github.com/other-team/teamai-public.git --name other-team
-teamai source list
-teamai source browse other-team    # browse available skills
-teamai source remove other-team
-```
-
-Subscribed skills sync automatically on `teamai pull`.
-
-### HTTP source
-
-Attach an HTTP source alongside your existing git main repo — useful for server-managed skill delivery without changing the main repo:
-
-```bash
-teamai source add-http https://your-team-host/api --token <api-key>
-teamai source list            # shows under "HTTP source"
-teamai source remove-http     # detach and uninstall its resources
-```
-
-The HTTP source reports agent status and pulls down skill commands on each session via hook dispatch. Only one HTTP source is supported per installation.
-
-## CI Integration
-
-`teamai ci extract-mr` plugs into CI to extract learnings from every MR:
-
-```bash
-# Post suggestions as comments (on PR open/update)
-teamai ci extract-mr --url "$MR_URL" --mode comment --individual-comments
-
-# Write approved items after merge
-teamai ci extract-mr --url "$MR_URL" --mode write --team-repo ./team-repo
-```
-
-Ready-to-use templates: `examples/ci/github-actions-mr-extract.yml` (GitHub Actions), `examples/ci/coding-ci-mr-extract.yaml` (Coding CI).
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,65 +11,144 @@
 [![npm downloads](https://img.shields.io/npm/dm/teamai-cli.svg)](https://www.npmjs.com/package/teamai-cli)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-[![Discord](https://img.shields.io/discord/1234567890?label=Discord&logo=discord)](https://discord.gg/gervEZm58g)
+[![用户交流](https://img.shields.io/badge/用户交流-Discord-5865F2?logo=discord&logoColor=white)](https://discord.gg/gervEZm58g)
+[![开发者交流](https://img.shields.io/badge/开发者交流-Discord-5865F2?logo=discord&logoColor=white)](https://discord.gg/DeHHxPnfZF)
 
-💬 **用户讨论：** [Discord](https://discord.gg/gervEZm58g) | 🛠 **开发者交流：** [Discord](https://discord.gg/DeHHxPnfZF)
+面向 AI 智能体的团队 Harness 分发工具。
 
-让每个 AI 编程助手都按同一套标准工作。
+通过 Git 统一管理 skills、rules、docs，驾驭 Claude Code / Codex / CodeBuddy / WorkBuddy 等多种 AI 工具。
 
-通过 Git 统一管理 skills、rules、docs，驾驭 20+ 种 AI 工具——一个人也能用，团队用更强。
+一个人也能用，团队用更强。
 
-**支持：** Claude Code、Codex、Cursor、CodeBuddy IDE，以及 Gemini CLI、Windsurf、Trae、Aider、Amp、OpenClaw 等 20+ 种 AI 编程工具（skills 同步）。
+## 快速开始
 
-> 📖 **完整使用指南**：[docs/usage-guide.md](docs/usage-guide.md) — 涵盖从团队创建到日常使用的全流程。
-
-> 📚 **Provider 说明**：[docs/providers.md](docs/providers.md) — GitHub / TGit 差异与认证配置。
-
-## 安装
+### 安装
 
 ```bash
 npm install -g teamai-cli
-npm install -g @tencent/teamai-cli --registry=http://r.tnpm.oa.com  # 腾讯内部
 ```
 
-前置要求：Node.js 20+。更新：`npm update -g teamai-cli`
+### 团队管理员 / 个人使用者
 
-## 快速开始
+在 Git 托管平台（GitHub 或 TGit）创建共享经验仓库，**授予团队成员写权限**，然后让他们运行 `teamai init --repo https://github.com/yourorg/yourrepo`。
+
+> 个人使用无需单独建仓：`teamai init` 会检查目标仓库，不存在时自动创建。
 
 ### 团队成员
 
 ```bash
 # 用户级初始化（默认，资源安装到 ~/ 下）
-teamai init --repo yourteam/yourproject
+teamai init --repo https://github.com/yourorg/yourrepo
 
 # 项目级初始化（资源安装到项目目录下）
 cd /path/to/my-project
-teamai init --repo yourteam/yourproject --scope project
-
-# 非交互模式（适用于 CI/CD 或 AI 自动化场景）
-teamai init --repo yourteam/yourproject --scope user --role hai_dev --force
+teamai init --repo https://github.com/yourorg/yourrepo --scope project
 ```
 
-### 管理员
+初始化完成后，每次开启 AI 会话时都会自动拉取管理员发布的 skills / rules 等 Harness 更新，无需手动同步。
 
-在 Git 托管平台（GitHub 或 TGit）创建共享经验仓库，授予团队成员写权限，然后让他们运行 `teamai init --repo <org>/<repo>`。
+> **完整使用指南**：[docs/usage-guide.md](docs/usage-guide.md) — 涵盖从团队创建到日常使用的全流程。
 
-CLI 自动根据仓库 URL 选择 provider：
+## Harness 管理和分发
 
-- `yourorg/yourrepo` 或 `https://github.com/yourorg/yourrepo` → GitHub
-- `https://git.woa.com/yourteam/yourrepo` → TGit
+TeamAI 把 skills、rules、docs、hooks 统一存放在共享 Git 仓库，通过「push → 评审合并 → pull」的流程分发到每位成员的本地 AI 工具，并支持订阅其他团队的 Harness。
 
-### 只读消费者（HTTP 模式）
+### 工作原理
 
-仅消费 skills/rules、无需 git 访问的用户：
+```
+teamai push → 创建分支 + MR → reviewer 审批合并
+                                    ↓
+           SessionStart hook → teamai pull → 同步到本地 AI 工具
+```
+
+成员通过 `teamai push` 提交变更并创建合并请求供审核。合并后，`teamai pull`（由 SessionStart hook 在会话启动时自动触发）将最新资源同步到本地。Skills 会同步到 `~/.claude/skills/`、`~/.codex/skills/`、`~/.cursor/skills/`、`~/.codebuddy/skills/` 等目录。
+
+### 团队 Hooks
+
+在 `hooks/hooks.yaml` 中声明自定义 hooks，`teamai pull` 自动分发到所有 AI 工具：
+
+```yaml
+hooks:
+  - id: block-secret
+    description: 提交前扫描密钥
+    event: PreToolUse
+    matcher: Bash
+    command: 'bash -lc "~/.teamai/team-scripts/scan-secret.sh" || true'
+    tools: [claude, cursor]
+```
 
 ```bash
-teamai init --http https://your-team-host/api --token <api-key>
+teamai hooks list      # 查看生效的 hooks
+teamai hooks inject    # 强制重新注入到所有工具
+teamai hooks remove    # 移除所有 teamai 管理的 hooks
 ```
 
-- 只读模式：`push` / `contribute` / `remove` 不可用。
-- 无需 git clone——skills/rules 通过 report/sync/ack 生命周期按 session 下发。
-- 支持的 agent 在 session 启动时自动上报已安装 skill 状态，并拉取服务端管理的安装/更新/卸载指令。
+### 跨团队 Skill 订阅
+
+订阅其他团队的公开 skill 仓库：
+
+```bash
+teamai source add https://github.com/other-team/teamai-public.git --name other-team
+teamai source list
+teamai source browse other-team    # 浏览可用 skills
+teamai source remove other-team
+```
+
+订阅的 skills 在 `teamai pull` 时自动同步。
+
+## 知识库
+
+除了分发 Harness，TeamAI 还把团队沉淀的经验和代码结构组织成可检索的知识库，让 AI 在需要时自动召回。
+
+### 自动经验沉淀
+
+Session 结束时，Stop hook 对 session 价值评分（工具多样性、skill 使用、错误处理、时长）。达标后 AI 会建议：
+
+```
+建议运行 /teamai-share-learnings 总结本次 session 的经验并分享给团队。
+```
+
+`/teamai-share-learnings` skill 自动总结 session 经验并推送到团队仓库。每个 session 最多提示一次。
+
+### 团队知识检索
+
+让 AI 在执行任务前自动检索团队积累的知识。该功能**默认关闭**，需显式开启——团队可在 `teamai.yaml` 设 `sharing.recall.enabled: true` 作为默认值，成员也可本地覆盖：
+
+```bash
+teamai recall enable     # 开启：部署 teamai-recall 子 agent + 注入引导规则
+teamai recall disable    # 关闭：移除子 agent 和规则
+teamai recall status     # 查看生效状态（团队默认 + 用户覆盖）
+```
+
+**通过子 agent 检索**：开启后 `teamai pull` 会把内置的 `teamai-recall` 子 agent 部署到各 AI 工具的 `agents/` 目录。AI 在任务开始前调用它——由子 agent 提取关键词、执行检索、读取命中的源文件，最后返回结构化的团队知识摘要。子 agent 底层调用的仍是 `teamai recall` 命令，也可手动直接运行：
+
+```bash
+$ teamai recall "port conflict"
+[1/2] MR review caught a port-conflict bug ★1 [user]
+Author: member-a | Score: 18.5 | Tags: troubleshooting, networking
+
+[2/2] Deployment configuration best practices [project]
+Author: member-b | Score: 12.0 | Tags: deploy, config
+```
+
+**检索内容覆盖两部分**：
+
+- **共享检索索引**（`search-index.json`）：learnings（session 经验）、docs（团队文档）、rules（编码规则）、skills（各 `SKILL.md`）四类，源自团队仓库对应目录，在 `teamai pull` / `teamai contribute` 时构建重建。
+- **代码知识图谱**（`teamwiki/`）：由 `teamai import` 生成，检索时实时查询。
+
+排序采用 BM25 + 图谱增强，合并用户 / 项目双 scope 结果并标注来源；搜索会隐式为命中文档投票，优质内容自然上浮。
+
+### 代码知识图谱
+
+`teamai import` 将源码仓库解析为 `teamwiki/` 下的结构化图谱，实现结构感知的检索：
+
+```bash
+teamai import --from-repo https://github.com/org/repo
+teamai import --from-org myorg              # 批量导入所有仓库
+teamai codebase --lint                      # 健康检查
+```
+
+图谱存储组件、接口、配置和跨仓库依赖边。`teamai recall` 利用图谱进行增强排名。
 
 ## 命令一览
 
@@ -94,139 +173,6 @@ teamai init --http https://your-team-host/api --token <api-key>
 | `teamai uninstall` | 移除所有 teamai 资源和 hooks |
 
 全局选项：`--dry-run`、`--verbose`
-
-## 工作原理
-
-```
-teamai push → 创建分支 + MR → reviewer 审批合并
-                                    ↓
-           SessionStart hook → teamai pull → 同步到本地 AI 工具
-```
-
-TeamAI 将 skills、rules、docs 和 learnings 存储在共享 Git 仓库中。成员通过 `teamai push` 提交变更并创建合并请求供审核。合并后，`teamai pull`（通过 hooks 在 session 启动时自动触发）将最新资源同步到每位成员的本地 AI 工具。
-
-Skills 同步到 `~/.claude/skills/`、`~/.codex/skills/`、`~/.cursor/skills/`、`~/.codebuddy/skills/` 等目录。
-
-## 角色化 Skills
-
-Skills 按角色命名空间组织。`teamai init` 时选择 `primaryRole` 和可选的 `additionalRoles`，`teamai pull` 仅同步匹配的命名空间。
-
-```yaml
-# ~/.teamai/config.yaml
-primaryRole: hai
-additionalRoles:
-  - pm
-```
-
-以上配置会同步 `skills/common/`、`skills/hai/`、`skills/pm/` 下的所有 skills。
-
-推送时，CLI 自动检测可用命名空间并提示选择（或使用 `teamai push --role pm` 直接指定）。
-
-## 团队知识检索
-
-`teamai recall` 搜索团队积累的知识：
-
-```bash
-$ teamai recall "port conflict"
-[1/2] MR review caught a port-conflict bug ★1 [user]
-Author: member-a | Score: 18.5 | Tags: troubleshooting, networking
-
-[2/2] Deployment configuration best practices [project]
-Author: member-b | Score: 12.0 | Tags: deploy, config
-```
-
-- 中英文混合搜索，BM25 + 图谱增强排名。
-- 双 scope（用户 + 项目）合并结果，标注来源。
-- 隐式投票：搜索自动提升匹配文档权重，优质文档自然上浮。
-
-```bash
-teamai recall enable     # 启用 recall + 部署 subagent
-teamai recall disable    # 禁用 recall + 移除 subagent
-teamai recall status     # 查看生效状态
-```
-
-## 代码知识图谱
-
-`teamai import` 将源码仓库解析为 `teamwiki/` 下的结构化图谱，实现结构感知的检索：
-
-```bash
-teamai import --from-repo https://github.com/org/repo
-teamai import --from-org myorg              # 批量导入所有仓库
-teamai codebase --lint                      # 健康检查
-```
-
-图谱存储组件、接口、配置和跨仓库依赖边。`teamai recall` 利用图谱进行增强排名。
-
-## 自动经验沉淀
-
-Session 结束时，Stop hook 对 session 价值评分（工具多样性、skill 使用、错误处理、时长）。达标后 AI 会建议：
-
-```
-建议运行 /teamai-share-learnings 总结本次 session 的经验并分享给团队。
-```
-
-`/teamai-share-learnings` skill 自动总结 session 经验并推送到团队仓库。每个 session 最多提示一次。
-
-## 团队 Hooks
-
-在 `hooks/hooks.yaml` 中声明自定义 hooks，`teamai pull` 自动分发到所有 AI 工具：
-
-```yaml
-hooks:
-  - id: block-secret
-    description: 提交前扫描密钥
-    event: PreToolUse
-    matcher: Bash
-    command: 'bash -lc "~/.teamai/team-scripts/scan-secret.sh" || true'
-    tools: [claude, cursor]
-```
-
-```bash
-teamai hooks list      # 查看生效的 hooks
-teamai hooks inject    # 强制重新注入到所有工具
-teamai hooks remove    # 移除所有 teamai 管理的 hooks
-```
-
-## 跨团队 Skill 订阅
-
-### Git 源
-
-订阅其他团队的公开 skill 仓库：
-
-```bash
-teamai source add https://github.com/other-team/teamai-public.git --name other-team
-teamai source list
-teamai source browse other-team    # 浏览可用 skills
-teamai source remove other-team
-```
-
-订阅的 skills 在 `teamai pull` 时自动同步。
-
-### HTTP 源
-
-在已有 git 主仓的基础上附加 HTTP 源——适用于服务端管理的 skill 下发，无需修改主仓：
-
-```bash
-teamai source add-http https://your-team-host/api --token <api-key>
-teamai source list            # 在 "HTTP source" 下显示
-teamai source remove-http     # 解绑并卸载其资源
-```
-
-HTTP 源通过 hook dispatch 在每次 session 中上报状态并拉取 skill 指令。每个安装仅支持一个 HTTP 源。
-
-## CI 集成
-
-`teamai ci extract-mr` 接入 CI，从每个 MR 自动提取知识：
-
-```bash
-# 以评论形式发布建议（PR 打开/更新时）
-teamai ci extract-mr --url "$MR_URL" --mode comment --individual-comments
-
-# 合并后写入知识库
-teamai ci extract-mr --url "$MR_URL" --mode write --team-repo ./team-repo
-```
-
-开箱即用模板：`examples/ci/github-actions-mr-extract.yml`（GitHub Actions）、`examples/ci/coding-ci-mr-extract.yaml`（Coding CI）。
 
 ## 许可证
 


### PR DESCRIPTION
## Summary

Follow-up to #189, applying the pending review feedback and restructuring both READMEs (EN + ZH stay in sync).

- **Two top-level feature sections**: `Harness Management & Distribution` (How It Works, Team Hooks, Cross-team Skill Subscription) and `Knowledge Base` (Automatic Experience Sharing, Team Knowledge Recall, Codebase Knowledge Graph).
- **Layout**: Install merged into Quick Start; How It Works moved before the Commands table; the Commands reference table relocated to just above License.
- **Team Knowledge Recall rewritten to match implementation**: off by default (`sharing.recall.enabled`/`recallEnabled`), searched via the `teamai-recall` subagent, index covers learnings/docs/rules/skills plus the `teamwiki/` codebase graph.
- **Applied #189 pending review comments**: single `npm install` line, dropped the read-only HTTP quick-start block, named tools in the tagline, removed the provider-notes and supported-tools lines, reordered admin before members.
- **Badges/examples**: replaced the broken Discord widget badge with static User/Developer chat badges; used full repo URLs in `init` examples; reduced decorative emoji.
- **ZH tagline unified with the logo**: 面向 AI 智能体的团队 Harness 分发工具.
- **Removed** Role-scoped Skills and CI Integration sections (already covered in `docs/usage-guide.md`).

## Test plan

- [x] EN and ZH READMEs stay in sync (identical heading hierarchy, verified via `grep '^#'`)
- [x] Recall section wording verified against source (`src/types.ts` `isRecallEnabled` default `false`, `src/builtin-agents.ts` `teamai-recall`, `src/utils/search-index.ts` four index categories)
- [x] Discord badges render (static shields.io badges, no widget dependency)
- [ ] Visual render check on GitHub after push

Made with [Cursor](https://cursor.com)