### PR TITLE
feat(local-agent): bind workspace to project instead of group

### DIFF
--- a/src/__tests__/local-agent-routes.test.ts
+++ b/src/__tests__/local-agent-routes.test.ts
@@ -19,14 +19,14 @@ describe('local-agent: resolveRoute – path mapping', () => {
   it('supports overriding every route independently', () => {
     const config = {
       routes: {
-        userGroups: '/v2/groups',
+        projects: '/v2/groups',
         report: '/v2/report',
         sync: '/v2/sync',
         ack: '/v2/ack',
         getConfig: '/v2/config',
       },
     };
-    expect(resolveRoute(config, 'userGroups')).toBe('/v2/groups');
+    expect(resolveRoute(config, 'projects')).toBe('/v2/groups');
     expect(resolveRoute(config, 'report')).toBe('/v2/report');
     expect(resolveRoute(config, 'sync')).toBe('/v2/sync');
     expect(resolveRoute(config, 'ack')).toBe('/v2/ack');

--- a/src/__tests__/local-agent.test.ts
+++ b/src/__tests__/local-agent.test.ts
@@ -148,7 +148,7 @@ describe('local-agent: local_agent_id derivation (per-tool install dir)', () => 
 });
 
 describe('local-agent: bindCurrentProject --skip', () => {
-  it('writes groupId 0 and __skipped__ marker to config', async () => {
+  it('writes projectId 0 and __skipped__ marker to config', async () => {
     await setupConfig();
     // Create a git repo in tmpDir so resolveWorkspacePath works
     const projectDir = path.join(tmpDir, 'my-project');
@@ -166,8 +166,8 @@ describe('local-agent: bindCurrentProject --skip', () => {
     const realProjectDir = fse.realpathSync(projectDir);
     const binding = config.workspaceBindings[realProjectDir] ?? config.workspaceBindings[projectDir];
     expect(binding).toBeDefined();
-    expect(binding.groupId).toBe(0);
-    expect(binding.groupName).toBe('__skipped__');
+    expect(binding.projectId).toBe(0);
+    expect(binding.projectName).toBe('__skipped__');
     expect(binding.boundAt).toBeTruthy();
   });
 });
@@ -181,12 +181,12 @@ describe('local-agent: emitBindingHint via reportAndSyncLocalAgent', () => {
     const { execFileSync } = await import('node:child_process');
     execFileSync('git', ['init'], { cwd: projectDir, stdio: 'ignore' });
 
-    // Mock global fetch to handle /api/user-groups/mine and /api/local-agent/report
+    // Mock global fetch to handle /api/projects/mine and /api/local-agent/report
     const fetchMock = vi.fn(async (url: string) => {
-      if (url.includes('/api/user-groups/mine')) {
+      if (url.includes('/api/projects/mine')) {
         return new Response(JSON.stringify({
           ok: true,
-          groups: [
+          projects: [
             { id: 100, name: 'alpha' },
             { id: 200, name: 'beta' },
           ],
@@ -221,13 +221,13 @@ describe('local-agent: emitBindingHint via reportAndSyncLocalAgent', () => {
 
     const parsed = JSON.parse(output.trim().split('\n').find((l) => l.includes('hookSpecificOutput'))!);
     const ctx = parsed.hookSpecificOutput.additionalContext;
-    expect(ctx).toContain('[ClawPro组织 绑定提示]');
-    expect(ctx).toContain('当前项目未绑定ClawPro组织');
-    expect(ctx).toContain('绑定到「alpha」组织');
-    expect(ctx).toContain('绑定到「beta」组织');
+    expect(ctx).toContain('[ClawPro项目 绑定提示]');
+    expect(ctx).toContain('当前工作区未绑定ClawPro项目');
+    expect(ctx).toContain('绑定到「alpha」项目');
+    expect(ctx).toContain('绑定到「beta」项目');
     expect(ctx).toContain('不绑定，以后也不再提示');
-    expect(ctx).toContain('teamai bind-project --group-id 100');
-    expect(ctx).toContain('teamai bind-project --group-id 200');
+    expect(ctx).toContain('teamai bind-project --project-id 100');
+    expect(ctx).toContain('teamai bind-project --project-id 200');
     expect(ctx).toContain('teamai bind-project --skip');
   });
 
@@ -274,7 +274,7 @@ describe('local-agent: emitBindingHint via reportAndSyncLocalAgent', () => {
     execFileSync('git', ['init'], { cwd: projectDir, stdio: 'ignore' });
 
     await setupConfig({
-      [projectDir]: { groupId: 1, groupName: 'existing', boundAt: '2026-01-01T00:00:00.000Z' },
+      [projectDir]: { projectId: 1, projectName: 'existing', boundAt: '2026-01-01T00:00:00.000Z' },
     });
 
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({ ok: true })));
@@ -302,7 +302,7 @@ describe('local-agent: emitBindingHint via reportAndSyncLocalAgent', () => {
     expect(output).not.toContain('hookSpecificOutput');
   });
 
-  it('does NOT emit hint when project is skipped (groupId 0)', async () => {
+  it('does NOT emit hint when project is skipped (projectId 0)', async () => {
     process.env.TEAMAI_BIND_PROMPT_ENABLED = '1';
     const projectDir = path.join(tmpDir, 'skipped-project');
     await fse.ensureDir(projectDir);
@@ -310,7 +310,7 @@ describe('local-agent: emitBindingHint via reportAndSyncLocalAgent', () => {
     execFileSync('git', ['init'], { cwd: projectDir, stdio: 'ignore' });
 
     await setupConfig({
-      [projectDir]: { groupId: 0, groupName: '__skipped__', boundAt: '2026-01-01T00:00:00.000Z' },
+      [projectDir]: { projectId: 0, projectName: '__skipped__', boundAt: '2026-01-01T00:00:00.000Z' },
     });
 
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({ ok: true })));

--- a/src/index.ts
+++ b/src/index.ts
@@ -589,13 +589,13 @@ program
 
 program
   .command('bind-project')
-  .description('Bind the current project to a ClawPro organization/group for HTTP local-agent sync')
-  .option('--group-id <id>', 'Group ID from /user-groups/mine')
-  .option('--skip', 'Mark current project as skipped (never prompt again)')
+  .description('Bind the current workspace to a ClawPro project for HTTP local-agent sync')
+  .option('--project-id <id>', 'Project ID from /projects/mine')
+  .option('--skip', 'Mark current workspace as skipped (never prompt again)')
   .action(async (cmdOpts) => {
     const { bindCurrentProject } = await import('./local-agent.js');
     await bindCurrentProject({
-      groupId: cmdOpts.groupId ? Number.parseInt(cmdOpts.groupId, 10) : undefined,
+      projectId: cmdOpts.projectId ? Number.parseInt(cmdOpts.projectId, 10) : undefined,
       skip: !!cmdOpts.skip,
     });
   });

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -53,8 +53,8 @@ type ResourceKind = 'skills' | 'rules' | 'claudemd';
 type CommandResourceKind = 'skill' | 'rule' | 'claudemd';
 
 interface WorkspaceBinding {
-  groupId: number;
-  groupName?: string;
+  projectId: number;
+  projectName?: string;
   boundAt: string;
 }
 
@@ -86,7 +86,7 @@ export interface LocalAgentConfig {
  * (see LocalAgentConfig.routes) without touching call sites.
  */
 export const DEFAULT_ROUTES = {
-  userGroups: '/api/user-groups/mine',
+  projects: '/api/projects/mine',
   report: '/api/local-agent/report',
   sync: '/api/local-agent/sync',
   ack: '/api/local-agent/commands/ack',
@@ -95,10 +95,10 @@ export const DEFAULT_ROUTES = {
 
 export type RouteName = keyof typeof DEFAULT_ROUTES;
 
-interface LocalAgentGroup {
+interface LocalAgentProject {
   id: number;
   name: string;
-  is_primary?: boolean;
+  description?: string;
 }
 
 interface ManifestResource {
@@ -323,11 +323,18 @@ function getManifestScope(
 export async function loadLocalAgentConfig(): Promise<LocalAgentConfig | null> {
   const fileConfig = await readJson<LocalAgentConfig>(getConfigPath());
   if (fileConfig?.endpoint) {
-    return {
+    const config = {
       ...fileConfig,
       endpoint: normalizeEndpoint(fileConfig.endpoint),
       workspaceBindings: fileConfig.workspaceBindings ?? {},
     };
+    // Migrate: clear legacy group-based bindings (groupId without projectId)
+    for (const [wsPath, binding] of Object.entries(config.workspaceBindings)) {
+      if ('groupId' in binding && !('projectId' in (binding as Record<string, unknown>))) {
+        delete config.workspaceBindings[wsPath];
+      }
+    }
+    return config;
   }
 
   const envEndpoint =
@@ -455,14 +462,14 @@ async function appendErrorLog(entry: unknown): Promise<void> {
   }
 }
 
-export async function fetchUserGroups(config: LocalAgentConfig): Promise<LocalAgentGroup[]> {
-  const response = await localAgentFetch<{ ok?: boolean; groups?: LocalAgentGroup[] }>(
+export async function fetchUserProjects(config: LocalAgentConfig): Promise<LocalAgentProject[]> {
+  const response = await localAgentFetch<{ ok?: boolean; projects?: LocalAgentProject[] }>(
     config,
     localAgentTag({}),
-    'userGroups',
+    'projects',
     { method: 'GET' },
   );
-  return response.groups ?? [];
+  return response.projects ?? [];
 }
 
 /** Mask secret values (CLI flags / key=value / bearer tokens) so they don't reach logs. */
@@ -676,56 +683,54 @@ async function askViaTty(prompt: string): Promise<string | null> {
   }
 }
 
-async function promptForGroupBinding(
+async function promptForProjectBinding(
   workspacePath: string,
-  groups: LocalAgentGroup[],
-): Promise<LocalAgentGroup | null> {
-  if (groups.length === 0) return null;
+  projects: LocalAgentProject[],
+): Promise<LocalAgentProject | null> {
+  if (projects.length === 0) return null;
 
   log.debug(`local-agent: workspace not bound: ${workspacePath}`);
-  const answer = await askViaTty('是否绑定到一个组织？[y/N] ');
+  const answer = await askViaTty('是否绑定到一个项目？[y/N] ');
   if (!answer || answer.toLowerCase() !== 'y') return null;
 
-  if (groups.length === 1) return groups[0];
+  if (projects.length === 1) return projects[0];
 
-  log.info('可用组织:');
-  groups.forEach((group, index) => {
-    const suffix = group.is_primary ? ' (默认)' : '';
-    log.info(`  ${index + 1}. ${group.name}${suffix} [id=${group.id}]`);
+  log.info('可用项目:');
+  projects.forEach((project, index) => {
+    const desc = project.description ? ` - ${project.description}` : '';
+    log.info(`  ${index + 1}. ${project.name}${desc} [id=${project.id}]`);
   });
 
-  const primary = groups.find((group) => group.is_primary) ?? groups[0];
-  const defaultIndex = groups.indexOf(primary) + 1;
-  const selection = await askViaTty(`选择组织编号（默认 ${defaultIndex}，0 跳过）: `);
+  const selection = await askViaTty(`选择项目编号（1-${projects.length}，0 跳过）: `);
   if (selection === null || selection === '0') return null;
-  const index = selection ? Number.parseInt(selection, 10) : defaultIndex;
-  if (Number.isNaN(index) || index < 1 || index > groups.length) return null;
-  return groups[index - 1];
+  const index = selection ? Number.parseInt(selection, 10) : 0;
+  if (Number.isNaN(index) || index < 1 || index > projects.length) return null;
+  return projects[index - 1];
 }
 
-export async function bindWorkspaceToGroup(
+export async function bindWorkspaceToProject(
   workspacePath: string,
-  groupId?: number,
+  projectId?: number,
 ): Promise<WorkspaceBinding | null> {
   const config = await loadLocalAgentConfig();
   if (!config) {
     throw new Error('HTTP local agent is not initialized. Run `teamai init --http <ENDPOINT> --token <API_TOKEN>` first.');
   }
 
-  const groups = await fetchUserGroups(config);
-  const group = groupId
-    ? groups.find((item) => item.id === groupId)
-    : await promptForGroupBinding(workspacePath, groups);
-  if (!group) return null;
+  const projects = await fetchUserProjects(config);
+  const project = projectId
+    ? projects.find((item) => item.id === projectId)
+    : await promptForProjectBinding(workspacePath, projects);
+  if (!project) return null;
 
   const binding: WorkspaceBinding = {
-    groupId: group.id,
-    groupName: group.name,
+    projectId: project.id,
+    projectName: project.name,
     boundAt: new Date().toISOString(),
   };
   config.workspaceBindings[workspacePath] = binding;
   await saveLocalAgentConfig(config);
-  log.success(`已将项目绑定到组织：${group.name} [id=${group.id}]`);
+  log.success(`已将工作区绑定到项目：${project.name} [id=${project.id}]`);
   return binding;
 }
 
@@ -735,21 +740,21 @@ async function ensureWorkspaceBinding(
 ): Promise<void> {
   if (config.workspaceBindings[workspacePath]) return;
 
-  let groups: LocalAgentGroup[];
+  let projects: LocalAgentProject[];
   try {
-    groups = await fetchUserGroups(config);
+    projects = await fetchUserProjects(config);
   } catch (e) {
-    log.debug(`local-agent: failed to load user groups: ${(e as Error).message}`);
+    log.debug(`local-agent: failed to load user projects: ${(e as Error).message}`);
     return;
   }
 
-  if (groups.length === 0) return;
+  if (projects.length === 0) return;
 
-  const group = await promptForGroupBinding(workspacePath, groups);
-  if (group) {
+  const project = await promptForProjectBinding(workspacePath, projects);
+  if (project) {
     config.workspaceBindings[workspacePath] = {
-      groupId: group.id,
-      groupName: group.name,
+      projectId: project.id,
+      projectName: project.name,
       boundAt: new Date().toISOString(),
     };
     await saveLocalAgentConfig(config);
@@ -757,12 +762,12 @@ async function ensureWorkspaceBinding(
   }
 
   // TTY prompt failed (running as hook in background) — output context for AI to prompt user
-  const groupList = groups.map((g) => `${g.name} (id=${g.id})`).join(', ');
+  const projectList = projects.map((p) => `${p.name} (id=${p.id})`).join(', ');
   const context = [
-    '[teamai] 当前项目尚未绑定组织，无法接收组织下发的 skills/rules/claudemd 资源。',
-    `可用组织: ${groupList}`,
+    '[teamai] 当前工作区尚未绑定项目，无法接收项目下发的 skills/rules/claudemd 资源。',
+    `可用项目: ${projectList}`,
     `请提示用户运行: teamai bind-project`,
-    `或指定组织: teamai bind-project --group-id <id>`,
+    `或指定项目: teamai bind-project --project-id <id>`,
   ].join('\n');
   const hookOutput = JSON.stringify({
     hookSpecificOutput: {
@@ -794,22 +799,22 @@ async function emitBindingHint(
   if (fs.existsSync(hintMarker)) return;
   try { fs.writeFileSync(hintMarker, ''); } catch {}
 
-  let groups: LocalAgentGroup[];
+  let projects: LocalAgentProject[];
   try {
-    groups = await fetchUserGroups(config);
+    projects = await fetchUserProjects(config);
   } catch {
     return;
   }
-  if (groups.length === 0) return;
+  if (projects.length === 0) return;
 
-  const skipNum = groups.length + 1;
-  const choices = groups.map((g, i) => `${i + 1}. 绑定到「${g.name}」组织`);
-  const actions = groups.map((g, i) => `- 用户回复 ${i + 1} → 执行 \`teamai bind-project --group-id ${g.id}\`，完成后回复"绑定完成，请开新会话生效"`);
+  const skipNum = projects.length + 1;
+  const choices = projects.map((p, i) => `${i + 1}. 绑定到「${p.name}」项目`);
+  const actions = projects.map((p, i) => `- 用户回复 ${i + 1} → 执行 \`teamai bind-project --project-id ${p.id}\`，完成后回复"绑定完成，请开新会话生效"`);
   const context = [
-    '[ClawPro组织 绑定提示] 你必须原样展示下面的选项列表，不得修改编号或内容。等用户回复数字后执行对应命令。',
+    '[ClawPro项目 绑定提示] 你必须原样展示下面的选项列表，不得修改编号或内容。等用户回复数字后执行对应命令。',
     '',
     '---',
-    '当前项目未绑定ClawPro组织。绑定后可同步团队 skills/rules。请回复数字选择：',
+    '当前工作区未绑定ClawPro项目。绑定后可同步团队 skills/rules。请回复数字选择：',
     '',
     ...choices,
     `${skipNum}. 不绑定，以后也不再提示`,
@@ -985,7 +990,7 @@ export async function buildReportPayload(
         path: workspacePath,
         name: path.basename(workspacePath),
         ide_type: normalizeAgentType(tool),
-        group_id: binding?.groupId,
+        project_id: binding?.projectId,
         skills: wsScope.skills,
         rules: wsScope.rules,
       },
@@ -1012,7 +1017,7 @@ async function buildSyncPayload(
         path: workspacePath,
         name: path.basename(workspacePath),
         ide_type: normalizeAgentType(context.tool ?? 'workbuddy'),
-        group_id: binding?.groupId,
+        project_id: binding?.projectId,
       },
     ];
   }
@@ -1605,7 +1610,7 @@ export async function pullLocalAgentForCwd(context?: LocalAgentContext): Promise
 /** Summary of the configured HTTP local-agent bypass, for `teamai source list`. */
 export interface LocalAgentSummary {
   endpoint: string;
-  boundGroups: Array<{ path: string; groupName?: string; groupId: number }>;
+  boundProjects: Array<{ path: string; projectName?: string; projectId: number }>;
   resourceCounts: { skills: number; rules: number; claudemd: number };
 }
 
@@ -1618,10 +1623,9 @@ export async function describeLocalAgent(): Promise<LocalAgentSummary | null> {
   const config = await loadLocalAgentConfig();
   if (!config) return null;
 
-  const boundGroups = Object.entries(config.workspaceBindings)
-    // groupId 0 is the "__skipped__" sentinel — not a real binding.
-    .filter(([, b]) => b.groupId !== 0)
-    .map(([workspacePath, b]) => ({ path: workspacePath, groupName: b.groupName, groupId: b.groupId }));
+  const boundProjects = Object.entries(config.workspaceBindings)
+    .filter(([, b]) => b.projectId !== 0)
+    .map(([workspacePath, b]) => ({ path: workspacePath, projectName: b.projectName, projectId: b.projectId }));
 
   const manifest = await loadManifest();
   const counts = { skills: 0, rules: 0, claudemd: 0 };
@@ -1631,7 +1635,7 @@ export async function describeLocalAgent(): Promise<LocalAgentSummary | null> {
     counts.claudemd += Object.keys(scope.claudemd ?? {}).length;
   }
 
-  return { endpoint: config.endpoint, boundGroups, resourceCounts: counts };
+  return { endpoint: config.endpoint, boundProjects, resourceCounts: counts };
 }
 
 /** Parse a manifest scope key back into (scope, workspacePath). */
@@ -1700,7 +1704,7 @@ export async function removeLocalAgentHttp(): Promise<void> {
   log.success('HTTP source removed (resources uninstalled, config cleared).');
 }
 
-export async function bindCurrentProject(options?: { groupId?: number; skip?: boolean; cwd?: string }): Promise<void> {
+export async function bindCurrentProject(options?: { projectId?: number; skip?: boolean; cwd?: string }): Promise<void> {
   const workspacePath = await resolveWorkspacePath(options?.cwd ?? process.cwd());
   if (!workspacePath) {
     throw new Error('Cannot resolve current workspace path.');
@@ -1710,12 +1714,12 @@ export async function bindCurrentProject(options?: { groupId?: number; skip?: bo
     if (!config) {
       throw new Error('Local agent not initialized. Run `teamai init --http` first.');
     }
-    config.workspaceBindings[workspacePath] = { groupId: 0, groupName: '__skipped__', boundAt: new Date().toISOString() };
+    config.workspaceBindings[workspacePath] = { projectId: 0, projectName: '__skipped__', boundAt: new Date().toISOString() };
     await saveLocalAgentConfig(config);
-    log.info(`已跳过绑定，以后不再提示此项目。`);
+    log.info(`已跳过绑定，以后不再提示此工作区。`);
     return;
   }
-  const binding = await bindWorkspaceToGroup(workspacePath, options?.groupId);
+  const binding = await bindWorkspaceToProject(workspacePath, options?.projectId);
   if (!binding) {
     log.info('未绑定项目。');
   }

--- a/src/source.ts
+++ b/src/source.ts
@@ -250,8 +250,8 @@ export async function sourceList(): Promise<void> {
     log.info('HTTP source (report/sync/ack):');
     log.info(`  ${httpSource.endpoint}`);
     log.dim(`    ${skills} skill(s), ${rules} rule(s), ${claudemd} claude.md`);
-    for (const g of httpSource.boundGroups) {
-      log.dim(`    bound: ${g.groupName ?? g.groupId} — ${g.path}`);
+    for (const p of httpSource.boundProjects) {
+      log.dim(`    bound: ${p.projectName ?? p.projectId} — ${p.path}`);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Replace group-based workspace binding with project-based binding
- API changes from `GET /api/user-groups/mine` to `GET /api/projects/mine`
- Local config stores `projectId/projectName` instead of `groupId/groupName`
- Report/sync payloads now send `project_id` per workspace
- Old group-based bindings in config.json are auto-cleared on load

## Test plan
- [x] `npx tsc --noEmit` — type check passes
- [x] `npx vitest run` — all related tests pass (bindCurrentProject --skip, emitBindingHint, etc.)
- [x] `npm run build` — build succeeds
- [ ] E2E: `teamai bind-project --project-id <id>` binds successfully
- [ ] E2E: `teamai bind-project --skip` writes skip marker
- [ ] E2E: `teamai bind-project` (interactive) lists projects from /api/projects/mine
- [ ] E2E: report/sync payloads contain `project_id` instead of `group_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)