### PR TITLE
fix(test): align intervention e2e assertion with toolError field

### DIFF
--- a/src/__tests__/intervention-e2e.test.ts
+++ b/src/__tests__/intervention-e2e.test.ts
@@ -96,7 +96,7 @@ describe('Human Intervention metric — end to end', () => {
     const events = await readEvents();
     expect(events.length).toBe(4);
     const stopEvent = events.find((e) => e.type === 'stop');
-    expect(stopEvent!.interventions).toEqual({ interrupt: 1, toolReject: 1 });
+    expect(stopEvent!.interventions).toEqual({ interrupt: 1, toolReject: 1, toolError: 0 });
 
     // 3. Dashboard rebuild surfaces the per-session intervention badge data.
     const sessions = rebuildSessions(events);


### PR DESCRIPTION
## Problem

`main` 的 CI E2E job (`E2E (GitHub provider, full surface)`) 一直红。失败测试：`src/__tests__/intervention-e2e.test.ts`。

```
AssertionError: expected { interrupt: 1, toolReject: 1, toolError: 0 }
                to deeply equal { interrupt: 1, toolReject: 1 }
```

## Root cause

这是一次语义冲突（两个 PR 各自绿、合并到 main 后互相不兼容）。`dashboard-collector.ts` 的 Stop 事件 `interventions` 快照新增了 `toolError` 字段（#203/#204），但这条 E2E 测试的 `toEqual` 断言仍停留在旧的两字段结构。`toEqual` 深度精确匹配，多出的 `toolError: 0` 导致断言失败。两条分支各自 CI 全绿，落到 main 后才暴露。

## Fix

将断言对齐到新的三字段产出：

```ts
expect(stopEvent!.interventions).toEqual({ interrupt: 1, toolReject: 1, toolError: 0 });
```

单行改动，不触碰生产代码。

## Test Plan

- [x] `npm run build` — 通过
- [x] `npx tsc --noEmit` — No errors
- [x] `npx vitest run --config vitest.e2e.config.ts src/__tests__/intervention-e2e.test.ts` — 2 passed
- [x] 完整 E2E 套件 `npx vitest run --config vitest.e2e.config.ts` — 9 files / 55 passed (22 skipped，缺 provider token 的无关用例)

🤖 Generated with [Claude Code](https://claude.com/claude-code)