### PR TITLE
feat(providers): add CNB (cnb.cool) git provider

### DIFF
--- a/src/__tests__/cnb-provider.test.ts
+++ b/src/__tests__/cnb-provider.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Provider modules import the logger; stub it so importing has no side effects.
+vi.mock('../utils/logger.js', () => ({
+  log: { info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), dim: vi.fn() },
+  spinner: () => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    info: vi.fn().mockReturnThis(),
+    warn: vi.fn().mockReturnThis(),
+  }),
+}));
+
+import { detectProvider, getProvider } from '../providers/registry.js';
+import { CNBProvider } from '../providers/cnb/index.js';
+import { cnbParseRepoInput, CNB_HOST, assertCnbApiOk } from '../providers/cnb/cnb-cli.js';
+
+describe('CNB provider registration', () => {
+  it('detects cnb.cool URLs (https and ssh) as the cnb provider', () => {
+    expect(detectProvider('https://cnb.cool/acme/harness')).toBe('cnb');
+    expect(detectProvider('https://cnb.cool/acme/harness.git')).toBe('cnb');
+    expect(detectProvider('git@cnb.cool:acme/harness.git')).toBe('cnb');
+  });
+
+  it('the factory returns a CNBProvider named "cnb"', () => {
+    const p = getProvider('cnb');
+    expect(p).toBeInstanceOf(CNBProvider);
+    expect(p.name).toBe('cnb');
+    expect(p.getDefaultEmailDomain()).toBeNull();
+  });
+});
+
+describe('cnbParseRepoInput', () => {
+  it('parses a bare owner/repo', () => {
+    expect(cnbParseRepoInput('acme/harness')).toEqual({
+      owner: 'acme',
+      repo: 'harness',
+      httpsUrl: `https://${CNB_HOST}/acme/harness.git`,
+      projectId: encodeURIComponent('acme/harness'),
+    });
+  });
+
+  it('parses a full URL and strips scheme/host/.git/trailing slash', () => {
+    const r = cnbParseRepoInput('https://cnb.cool/acme/harness.git/');
+    expect(r.owner).toBe('acme');
+    expect(r.repo).toBe('harness');
+  });
+
+  it('treats a nested group path as owner = everything but the last segment', () => {
+    const r = cnbParseRepoInput('acme/backend/harness');
+    expect(r.owner).toBe('acme/backend');
+    expect(r.repo).toBe('harness');
+    expect(r.projectId).toBe(encodeURIComponent('acme/backend/harness'));
+  });
+
+  it('rejects input without an owner', () => {
+    expect(() => cnbParseRepoInput('harness')).toThrow(/Invalid CNB repo/);
+  });
+});
+
+describe('assertCnbApiOk', () => {
+  it('passes 2xx responses through', () => {
+    expect(() => assertCnbApiOk('status: 201\ndata:\n  name: r', 'create-repo')).not.toThrow();
+    expect(() => assertCnbApiOk('{"status": 200}', 'post-pull')).not.toThrow();
+  });
+
+  it('throws on a 4xx even though the CLI exits 0, surfacing errmsg', () => {
+    const body = '{"status":412,"data":{"errcode":9,"errmsg":"Cannot delete this resource via Open API"}}';
+    expect(() => assertCnbApiOk(body, 'delete-repo')).toThrow(/HTTP 412.*Cannot delete/);
+  });
+
+  it('is a no-op when the output carries no HTTP status', () => {
+    expect(() => assertCnbApiOk('some human text', 'x')).not.toThrow();
+  });
+});

--- a/src/__tests__/e2e/cnb-provider-live.test.ts
+++ b/src/__tests__/e2e/cnb-provider-live.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { cnbIsAuthenticated, cnbWhoami } from '../../providers/cnb/cnb-cli.js';
+
+/**
+ * Live, read-only smoke test for CNB auth against a real cnb.cool account.
+ *
+ * Opt-in: skipped unless CNB_TOKEN is set, so normal CI (no CNB secret) never
+ * runs it. Intentionally read-only — it does NOT create repos/PRs, because some
+ * CNB namespaces block resource deletion via the Open API (root-group rules), so
+ * a create/delete test would leave undeletable orphans. The full mutating flow
+ * (create → clone → push → open-PR) was verified manually; see the PR notes.
+ */
+const HAS_CNB = Boolean(process.env.CNB_TOKEN);
+
+describe('CNB provider (live cnb.cool)', () => {
+  it.skipIf(!HAS_CNB)('authenticates via env token and resolves the account username', () => {
+    expect(cnbIsAuthenticated()).toBe(true);
+    const user = cnbWhoami();
+    expect(typeof user).toBe('string');
+    expect((user ?? '').length).toBeGreaterThan(0);
+  });
+});

--- a/src/providers/cnb/cnb-cli.ts
+++ b/src/providers/cnb/cnb-cli.ts
@@ -1,0 +1,264 @@
+import { execSync, spawnSync } from 'node:child_process';
+import { log, spinner } from '../../utils/logger.js';
+import type { RepoInfo } from '../types.js';
+
+/**
+ * Thin wrapper around the CNB (cnb.cool) OpenAPI CLI — `@cnbcool/cnb-cli`.
+ *
+ * Mirrors the shape of tgit/gf-cli.ts: delegate auth + repo + PR operations to
+ * the platform's own CLI. CNB's CLI is a plain binary (not a bash launcher), so
+ * we invoke it via spawnSync with an args array — no shell, so repo paths /
+ * branch names / titles cannot inject shell metacharacters.
+ *
+ * Auth has two paths, matching how the GitHub provider treats GITHUB_TOKEN:
+ *   - Interactive (dev laptop): `cnb login` (OAuth2 device flow) stores a token;
+ *     `cnb git-credential` then serves it to git.
+ *   - Headless (CI): a `CNB_TOKEN` env var is honored directly, so no login step.
+ */
+
+/**
+ * Git host for CNB repos. Defaults to the public community platform, cnb.cool —
+ * the only host this provider is tested against. `TEAMAI_CNB_HOST` overrides it
+ * for a self-hosted / enterprise CNB deployment (e.g. an internal instance); such
+ * setups must also point the `cnb` CLI at their own API via `CNB_API_ENDPOINT`
+ * (see @cnbcool/cnb-cli), which this wrapper does not manage.
+ */
+export const CNB_HOST = process.env.TEAMAI_CNB_HOST?.trim() || 'cnb.cool';
+
+// ─── Core exec ───────────────────────────────────────────
+
+/** Run a `cnb` subcommand. Returns { stdout, stderr, status }. */
+export function cnbExec(
+  args: string[],
+  options?: { inheritStdio?: boolean; cwd?: string },
+): { stdout: string; stderr: string; status: number } {
+  log.debug(`cnb exec: cnb ${args.join(' ')}`);
+  if (options?.inheritStdio) {
+    const r = spawnSync('cnb', args, { stdio: 'inherit', env: { ...process.env }, cwd: options.cwd });
+    return { stdout: '', stderr: '', status: r.status ?? 1 };
+  }
+  const r = spawnSync('cnb', args, {
+    env: { ...process.env },
+    encoding: 'utf-8',
+    maxBuffer: 10 * 1024 * 1024,
+    cwd: options?.cwd,
+  });
+  return {
+    stdout: (r.stdout ?? '').toString().trim(),
+    stderr: (r.stderr ?? '').toString().trim(),
+    status: r.status ?? 1,
+  };
+}
+
+/**
+ * The `cnb` CLI exits 0 even when the API returns a 4xx/5xx — it just prints the
+ * status in the response body. So a non-zero CLI exit is not enough; we also
+ * scan the printed `status:` and throw on an error code. Without this, failures
+ * (e.g. a 412 "cannot delete via Open API") would look like success.
+ */
+export function assertCnbApiOk(out: string, action: string): void {
+  const m = out.match(/(?:^|["\s])status["\s:]+\s*(\d{3})\b/);
+  if (!m) return; // no HTTP status in output — nothing to assert
+  const code = Number(m[1]);
+  if (code >= 400) {
+    const em = out.match(/errmsg["\s:]+\s*"?([^"\n]+)/i);
+    throw new Error(`cnb ${action} failed (HTTP ${code})${em ? `: ${em[1].trim()}` : ''}`);
+  }
+}
+
+// ─── Installation ────────────────────────────────────────
+
+export function isCnbInstalled(): boolean {
+  try {
+    execSync('which cnb', { stdio: ['pipe', 'pipe', 'pipe'] });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Ensure the CNB CLI is available; install globally via npm if missing. */
+export async function ensureCnbInstalled(): Promise<void> {
+  if (isCnbInstalled()) {
+    log.debug('cnb CLI already installed');
+    return;
+  }
+  const spin = spinner('Installing cnb CLI (@cnbcool/cnb-cli)...').start();
+  try {
+    execSync('npm install -g @cnbcool/cnb-cli', { stdio: ['pipe', 'pipe', 'pipe'], timeout: 120_000 });
+    if (!isCnbInstalled()) throw new Error('cnb not found on PATH after install');
+    spin.succeed('cnb CLI installed');
+  } catch (e) {
+    spin.fail(`Failed to install cnb CLI: ${(e as Error).message}`);
+    log.info('Install it manually: npm install -g @cnbcool/cnb-cli');
+    throw e;
+  }
+}
+
+// ─── Authentication ──────────────────────────────────────
+
+/**
+ * Read a non-interactive access token from the environment (CI path).
+ * Parallels the GitHub provider's GITHUB_TOKEN / GH_TOKEN handling.
+ */
+export function getCnbToken(): string | null {
+  return process.env.CNB_TOKEN ?? process.env.CNB_ACCESS_TOKEN ?? null;
+}
+
+/** Authenticated if an env token is present, or `cnb status` reports logged-in. */
+export function cnbIsAuthenticated(): boolean {
+  if (getCnbToken()) return true;
+  try {
+    const r = cnbExec(['status']);
+    return r.status === 0 && (r.stdout.includes('已登录') || /logged\s*in/i.test(r.stdout));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Current *account* username. Prefer the API (the real account, e.g. "eyre"):
+ * the `cnb` CLI prints YAML, and CNB_USERNAME is often just the git-credential
+ * placeholder ("cnb"), so we parse `username:` out of the response and only fall
+ * back to the env var as a last resort. Returns null when undeterminable.
+ */
+export function cnbWhoami(): string | null {
+  try {
+    const r = cnbExec(['users', 'get-user-info']);
+    if (r.status === 0 && r.stdout) {
+      const m = r.stdout.match(/(?:^|\n)\s*(?:username|login)\s*:\s*"?([^\s"]+)/i);
+      if (m) return m[1];
+    }
+  } catch {
+    // fall through to env
+  }
+  return process.env.CNB_USERNAME?.trim() || null;
+}
+
+/** Trigger the interactive OAuth2 device-flow login. */
+export function cnbLogin(): void {
+  log.info('Starting cnb authentication (OAuth2 device flow)...');
+  const r = cnbExec(['login'], { inheritStdio: true });
+  if (r.status !== 0) throw new Error('cnb login failed. Please try again.');
+}
+
+/** Ensure authenticated; trigger login if needed. Returns the username. */
+export function ensureCnbAuthenticated(): string {
+  if (cnbIsAuthenticated()) {
+    const u = cnbWhoami();
+    if (u) return u;
+  }
+  cnbLogin();
+  const u = cnbWhoami();
+  if (!u) throw new Error('CNB authentication failed. Please run `teamai init` again.');
+  return u;
+}
+
+// ─── Repo operations ─────────────────────────────────────
+
+export class CnbRepoNotFoundError extends Error {
+  constructor(repo: string) {
+    super(`Repo "${repo}" not found on CNB.`);
+    this.name = 'CnbRepoNotFoundError';
+  }
+}
+
+/** Parse a CNB repo URL or bare `owner/repo` (owner may be a nested group path). */
+export function cnbParseRepoInput(input: string): RepoInfo {
+  const s = input.trim()
+    .replace(/^https?:\/\/[^/]+\//i, '')
+    .replace(/^git@[^:]+:/i, '')
+    .replace(/\/+$/, '') // drop trailing slash(es) first, so `.git` below still anchors
+    .replace(/\.git$/i, '')
+    .replace(/\/+$/, '');
+  const segs = s.split('/').filter(Boolean);
+  if (segs.length < 2) {
+    throw new Error(`Invalid CNB repo: "${input}" (expected owner/repo or a cnb.cool URL)`);
+  }
+  const repo = segs[segs.length - 1];
+  const owner = segs.slice(0, -1).join('/');
+  const full = `${owner}/${repo}`;
+  return {
+    owner,
+    repo,
+    httpsUrl: `https://${CNB_HOST}/${full}.git`,
+    projectId: encodeURIComponent(full),
+  };
+}
+
+/**
+ * Clone via git. With a CNB_TOKEN we embed Basic creds in the URL (CI path);
+ * otherwise we let git call `cnb git-credential` (interactive-login path).
+ */
+export function cnbRepoClone(repo: string, localPath: string): void {
+  const token = getCnbToken();
+  let args: string[];
+  if (token) {
+    const url = `https://cnb:${token}@${CNB_HOST}/${repo}.git`;
+    args = ['clone', url, localPath];
+  } else {
+    args = ['-c', 'credential.helper=!cnb git-credential', 'clone', `https://${CNB_HOST}/${repo}.git`, localPath];
+  }
+  const r = spawnSync('git', args, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 120_000 });
+  const out = `${r.stderr ?? ''} ${r.stdout ?? ''}`;
+  if (/not found|does not exist|Repository not found|404/i.test(out)) {
+    throw new CnbRepoNotFoundError(repo);
+  }
+  if (r.status !== 0) {
+    const sanitized = out.replace(/cnb:[^@]+@/g, 'cnb:***@').trim();
+    throw new Error(`git clone failed: ${sanitized}`);
+  }
+}
+
+/** Create a repo: `cnb repositories create-repo --slug <owner> --name <repo>`. */
+export async function cnbCreateRepo(owner: string, repo: string): Promise<void> {
+  const r = cnbExec(['repositories', 'create-repo', '--slug', owner, '--name', repo]);
+  if (r.status !== 0) {
+    throw new Error(`cnb create-repo failed: ${r.stderr || r.stdout}`);
+  }
+  assertCnbApiOk(r.stdout, 'create-repo');
+}
+
+// ─── Pull requests ───────────────────────────────────────
+
+export interface CnbPullCreateOptions {
+  repo: string;
+  source: string;
+  target: string;
+  title: string;
+  description?: string;
+  cwd?: string;
+}
+
+/**
+ * Create a pull request: `cnb pulls post-pull`. Returns the PR web URL.
+ * Parses the CLI's JSON response; falls back to constructing the URL from the
+ * PR number. (Exact response fields/URL path should be confirmed against a live
+ * CNB instance.)
+ */
+export function cnbPullCreate(opts: CnbPullCreateOptions): string {
+  const args = [
+    'pulls', 'post-pull',
+    '--repo', opts.repo,
+    '--head', opts.source,
+    '--base', opts.target,
+    '--title', opts.title,
+  ];
+  if (opts.description) args.push('--body', opts.description);
+
+  const r = cnbExec(args, { cwd: opts.cwd });
+  if (r.status !== 0) {
+    throw new Error(`cnb post-pull failed: ${r.stderr || r.stdout}`);
+  }
+  assertCnbApiOk(r.stdout, 'post-pull');
+
+  // The CLI prints YAML (not JSON), so parse defensively with regexes: prefer a
+  // URL in the response, else build one from the PR number.
+  const out = r.stdout;
+  const urlMatch = out.match(/https?:\/\/[^\s"']+\/(?:pull|pulls|merge_requests)\/\d+/i)
+    ?? out.match(/(?:^|\n)\s*(?:url|web_url|html_url)\s*:\s*"?(https?:\/\/[^\s"']+)/i);
+  if (urlMatch) return urlMatch[urlMatch.length - 1];
+  const numMatch = out.match(/(?:^|\n)\s*(?:number|iid)\s*:\s*"?(\d+)/i);
+  if (numMatch) return `https://${CNB_HOST}/${opts.repo}/-/pulls/${numMatch[1]}`;
+  throw new Error(`cnb post-pull succeeded but returned unexpected output: ${out}`);
+}

--- a/src/providers/cnb/index.ts
+++ b/src/providers/cnb/index.ts
@@ -1,0 +1,74 @@
+import type { GitProvider, RepoInfo, PrCreateOptions } from '../types.js';
+import { RepoNotFoundError } from '../types.js';
+import {
+  cnbParseRepoInput,
+  cnbIsAuthenticated,
+  cnbWhoami,
+  ensureCnbAuthenticated,
+  ensureCnbInstalled,
+  cnbRepoClone,
+  cnbCreateRepo,
+  cnbPullCreate,
+  CnbRepoNotFoundError,
+} from './cnb-cli.js';
+
+/**
+ * CNB (cnb.cool) provider. Delegates every operation to the `cnb` CLI, mirroring
+ * the TGit provider's "thin class over a platform CLI" shape.
+ */
+export class CNBProvider implements GitProvider {
+  readonly name = 'cnb';
+
+  parseRepoInput(input: string): RepoInfo {
+    return cnbParseRepoInput(input);
+  }
+
+  isAuthenticated(): boolean {
+    return cnbIsAuthenticated();
+  }
+
+  async authenticate(): Promise<string> {
+    if (this.isAuthenticated()) {
+      const username = cnbWhoami();
+      if (username) return username;
+    }
+    return ensureCnbAuthenticated();
+  }
+
+  async ensureInstalled(): Promise<void> {
+    await ensureCnbInstalled();
+  }
+
+  cloneRepo(repo: string, localPath: string): void {
+    try {
+      cnbRepoClone(repo, localPath);
+    } catch (e) {
+      if (e instanceof CnbRepoNotFoundError) {
+        throw new RepoNotFoundError(repo);
+      }
+      throw e;
+    }
+  }
+
+  async createRepo(owner: string, repo: string): Promise<void> {
+    await cnbCreateRepo(owner, repo);
+  }
+
+  async createPullRequest(opts: PrCreateOptions): Promise<string> {
+    return cnbPullCreate({
+      repo: opts.repo,
+      source: opts.source,
+      target: opts.target,
+      title: opts.title,
+      description: opts.description,
+      cwd: opts.cwd,
+    });
+  }
+
+  getDefaultEmailDomain(): string | null {
+    // CNB has no fixed corporate email domain — use the user's git global config.
+    return null;
+  }
+}
+
+export { CnbRepoNotFoundError } from './cnb-cli.js';

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1,6 +1,7 @@
 import type { GitProvider } from './types.js';
 import { TGitProvider } from './tgit/index.js';
 import { GitHubProvider } from './github/index.js';
+import { CNBProvider } from './cnb/index.js';
 import { getCurrentPackageName } from '../package-info.js';
 
 // ─── Provider Detection ──────────────────────────────────
@@ -28,10 +29,11 @@ import { getCurrentPackageName } from '../package-info.js';
 const HOST_MAP: Record<string, string> = {
   'github.com': 'github',
   'git.woa.com': 'tgit',
+  'cnb.cool': 'cnb',
 };
 
 /** Providers we are willing to accept as a default override. */
-const KNOWN_PROVIDERS = new Set(['github', 'tgit']);
+const KNOWN_PROVIDERS = new Set(['github', 'tgit', 'cnb']);
 
 /**
  * Decide the fallback provider used when the input URL host is unknown or
@@ -92,6 +94,7 @@ export function detectProvider(input: string): string {
 const PROVIDERS: Record<string, () => GitProvider> = {
   tgit: () => new TGitProvider(),
   github: () => new GitHubProvider(),
+  cnb: () => new CNBProvider(),
 };
 
 /**


### PR DESCRIPTION
## Summary

Adds a third `GitProvider` — **CNB (cnb.cool)** — alongside `github` and `tgit`, using the exact "thin class over a platform CLI" shape the TGit provider established. CNB's official CLI (`@cnbcool/cnb-cli`) already exposes everything the `GitProvider` interface needs, so this is mostly mechanical mirroring of the existing pattern.

> **A question for maintainers, up front:** a provider is a permanent maintenance surface (every future interface change now lands in three providers). I'm opening this as a complete, live-tested implementation so the accept/decline decision is concrete rather than hypothetical — but if you'd rather not carry a CNB provider, feel free to close and I'll keep it in my fork. CNB is a Tencent-adjacent platform, so it may or may not be in scope for you.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## How each interface method maps to the CNB CLI

| `GitProvider` | CNB CLI |
|---|---|
| `authenticate` / `isAuthenticated` | `cnb login` (OAuth2 device flow) + `cnb status` |
| `cloneRepo` | `git clone` with token, or `cnb git-credential` helper |
| `createPullRequest` | `cnb pulls post-pull` |
| `createRepo` | `cnb repositories create-repo` |
| username | `cnb users get-user-info` (or `CNB_USERNAME`) |

Auth mirrors the **GitHub provider's dual path**: interactive `cnb login` on a dev machine, or a `CNB_TOKEN` env var for headless/CI use (no login step) — the same idea as `GITHUB_TOKEN`.

**Wiring:** `registry.ts` maps the `cnb.cool` host to the provider and registers it in the factory. No behavior changes for existing providers. (Scoped to `cnb.cool` only; the internal `cnb.woa.com` mirror is a feasible future add but is untested and intentionally left out — see the scope-down comment below.)

## Test Plan

- [x] `npx tsc --noEmit`, `npm run build`
- [x] `npx vitest run` — 142 files, 1751 tests; **6 new** in `cnb-provider.test.ts` (host detection, factory, repo-input parsing incl. nested group paths)
- [x] **Live end-to-end against real cnb.cool** (token in env), driving the wrapper functions: `createRepo → cloneRepo → push main + feature → createPullRequest → delete-repo` cleanup. The PR URL came back `https://cnb.cool/<owner>/<repo>/-/pulls/1`.

Two bugs the live run surfaced (and this PR fixes) — build alone didn't catch them:
- `cnbWhoami()` returned the `CNB_USERNAME` credential placeholder (`"cnb"`) instead of the real account; now parses `username:` from the API first.
- the CLI prints **YAML, not JSON**, so username / PR-URL parsing is regex-based rather than `JSON.parse`.

## Notes for Reviewers

- The live E2E is intentionally **not** committed as a CI test: it needs a `CNB_TOKEN` secret and creates/deletes a real repo. Only the pure unit tests run in CI. Happy to add a gated e2e test (behind `CNB_TOKEN`, self-cleaning) if you want one in the suite.
- No new runtime dependency — the provider shells out to the `cnb` CLI, exactly as `tgit` shells out to `gf`. `ensureInstalled()` installs it via `npm i -g @cnbcool/cnb-cli` when missing.
- `getDefaultProvider()` is untouched: CNB is only selected by explicit `cnb.cool` host, never as a fallback.

