### PR TITLE
fix(tgit): correct REST auth scheme and rename TGit token to TGIT_TOKEN

### DIFF
--- a/examples/ci/README.md
+++ b/examples/ci/README.md
@@ -17,7 +17,7 @@
 2. 触发频率建议每日一次（示例中为 UTC 02:17）。
 3. 必须配置好对应 secret：
    - GitHub Actions：`TEAMAI_SYNC_TOKEN`（需要 repo 读写权限）
-   - Coding CI：`TAI_PAT_TOKEN`（同上）
+   - Coding CI：`TGIT_TOKEN`（同上）
 4. `.teamai/repo-whitelist.yaml` 必须存在且至少包含一个 repo entry。
 
 ## 增量模式说明
@@ -56,6 +56,6 @@
 1. 这两个文件是**模板**，使用前需按文件内注释替换占位符（本仓库路径、知识仓库路径、默认分支、AI 网关地址）。
 2. `teamai ci extract-mr` 会调用本地 AI CLI 做提炼，因此**必须**安装 AI CLI（`@anthropic-ai/claude-code`）并配置凭证：
    - GitHub Actions：`ANTHROPIC_AUTH_TOKEN`（Secret）+ `ANTHROPIC_BASE_URL` / 模型名（Variables）
-   - 智研 / Coding CI（工蜂）：`ANTHROPIC_AUTH_TOKEN`、`TAI_PAT_TOKEN`（均为 Secret）
-3. 需要对团队知识仓库有 push 权限的 token：GitHub 用 `TEAMAI_SYNC_TOKEN`，工蜂用 `TAI_PAT_TOKEN`。
+   - 智研 / Coding CI（工蜂）：`ANTHROPIC_AUTH_TOKEN`、`TGIT_TOKEN`（均为 Secret）
+3. 需要对团队知识仓库有 push 权限的 token：GitHub 用 `TEAMAI_SYNC_TOKEN`，工蜂用 `TGIT_TOKEN`。
 4. 智研 / Coding CI（工蜂）的 MR 触发规则**必须写在 YAML 的 `mr:` 块**，仅在 UI 勾选无效。

--- a/examples/ci/coding-ci-mr-extract.yaml
+++ b/examples/ci/coding-ci-mr-extract.yaml
@@ -8,37 +8,37 @@
 #      触发方式勾选 MR。注意：MR 触发规则**必须**在本 YAML 的 `mr:` 块声明，
 #      仅在智研 UI 勾选无效。
 #   2. Pipeline Secret：
-#        - TAI_PAT_TOKEN：对团队知识仓库有 push 权限的 TGit Personal Access Token
+#        - TGIT_TOKEN：对团队知识仓库有 push 权限的 TGit Personal Access Token
 #        - ANTHROPIC_AUTH_TOKEN：AI 认证 Token
 #      说明：teamai ci extract-mr 复用了 AI 提炼逻辑（callClaude），comment 与
 #      write 两种模式都会 spawn 本地 AI CLI，因此 AI CLI 与凭证是**必须**的，不是可选。
-#   3. 把下方占位符改成你的实际值：
-#        - <team>/<your-repo>       本仓库路径
-#        - <team>/<knowledge-repo>  团队知识仓库路径
-#        - <默认分支>               本仓库默认分支（master 或 main）
-#        - <your-anthropic-base-url> AI 网关地址
+#   3. 把下方 env 中的占位符改成你的实际值：
+#        - TEAMAI_KNOWLEDGE_REPO   团队知识仓库路径（如 myteam/knowledge）
+#        - ANTHROPIC_BASE_URL      AI 网关地址（如 https://api.anthropic.com）
 
 version: 2
 
 # ── MR 触发规则（必须在 YAML 中声明，UI 配置无效）────────────
 mr:
   action:
-    - open
-    - push-update
-    - merge
-  branches:
-    include:
-      - <默认分支>          # 按仓库实际填：master 或 main
+  - open
+  - push-update
+  - merge
+  is_local_mr: true
+  is_block_mr: true
+  auto_cancel_same_merge_request: true
 
 # ── 密钥与环境变量 ────────────────────────────────────────────
 env:
-  TAI_PAT_TOKEN:
-    secret: ${TAI_PAT_TOKEN_SECRET}
+  TGIT_TOKEN:
+    secret: ${TGIT_TOKEN_SECRET}
   ANTHROPIC_AUTH_TOKEN:
     secret: ${ANTHROPIC_AUTH_TOKEN_SECRET}
-  ANTHROPIC_BASE_URL: <your-anthropic-base-url>        # 如 https://api.anthropic.com
+  TEAMAI_KNOWLEDGE_REPO:                                # 团队知识仓库路径（如 myteam/knowledge）
+  TEAMAI_KNOWLEDGE_BRANCH: main                        # 知识仓库默认分支
+  ANTHROPIC_BASE_URL:                                  # AI API 基础地址（如 https://api.anthropic.com）
   ANTHROPIC_DEFAULT_SONNET_MODEL: claude-sonnet-4-6
-  ANTHROPIC_DEFAULT_HAIKU_MODEL: claude-haiku-4-5-20251001
+  ANTHROPIC_DEFAULT_HAIKU_MODEL: claude-haiku-4-5
   ANTHROPIC_DEFAULT_OPUS_MODEL: claude-opus-4-8
 
 # ── 流水线阶段 ────────────────────────────────────────────────
@@ -57,16 +57,18 @@ stages:
         #   npm install -g ./teamai-cli-<version>.tgz @anthropic-ai/claude-code
         - npm install -g teamai-cli @anthropic-ai/claude-code 2>&1 | tail -3
         - |
-          echo "machine git.woa.com login oauth2 password ${TAI_PAT_TOKEN}" > ~/.netrc
+          echo "machine git.woa.com login oauth2 password ${TGIT_TOKEN}" > ~/.netrc
           chmod 600 ~/.netrc
           echo "=== [TeamAI] TGit auth configured ==="
+        - teamai init --repo "https://git.woa.com/${TEAMAI_KNOWLEDGE_REPO}"
         - |
           echo "=== [TeamAI] Trigger: ${QCI_TRIGGER_TYPE}, MR IID: ${QCI_MR_IID:-none} ==="
-          if [ "${QCI_TRIGGER_TYPE}" != "TRIGGER_MR" ] || [ -z "${QCI_MR_IID}" ]; then
-            echo "=== [TeamAI] SKIP: No MR context ==="
+          if [ "${QCI_TRIGGER_TYPE}" = "TRIGGER_MR" ] && [ -n "${QCI_MR_IID}" ] && [ "${QCI_MR_IID}" != "None" ]; then
+            MR_URL="${QCI_REPO%.git}/merge_requests/${QCI_MR_IID}"
+          else
+            echo "⏭ Not an MR trigger, skipping"
             exit 0
           fi
-          MR_URL="https://git.woa.com/<team>/<your-repo>/merge_requests/${QCI_MR_IID}"
           echo "=== [TeamAI] MR_URL=$MR_URL ==="
           teamai ci extract-mr --url "$MR_URL" --mode comment --individual-comments
 
@@ -80,21 +82,21 @@ stages:
         cmds:
         - npm install -g teamai-cli @anthropic-ai/claude-code 2>&1 | tail -3
         - |
-          echo "machine git.woa.com login oauth2 password ${TAI_PAT_TOKEN}" > ~/.netrc
+          echo "machine git.woa.com login oauth2 password ${TGIT_TOKEN}" > ~/.netrc
           chmod 600 ~/.netrc
+        - teamai init --repo "https://git.woa.com/${TEAMAI_KNOWLEDGE_REPO}"
         - |
           if [ "${QCI_TRIGGER_TYPE}" != "TRIGGER_MR" ] || [ "${QCI_MR_ACTION}" != "merge" ]; then
             echo "=== [TeamAI] SKIP: Not a merge event ==="
             exit 0
           fi
-          MR_URL="https://git.woa.com/<team>/<your-repo>/merge_requests/${QCI_MR_IID}"
+          MR_URL="${QCI_REPO%.git}/merge_requests/${QCI_MR_IID}"
           echo "=== [TeamAI] Writing knowledge for $MR_URL ==="
-          git clone "https://oauth2:${TAI_PAT_TOKEN}@git.woa.com/<team>/<knowledge-repo>.git" team-repo
+          git clone -b "${TEAMAI_KNOWLEDGE_BRANCH}" "https://oauth2:${TGIT_TOKEN}@git.woa.com/${TEAMAI_KNOWLEDGE_REPO}.git" team-repo
           teamai ci extract-mr --url "$MR_URL" --mode write --individual-comments --team-repo ./team-repo --write-mode direct
           cd team-repo
-          # git user.name/email 建议用 TAI_PAT_TOKEN 对应账号
           git config user.name "teamai-ci"
-          git config user.email "teamai-ci@tencent.com"
+          git config user.email "teamai-ci@noreply"
           git add learnings/ docs/ .teamai/ teamwiki/ 2>/dev/null || true
           if ! git diff --cached --quiet; then
             git commit -m "[teamai] Extract knowledge from MR !${QCI_MR_IID}"
@@ -104,9 +106,10 @@ stages:
             echo "=== [TeamAI] No changes ==="
           fi
 
-is_block_mr: 0
-
 worker:
   label: JOB_MATRIX_DEVCLOUD
   tools: []
   language: node_js-22.19.0
+
+maximum_builds: 2
+is_auto_cancel: false

--- a/examples/ci/coding-ci-teamai-sync.yaml
+++ b/examples/ci/coding-ci-teamai-sync.yaml
@@ -12,7 +12,7 @@ jobs:
             - run: npm install -g teamai-cli
             - run: teamai import --from-repo-list .teamai/repo-whitelist.yaml --incremental
               env:
-                  TAI_PAT_TOKEN: ${{ secrets.TAI_PAT_TOKEN }}
+                  TGIT_TOKEN: ${{ secrets.TGIT_TOKEN }}
             - run: |
                   git add docs/team-codebase .teamai/domains.yaml .teamai/domains.history.jsonl
                   git diff --cached --quiet || (git commit -m "chore(team-codebase): scheduled sync" && git push)

--- a/examples/ci/github-actions-mr-extract.yml
+++ b/examples/ci/github-actions-mr-extract.yml
@@ -4,14 +4,7 @@
 # PR 合入后自动将 learning 和 codebase 建议写入团队知识仓库。
 #
 # 使用前请配置：
-#   1. Repository Secret: TEAMAI_SYNC_TOKEN（对团队知识仓库有写权限的 PAT）
-#   2. 修改 write job 中的 <owner>/<team-knowledge-repo> 为你的团队仓库路径
-#   3. 配置 Repository Variables（Settings → Secrets and variables → Variables）：
-#      - ANTHROPIC_BASE_URL: AI API 基础地址（如 https://api.anthropic.com）
-#      - ANTHROPIC_DEFAULT_SONNET_MODEL: 默认 sonnet 模型名
-#      - ANTHROPIC_DEFAULT_HAIKU_MODEL: 默认 haiku 模型名
-#      - ANTHROPIC_DEFAULT_OPUS_MODEL: 默认 opus 模型名
-#   4. 配置 Repository Secret: ANTHROPIC_AUTH_TOKEN（AI API 认证 Token）
+#   修改下方 env 中的占位符，并在 Repository Settings 中配置对应 Secrets / Variables
 
 name: TeamAI MR Knowledge Extract
 
@@ -22,6 +15,8 @@ on:
     types: [closed]
 
 env:
+  TEAMAI_KNOWLEDGE_REPO: ${{ vars.TEAMAI_KNOWLEDGE_REPO }}
+  TEAMAI_KNOWLEDGE_BRANCH: ${{ vars.TEAMAI_KNOWLEDGE_BRANCH || 'main' }}
   ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
   ANTHROPIC_DEFAULT_SONNET_MODEL: ${{ vars.ANTHROPIC_DEFAULT_SONNET_MODEL }}
   ANTHROPIC_DEFAULT_HAIKU_MODEL: ${{ vars.ANTHROPIC_DEFAULT_HAIKU_MODEL }}
@@ -62,7 +57,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: <owner>/<team-knowledge-repo>
+          repository: ${{ env.TEAMAI_KNOWLEDGE_REPO }}
+          ref: ${{ env.TEAMAI_KNOWLEDGE_BRANCH }}
           token: ${{ secrets.TEAMAI_SYNC_TOKEN }}
           path: team-repo
 

--- a/src/__tests__/gf-org.test.ts
+++ b/src/__tests__/gf-org.test.ts
@@ -143,10 +143,16 @@ describe('gfListOrgRepos', () => {
         await expect(gfListOrgRepos('my-group')).rejects.toThrow('TGit API HTTP 403');
     });
 
-    it('token 缺失 — 抛 TGit token unavailable', async () => {
+    it('token 缺失 — 抛 No TGit credentials found', async () => {
+        const savedToken = process.env['TGIT_TOKEN'];
+        delete process.env['TGIT_TOKEN'];
         (gfGetOAuthToken as Mock).mockReturnValue(null);
 
-        await expect(gfListOrgRepos('my-group')).rejects.toThrow('TGit token unavailable');
+        try {
+            await expect(gfListOrgRepos('my-group')).rejects.toThrow('No TGit credentials found');
+        } finally {
+            if (savedToken !== undefined) process.env['TGIT_TOKEN'] = savedToken;
+        }
     });
 
     it('archived 字段缺失时默认 false', async () => {

--- a/src/__tests__/tgit-rest-auth.test.ts
+++ b/src/__tests__/tgit-rest-auth.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Mock } from 'vitest';
+
+vi.mock('../../src/providers/tgit/gf-cli.js', () => ({
+    gfGetOAuthToken: vi.fn(),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+    log: {
+        info: vi.fn(),
+        success: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+        dim: vi.fn(),
+    },
+}));
+
+import { getTGitToken, tgitAuthHeaders, tgitFetch } from '../providers/tgit/rest-auth.js';
+import { gfGetOAuthToken } from '../providers/tgit/gf-cli.js';
+
+function makeResponse(status: number): Response {
+    return {
+        status,
+        ok: status >= 200 && status < 300,
+        text: () => Promise.resolve(''),
+        json: () => Promise.resolve({}),
+    } as unknown as Response;
+}
+
+describe('rest-auth', () => {
+    let mockFetch: Mock;
+    const savedToken = process.env['TGIT_TOKEN'];
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+        mockFetch = vi.fn();
+        vi.stubGlobal('fetch', mockFetch);
+        delete process.env['TGIT_TOKEN'];
+    });
+
+    afterEach(() => {
+        if (savedToken === undefined) {
+            delete process.env['TGIT_TOKEN'];
+        } else {
+            process.env['TGIT_TOKEN'] = savedToken;
+        }
+    });
+
+    describe('getTGitToken', () => {
+        it('TGIT_TOKEN set → private-token scheme', () => {
+            process.env['TGIT_TOKEN'] = 'pat-123';
+            expect(getTGitToken()).toEqual({ token: 'pat-123', scheme: 'private-token' });
+        });
+
+        it('no TGIT_TOKEN, OAuth token → bearer scheme', () => {
+            (gfGetOAuthToken as Mock).mockReturnValue('oauth-x');
+            expect(getTGitToken()).toEqual({ token: 'oauth-x', scheme: 'bearer' });
+        });
+
+        it('neither credential → throws', () => {
+            (gfGetOAuthToken as Mock).mockReturnValue(null);
+            expect(() => getTGitToken()).toThrow(/No TGit credentials found/);
+        });
+    });
+
+    describe('tgitAuthHeaders', () => {
+        it('bearer and private-token produce correct headers', () => {
+            expect(tgitAuthHeaders('tok', 'bearer')).toEqual({ Authorization: 'Bearer tok' });
+            expect(tgitAuthHeaders('tok', 'private-token')).toEqual({ 'PRIVATE-TOKEN': 'tok' });
+        });
+    });
+
+    describe('tgitFetch', () => {
+        it('200 response → one call with PRIVATE-TOKEN header and correct base URL', async () => {
+            process.env['TGIT_TOKEN'] = 'pat-123';
+            mockFetch.mockResolvedValueOnce(makeResponse(200));
+
+            const resp = await tgitFetch('/projects');
+
+            expect(resp.status).toBe(200);
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+            const [url, init] = mockFetch.mock.calls[0];
+            expect(url).toMatch(/^https:\/\/git\.woa\.com\/api\/v3/);
+            expect((init.headers as Record<string, string>)['PRIVATE-TOKEN']).toBe('pat-123');
+        });
+
+        it('401 → retries once with the opposite scheme', async () => {
+            // Fresh module so the module-level scheme cache does not leak.
+            vi.resetModules();
+            process.env['TGIT_TOKEN'] = 'pat-123';
+            const localFetch: Mock = vi.fn()
+                .mockResolvedValueOnce(makeResponse(401))
+                .mockResolvedValueOnce(makeResponse(200));
+            vi.stubGlobal('fetch', localFetch);
+
+            const mod = await import('../providers/tgit/rest-auth.js');
+            const resp = await mod.tgitFetch('/projects');
+
+            expect(resp.status).toBe(200);
+            expect(localFetch).toHaveBeenCalledTimes(2);
+
+            const firstHeaders = localFetch.mock.calls[0][1].headers as Record<string, string>;
+            const secondHeaders = localFetch.mock.calls[1][1].headers as Record<string, string>;
+            // First call uses private-token (from TGIT_TOKEN), fallback uses bearer.
+            expect(firstHeaders['PRIVATE-TOKEN']).toBe('pat-123');
+            expect(secondHeaders.Authorization).toBe('Bearer pat-123');
+        });
+
+        it('both schemes fail → returns the original status, not the retry status', async () => {
+            // A genuine 403 (authorized-but-forbidden) must not be masked as the
+            // retry's 401, which would invert the caller's 401-vs-403 remedy.
+            vi.resetModules();
+            process.env['TGIT_TOKEN'] = 'pat-123';
+            const localFetch: Mock = vi.fn()
+                .mockResolvedValueOnce(makeResponse(403))
+                .mockResolvedValueOnce(makeResponse(401));
+            vi.stubGlobal('fetch', localFetch);
+
+            const mod = await import('../providers/tgit/rest-auth.js');
+            const resp = await mod.tgitFetch('/projects');
+
+            expect(localFetch).toHaveBeenCalledTimes(2);
+            expect(resp.status).toBe(403);
+        });
+    });
+});

--- a/src/ci/extract-mr.ts
+++ b/src/ci/extract-mr.ts
@@ -19,6 +19,7 @@ import { log } from '../utils/logger.js';
 import type { LearningDraft, CodebaseSuggestion } from '../types.js';
 import { postOrUpdateMrComment, postIndividualComments, postCodebaseGraphComment, parseMrUrl } from './mr-comment.js';
 import { readRejections, shouldWrite } from './read-rejections.js';
+import { tgitFetch } from '../providers/tgit/rest-auth.js';
 
 // ─── 类型 ────────────────────────────────────────────────
 
@@ -40,7 +41,7 @@ export interface CiExtractMrOptions {
  *
  * 通过 provider API 获取当前 token 对应的用户信息：
  * - GitHub: GITHUB_TOKEN → GET /user
- * - TGit: TAI_PAT_TOKEN → GET /api/v3/user
+ * - TGit: TGIT_TOKEN → GET /api/v3/user
  */
 async function configureGitUser(repoPath: string, provider: 'github' | 'tgit'): Promise<void> {
   const { execFileSync } = await import('node:child_process');
@@ -62,17 +63,13 @@ async function configureGitUser(repoPath: string, provider: 'github' | 'tgit'): 
         }
       }
     } else {
-      const token = process.env['TAI_PAT_TOKEN'];
-      if (token) {
-        const resp = await fetch('https://git.woa.com/api/v3/user', {
-          headers: { Authorization: `Bearer ${token}` },
-          signal: AbortSignal.timeout(8000),
-        });
-        if (resp.ok) {
-          const user = (await resp.json()) as { username: string; email: string };
-          name = user.username;
-          email = user.email;
-        }
+      // tgitFetch throws when no TGit credential is available; the outer
+      // catch below logs and falls back to the default git user.
+      const resp = await tgitFetch('/user', { signal: AbortSignal.timeout(8000) });
+      if (resp.ok) {
+        const user = (await resp.json()) as { username: string; email: string };
+        name = user.username;
+        email = user.email;
       }
     }
   } catch {

--- a/src/ci/mr-comment.ts
+++ b/src/ci/mr-comment.ts
@@ -7,7 +7,7 @@
  */
 
 import type { LearningDraft, CodebaseSuggestion } from '../types.js';
-import { gfGetOAuthToken } from '../providers/tgit/gf-cli.js';
+import { tgitFetch } from '../providers/tgit/rest-auth.js';
 import { log } from '../utils/logger.js';
 
 // ─── 常量 ────────────────────────────────────────────────
@@ -178,29 +178,10 @@ async function updateGitHubComment(
 
 // ─── TGit Comment API ───────────────────────────────────
 
-function getTGitToken(): string {
-  const envToken = process.env['TAI_PAT_TOKEN'];
-  if (envToken) return envToken;
-
-  const oauthToken = gfGetOAuthToken();
-  if (oauthToken) return oauthToken;
-
-  throw new Error('未设置 TAI_PAT_TOKEN 环境变量，且无法从 gf credential 获取 token');
-}
-
 async function tgitRequest(path: string, method: string, body?: unknown): Promise<Response> {
-  const token = getTGitToken();
-  const url = `https://git.woa.com/api/v3${path}`;
-  const headers: Record<string, string> = {
-    Authorization: `Bearer ${token}`,
-    'Content-Type': 'application/json',
-  };
-
-  return fetch(url, {
+  return tgitFetch(path, {
     method,
-    headers,
     body: body ? JSON.stringify(body) : undefined,
-    signal: AbortSignal.timeout(API_TIMEOUT_MS),
   });
 }
 

--- a/src/ci/read-rejections.ts
+++ b/src/ci/read-rejections.ts
@@ -7,7 +7,7 @@
  */
 
 import { parseMrUrl } from './mr-comment.js';
-import { gfGetOAuthToken } from '../providers/tgit/gf-cli.js';
+import { tgitFetch } from '../providers/tgit/rest-auth.js';
 import { log } from '../utils/logger.js';
 
 const API_TIMEOUT_MS = 15_000;
@@ -111,23 +111,8 @@ interface TGitNote {
   comments: TGitNoteComment[];
 }
 
-function getTGitToken(): string {
-  const envToken = process.env['TAI_PAT_TOKEN'];
-  if (envToken) return envToken;
-  const oauthToken = gfGetOAuthToken();
-  if (oauthToken) return oauthToken;
-  throw new Error('未设置 TAI_PAT_TOKEN 且无法获取 OAuth token');
-}
-
 async function tgitRequest(path: string): Promise<Response> {
-  const token = getTGitToken();
-  return fetch(`https://git.woa.com/api/v3${path}`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    },
-    signal: AbortSignal.timeout(API_TIMEOUT_MS),
-  });
+  return tgitFetch(path);
 }
 
 async function getMrGlobalId(projectId: string, mrIid: string): Promise<number> {

--- a/src/mr-hint.ts
+++ b/src/mr-hint.ts
@@ -2,7 +2,7 @@ import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { gfGetOAuthToken } from './providers/tgit/gf-cli.js';
+import { getTGitToken, tgitFetch } from './providers/tgit/rest-auth.js';
 import { log } from './utils/logger.js';
 
 // ─── MR Hint data flow ──────────────────────────────────
@@ -210,20 +210,20 @@ async function listTGitMergedMRs(
   repo: string,
   since: Date,
 ): Promise<MRSummary[]> {
-  const token = gfGetOAuthToken();
-  if (!token) {
+  try {
+    getTGitToken();
+  } catch {
     log.debug('mr-hint: no TGit token, skipping TGit MR check');
     return [];
   }
 
   const projectId = encodeURIComponent(`${owner}/${repo}`);
-  const apiUrl =
-    `https://git.woa.com/api/v3/projects/${projectId}/merge_requests` +
+  const apiPath =
+    `/projects/${projectId}/merge_requests` +
     `?state=merged&order_by=updated_at&sort=desc&per_page=${MAX_MRS}`;
 
   try {
-    const resp = await fetch(apiUrl, {
-      headers: { Authorization: `Bearer ${token}` },
+    const resp = await tgitFetch(apiPath, {
       signal: AbortSignal.timeout(8000),
     });
     if (!resp.ok) {

--- a/src/providers/tgit/gf-cli.ts
+++ b/src/providers/tgit/gf-cli.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { pathExists, ensureDir } from '../../utils/fs.js';
 import { log, spinner } from '../../utils/logger.js';
 import { TEAMAI_HOME } from '../../types.js';
+import { tgitFetch } from './rest-auth.js';
 
 /** Path where gf CLI is installed */
 const GF_INSTALL_DIR = path.join(TEAMAI_HOME, 'gf');
@@ -267,28 +268,15 @@ export function gfGetOAuthToken(): string | null {
 
 /**
  * Create a repo on TGit using the REST API.
- * Uses the OAuth token from gf's credential store with Bearer auth.
+ * Authentication (token + scheme) is handled by {@link tgitFetch}.
  */
 export async function gfCreateRepo(owner: string, repo: string): Promise<void> {
-  const token = gfGetOAuthToken();
-  if (!token) {
-    throw new Error('Cannot retrieve OAuth token. Please run `gf auth login` first.');
-  }
-
-  const authHeaders = {
-    'Content-Type': 'application/json',
-    'Authorization': `Bearer ${token}`,
-  };
-
   // Look up namespace ID for the owner (group or user).
   // For multi-segment paths like "HyperAI/ElasticLLM", the API's `path` field
   // only contains the last segment ("ElasticLLM"), so we search by the last
   // segment and match against `full_path` which includes parent groups.
   const searchTerm = owner.includes('/') ? owner.split('/').pop()! : owner;
-  const nsResp = await fetch(
-    `https://git.woa.com/api/v3/namespaces?search=${encodeURIComponent(searchTerm)}`,
-    { headers: authHeaders },
-  );
+  const nsResp = await tgitFetch(`/namespaces?search=${encodeURIComponent(searchTerm)}`);
   if (!nsResp.ok) {
     throw new Error(`Failed to look up namespace "${owner}": ${nsResp.status}`);
   }
@@ -302,14 +290,10 @@ export async function gfCreateRepo(owner: string, repo: string): Promise<void> {
     body.namespace_id = ns.id;
   }
 
-  const createResp = await fetch(
-    'https://git.woa.com/api/v3/projects',
-    {
-      method: 'POST',
-      headers: authHeaders,
-      body: JSON.stringify(body),
-    },
-  );
+  const createResp = await tgitFetch('/projects', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
   if (!createResp.ok) {
     const errBody = await createResp.text().catch(() => '');
     throw new Error(`Failed to create repo: ${createResp.status} ${errBody}`);

--- a/src/providers/tgit/gf-org.ts
+++ b/src/providers/tgit/gf-org.ts
@@ -1,5 +1,5 @@
 import type { OrgRepoInfo } from '../types.js';
-import { gfGetOAuthToken } from './gf-cli.js';
+import { getTGitToken, tgitAuthHeaders } from './rest-auth.js';
 import { log } from '../../utils/logger.js';
 
 const TGIT_API_BASE = 'https://git.woa.com/api/v3';
@@ -57,20 +57,15 @@ export async function gfListOrgRepos(
     group: string,
     opts?: { maxRepos?: number },
 ): Promise<OrgRepoInfo[]> {
-    const token = gfGetOAuthToken();
-    if (!token) {
-        throw new Error(
-            'TGit token unavailable: configure ~/.netrc for git.woa.com or set TAI_PAT_TOKEN',
-        );
-    }
+    const { token, scheme } = getTGitToken();
 
     const maxRepos = opts?.maxRepos ?? DEFAULT_MAX_REPOS;
     const perPage = DEFAULT_PER_PAGE;
     const encodedGroup = encodeURIComponent(group);
 
     const headers = {
-        'Authorization': `Bearer ${token}`,
-        'Accept': 'application/json',
+        ...tgitAuthHeaders(token, scheme),
+        Accept: 'application/json',
     };
 
     const collected: OrgRepoInfo[] = [];

--- a/src/providers/tgit/mr-fetch.ts
+++ b/src/providers/tgit/mr-fetch.ts
@@ -1,7 +1,6 @@
-import { execFileSync } from 'node:child_process';
 import { type MRData } from '../../types.js';
 import { log } from '../../utils/logger.js';
-import { gfExec, gfGetOAuthToken } from './gf-cli.js';
+import { tgitFetch } from './rest-auth.js';
 
 /** TGit MR URL 解析结果 */
 interface ParsedTGitMR {
@@ -26,124 +25,78 @@ function parseTGitMRUrl(url: string): ParsedTGitMR {
   return { group: match[1], project: match[2], mrIid: match[3] };
 }
 
-/** gf mr desc 返回的 JSON 结构（仅使用的字段） */
-interface GfMRDesc {
+/** TGit REST API 返回的 MR 元信息（仅使用的字段） */
+interface TGitMR {
+  id: number;
+  iid: number;
   title: string;
   description: string;
   author: { username: string };
-  merged_at: string | null;
+  // 部分工蜂版本不返回 merged_at，回退到 resolved_at / updated_at
+  merged_at?: string | null;
+  resolved_at?: string | null;
+  updated_at?: string | null;
+}
+
+/** /changes 接口的 diff 载荷：工蜂用 `files`，标准 GitLab 用 `changes` */
+interface TGitChangesResponse {
+  files?: Array<{ diff: string }>;
+  changes?: Array<{ diff: string }>;
 }
 
 /**
- * 通过 TGit REST API 获取 MR 数据（gf CLI 不可用时的 fallback）。
+ * 通过 TGit REST API（git.woa.com/api/v3）获取 MR 的完整数据。
  *
- * 使用 ~/.netrc 中存储的 OAuth token 调用 git.woa.com API。
+ * gf CLI 无法返回 MR diff，因此改为纯 REST 实现：
+ *   1. GET /projects/{enc}/merge_requests?iid={iid} 获取元信息
+ *   2. GET /projects/{enc}/merge_request/{globalId}/changes 获取 diff
+ *      （读 files/changes 字段，截断至 50KB，失败非致命）
+ * 鉴权与 auth scheme 由 tgitFetch 统一处理。
  *
- * @param group   - 项目所属 group（可含子 group，如 group/subgroup）
- * @param project - 项目名称
- * @param mrIid   - MR 内部编号（字符串数字）
+ * @param url - TGit MR 完整 web URL，例如 https://git.woa.com/group/repo/merge_requests/456
  * @returns 包含标题、描述、提交列表、diff 的 MRData 对象
- * @throws Error 当 token 不可用或 API 调用失败时
+ * @throws Error 当 URL 格式不合法、MR 不存在或元信息 API 调用失败时
  */
-async function fetchTGitMRViaApi(group: string, project: string, mrIid: string): Promise<MRData> {
-  const token = gfGetOAuthToken();
-  if (!token) {
-    throw new Error('TGit REST API fallback 不可用：无法从 ~/.netrc 获取 OAuth token，请先运行 `gf auth login`');
-  }
+export async function fetchTGitMR(url: string): Promise<MRData> {
+  const { group, project, mrIid } = parseTGitMRUrl(url);
+  log.debug(`fetchTGitMR: ${group}/${project}!${mrIid}`);
 
-  const encodedPath = encodeURIComponent(`${group}/${project}`);
-  const baseUrl = `https://git.woa.com/api/v3/projects/${encodedPath}`;
-  const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+  const enc = encodeURIComponent(`${group}/${project}`);
 
-  // 获取 MR 元信息（TGit 不支持 /merge_requests/{iid} 路径，需用 ?iid= 查询）
-  const listResp = await fetch(`${baseUrl}/merge_requests?iid=${mrIid}`, { headers });
-  if (!listResp.ok) {
-    throw new Error(`TGit API 返回错误 ${listResp.status}：${await listResp.text()}`);
+  // ── 1. 获取元信息（TGit 不支持 /merge_requests/{iid} 路径，需用 ?iid= 查询）──
+  const resp = await tgitFetch(`/projects/${enc}/merge_requests?iid=${mrIid}`);
+  if (!resp.ok) {
+    throw new Error(`TGit API 返回错误 ${resp.status}：${await resp.text()}`);
   }
-  const mrList = await listResp.json() as Array<{ id: number; title: string; description: string; author: { username: string }; merged_at: string | null }>;
-  const mr = mrList.find((m) => String(m.id) !== undefined);
+  const mrList = await resp.json() as TGitMR[];
+  if (!Array.isArray(mrList)) {
+    throw new Error(`TGit API 返回了非预期的响应（期望 MR 列表）：${JSON.stringify(mrList).slice(0, 200)}`);
+  }
+  const mr = mrList.find((m) => String(m.iid) === mrIid);
   if (!mr) {
     throw new Error(`TGit MR !${mrIid} 不存在`);
   }
 
-  // 获取 MR diff（使用全局 id，截断至 50KB）
-  const diffResp = await fetch(`${baseUrl}/merge_requests/${mr.id}/changes`, { headers });
+  // ── 2. 获取 diff（使用全局 id，单数 merge_request 路径，截断至 50KB，失败不阻断）──
   let diff = '';
-  if (diffResp.ok) {
-    const diffData = await diffResp.json() as { changes: Array<{ diff: string }> };
-    diff = (diffData.changes ?? []).map((c) => c.diff).join('\n').slice(0, 50000);
+  try {
+    const diffResp = await tgitFetch(`/projects/${enc}/merge_request/${mr.id}/changes`);
+    if (diffResp.ok) {
+      const diffData = await diffResp.json() as TGitChangesResponse;
+      const fileDiffs = diffData.files ?? diffData.changes ?? [];
+      diff = fileDiffs.map((c) => c.diff).join('\n').slice(0, 50000);
+    } else {
+      log.debug(`TGit MR diff 获取失败（${diffResp.status}），diff 将为空`);
+    }
+  } catch (err) {
+    log.debug(`TGit MR diff 获取异常，diff 将为空：${(err as Error).message}`);
   }
 
   return {
     title: mr.title,
     description: mr.description ?? '',
     author: mr.author?.username,
-    mergedAt: mr.merged_at ?? undefined,
-    commits: [],
-    diff,
-    url: `https://git.woa.com/${group}/${project}/merge_requests/${mrIid}`,
-  };
-}
-
-/**
- * 通过 gf CLI 获取 TGit MR 的完整数据，gf CLI 不可用时自动 fallback 到 REST API。
- *
- * 依次执行：
- *   1. `gf mr desc <mr_iid> --repo <group>/<project> --json` 获取元信息
- *   2. `gf mr diff <mr_iid> --repo <group>/<project>` 获取 diff（截断至 50KB）
- *   若 gf CLI 失败，则尝试通过 TGit REST API 获取数据。
- *
- * @param url - TGit MR 完整 web URL，例如 https://git.woa.com/group/repo/merge_requests/456
- * @returns 包含标题、描述、提交列表、diff 的 MRData 对象
- * @throws Error 当 URL 格式不合法或 gf CLI 与 REST API 均调用失败时
- */
-export async function fetchTGitMR(url: string): Promise<MRData> {
-  const { group, project, mrIid } = parseTGitMRUrl(url);
-  const repoArg = `${group}/${project}`;
-
-  log.debug(`fetchTGitMR: ${repoArg}!${mrIid}`);
-
-  // ── 1. 获取元信息（优先 gf CLI，不可用时 fallback 到 REST API）─────────────────
-  let mrDesc: GfMRDesc;
-  try {
-    const result = gfExec(['mr', 'desc', mrIid, '-R', repoArg, '--json']);
-    if (result.status !== 0) {
-      throw new Error(result.stderr || result.stdout);
-    }
-    mrDesc = JSON.parse(result.stdout) as GfMRDesc;
-  } catch (gfErr) {
-    log.debug(`gf CLI 不可用（${(gfErr as Error).message}），尝试 REST API fallback`);
-    try {
-      return await fetchTGitMRViaApi(group, project, mrIid);
-    } catch (apiErr) {
-      throw new Error(
-        `Failed to fetch TGit MR via gf CLI (${(gfErr as Error).message}) ` +
-        `and REST API fallback (${(apiErr as Error).message})`,
-      );
-    }
-  }
-
-  // ── 2. 获取 diff ─────────────────────────────────────────
-  let diff: string;
-  try {
-    const rawDiff = execFileSync('gf', ['mr', 'diff', String(mrIid), '-R', repoArg], {
-      maxBuffer: 50 * 1024 * 1024,
-      encoding: 'utf8',
-    });
-    // 截断至约 50KB（50000 字符）
-    diff = rawDiff.slice(0, 50000);
-  } catch (err) {
-    // diff 获取失败不阻断流程，记录警告并置空
-    log.debug(`gf mr diff 失败，diff 将为空：${(err as Error).message}`);
-    diff = '';
-  }
-
-  // ── 3. 组装结果（gf mr desc 不含 commits 字段，设为空数组） ──
-  return {
-    title: mrDesc.title,
-    description: mrDesc.description ?? '',
-    author: mrDesc.author?.username,
-    mergedAt: mrDesc.merged_at ?? undefined,
+    mergedAt: mr.merged_at ?? mr.resolved_at ?? mr.updated_at ?? undefined,
     commits: [],
     diff,
     url,

--- a/src/providers/tgit/rest-auth.ts
+++ b/src/providers/tgit/rest-auth.ts
@@ -1,0 +1,105 @@
+import { gfGetOAuthToken } from './gf-cli.js';
+import { log } from '../../utils/logger.js';
+
+/** Authentication scheme accepted by the git.woa.com REST API. */
+export type TGitAuthScheme = 'private-token' | 'bearer';
+
+/** Base URL for the TGit REST API (git.woa.com/api/v3). */
+const TGIT_API_BASE = 'https://git.woa.com/api/v3';
+
+/**
+ * The auth scheme confirmed to work earlier this process.
+ *
+ * Once a request succeeds after a scheme fallback, we cache the working
+ * scheme so subsequent calls skip the failed attempt.
+ */
+let cachedScheme: TGitAuthScheme | null = null;
+
+/**
+ * Resolve the TGit REST credential and its matching auth scheme.
+ *
+ * A `TGIT_TOKEN` env var is treated as a git.woa.com Personal Access Token
+ * (works with the `PRIVATE-TOKEN` header). Otherwise the OAuth token stored
+ * in ~/.netrc by `gf auth login` is used (works with `Authorization: Bearer`).
+ *
+ * @returns the token and the auth scheme it requires
+ * @throws Error when no credential is available
+ */
+export function getTGitToken(): { token: string; scheme: TGitAuthScheme } {
+  const envToken = process.env['TGIT_TOKEN'];
+  if (envToken && envToken.length > 0) {
+    return { token: envToken, scheme: 'private-token' };
+  }
+
+  const oauthToken = gfGetOAuthToken();
+  if (oauthToken) {
+    return { token: oauthToken, scheme: 'bearer' };
+  }
+
+  throw new Error(
+    'No TGit credentials found. Set the TGIT_TOKEN environment variable ' +
+    '(a git.woa.com Personal Access Token) or run `gf auth login`.',
+  );
+}
+
+/**
+ * Build the authorization header for the given token and scheme.
+ *
+ * @param token  - the credential value
+ * @param scheme - 'bearer' or 'private-token'
+ * @returns a header object carrying the credential
+ */
+export function tgitAuthHeaders(token: string, scheme: TGitAuthScheme): Record<string, string> {
+  if (scheme === 'bearer') {
+    return { Authorization: `Bearer ${token}` };
+  }
+  return { 'PRIVATE-TOKEN': token };
+}
+
+/**
+ * Fetch a path from the TGit REST API with automatic auth-scheme handling.
+ *
+ * The token and its resolved scheme come from {@link getTGitToken}, unless a
+ * working scheme was cached earlier this process (then the cache wins). On a
+ * 401/403 the request is retried once with the opposite scheme; if that
+ * succeeds the working scheme is cached for later calls.
+ *
+ * @param path - API path beginning with '/', appended to git.woa.com/api/v3
+ * @param init - optional fetch init; its headers and signal are respected
+ * @returns the final Response (callers inspect status themselves)
+ * @throws Error when no TGit credential is available
+ */
+export async function tgitFetch(path: string, init?: RequestInit): Promise<Response> {
+  const { token, scheme: resolvedScheme } = getTGitToken();
+  const scheme = cachedScheme ?? resolvedScheme;
+  const url = `${TGIT_API_BASE}${path}`;
+
+  const callerHeaders = { ...(init?.headers as Record<string, string> | undefined) };
+  const baseHeaders: Record<string, string> = { 'Content-Type': 'application/json', ...callerHeaders };
+
+  // A fresh timeout signal per attempt when the caller supplied none: an
+  // already-fired timeout signal cannot be reused for the fallback retry.
+  const doFetch = (activeScheme: TGitAuthScheme): Promise<Response> => fetch(url, {
+    ...init,
+    headers: { ...baseHeaders, ...tgitAuthHeaders(token, activeScheme) },
+    signal: init?.signal ?? AbortSignal.timeout(15000),
+  });
+
+  const resp = await doFetch(scheme);
+  if (resp.status !== 401 && resp.status !== 403) {
+    return resp;
+  }
+
+  // Auth rejected — retry once with the opposite scheme.
+  const altScheme: TGitAuthScheme = scheme === 'bearer' ? 'private-token' : 'bearer';
+  log.debug(`TGit auth scheme "${scheme}" rejected (${resp.status}); retrying with "${altScheme}"`);
+  const altResp = await doFetch(altScheme);
+  if (altResp.status !== 401 && altResp.status !== 403) {
+    cachedScheme = altScheme;
+    return altResp;
+  }
+  // Both schemes failed: the retry did not help, so the original status is the
+  // meaningful one (e.g. a genuine 403 authorized-but-forbidden, not a scheme
+  // mismatch). Returning it avoids inverting the caller's 401-vs-403 remedy.
+  return resp;
+}


### PR DESCRIPTION
## Problem

The TeamAI MR knowledge-extract CI pipeline failed on **every** run. Root causes, verified live against `git.woa.com/api/v3`:

1. **Wrong auth scheme.** All TGit REST calls sent `Authorization: Bearer`, but a git.woa.com Personal Access Token only authenticates via `PRIVATE-TOKEN`/`private_token` (Bearer → 401/403). OAuth tokens are the opposite.
2. **Nonexistent gf commands.** `fetchTGitMR` called `gf mr desc` / `gf mr diff` — neither exists, and the gf CLI cannot return an MR diff at all.
3. **Wrong diff endpoint/payload.** Needed singular `merge_request/{globalId}/changes`; this TGit version returns the diff under `files[]`, not `changes[]`; `merged_at` is not returned.

## Changes

- **New `src/providers/tgit/rest-auth.ts`** — centralized `tgitFetch()`: `PRIVATE-TOKEN` for a PAT (`TGIT_TOKEN` env), `Bearer` for an OAuth token (`~/.netrc`), with a one-shot 401/403 scheme fallback + process-level cache.
- **`mr-fetch.ts` → REST-only** — removed the dead gf branch; fixed the diff endpoint (singular path, read `files[]`/`changes[]`), `merged_at → resolved_at → updated_at` fallback, and an always-true MR match.
- Routed all TGit REST callers (`gf-cli`, `mr-comment`, `read-rejections`, `extract-mr`, `gf-org`, `mr-hint`) through the helper.
- **Renamed the TGit token env var `TAI_PAT_TOKEN` → `TGIT_TOKEN`** (TGit usages only; iWiki's `TAI_PAT_TOKEN` is a different token and is left untouched).
- **CI examples:** consolidate repo config into a top-level `env:` block and add the GitHub-Actions example. **Supersedes #195** (folds in its refactor, reconciled to `TGIT_TOKEN`).
- Added `rest-auth` unit tests; made the `gf-org` no-credentials test env-independent.

## Test Plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — success
- [x] `npx vitest run` — 1680 passed
- [x] Real E2E against MR 206: fetched title / author / description / 50KB diff / merged timestamp via **both** the PAT (`TGIT_TOKEN`) path and the OAuth (`~/.netrc`) fallback path — the exact step that previously 401'd.

> Note for deployers: the ZhiYan pipeline secret must be renamed `TAI_PAT_TOKEN` → `TGIT_TOKEN` and pointed at a valid git.woa.com PAT (with `api` scope + write to the knowledge repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)