### PR TITLE
fix(push): clear timeout timer after push settles to avoid event-loop hang

### DIFF
--- a/src/__tests__/async-timeout.test.ts
+++ b/src/__tests__/async-timeout.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest';
+import { withTimeout } from '../utils/async.js';
+
+describe('withTimeout', () => {
+  it('returns the promise value when it resolves before the timeout', async () => {
+    const result = await withTimeout(Promise.resolve('ok'), 5000, 'boom');
+    expect(result).toBe('ok');
+  });
+
+  it('rejects with the timeout message when the promise exceeds the timeout', async () => {
+    const never = new Promise<string>(() => {});
+    await expect(withTimeout(never, 20, 'timed out')).rejects.toThrow('timed out');
+  });
+
+  it('propagates the promise rejection when it rejects before the timeout', async () => {
+    await expect(
+      withTimeout(Promise.reject(new Error('push failed')), 5000, 'timed out'),
+    ).rejects.toThrow('push failed');
+  });
+
+  // ── The actual bug fix: a plain Promise.race leaves the losing setTimeout
+  //    pending, pinning the event loop for the full timeoutMs after a fast
+  //    success. withTimeout must clear it so the process can exit promptly.
+  it('clears the timeout timer when the promise resolves first (no event-loop leak)', async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+
+    try {
+      const result = await withTimeout(Promise.resolve('ok'), 5000, 'boom');
+      expect(result).toBe('ok');
+
+      // Exactly one timer was scheduled by withTimeout ...
+      expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+      const scheduledTimer = setTimeoutSpy.mock.results[0].value;
+      // ... and it was cleared once the push settled, so it cannot pin the loop.
+      expect(clearTimeoutSpy).toHaveBeenCalledWith(scheduledTimer);
+    } finally {
+      setTimeoutSpy.mockRestore();
+      clearTimeoutSpy.mockRestore();
+    }
+  });
+
+  it('clears the timeout timer when the promise rejects first', async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+
+    try {
+      await expect(
+        withTimeout(Promise.reject(new Error('nope')), 5000, 'boom'),
+      ).rejects.toThrow('nope');
+
+      const scheduledTimer = setTimeoutSpy.mock.results[0].value;
+      expect(clearTimeoutSpy).toHaveBeenCalledWith(scheduledTimer);
+    } finally {
+      setTimeoutSpy.mockRestore();
+      clearTimeoutSpy.mockRestore();
+    }
+  });
+
+  it('does not keep the process alive after a fast success', async () => {
+    // A regression here would leave a pending 5s timer: even though the call
+    // returns immediately, the Node process would not exit for ~5s. We assert
+    // the handles clear by checking no extra timer survives the await.
+    const before = process.getActiveResourcesInfo?.() ?? [];
+    const baselineTimers = before.filter((t) => t === 'Timeout').length;
+
+    await withTimeout(Promise.resolve('ok'), 5000, 'boom');
+
+    const after = process.getActiveResourcesInfo?.() ?? [];
+    const afterTimers = after.filter((t) => t === 'Timeout').length;
+    expect(afterTimers).toBe(baselineTimers);
+  });
+});

--- a/src/contribute.ts
+++ b/src/contribute.ts
@@ -4,6 +4,7 @@ import fse from 'fs-extra';
 import { requireInit, detectProjectConfig, loadTeamConfig, loadLocalConfigForScope } from './config.js';
 import { assertNotReadOnly } from './read-only.js';
 import { pushRepoDirectly, pullRepo } from './utils/git.js';
+import { withTimeout } from './utils/async.js';
 import { ensureDir, pathExists } from './utils/fs.js';
 import { log, spinner } from './utils/logger.js';
 import { markContributed } from './contribute-check.js';
@@ -168,19 +169,15 @@ export async function contribute(
       log.debug(`contribute: index rebuild skipped: ${(e as Error).message}`);
     }
 
-    // Push directly to master with timeout
+    // Push directly to master with timeout. withTimeout clears its timer once
+    // the push settles, so a fast push does not leave a 10s timer pinning the
+    // event loop (and hanging the CLI) after the work is done.
     const commitMsg = `[teamai] Contribute session knowledge from ${username}`;
-    const pushPromise = pushRepoDirectly(
-      repoPath,
-      commitMsg,
-      [`learnings/${filename}`],
+    await withTimeout(
+      pushRepoDirectly(repoPath, commitMsg, [`learnings/${filename}`]),
+      10_000,
+      'Push timeout (10s)',
     );
-
-    const timeoutPromise = new Promise<never>((__, reject) =>
-      setTimeout(() => reject(new Error('Push timeout (10s)')), 10_000),
-    );
-
-    await Promise.race([pushPromise, timeoutPromise]);
 
     pushSpin.succeed(`Contributed: learnings/${filename}`);
 

--- a/src/team-push.ts
+++ b/src/team-push.ts
@@ -4,6 +4,7 @@ import { readUsageEvents, truncateUsageAfterReport } from './usage-tracker.js';
 import { aggregateUsage } from './stats.js';
 import { readEvents, aggregateSessionMetrics } from './dashboard-collector.js';
 import { createGit, pushRepoDirectly, pullRepo, resetToCleanMaster } from './utils/git.js';
+import { withTimeout } from './utils/async.js';
 import { writeFile, readFileSafe, ensureDir, pathExists, readJson, writeJson } from './utils/fs.js';
 import { log } from './utils/logger.js';
 import type { UserStats, UserInterventionStats, SessionMetrics, TokenUsage, DashboardEvent } from './types.js';
@@ -385,13 +386,14 @@ export async function reportUsageToTeam(
       : (hasInterventions || hasPromptTokens)
         ? `[teamai] Update session stats for ${username}`
         : `[teamai] Update votes for ${username}`;
-    const pushPromise = pushRepoDirectly(repoPath, commitMsg, filesToPush);
-
-    const timeoutPromise = new Promise<never>((__, reject) =>
-      setTimeout(() => reject(new Error('Auto-report timeout (5s)')), 5000),
+    // Guard the push with a 5s timeout. withTimeout clears its timer once the
+    // push settles, so a fast success does not leave a 5s timer pinning the
+    // event loop (and hanging `teamai pull`) after the work is done.
+    await withTimeout(
+      pushRepoDirectly(repoPath, commitMsg, filesToPush),
+      5000,
+      'Auto-report timeout (5s)',
     );
-
-    await Promise.race([pushPromise, timeoutPromise]);
 
     // Success — truncate reported usage events (only if caller allows it)
     if (hasUsage && !options?.skipTruncate) {

--- a/src/utils/async.ts
+++ b/src/utils/async.ts
@@ -1,0 +1,36 @@
+// ─── Promise / timer helpers ───────────────────────────
+
+/**
+ * Race a promise against a timeout, and — crucially — clear the timeout timer
+ * when the promise settles first.
+ *
+ * A plain `Promise.race([promise, timeoutPromise])` leaves the losing timer
+ * pending on the Node event loop: when `promise` resolves quickly, the timeout
+ * callback stays scheduled and keeps the process alive for the full `timeoutMs`
+ * after all real work has finished. For a hook-driven CLI this is a frequent,
+ * very visible hang — e.g. `teamai pull` auto-reporting usage pushes with a 5s
+ * guard would sit idle at the terminal for ~5s on every successful push.
+ *
+ * Clearing the timer on the fast path lets the process exit as soon as its work
+ * is done, while still rejecting promptly if `promise` exceeds `timeoutMs`.
+ *
+ * @returns the resolved value of `promise`
+ * @throws  `Error(message)` if `timeoutMs` elapses before `promise` settles,
+ *          or whatever `promise` rejects with otherwise.
+ */
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
## Problem

`reportUsageToTeam` (run from `pull()` on every `teamai pull` that has usage events to report — i.e. on most session-start hook fires) and `contribute()` both guarded their git push with a plain `Promise.race`:

```ts
const pushPromise = pushRepoDirectly(repoPath, commitMsg, filesToPush);
const timeoutPromise = new Promise<never>((__, reject) =>
  setTimeout(() => reject(new Error('Auto-report timeout (5s)')), 5000),
);
await Promise.race([pushPromise, timeoutPromise]);
```

When the push resolves quickly — the normal case — **the losing `setTimeout` is never cleared**. It stays pending on the Node event loop, so the process hangs at the terminal for the full `5000` ms (pull) / `10_000` ms (contribute) *after all real work has finished*.

Because `teamai pull` runs from session-start hooks, this hang recurred on nearly every session and was very visible. `clearTimeout` never appears in either file; by contrast `clone.ts` already implements the correct pattern (`clearTimeout(timer)` in both the `close` and `error` handlers).

## Fix

Replace both sites with a shared `withTimeout()` helper (`src/utils/async.ts`) that clears its timer in a `finally` once the guarded promise settles:

```ts
export async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
  let timer: ReturnType<typeof setTimeout> | undefined;
  const timeoutPromise = new Promise<never>((_, reject) => {
    timer = setTimeout(() => reject(new Error(message)), timeoutMs);
  });
  try {
    return await Promise.race([promise, timeoutPromise]);
  } finally {
    if (timer) clearTimeout(timer);
  }
}
```

Behavior is otherwise unchanged: it still rejects with the timeout message if the push exceeds the budget, and propagates the push's own rejection if it fails first.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — succeeds
- [x] `npm test` — 1766 passed (1760 baseline + 6 new)
- [x] New unit tests (`src/__tests__/async-timeout.test.ts`) assert the timer is cleared on both the success and failure paths, plus a handle-count check that no timer survives a fast success.
- [x] End-to-end timing demo (inlined old vs new pattern, 3000 ms budget, ~60 ms push):
  - OLD: race returns in 62 ms, but `real 3.04s` — process hangs on the leaked timer.
  - NEW: race returns in 62 ms, `real 0.11s` — process exits promptly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)