### PR TITLE
fix(codebase): persist git baseline in source-manifest & real git-diff incremental

### DIFF
--- a/src/codebase-cmd.ts
+++ b/src/codebase-cmd.ts
@@ -225,7 +225,14 @@ async function printCodebaseStatus(opts: CodebaseCmdOptions): Promise<void> {
         }
     }
     const manifestPath = path.join(teamwikiDir, 'source-manifest.json');
-    let manifest: { headSha?: string; repoUrl?: string; branch?: string; lastScan?: string; files?: unknown[] };
+    let manifest: {
+        headSha?: string;
+        repoUrl?: string;
+        branch?: string;
+        lastScan?: string;
+        files?: unknown[];
+        ingestedMrs?: Array<{ url: string; headSha?: string; at: string }>;
+    };
     try {
         manifest = JSON.parse(await readFile(manifestPath, 'utf-8'));
     } catch {
@@ -244,6 +251,7 @@ async function printCodebaseStatus(opts: CodebaseCmdOptions): Promise<void> {
             branch: manifest.branch ?? null,
             lastScan: manifest.lastScan ?? null,
             fileCount: Array.isArray(manifest.files) ? manifest.files.length : 0,
+            ingestedMrs: manifest.ingestedMrs ?? [],
         }, null, 2));
         return;
     }
@@ -253,4 +261,10 @@ async function printCodebaseStatus(opts: CodebaseCmdOptions): Promise<void> {
     console.log(`  branch:   ${manifest.branch ?? chalk.dim('(none)')}`);
     console.log(`  lastScan: ${manifest.lastScan ?? chalk.dim('(none)')}`);
     console.log(`  files:    ${Array.isArray(manifest.files) ? manifest.files.length : 0}`);
+    const mrs = manifest.ingestedMrs ?? [];
+    console.log(`  ingested MRs: ${mrs.length}`);
+    for (const mr of mrs) {
+        const sha = mr.headSha ? mr.headSha.slice(0, 8) : '(no sha)';
+        console.log(`    - ${mr.url}  @${sha}  ${mr.at}`);
+    }
 }

--- a/src/codebase-cmd.ts
+++ b/src/codebase-cmd.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { readFile } from 'node:fs/promises';
 
 import chalk from 'chalk';
 
@@ -25,6 +26,7 @@ export interface CodebaseCmdOptions extends GlobalOptions {
     output?: string;
     project?: string;
     maxFiles?: string;
+    status?: boolean;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -81,6 +83,11 @@ export async function codebaseCmd(opts: CodebaseCmdOptions): Promise<void> {
             project: opts.project,
             maxFiles: opts.maxFiles ? parseInt(opts.maxFiles, 10) : undefined,
         });
+        return;
+    }
+
+    if (opts.status) {
+        await printCodebaseStatus(opts);
         return;
     }
 
@@ -195,4 +202,55 @@ export async function codebaseCmd(opts: CodebaseCmdOptions): Promise<void> {
             process.exitCode = 1;
         }
     }
+}
+
+/**
+ * Print the git baseline recorded in teamwiki/source-manifest.json.
+ *
+ * Reports headSha / repoUrl / branch / lastScan / file count so users can
+ * tell which commit the knowledge base corresponds to.
+ */
+async function printCodebaseStatus(opts: CodebaseCmdOptions): Promise<void> {
+    const cwd = process.cwd();
+    let teamwikiDir: string;
+    if (opts.output) {
+        teamwikiDir = path.resolve(opts.output, 'teamwiki');
+    } else {
+        try {
+            const { autoDetectInit } = await import('./config.js');
+            const { localConfig: lc } = await autoDetectInit();
+            teamwikiDir = path.join(lc.repo.localPath, 'teamwiki');
+        } catch {
+            teamwikiDir = path.join(cwd, '.teamai', 'team-repo', 'teamwiki');
+        }
+    }
+    const manifestPath = path.join(teamwikiDir, 'source-manifest.json');
+    let manifest: { headSha?: string; repoUrl?: string; branch?: string; lastScan?: string; files?: unknown[] };
+    try {
+        manifest = JSON.parse(await readFile(manifestPath, 'utf-8'));
+    } catch {
+        if (opts.json) {
+            console.log(JSON.stringify({ error: 'no-manifest', manifestPath }));
+        } else {
+            console.log(chalk.yellow(`No source-manifest.json found at ${manifestPath}`));
+        }
+        process.exitCode = 1;
+        return;
+    }
+    if (opts.json) {
+        console.log(JSON.stringify({
+            headSha: manifest.headSha ?? null,
+            repoUrl: manifest.repoUrl ?? null,
+            branch: manifest.branch ?? null,
+            lastScan: manifest.lastScan ?? null,
+            fileCount: Array.isArray(manifest.files) ? manifest.files.length : 0,
+        }, null, 2));
+        return;
+    }
+    console.log(chalk.bold('Knowledge-base baseline'));
+    console.log(`  headSha:  ${manifest.headSha ?? chalk.dim('(none)')}`);
+    console.log(`  repoUrl:  ${manifest.repoUrl ?? chalk.dim('(none)')}`);
+    console.log(`  branch:   ${manifest.branch ?? chalk.dim('(none)')}`);
+    console.log(`  lastScan: ${manifest.lastScan ?? chalk.dim('(none)')}`);
+    console.log(`  files:    ${Array.isArray(manifest.files) ? manifest.files.length : 0}`);
 }

--- a/src/codebase-extract.ts
+++ b/src/codebase-extract.ts
@@ -49,6 +49,8 @@ export interface ExtractCodebaseOptions {
   repoUrl?: string;
   /** Branch name, persisted into source-manifest.json baseline. */
   branch?: string;
+  /** Source MR/PR URL to record as ingested into source-manifest.json (P5). */
+  sourceMrUrl?: string;
 }
 
 interface ExtractResult {
@@ -777,11 +779,18 @@ export async function extractCodebase(opts: ExtractCodebaseOptions): Promise<voi
   // Persist git baseline from prior incremental manifest when not explicitly supplied
   let prevRepoUrl: string | undefined;
   let prevBranch: string | undefined;
-  if (opts.incremental) {
+  let prevIngestedMrs: Array<{ url: string; headSha?: string; at: string }> = [];
+  // Load prior baseline on incremental, or when recording a MR (preserve existing ingestedMrs).
+  if (opts.incremental || opts.sourceMrUrl) {
     try {
-      const prev = JSON.parse(await readFile(manifestPath, 'utf-8')) as { repoUrl?: string; branch?: string };
+      const prev = JSON.parse(await readFile(manifestPath, 'utf-8')) as {
+        repoUrl?: string;
+        branch?: string;
+        ingestedMrs?: Array<{ url: string; headSha?: string; at: string }>;
+      };
       prevRepoUrl = prev.repoUrl;
       prevBranch = prev.branch;
+      prevIngestedMrs = prev.ingestedMrs ?? [];
     } catch { /* no prior manifest */ }
   }
 
@@ -796,6 +805,14 @@ export async function extractCodebase(opts: ExtractCodebaseOptions): Promise<voi
   const branch = opts.branch ?? prevBranch;
   if (repoUrl) manifestObject.repoUrl = repoUrl;
   if (branch) manifestObject.branch = branch;
+  // P5: record ingested MR (upsert by url) when invoked via --from-mr
+  let ingestedMrs = prevIngestedMrs;
+  if (opts.sourceMrUrl) {
+    const at = new Date().toISOString();
+    const entry = { url: opts.sourceMrUrl, headSha, at };
+    ingestedMrs = [...prevIngestedMrs.filter((m) => m.url !== opts.sourceMrUrl), entry];
+  }
+  if (ingestedMrs.length > 0) manifestObject.ingestedMrs = ingestedMrs;
   const manifestContent = JSON.stringify(manifestObject, null, 2);
   await writeFile(manifestPath, manifestContent, 'utf-8');
 

--- a/src/codebase-extract.ts
+++ b/src/codebase-extract.ts
@@ -45,6 +45,10 @@ export interface ExtractCodebaseOptions {
   skipEnrich?: boolean;
   /** 产出根目录（teamwiki/ 写到此目录下）。默认与 path 相同。 */
   outputRoot?: string;
+  /** Remote repository URL, persisted into source-manifest.json baseline. */
+  repoUrl?: string;
+  /** Branch name, persisted into source-manifest.json baseline. */
+  branch?: string;
 }
 
 interface ExtractResult {
@@ -770,15 +774,29 @@ export async function extractCodebase(opts: ExtractCodebaseOptions): Promise<voi
     const deletedSet = new Set(deletedFiles);
     allManifestFiles = allManifestFiles.filter(f => !deletedSet.has(f.relativePath));
   }
-  const manifestContent = JSON.stringify(
-    {
-      version: 1,
-      lastScan: new Date().toISOString(),
-      files: allManifestFiles,
-    },
-    null,
-    2,
-  );
+  // Persist git baseline from prior incremental manifest when not explicitly supplied
+  let prevRepoUrl: string | undefined;
+  let prevBranch: string | undefined;
+  if (opts.incremental) {
+    try {
+      const prev = JSON.parse(await readFile(manifestPath, 'utf-8')) as { repoUrl?: string; branch?: string };
+      prevRepoUrl = prev.repoUrl;
+      prevBranch = prev.branch;
+    } catch { /* no prior manifest */ }
+  }
+
+  const headSha = collectionManifest.commit;
+  const manifestObject: Record<string, unknown> = {
+    version: 1,
+    lastScan: new Date().toISOString(),
+    files: allManifestFiles,
+  };
+  if (headSha) manifestObject.headSha = headSha;
+  const repoUrl = opts.repoUrl ?? prevRepoUrl;
+  const branch = opts.branch ?? prevBranch;
+  if (repoUrl) manifestObject.repoUrl = repoUrl;
+  if (branch) manifestObject.branch = branch;
+  const manifestContent = JSON.stringify(manifestObject, null, 2);
   await writeFile(manifestPath, manifestContent, 'utf-8');
 
   const byKind: Record<string, number> = {};

--- a/src/codebase-extract.ts
+++ b/src/codebase-extract.ts
@@ -780,19 +780,19 @@ export async function extractCodebase(opts: ExtractCodebaseOptions): Promise<voi
   let prevRepoUrl: string | undefined;
   let prevBranch: string | undefined;
   let prevIngestedMrs: Array<{ url: string; headSha?: string; at: string }> = [];
-  // Load prior baseline on incremental, or when recording a MR (preserve existing ingestedMrs).
-  if (opts.incremental || opts.sourceMrUrl) {
-    try {
-      const prev = JSON.parse(await readFile(manifestPath, 'utf-8')) as {
-        repoUrl?: string;
-        branch?: string;
-        ingestedMrs?: Array<{ url: string; headSha?: string; at: string }>;
-      };
-      prevRepoUrl = prev.repoUrl;
-      prevBranch = prev.branch;
-      prevIngestedMrs = prev.ingestedMrs ?? [];
-    } catch { /* no prior manifest */ }
-  }
+  // Always carry forward prior baseline provenance (repoUrl / branch /
+  // ingestedMrs) so a full re-extract does not silently drop it. A missing
+  // or unreadable manifest just leaves the defaults.
+  try {
+    const prev = JSON.parse(await readFile(manifestPath, 'utf-8')) as {
+      repoUrl?: string;
+      branch?: string;
+      ingestedMrs?: Array<{ url: string; headSha?: string; at: string }>;
+    };
+    prevRepoUrl = prev.repoUrl;
+    prevBranch = prev.branch;
+    prevIngestedMrs = prev.ingestedMrs ?? [];
+  } catch { /* no prior manifest */ }
 
   const headSha = collectionManifest.commit;
   const manifestObject: Record<string, unknown> = {

--- a/src/import-repo.ts
+++ b/src/import-repo.ts
@@ -56,6 +56,8 @@ export interface ImportFromRepoOptions {
     skipAutoPush?: boolean;
     /** Skip AI enrichment (only clone + extract + graph, no LLM calls) */
     skipEnrich?: boolean;
+    /** Source MR/PR URL to record as ingested (P5, passed through to extractCodebase). */
+    sourceMrUrl?: string;
 }
 
 // ─── Cross-Repo Edge Detection ─────────────────────────
@@ -537,7 +539,7 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
     const {
         url, depth = 1, forceSsh = false, forceAnonymous = false,
         explicitDomain, dryRun = false, output, interactive = true,
-        incremental = false, skipAutoPush = false, skipEnrich = false,
+        incremental = false, skipAutoPush = false, skipEnrich = false, sourceMrUrl,
     } = opts;
 
     // 1. Parse provider and repo info
@@ -684,6 +686,7 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
                 path: cacheDir, project: slug, json: false, skipEnrich, incremental,
                 repoUrl: url,
                 branch: cloneBranch === 'HEAD' ? undefined : cloneBranch,
+                sourceMrUrl,
             });
             // Move artifacts from cacheDir/teamwiki/ to target teamwikiRoot
             if (await fs.pathExists(cacheWiki)) {

--- a/src/import-repo.ts
+++ b/src/import-repo.ts
@@ -680,7 +680,11 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
                     await fs.copy(existingManifest, path.join(cacheDir, 'teamwiki', 'source-manifest.json'));
                 }
             }
-            await extractCodebase({ path: cacheDir, project: slug, json: false, skipEnrich, incremental });
+            await extractCodebase({
+                path: cacheDir, project: slug, json: false, skipEnrich, incremental,
+                repoUrl: url,
+                branch: cloneBranch === 'HEAD' ? undefined : cloneBranch,
+            });
             // Move artifacts from cacheDir/teamwiki/ to target teamwikiRoot
             if (await fs.pathExists(cacheWiki)) {
                 const evidenceSrc = path.join(cacheWiki, 'evidence', 'code', slug);

--- a/src/import.ts
+++ b/src/import.ts
@@ -229,6 +229,7 @@ export async function importCmd(opts: ImportOptions): Promise<void> {
                   incremental: true,
                   interactive: false,
                   skipAutoPush: true,
+                  sourceMrUrl: opts.fromMr,
                 });
                 ctx.didUpdate = true;
               } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -709,6 +709,7 @@ program
   .addOption(new Option('--upgrade-wiki', 'Migrate docs/team-codebase/ to teamwiki/ graph format').hideHelp())
   .option('--lint', 'Run global consistency lint over docs/team-codebase')
   .option('--fix', 'Apply low-risk mechanical fixes (only with --lint)')
+  .option('--status', 'Show knowledge-base git baseline (headSha / repoUrl / branch)')
   .addOption(new Option('--severity <level>', 'Minimum severity to report: high|medium|low|info').default('info').hideHelp())
   .addOption(new Option('--stale-days <n>', 'Threshold for sync-stale check').default('60').hideHelp())
   .addOption(new Option('--pending-review-threshold <n>', 'Threshold for pending-review backlog').default('10').hideHelp())

--- a/src/wiki-engine/code-knowledge/code-collector.ts
+++ b/src/wiki-engine/code-knowledge/code-collector.ts
@@ -153,6 +153,20 @@ export async function gitCommit(root: string): Promise<string | undefined> {
 }
 
 /**
+ * Report whether the git working tree at root is clean (no staged, unstaged,
+ * or untracked changes). Returns false when git is unavailable, so callers
+ * treat "unknown" as dirty and fall back to a full scan.
+ */
+export async function isWorkingTreeClean(root: string): Promise<boolean> {
+  try {
+    const { stdout } = await execFileAsync("git", ["-C", root, "status", "--porcelain"]);
+    return stdout.trim().length === 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Compute changed files between two git commits via `git diff --name-status`.
  *
  * Returns added/changed/deleted relative paths (POSIX-normalized). Renames
@@ -166,7 +180,7 @@ export async function gitDiffNameStatus(
   newSha: string,
 ): Promise<{ added: string[]; changed: string[]; deleted: string[] } | null> {
   try {
-    const { stdout } = await execFileAsync("git", ["-C", root, "diff", "--name-status", "-M", "-C", oldSha, newSha]);
+    const { stdout } = await execFileAsync("git", ["-C", root, "-c", "core.quotePath=false", "diff", "--name-status", "-M", "-C", oldSha, newSha]);
     const added: string[] = [];
     const changed: string[] = [];
     const deleted: string[] = [];

--- a/src/wiki-engine/code-knowledge/code-collector.ts
+++ b/src/wiki-engine/code-knowledge/code-collector.ts
@@ -143,12 +143,59 @@ function languageFor(filePath: string): string {
   return map[ext] ?? "text";
 }
 
-async function gitCommit(root: string): Promise<string | undefined> {
+export async function gitCommit(root: string): Promise<string | undefined> {
   try {
     const { stdout } = await execFileAsync("git", ["-C", root, "rev-parse", "HEAD"]);
     return stdout.trim() || undefined;
   } catch {
     return undefined;
+  }
+}
+
+/**
+ * Compute changed files between two git commits via `git diff --name-status`.
+ *
+ * Returns added/changed/deleted relative paths (POSIX-normalized). Renames
+ * are decomposed into a delete of the old path and an add of the new path.
+ * Returns null when git is unavailable or the diff fails, so callers can
+ * fall back to full sha256 comparison.
+ */
+export async function gitDiffNameStatus(
+  root: string,
+  oldSha: string,
+  newSha: string,
+): Promise<{ added: string[]; changed: string[]; deleted: string[] } | null> {
+  try {
+    const { stdout } = await execFileAsync("git", ["-C", root, "diff", "--name-status", "-M", "-C", oldSha, newSha]);
+    const added: string[] = [];
+    const changed: string[] = [];
+    const deleted: string[] = [];
+    for (const line of stdout.split("\n")) {
+      if (!line.trim()) continue;
+      const parts = line.split("\t");
+      const status = parts[0];
+      if (status === "A" && parts.length >= 2) {
+        added.push(toPosix(parts[1]));
+      } else if (status === "M" && parts.length >= 2) {
+        changed.push(toPosix(parts[1]));
+      } else if (status === "D" && parts.length >= 2) {
+        deleted.push(toPosix(parts[1]));
+      } else if (status.startsWith("R") && parts.length >= 3) {
+        // rename: old path deleted, new path added
+        deleted.push(toPosix(parts[1]));
+        added.push(toPosix(parts[2]));
+      } else if (status.startsWith("C") && parts.length >= 3) {
+        // copy: only the new path is added
+        added.push(toPosix(parts[2]));
+      }
+      // malformed or other status codes are ignored
+    }
+    added.sort();
+    changed.sort();
+    deleted.sort();
+    return { added, changed, deleted };
+  } catch {
+    return null;
   }
 }
 

--- a/src/wiki-engine/code-knowledge/code-incremental.ts
+++ b/src/wiki-engine/code-knowledge/code-incremental.ts
@@ -1,7 +1,7 @@
 import { readFile, writeFile, stat, mkdir } from "node:fs/promises";
 import path from "node:path";
 
-import { collectCode, gitCommit, gitDiffNameStatus } from "./code-collector.js";
+import { collectCode, gitCommit, gitDiffNameStatus, isWorkingTreeClean } from "./code-collector.js";
 import type { CodeFact } from "./code-extractors.js";
 import type { InterfaceInventory } from "../interface-scanner.js";
 
@@ -27,8 +27,11 @@ export async function detectCodeIncrementalChanges(
   const oldSha = previous.headSha;
   const newSha = await gitCommit(root);
 
-  // Git incremental path: use git diff when both commits are known
-  if (oldSha && newSha) {
+  // Git incremental path: only when both commits are known AND the working
+  // tree is clean. A dirty tree has uncommitted/untracked changes that a
+  // commit-to-commit diff cannot see, so we fall back to the full sha256
+  // scan (which reads the working tree) to avoid silent staleness.
+  if (oldSha && newSha && (await isWorkingTreeClean(root))) {
     const gitChanges = await gitDiffNameStatus(root, oldSha, newSha);
     if (gitChanges !== null) {
       const { added, changed, deleted } = gitChanges;

--- a/src/wiki-engine/code-knowledge/code-incremental.ts
+++ b/src/wiki-engine/code-knowledge/code-incremental.ts
@@ -1,7 +1,7 @@
 import { readFile, writeFile, stat, mkdir } from "node:fs/promises";
 import path from "node:path";
 
-import { collectCode } from "./code-collector.js";
+import { collectCode, gitCommit, gitDiffNameStatus } from "./code-collector.js";
 import type { CodeFact } from "./code-extractors.js";
 import type { InterfaceInventory } from "../interface-scanner.js";
 
@@ -12,13 +12,44 @@ export interface CodeIncrementalChange {
   affectedPages: string[];
 }
 
-export async function detectCodeIncrementalChanges(root: string, manifestPath: string, project: string): Promise<CodeIncrementalChange> {
-  const previous = (await exists(manifestPath)) ? (JSON.parse(await readFile(manifestPath, "utf8")) as { files?: Array<{ relativePath: string; sha256: string }> }) : { files: [] };
+export async function detectCodeIncrementalChanges(
+  root: string,
+  manifestPath: string,
+  project: string,
+): Promise<CodeIncrementalChange> {
+  const previous = (await exists(manifestPath))
+    ? (JSON.parse(await readFile(manifestPath, "utf8")) as {
+        headSha?: string;
+        files?: Array<{ relativePath: string; sha256: string }>;
+      })
+    : { files: [] };
+
+  const oldSha = previous.headSha;
+  const newSha = await gitCommit(root);
+
+  // Git incremental path: use git diff when both commits are known
+  if (oldSha && newSha) {
+    const gitChanges = await gitDiffNameStatus(root, oldSha, newSha);
+    if (gitChanges !== null) {
+      const { added, changed, deleted } = gitChanges;
+      return {
+        added,
+        changed,
+        deleted,
+        affectedPages: affectedPages(project, [...added, ...changed, ...deleted]),
+      };
+    }
+  }
+
+  // Fallback: full sha256 comparison when git is unavailable or no baseline
   const current = await collectCode({ root });
   const previousByPath = new Map((previous.files ?? []).map((file) => [file.relativePath, file.sha256]));
   const currentByPath = new Map(current.manifest.files.map((file) => [file.relativePath, file.sha256]));
   const added = [...currentByPath.keys()].filter((file) => !previousByPath.has(file)).sort();
-  const changed = [...currentByPath.entries()].filter(([file, sha]) => previousByPath.has(file) && previousByPath.get(file) !== sha).map(([file]) => file).sort();
+  const changed = [...currentByPath.entries()]
+    .filter(([file, sha]) => previousByPath.has(file) && previousByPath.get(file) !== sha)
+    .map(([file]) => file)
+    .sort();
   const deleted = [...previousByPath.keys()].filter((file) => !currentByPath.has(file)).sort();
   return { added, changed, deleted, affectedPages: affectedPages(project, [...added, ...changed, ...deleted]) };
 }


### PR DESCRIPTION
## Summary

Fixes #213. `source-manifest.json` had no git baseline: the collected HEAD commit was dropped on write, so `--incremental` fell back to a full sha256 rescan and there was no way to tell which commit the knowledge base corresponded to. This PR persists the baseline, makes incremental a real git diff, and records ingested MRs.

## What changed

**1. Persist git baseline (`headSha` / `repoUrl` / `branch`)**
- `source-manifest.json` now stores `headSha` (from the already-collected `collectCode().manifest.commit`), plus `repoUrl` / `branch` threaded from `import --from-repo`.
- A full re-extract carries these forward instead of dropping them.

**2. Real git-diff incremental**
- `detectCodeIncrementalChanges` uses `git diff --name-status -M -C <oldSha> <newSha>` when a baseline exists, decomposing renames/copies into delete+add.
- Falls back to the original sha256 full scan when git is unavailable, there is no baseline, **or the working tree is dirty** (a commit-to-commit diff cannot see uncommitted/untracked changes).
- `-c core.quotePath=false` so non-ASCII paths are not octal-quoted.

**3. Observability — `teamai codebase --status`**
- Prints the knowledge-base baseline (`headSha` / `repoUrl` / `branch` / `lastScan` / file count) and the ingested-MR list, in text or `--json`.

**4. Record ingested MRs (P5)**
- `source-manifest.json` gains `ingestedMrs: [{ url, headSha?, at }]`, upserted by url on each `--from-mr` refresh, so batched catch-up ("are MRs !225–!234 in yet?") is answerable.

## Scope notes
- The issue's claim that `importFromRepo` never passes `incremental` is **not accurate** against current code — it already does; no change needed there.
- `--from-mr`'s conditional teamwiki refresh (orchestrated in `import.ts`) is intentionally gated on an existing evidence dir: first-time ingestion is `--from-repo`'s job. Not treated as a bug.

## Test Plan
All executed against the built CLI on real git repos:
- [x] `tsc --noEmit`, `npm run build`, full unit suite (1674 tests) green
- [x] Full extract → `source-manifest.json` contains `headSha` matching `git rev-parse HEAD`
- [x] Incremental after commit → git-diff yields exact changed/added/deleted set (verified against `git diff`); `headSha` advances
- [x] Rename (`git mv`) → decomposed to delete old + add new in the manifest
- [x] **Dirty tree** incremental → falls back to sha256 and picks up uncommitted + untracked files
- [x] Non-git directory → no `headSha` written; incremental falls back without crashing
- [x] `teamai codebase --status` (text + `--json`) prints baseline and ingested MRs
- [x] `ingestedMrs` upsert: first MR → 1 entry; same url again → still 1; different url → 2
- [x] Full re-extract preserves prior `repoUrl` / `branch` / `ingestedMrs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)