### PR TITLE
fix(local-agent): install workspace-scope resources at project level

### DIFF
--- a/src/__tests__/local-agent.test.ts
+++ b/src/__tests__/local-agent.test.ts
@@ -503,3 +503,66 @@ describe('local-agent: skill directory naming (SKILL.md name vs server slug)', (
     expect(manifest.scopes.user.skills['server-slug-xyz'].dir_name).toBeUndefined();
   });
 });
+
+describe('local-agent: normalizeScope — workspace scope installs to project dir', () => {
+  const port = 42001;
+
+  it('installs to project-level skills dir when backend sends scope=workspace', async () => {
+    const projectDir = path.join(tmpDir, 'ws-project');
+    await fse.ensureDir(projectDir);
+    const { execFileSync } = await import('node:child_process');
+    execFileSync('git', ['init'], { cwd: projectDir, stdio: 'ignore' });
+    await fse.ensureDir(path.join(projectDir, '.codebuddy', 'skills'));
+    await setupConfig();
+
+    const { zipSync, strToU8 } = await import('fflate');
+    const skillMd = '---\nname: ws-skill\ndescription: test\n---\n# ws-skill\nbody\n';
+    const zip = zipSync({ 'ws-skill/SKILL.md': strToU8(skillMd) });
+
+    const acks: Array<Record<string, unknown>> = [];
+    const fetchMock = vi.fn(async (input: string | URL, init?: { body?: string }) => {
+      const url = String(input);
+      if (url.includes('/skill.zip')) {
+        return new Response(Buffer.from(zip));
+      }
+      if (url.includes('/local-agent/sync')) {
+        return new Response(JSON.stringify({
+          ok: true,
+          commands: [{
+            id: 1,
+            type: 'install_skill',
+            skill_slug: 'ws-skill',
+            skill_version: '1.0.0',
+            download_url: `http://127.0.0.1:${port}/skill.zip`,
+            scope: 'workspace',
+            workspace_path: projectDir,
+            project_id: 101,
+          }],
+        }));
+      }
+      if (url.includes('/commands/ack')) {
+        acks.push(JSON.parse(init?.body ?? '{}'));
+      }
+      return new Response(JSON.stringify({ ok: true }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ cwd: projectDir, tool: 'codebuddy', status: 'running' });
+
+    expect(acks[0]?.status).toBe('success');
+
+    // Skill must land under the project dir, not the user HOME.
+    const projectSkillDir = path.join(projectDir, '.codebuddy', 'skills', 'ws-skill');
+    const userSkillDir = path.join(tmpDir, '.codebuddy', 'skills', 'ws-skill');
+    await expect(fse.pathExists(projectSkillDir)).resolves.toBe(true);
+    await expect(fse.pathExists(userSkillDir)).resolves.toBe(false);
+
+    // The skill must be recorded under a `project:` manifest scope key
+    // (scopeKey('project', workspacePath)), not `user` or `instance`.
+    const manifest = await fse.readJson(path.join(tmpDir, '.teamai', 'local-agent', 'manifest.json'));
+    const projectKey = Object.keys(manifest.scopes ?? {}).find((key) => key.startsWith('project:'));
+    expect(projectKey).toBeDefined();
+    expect(manifest.scopes[projectKey!].skills['ws-skill']).toBeDefined();
+  });
+});

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -137,7 +137,7 @@ interface LocalAgentManifest {
 interface LocalAgentCommand {
   id: number;
   type?: string;
-  scope?: LocalAgentScope;
+  scope?: string;
   workspace_path?: string;
   download_url?: string;
   skill_slug?: string;
@@ -1092,6 +1092,25 @@ function commandVersion(command: LocalAgentCommand, kind: CommandResourceKind): 
   ) ?? command.resource_version ?? command.version;
 }
 
+/**
+ * Normalize a backend-sent scope string to an internal LocalAgentScope.
+ *
+ * The backend emits `user` / `workspace` (see clawpro local-agent-api.md);
+ * the deprecated `instance` is no longer sent. Internally project-level
+ * resources use the `project` scope, so `workspace` maps to `project`.
+ * Any unrecognized value falls back to `user` (global install).
+ *
+ * This only maps the scope; presence of `workspace_path` for project scope
+ * is validated by the caller (executeCommand throws if it is missing).
+ */
+function normalizeScope(raw?: string): LocalAgentScope {
+  if (raw === 'workspace' || raw === 'project') return 'project';
+  if (raw !== undefined && raw !== 'user' && raw !== 'instance') {
+    log.debug(`local-agent: unknown scope "${raw}", defaulting to user`);
+  }
+  return 'user';
+}
+
 function manifestKind(kind: CommandResourceKind): ResourceKind {
   return kind === 'skill' ? 'skills' : kind === 'rule' ? 'rules' : 'claudemd';
 }
@@ -1449,7 +1468,7 @@ async function executeCommand(
     throw new Error(`Unsupported command type: ${command.type ?? ''}`);
   }
 
-  const scope = command.scope ?? 'user';
+  const scope = normalizeScope(command.scope);
   const workspacePath = scope === 'project'
     ? await resolveWorkspacePath(command.workspace_path ?? context.cwd)
     : undefined;


### PR DESCRIPTION
## Problem

Backend `local-agent/sync` commands carry `scope="workspace"` for project-level resources (per `clawpro/local-agent-api.md`; the deprecated `instance` value is no longer sent). The CLI's internal scope enum only knows `"project"`, so `command.scope ?? 'user'` let `"workspace"` fall through to a user-level install — **project-scoped skills were installed into `~/` instead of the project directory.**

## Fix

- Add `normalizeScope()` mapping backend `"workspace"` (and `"project"`) to the internal `"project"` scope.
- Unknown scope values fall back to `"user"` with a debug log.
- `"instance"` collapses to `"user"` (phase-1 legacy value, already equivalent to user-level, no longer distributed).
- Relax `LocalAgentCommand.scope` to `string` to accept the wire value.

The downstream `scope === 'project'` install path (workspace_path resolution to project resource repo to project skills dir) is reused unchanged.

## Rebase note

This PR was rebased onto latest `main`. The earlier group->project binding work is now redundant — upstream #203 already landed that migration. This PR now contains **only** the scope-normalization bug fix that #203 did not address.

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run src/__tests__/local-agent.test.ts` — 17/17 pass (incl. new regression test)
- [x] `npm run build` succeeds
- [x] E2E: mock backend sends `scope:"workspace"` install command, skill installs to `<project>/.codebuddy/skills/`, NOT `~/.codebuddy/skills/`