### PR TITLE
docs: document CNB provider and `teamai session save`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm install -g teamai-cli
 
 ### Team admin / solo user
 
-Create a shared-experience repo on your git host (GitHub or TGit), **grant write access to team members**, then have them run `teamai init --repo https://github.com/yourorg/yourrepo`.
+Create a shared-experience repo on your git host (GitHub, TGit, or CNB), **grant write access to team members**, then have them run `teamai init --repo https://github.com/yourorg/yourrepo`.
 
 > Solo use needs no separate repo setup: `teamai init` checks the target repo and creates it automatically if it doesn't exist.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,7 +30,7 @@ npm install -g teamai-cli
 
 ### 团队管理员 / 个人使用者
 
-在 Git 托管平台（GitHub 或 TGit）创建共享经验仓库，**授予团队成员写权限**，然后让他们运行 `teamai init --repo https://github.com/yourorg/yourrepo`。
+在 Git 托管平台（GitHub、TGit 或 CNB）创建共享经验仓库，**授予团队成员写权限**，然后让他们运行 `teamai init --repo https://github.com/yourorg/yourrepo`。
 
 > 个人使用无需单独建仓：`teamai init` 会检查目标仓库，不存在时自动创建。
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,11 +1,12 @@
 # Git Provider 说明
 
-TeamAI CLI 通过 provider 抽象层支持多个 git 托管平台。当前实现了两个：
+TeamAI CLI 通过 provider 抽象层支持多个 git 托管平台。当前实现了三个：
 
 | Provider | Host            | 认证方式                            | 建议场景              |
 |----------|-----------------|--------------------------------------|----------------------|
 | `github` | github.com      | `gh` CLI 或 `GITHUB_TOKEN` 环境变量  | 开源项目、外部用户    |
 | `tgit`   | git.woa.com     | `gf` CLI（自动下载）+ `~/.netrc`     | 腾讯内部团队          |
+| `cnb`    | cnb.cool        | `cnb login` 或 `CNB_TOKEN` 环境变量  | CNB（云原生构建）用户 |
 
 ## Provider 自动检测
 
@@ -17,6 +18,8 @@ https://github.com/org/repo(.git)       → github
 git@github.com:org/repo.git             → github
 https://git.woa.com/team/repo(.git)     → tgit
 git@git.woa.com:team/repo.git           → tgit
+https://cnb.cool/org/repo(.git)         → cnb
+git@cnb.cool:org/repo.git               → cnb
 ```
 
 provider 选择会写入 team 仓库的 `teamai.yaml` 的 `provider` 字段，后续 `push` / `pull` 都按这个值来。
@@ -89,9 +92,56 @@ git@git.woa.com:Group/Subgroup/repo.git
 
 TGit 会把 git commit email 默认配置为 `<username>@tencent.com`。GitHub Provider 不设默认域（让用户的全局 git 配置生效）。
 
+## CNB Provider（cnb.cool）
+
+CNB（[云原生构建](https://cnb.cool)）provider 是对官方 CLI `@cnbcool/cnb-cli` 的薄封装，思路与 TGit 一致：把认证、建仓、建 PR 等操作都委托给平台自己的 CLI。CLI 缺失时会通过 `npm i -g @cnbcool/cnb-cli` 自动安装。
+
+### 认证
+
+两种方式，与 GitHub Provider 对待 `GITHUB_TOKEN` 的思路一致：
+
+**方式 1：`cnb login`（交互式，开发机推荐）**
+
+```bash
+cnb login   # OAuth2 device flow，登录后 `cnb git-credential` 为 git 提供凭据
+teamai init --repo https://cnb.cool/yourorg/yourrepo
+```
+
+**方式 2：`CNB_TOKEN` 环境变量（headless / CI）**
+
+```bash
+export CNB_TOKEN=xxxxxxxx
+teamai init --repo https://cnb.cool/yourorg/yourrepo
+```
+
+设置 `CNB_TOKEN` 后无需 `cnb login`。用户名从 `cnb users get-user-info` 解析，也可用 `CNB_USERNAME` 覆盖。
+
+### 支持的操作
+
+| 操作      | 实现                                                              |
+|-----------|-------------------------------------------------------------------|
+| clone     | `git clone https://cnb:$CNB_TOKEN@cnb.cool/...`，或 `cnb git-credential` |
+| 创建仓库  | `cnb repositories create-repo`                                    |
+| 创建 PR   | `cnb pulls post-pull`                                             |
+| 用户名    | `cnb users get-user-info`（或 `CNB_USERNAME`）                    |
+
+### 多级命名空间
+
+与 TGit 类似，CNB 支持 `org/subgroup/repo` 这种嵌套路径。
+
+### 默认 email 域
+
+CNB Provider 不设默认 email 域（同 GitHub）。
+
+### host 范围与自托管
+
+当前只支持公有社区平台 **cnb.cool**（唯一经过实测的 host），并且只在 URL 明确为 `cnb.cool` 时才会被选中，不会作为默认 fallback。
+
+内部/企业自托管实例（如内网镜像）可通过 `TEAMAI_CNB_HOST` 覆盖 git host，但这类部署还必须给 `cnb` CLI 设置 `CNB_API_ENDPOINT`（以及 `CNB_WEB_ENDPOINT`）指向对应 API——本封装不代管这些端点，且尚未实测，暂不作为受支持配置。
+
 ## 手动指定 Provider
 
-除了 URL 自动检测，也可以在 team 仓库的 `teamai.yaml` 中显式写 `provider: github` 或 `provider: tgit` 强制切换。一个典型的 `teamai.yaml`：
+除了 URL 自动检测，也可以在 team 仓库的 `teamai.yaml` 中显式写 `provider: github`、`provider: tgit` 或 `provider: cnb` 强制切换。一个典型的 `teamai.yaml`：
 
 ```yaml
 team: my-team

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -66,7 +66,7 @@ npm install -g teamai-cli
 teamai --version
 ```
 
-**Prerequisites:** Node.js ≥ 18, Git (the `gf` CLI is only needed by TGit users, and `teamai init` will install it automatically)
+**Prerequisites:** Node.js ≥ 18, Git (TGit users also need the `gf` CLI, and CNB users the `cnb` CLI — `teamai init` installs either automatically)
 
 ---
 
@@ -74,7 +74,7 @@ teamai --version
 
 > Only one admin needs to do this — other members can skip to [Member Onboarding](#member-onboarding).
 
-Create an empty repository on GitHub or TGit (Tencent's internal Git host) (suggested naming: `TeamAi-<team-name>`), or simply run `teamai init` — if the repo doesn't exist yet, you'll be prompted to create it automatically.
+Create an empty repository on GitHub, TGit (Tencent's internal Git host), or CNB (cnb.cool) (suggested naming: `TeamAi-<team-name>`), or simply run `teamai init` — if the repo doesn't exist yet, you'll be prompted to create it automatically.
 
 ### User Scope
 
@@ -665,6 +665,24 @@ Each session card also shows two badges:
 > Privacy: only turn counts and token counts are tracked — no prompt or transcript text is ever stored.
 
 These two metrics are likewise aggregated into `stats/<user>.yaml` (as `prompts` and `tokens` fields) during `teamai pull`, and shown in the "Conversation Volume & Token Usage" section of `teamai digest`, with team-wide totals, bucketed token totals, and per-person token usage rankings. Tools without transcript access (e.g. Cursor) degrade gracefully: turn counts are still tracked, while tokens show as 0 / N/A.
+
+### Session Save
+
+`teamai session save` folds the dashboard's existing per-session event stream (tool sequence, prompt turns, interventions) into a compact, privacy-scrubbed markdown summary — no LLM call, no new collection path.
+
+```bash
+teamai session save                    # record the most-recent session locally
+teamai session save --session-id <id>  # record a specific session
+teamai session save --push             # also push a "valuable" session to the team repo
+teamai session save --push --force     # push even a trivial session
+teamai session save --push --include-prompt  # also include the (redacted) first-ask line
+```
+
+**Local (always):** appends to `~/.teamai/session-logs/<year-month>.md`. Idempotent per session (a session already recorded that month is skipped), and logs older than 90 days are pruned automatically.
+
+**Team (`--push`, opt-in):** commits the summary directly (no PR) to `sessions/<user>/<year-month>.md` in the team repo — the exact path `teamai digest` reads, so the session shows up under **Session Highlights**. Only a **valuable** session is pushed by default: one that shows friction (an interrupt / tool-reject / correction) or substantial tool use (≥ 3 distinct tools). Trivial sessions stay local unless you pass `--force`. On a read-only (HTTP-mode) team, `--push` fails gracefully and the local log is still kept.
+
+> Privacy: the team-pushed payload is **counts + tool names only** by default. The first-ask prompt line is opt-in via `--include-prompt`, and even then it is run through the same secret redaction (`ghp_…` → `<REDACTED:…>`) used elsewhere. Local logs keep the redacted first-ask line since they never leave your machine.
 
 ### Hooks
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -64,7 +64,7 @@ npm install -g @tencent/teamai-cli --registry=http://r.tnpm.oa.com
 teamai --version
 ```
 
-**前置依赖：** Node.js ≥ 18、Git（`gf` CLI 仅 TGit 用户需要，`teamai init` 时会自动安装）
+**前置依赖：** Node.js ≥ 18、Git（TGit 用户还需 `gf` CLI、CNB 用户还需 `cnb` CLI，`teamai init` 时都会自动安装）
 
 ---
 
@@ -72,7 +72,7 @@ teamai --version
 
 > 只需一位管理员完成，其他成员跳到[成员接入](#成员接入)。
 
-在 TGit（腾讯工蜂）上创建一个空仓库（命名建议：`TeamAi-<团队名>`），或者直接执行 `teamai init`，不存在时会提示自动创建。
+在 GitHub、TGit（腾讯工蜂）或 CNB（cnb.cool）上创建一个空仓库（命名建议：`TeamAi-<团队名>`），或者直接执行 `teamai init`，不存在时会提示自动创建。
 
 ### 用户级（User Scope）
 
@@ -663,6 +663,24 @@ teamai dashboard --port 8080
 > 隐私：只统计**轮数与 token 数量**，不落地任何 prompt 或 transcript 原文。
 
 这两项同样随 `teamai pull` 聚合到 `stats/<user>.yaml`（`prompts` 与 `tokens` 字段），并在 `teamai digest` 的「对话量与 Token 用量」板块给出团队对话总轮数、token 总量（分桶）与人均 token 用量排行。拿不到 transcript 的工具（如 Cursor）会优雅降级：仍统计对话轮数，token 显示为 0 / N/A。
+
+### Session Save（会话存档）
+
+`teamai session save` 把 dashboard 已有的**单次会话事件流**（工具调用序列、prompt 轮次、干预记录）折叠成一份精简、脱敏的 markdown 摘要——不调用 LLM，也不新增采集路径。
+
+```bash
+teamai session save                    # 存档最近一次会话（本地）
+teamai session save --session-id <id>  # 存档指定会话
+teamai session save --push             # 把「有价值」的会话推送到团队仓库
+teamai session save --push --force     # 即便是琐碎会话也推送
+teamai session save --push --include-prompt  # 额外带上（脱敏后的）首个 prompt 行
+```
+
+**本地（始终执行）：** 追加到 `~/.teamai/session-logs/<年-月>.md`。按会话幂等（当月已记录的会话会跳过），且超过 90 天的日志会自动清理。
+
+**团队（`--push`，需显式开启）：** 直接提交（不走 PR）到团队仓库的 `sessions/<user>/<年-月>.md`——正是 `teamai digest` 读取的路径，于是该会话会出现在 **Session Highlights** 板块。默认只推送**有价值**的会话：出现摩擦（interrupt / tool-reject / correction）或工具使用充分（≥ 3 种不同工具）。琐碎会话除非加 `--force`，否则只留本地。对只读（HTTP 模式）的团队，`--push` 会优雅失败并保留本地日志。
+
+> 隐私：推送到团队的内容默认**只含计数 + 工具名**。首个 prompt 行需通过 `--include-prompt` 显式开启，且即便开启也会经过与别处一致的密钥脱敏（`ghp_…` → `<REDACTED:…>`）。本地日志因为不出本机，会保留脱敏后的首个 prompt 行。
 
 ### Hooks
 


### PR DESCRIPTION
## Summary

Follow-up documentation pass for two features that shipped without doc coverage:
- **#208** — the CNB (cnb.cool) git provider
- **#192** — `teamai session save`

Docs-only; no code changes. Bilingual docs kept in sync per the repo convention.

## Changes

**`docs/providers.md`** (the provider reference — the main gap; it still said "当前实现了两个")
- Provider count 两个 → 三个; added a `cnb` row to the table and to the auto-detection block.
- New **## CNB Provider（cnb.cool）** section: auth (`cnb login` OAuth2 device flow / `CNB_TOKEN` for CI), operations delegated to `@cnbcool/cnb-cli`, nested `org/subgroup/repo` paths, no default email domain, and the **cnb.cool-only scope** — with the `TEAMAI_CNB_HOST` + `CNB_API_ENDPOINT` note for self-hosted instances (feasible but untested, so not a supported config).
- Manual-provider example now lists `provider: cnb`.

**`README.md` / `README.zh-CN.md`**
- Git-host list "GitHub or TGit" → "GitHub, TGit, or CNB".

**`docs/usage-guide.md` / `docs/usage-guide.zh-CN.md`**
- Create-repo step and prerequisites now mention CNB (and the auto-installed `cnb` CLI).
- New **Session Save** section for `teamai session save`: `--push` / `--force` / `--include-prompt`, the local `~/.teamai/session-logs/<month>.md` path, 90-day retention, the "valuable" heuristic, how `--push` feeds `digest`'s Session Highlights, and the counts-only privacy posture.

## Test Plan

- [x] `npm run build`
- [x] Verified the documented CLI surface matches the build: `teamai session save --help` shows `--session-id` / `--push` / `--force` / `--include-prompt`; the `cnb.cool` host mapping is present in `dist/`.
- [x] Grep confirms no stale "实现了两个" remains; CNB now referenced across README + usage-guide + providers.md.
- [x] Bilingual pairs edited together (README, usage-guide).
