### PR TITLE
fix(hooks): run fire-and-forget Stop handlers detached; async version check

### DIFF
--- a/src/__tests__/hook-dispatch.test.ts
+++ b/src/__tests__/hook-dispatch.test.ts
@@ -207,4 +207,74 @@ describe('hook-dispatch', () => {
       expect(result.output).toBe('quick');
     });
   });
+
+  describe('foreground / background split', () => {
+    it('foreground mode runs only non-background handlers', async () => {
+      const fg = createHandler('contribute-check', 'hint');
+      const bg = createHandler('update');
+
+      const dispatcher = createDispatcher({
+        handlers: [
+          { event: 'stop', matcher: '*', handler: fg },
+          { event: 'stop', matcher: '*', handler: bg, background: true },
+        ],
+      });
+
+      const result = await dispatcher.dispatch('stop', '*', {}, 'claude', 'foreground');
+
+      expect(fg.execute).toHaveBeenCalledOnce();
+      expect(bg.execute).not.toHaveBeenCalled();
+      expect(result.output).toBe('hint');
+    });
+
+    it('background mode runs only background handlers', async () => {
+      const fg = createHandler('contribute-check', 'hint');
+      const bg = createHandler('update');
+
+      const dispatcher = createDispatcher({
+        handlers: [
+          { event: 'stop', matcher: '*', handler: fg },
+          { event: 'stop', matcher: '*', handler: bg, background: true },
+        ],
+      });
+
+      const result = await dispatcher.dispatch('stop', '*', {}, 'claude', 'background');
+
+      expect(bg.execute).toHaveBeenCalledOnce();
+      expect(fg.execute).not.toHaveBeenCalled();
+      // Background handlers are fire-and-forget — no output wired to the host.
+      expect(result.output).toBeNull();
+    });
+
+    it('default mode ("all") runs both, preserving backward compatibility', async () => {
+      const fg = createHandler('contribute-check');
+      const bg = createHandler('update');
+
+      const dispatcher = createDispatcher({
+        handlers: [
+          { event: 'stop', matcher: '*', handler: fg },
+          { event: 'stop', matcher: '*', handler: bg, background: true },
+        ],
+      });
+
+      await dispatcher.dispatch('stop', '*', {}, 'claude');
+
+      expect(fg.execute).toHaveBeenCalledOnce();
+      expect(bg.execute).toHaveBeenCalledOnce();
+    });
+
+    it('hasBackground reflects whether the event+matcher has a background handler', () => {
+      const dispatcher = createDispatcher({
+        handlers: [
+          { event: 'stop', matcher: '*', handler: createHandler('contribute-check') },
+          { event: 'stop', matcher: '*', handler: createHandler('update'), background: true },
+          { event: 'post-tool-use', matcher: 'Skill', handler: createHandler('track') },
+        ],
+      });
+
+      expect(dispatcher.hasBackground('stop', '*')).toBe(true);
+      expect(dispatcher.hasBackground('post-tool-use', 'Skill')).toBe(false);
+      expect(dispatcher.hasBackground('session-start', '*')).toBe(false);
+    });
+  });
 });

--- a/src/__tests__/update.test.ts
+++ b/src/__tests__/update.test.ts
@@ -2,9 +2,16 @@ import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 
 // ─── Mocks ──────────────────────────────────────────────
 
-vi.mock('node:child_process', () => ({
-  execSync: vi.fn(),
-}));
+// update.ts uses `promisify(execFile)`. Mock execFile with a promisify.custom
+// hook so promisify returns our controllable async mock; each test drives it
+// via mockExec.mockResolvedValue({ stdout, stderr }) / mockRejectedValue(err).
+const { mockExec } = vi.hoisted(() => ({ mockExec: vi.fn() }));
+vi.mock('node:child_process', async () => {
+  const { promisify } = await import('node:util');
+  const execFile = vi.fn();
+  (execFile as unknown as Record<symbol, unknown>)[promisify.custom] = mockExec;
+  return { execFile };
+});
 
 vi.mock('fs-extra', () => ({
   default: {
@@ -57,7 +64,6 @@ vi.mock('../utils/prompt.js', () => ({
 
 // ─── Imports (after mocks) ──────────────────────────────
 
-import { execSync } from 'node:child_process';
 import fse from 'fs-extra';
 import { loadState, saveState, loadLocalConfig, loadTeamConfig } from '../config.js';
 import { log } from '../utils/logger.js';
@@ -75,7 +81,7 @@ import {
 
 // ─── Typed mock references ──────────────────────────────
 
-const mockedExecSync = execSync as Mock;
+const mockedExecSync = mockExec as Mock;
 const mockedLoadState = loadState as Mock;
 const mockedSaveState = saveState as Mock;
 const mockedLoadLocalConfig = loadLocalConfig as Mock;
@@ -217,13 +223,14 @@ describe('checkForUpdate', () => {
       lastUpdateCheck: oldCheck,
       availableUpdate: null,
     });
-    mockedExecSync.mockReturnValue('99.0.0\n');
+    mockedExecSync.mockResolvedValue({ stdout: '99.0.0\n', stderr: '' });
 
     const result = await checkForUpdate();
 
     expect(mockedExecSync).toHaveBeenCalledTimes(1);
     expect(mockedExecSync).toHaveBeenCalledWith(
-      expect.stringContaining('npm view'),
+      'npm',
+      expect.arrayContaining(['view', 'version']),
       expect.any(Object),
     );
     expect(result.available).toBe(true);
@@ -259,7 +266,7 @@ describe('checkForUpdate', () => {
 
   it('should report no update when version is same', async () => {
     const current = getCurrentVersion();
-    mockedExecSync.mockReturnValue(`${current}\n`);
+    mockedExecSync.mockResolvedValue({ stdout: `${current}\n`, stderr: '' });
 
     const result = await checkForUpdate({ force: true });
 
@@ -271,7 +278,7 @@ describe('checkForUpdate', () => {
   // ─── Test #6: Newer version available ─────────────────
 
   it('should report update available when newer version exists', async () => {
-    mockedExecSync.mockReturnValue('99.0.0\n');
+    mockedExecSync.mockResolvedValue({ stdout: '99.0.0\n', stderr: '' });
 
     const result = await checkForUpdate({ force: true });
 
@@ -290,15 +297,16 @@ describe('checkForUpdate', () => {
 describe('doUpdate', () => {
   it('should execute npm install when policy is auto and update available', async () => {
     mockedExecSync
-      .mockReturnValueOnce('99.0.0\n') // npm view
-      .mockReturnValueOnce('')          // npm install
-      .mockReturnValueOnce('');         // teamai hooks inject --silent
+      .mockResolvedValueOnce({ stdout: '99.0.0\n', stderr: '' }) // npm view
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })          // npm install
+      .mockResolvedValueOnce({ stdout: '', stderr: '' });         // teamai hooks inject --silent
 
     await doUpdate();
 
     expect(mockedExecSync).toHaveBeenCalledTimes(3);
     expect(mockedExecSync).toHaveBeenCalledWith(
-      expect.stringContaining('npm install -g'),
+      'npm',
+      expect.arrayContaining(['install', '-g']),
       expect.any(Object),
     );
     expect(mockedLog.success).toHaveBeenCalledWith(
@@ -317,7 +325,7 @@ describe('doUpdate', () => {
       username: 'testuser',
       updatePolicy: 'prompt',
     });
-    mockedExecSync.mockReturnValueOnce('99.0.0\n');
+    mockedExecSync.mockResolvedValueOnce({ stdout: '99.0.0\n', stderr: '' });
 
     await doUpdate();
 
@@ -342,9 +350,9 @@ describe('doUpdate', () => {
       updatePolicy: 'prompt',
     });
     mockedExecSync
-      .mockReturnValueOnce('99.0.0\n')
-      .mockReturnValueOnce('')
-      .mockReturnValueOnce('');
+      .mockResolvedValueOnce({ stdout: '99.0.0\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' });
 
     await doUpdate();
 
@@ -362,7 +370,7 @@ describe('doUpdate', () => {
       username: 'testuser',
       updatePolicy: 'skip',
     });
-    mockedExecSync.mockReturnValueOnce('99.0.0\n');
+    mockedExecSync.mockResolvedValueOnce({ stdout: '99.0.0\n', stderr: '' });
 
     await doUpdate();
 
@@ -385,14 +393,15 @@ describe('doUpdate', () => {
       repo: 'https://...',
       autoUpdate: false,
     });
-    mockedExecSync.mockReturnValueOnce('99.0.0\n');  // the version check call
+    mockedExecSync.mockResolvedValueOnce({ stdout: '99.0.0\n', stderr: '' });  // the version check call
 
     await doUpdate();
 
-    // Only the version-check execSync ran; no npm install
+    // Only the version-check exec ran; no npm install
     expect(mockedExecSync).toHaveBeenCalledTimes(1);
     expect(mockedExecSync).not.toHaveBeenCalledWith(
-      expect.stringContaining('npm install'),
+      'npm',
+      expect.arrayContaining(['install']),
       expect.anything(),
     );
     expect(mockedLog.debug).toHaveBeenCalledWith(
@@ -415,14 +424,15 @@ describe('doUpdate', () => {
       autoUpdate: false,
     });
     mockedExecSync
-      .mockReturnValueOnce('99.0.0\n')  // version check
-      .mockReturnValueOnce('')          // npm install
-      .mockReturnValueOnce('');         // hooks inject
+      .mockResolvedValueOnce({ stdout: '99.0.0\n', stderr: '' })  // version check
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })          // npm install
+      .mockResolvedValueOnce({ stdout: '', stderr: '' });         // hooks inject
 
     await doUpdate();
 
     expect(mockedExecSync).toHaveBeenCalledWith(
-      expect.stringContaining('npm install -g'),
+      'npm',
+      expect.arrayContaining(['install', '-g']),
       expect.any(Object),
     );
   });
@@ -432,9 +442,9 @@ describe('doUpdate', () => {
   it('should proceed with install when lock is acquired', async () => {
     mockedFse.pathExists.mockResolvedValue(false);
     mockedExecSync
-      .mockReturnValueOnce('99.0.0\n')
-      .mockReturnValueOnce('')
-      .mockReturnValueOnce('');
+      .mockResolvedValueOnce({ stdout: '99.0.0\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' });
 
     await doUpdate();
 
@@ -454,7 +464,7 @@ describe('doUpdate', () => {
     mockedFse.pathExists.mockResolvedValue(true);
     mockedFse.readFile.mockResolvedValue(String(process.pid));
 
-    mockedExecSync.mockReturnValueOnce('99.0.0\n');
+    mockedExecSync.mockResolvedValueOnce({ stdout: '99.0.0\n', stderr: '' });
 
     await doUpdate();
 
@@ -468,7 +478,7 @@ describe('doUpdate', () => {
 
   it('should warn about permission denied on EACCES', async () => {
     mockedExecSync
-      .mockReturnValueOnce('99.0.0\n')
+      .mockResolvedValueOnce({ stdout: '99.0.0\n', stderr: '' })
       .mockImplementationOnce(() => {
         const err = new Error('npm ERR! code EACCES') as NodeJS.ErrnoException;
         err.code = 'EACCES';
@@ -487,7 +497,7 @@ describe('doUpdate', () => {
 
   it('should warn about timeout on npm install timeout', async () => {
     mockedExecSync
-      .mockReturnValueOnce('99.0.0\n')
+      .mockResolvedValueOnce({ stdout: '99.0.0\n', stderr: '' })
       .mockImplementationOnce(() => {
         throw new Error('ETIMEDOUT');
       });
@@ -503,7 +513,7 @@ describe('doUpdate', () => {
 
   it('should log up to date when no update available', async () => {
     const current = getCurrentVersion();
-    mockedExecSync.mockReturnValueOnce(`${current}\n`);
+    mockedExecSync.mockResolvedValueOnce({ stdout: `${current}\n`, stderr: '' });
 
     await doUpdate();
 
@@ -522,12 +532,13 @@ describe('checkForUpdate with corrupted state', () => {
       lastUpdateCheck: null,
       availableUpdate: null,
     });
-    mockedExecSync.mockReturnValue('99.0.0\n');
+    mockedExecSync.mockResolvedValue({ stdout: '99.0.0\n', stderr: '' });
 
     const result = await checkForUpdate();
 
     expect(mockedExecSync).toHaveBeenCalledWith(
-      expect.stringContaining('npm view'),
+      'npm',
+      expect.arrayContaining(['view', 'version']),
       expect.any(Object),
     );
     expect(result.available).toBe(true);
@@ -538,7 +549,7 @@ describe('checkForUpdate with corrupted state', () => {
 
 describe('update', () => {
   it('should only check and print when --check is set', async () => {
-    mockedExecSync.mockReturnValueOnce('99.0.0\n');
+    mockedExecSync.mockResolvedValueOnce({ stdout: '99.0.0\n', stderr: '' });
 
     await update({ check: true });
 
@@ -550,7 +561,7 @@ describe('update', () => {
 
   it('should print up to date when --check and no update', async () => {
     const current = getCurrentVersion();
-    mockedExecSync.mockReturnValueOnce(`${current}\n`);
+    mockedExecSync.mockResolvedValueOnce({ stdout: `${current}\n`, stderr: '' });
 
     await update({ check: true });
 
@@ -561,9 +572,9 @@ describe('update', () => {
 
   it('should run full update flow without --check', async () => {
     mockedExecSync
-      .mockReturnValueOnce('99.0.0\n')
-      .mockReturnValueOnce('')
-      .mockReturnValueOnce('');
+      .mockResolvedValueOnce({ stdout: '99.0.0\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' });
 
     await update({});
 
@@ -577,9 +588,9 @@ describe('update', () => {
 describe('hook refresh after update', () => {
   it('should spawn "teamai hooks inject --silent" after successful update', async () => {
     mockedExecSync
-      .mockReturnValueOnce('99.0.0\n') // npm view
-      .mockReturnValueOnce('')          // npm install
-      .mockReturnValueOnce('');         // teamai hooks inject --silent
+      .mockResolvedValueOnce({ stdout: '99.0.0\n', stderr: '' }) // npm view
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })          // npm install
+      .mockResolvedValueOnce({ stdout: '', stderr: '' });         // teamai hooks inject --silent
 
     await doUpdate();
 
@@ -588,8 +599,9 @@ describe('hook refresh after update', () => {
     );
     expect(mockedExecSync).toHaveBeenCalledTimes(3);
     expect(mockedExecSync).toHaveBeenCalledWith(
-      'teamai hooks inject --silent',
-      expect.objectContaining({ timeout: 15_000, stdio: 'pipe' }),
+      'teamai',
+      ['hooks', 'inject', '--silent'],
+      expect.objectContaining({ timeout: 15_000 }),
     );
     expect(mockedLog.success).toHaveBeenCalledWith(
       expect.stringContaining('Refreshed hooks'),
@@ -598,8 +610,8 @@ describe('hook refresh after update', () => {
 
   it('should silently skip hook refresh when spawn fails', async () => {
     mockedExecSync
-      .mockReturnValueOnce('99.0.0\n') // npm view
-      .mockReturnValueOnce('')          // npm install
+      .mockResolvedValueOnce({ stdout: '99.0.0\n', stderr: '' }) // npm view
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })          // npm install
       .mockImplementationOnce(() => {   // teamai hooks inject fails
         throw new Error('command not found');
       });

--- a/src/hook-dispatch-cli.ts
+++ b/src/hook-dispatch-cli.ts
@@ -3,9 +3,20 @@
  * Reads STDIN once, fans out to all matching handlers, writes at most one
  * handler's output to STDOUT. STDOUT is reserved for the AI-tool hook JSON
  * payload; all log lines go to STDERR (see setStderrOnly below).
+ *
+ * Foreground vs background:
+ *   Handlers that may return output the host injects back into the session run
+ *   inline (foreground). Pure side-effect handlers (version check, dashboard,
+ *   local-agent) are marked `background` and run in a detached child process so
+ *   a slow registry/network call cannot delay the host's hook completion —
+ *   critical for CodeBuddy's 10s hook timeout. Detaching also survives the
+ *   caller's process.exit(0) (index.ts), which otherwise kills in-process
+ *   fire-and-forget work before it finishes.
  */
 
-import { createDispatcher } from './hook-dispatch.js';
+import { spawn } from 'node:child_process';
+
+import { createDispatcher, type Dispatcher } from './hook-dispatch.js';
 import { buildHandlerRegistry } from './hook-handlers.js';
 import { log, setStderrOnly } from './utils/logger.js';
 
@@ -20,20 +31,49 @@ async function readStdin(): Promise<string> {
 }
 
 /**
- * Main CLI handler for hook-dispatch.
+ * Spawn a detached child that re-runs this same dispatch for background-only
+ * handlers, feeding it the already-consumed STDIN. The child is unref'd and
+ * detached so the parent (and thus the host's hook) can exit — even via the
+ * caller's process.exit(0) — without waiting for or killing it; its
+ * stdout/stderr are ignored so no open pipe keeps the parent alive.
  */
-export async function hookDispatchCli(event: string, tool: string, matcher: string): Promise<void> {
-  // Reserve STDOUT for the dispatcher's hook payload; log lines go to STDERR.
-  setStderrOnly(true);
+function spawnBackground(event: string, tool: string, matcher: string, raw: string): void {
+  try {
+    const args = [
+      process.argv[1],
+      'hook-dispatch',
+      event,
+      '--tool',
+      tool,
+      '--bg-only',
+    ];
+    if (matcher && matcher !== '*') {
+      args.push('--matcher', matcher);
+    }
+    const child = spawn(process.execPath, args, {
+      detached: true,
+      stdio: ['pipe', 'ignore', 'ignore'],
+    });
+    child.on('error', () => {});
+    if (child.stdin) {
+      child.stdin.on('error', () => {});
+      child.stdin.end(raw);
+    }
+    child.unref();
+  } catch {
+    // Never let a spawn failure surface to the host — background work is best-effort.
+  }
+}
 
-  const raw = await readStdin();
+/** Parse STDIN JSON and normalize the event name for downstream handlers. */
+function parseStdin(raw: string, event: string): Record<string, unknown> | null {
   let stdin: Record<string, unknown> = {};
   if (raw.trim()) {
     try {
       stdin = JSON.parse(raw);
     } catch {
       log.debug(`hook-dispatch: failed to parse STDIN JSON for event=${event}`);
-      return;
+      return null;
     }
   }
 
@@ -49,21 +89,64 @@ export async function hookDispatchCli(event: string, tool: string, matcher: stri
     };
     stdin.hook_event_name = EVENT_MAP[event] ?? event;
   }
+  return stdin;
+}
 
-  // Build dispatcher with full handler registry
-  const registry = buildHandlerRegistry();
-  const dispatcher = createDispatcher({ handlers: registry });
-
-  // Dispatch
-  const result = await dispatcher.dispatch(event, matcher, stdin, tool);
-
-  // Log errors (to debug, not STDOUT — STDOUT is reserved for hook output)
+/** Run one dispatch pass and log any handler errors (never to STDOUT). */
+async function runDispatch(
+  dispatcher: Dispatcher,
+  event: string,
+  matcher: string,
+  stdin: Record<string, unknown>,
+  tool: string,
+  mode: 'foreground' | 'background',
+): Promise<string | null> {
+  const result = await dispatcher.dispatch(event, matcher, stdin, tool, mode);
   for (const err of result.errors) {
     log.debug(`hook-dispatch: handler "${err.handlerName}" failed: ${err.error.message}`);
   }
+  return result.output;
+}
 
-  // Write output to STDOUT if any handler produced one
-  if (result.output) {
-    await new Promise<void>((resolve) => process.stdout.write(result.output as string, () => resolve()));
+/**
+ * Main CLI handler for hook-dispatch.
+ *
+ * @param bgOnly When true, this is the detached child: run only background
+ *   handlers and never spawn again (prevents recursion).
+ */
+export async function hookDispatchCli(
+  event: string,
+  tool: string,
+  matcher: string,
+  bgOnly = false,
+): Promise<void> {
+  // Reserve STDOUT for the dispatcher's hook payload; log lines go to STDERR.
+  setStderrOnly(true);
+
+  const raw = await readStdin();
+  const stdin = parseStdin(raw, event);
+  if (stdin === null) return;
+
+  const dispatcher = createDispatcher({ handlers: buildHandlerRegistry() });
+
+  // Detached child: run the fire-and-forget handlers, then exit. No output is
+  // wired back to the host (the parent already returned).
+  if (bgOnly) {
+    await runDispatch(dispatcher, event, matcher, stdin, tool, 'background');
+    return;
+  }
+
+  // Parent: kick off background handlers in a detached process first so they
+  // start working while we run the inline (foreground) pass.
+  if (dispatcher.hasBackground(event, matcher)) {
+    spawnBackground(event, tool, matcher, raw);
+  }
+
+  const output = await runDispatch(dispatcher, event, matcher, stdin, tool, 'foreground');
+
+  // Write output to STDOUT if any handler produced one, flushing before return
+  // so the caller's process.exit(0) cannot truncate it.
+  if (output) {
+    await new Promise<void>((resolve) => process.stdout.write(output, () => resolve()));
   }
 }

--- a/src/hook-dispatch.ts
+++ b/src/hook-dispatch.ts
@@ -24,7 +24,18 @@ export interface HandlerRegistration {
   handler: HookHandler;
   /** Per-handler timeout in ms. If exceeded, handler is treated as failed. */
   timeoutMs?: number;
+  /**
+   * Fire-and-forget handlers that never contribute STDOUT (pure side effects
+   * like version-check, votes-sync, dashboard-report). The CLI runs these in a
+   * detached background process so a slow network/registry call cannot delay
+   * the host's hook completion. Foreground handlers (those that may return
+   * output the host injects back into the session) always run inline.
+   */
+  background?: boolean;
 }
+
+/** Which subset of matched handlers to run in a single dispatch pass. */
+export type DispatchMode = 'all' | 'foreground' | 'background';
 
 export interface DispatchError {
   handlerName: string;
@@ -43,7 +54,15 @@ export interface DispatcherConfig {
 }
 
 export interface Dispatcher {
-  dispatch(event: string, matcher: string, stdin: Record<string, unknown>, tool: string): Promise<DispatchResult>;
+  dispatch(
+    event: string,
+    matcher: string,
+    stdin: Record<string, unknown>,
+    tool: string,
+    mode?: DispatchMode,
+  ): Promise<DispatchResult>;
+  /** True when the event+matcher has at least one background-marked handler. */
+  hasBackground(event: string, matcher: string): boolean;
 }
 
 // ─── Implementation ─────────────────────────────────────
@@ -75,12 +94,22 @@ function withTimeout<T>(promise: Promise<T>, ms: number, handlerName: string): P
  *     handlers must not also run during a specific matcher dispatch.
  */
 export function createDispatcher(config: DispatcherConfig): Dispatcher {
+  const matchedFor = (event: string, matcher: string) =>
+    config.handlers.filter((reg) => reg.event === event && reg.matcher === matcher);
+
   return {
-    async dispatch(event, matcher, stdin, tool): Promise<DispatchResult> {
-      // Find all handlers that should fire for this event+matcher
-      const matched = config.handlers.filter((reg) => {
-        if (reg.event !== event) return false;
-        return reg.matcher === matcher;
+    hasBackground(event, matcher): boolean {
+      return matchedFor(event, matcher).some((reg) => reg.background === true);
+    },
+
+    async dispatch(event, matcher, stdin, tool, mode = 'all'): Promise<DispatchResult> {
+      // Find all handlers that should fire for this event+matcher, then narrow
+      // to the requested mode so the inline pass and the detached background
+      // pass each run their own subset.
+      const matched = matchedFor(event, matcher).filter((reg) => {
+        if (mode === 'foreground') return reg.background !== true;
+        if (mode === 'background') return reg.background === true;
+        return true;
       });
 
       // Execute all matched handlers concurrently with isolation + per-handler timeout

--- a/src/hook-handlers.ts
+++ b/src/hook-handlers.ts
@@ -22,6 +22,8 @@ export interface HandlerRegistration {
   matcher: string;
   handler: HookHandler;
   timeoutMs: number;
+  /** Fire-and-forget: run detached so it can't delay host hook completion. */
+  background?: boolean;
 }
 
 // ─── Timeout constants ──────────────────────────────────
@@ -308,11 +310,16 @@ export function buildHandlerRegistry(): HandlerRegistration[] {
     { event: 'session-start', matcher: '*', handler: localAgentHandler, timeoutMs: LOCAL_AGENT_TIMEOUT_MS },
 
     // ─── Stop ─────────────────────────────────────────
-    { event: 'stop', matcher: '*', handler: updateHandler, timeoutMs: UPDATE_TIMEOUT_MS },
+    // votes-sync and contribute-check may return a hint the host injects back
+    // into the session, so they run inline. The rest are pure side effects —
+    // the update check in particular shells out to the npm registry — so they
+    // run detached to avoid pushing the Stop hook past the host's hook timeout
+    // (CodeBuddy: 10s).
+    { event: 'stop', matcher: '*', handler: updateHandler, timeoutMs: UPDATE_TIMEOUT_MS, background: true },
     { event: 'stop', matcher: '*', handler: votesSyncHandler, timeoutMs: VOTES_SYNC_TIMEOUT_MS },
     { event: 'stop', matcher: '*', handler: contributeCheckHandler, timeoutMs: CONTRIBUTE_CHECK_TIMEOUT_MS },
-    { event: 'stop', matcher: '*', handler: dashboardReportHandler, timeoutMs: DASHBOARD_TIMEOUT_MS },
-    { event: 'stop', matcher: '*', handler: localAgentHandler, timeoutMs: LOCAL_AGENT_TIMEOUT_MS },
+    { event: 'stop', matcher: '*', handler: dashboardReportHandler, timeoutMs: DASHBOARD_TIMEOUT_MS, background: true },
+    { event: 'stop', matcher: '*', handler: localAgentHandler, timeoutMs: LOCAL_AGENT_TIMEOUT_MS, background: true },
 
     // ─── PostToolUse ──────────────────────────────────
     { event: 'post-tool-use', matcher: '*', handler: dashboardReportHandler, timeoutMs: DASHBOARD_TIMEOUT_MS },

--- a/src/index.ts
+++ b/src/index.ts
@@ -603,10 +603,11 @@ program
   .option('--stdin', 'Read hook data from STDIN (accepted for forward compat, always reads STDIN)')
   .option('--tool <name>', 'Tool identifier (e.g. codebuddy, workbuddy, claude)')
   .option('--matcher <matcher>', 'Hook matcher for PostToolUse (e.g. Skill, Bash)')
-  .action(async (event: string, cmdOpts: { stdin?: boolean; tool?: string; matcher?: string }) => {
+  .option('--bg-only', 'Internal: run only fire-and-forget background handlers (used by the detached child)')
+  .action(async (event: string, cmdOpts: { stdin?: boolean; tool?: string; matcher?: string; bgOnly?: boolean }) => {
     const { hookDispatchCli } = await import('./hook-dispatch-cli.js');
     try {
-      await hookDispatchCli(event, cmdOpts.tool ?? 'claude', cmdOpts.matcher ?? '*');
+      await hookDispatchCli(event, cmdOpts.tool ?? 'claude', cmdOpts.matcher ?? '*', cmdOpts.bgOnly ?? false);
     } finally {
       // Hook subprocesses must exit promptly: a hung/unreachable backend fetch can
       // leave a socket pending on the event loop, blocking natural exit and tripping

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,4 +1,5 @@
-import { execSync } from 'node:child_process';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import fse from 'fs-extra';
 import { loadState, saveState, loadLocalConfig, loadTeamConfig } from './config.js';
 import { resolveEffectiveUpdatePolicy } from './update-policy.js';
@@ -13,6 +14,8 @@ import { askConfirmation } from './utils/prompt.js';
 // for backwards compatibility with existing callers of `./update.js`.
 import { getCurrentVersion, getCurrentPackageName } from './package-info.js';
 export { getCurrentVersion, getCurrentPackageName };
+
+const execFileAsync = promisify(execFile);
 
 // ─── Constants ──────────────────────────────────────────
 
@@ -53,11 +56,15 @@ export async function fetchLatestVersion(
   const pkgName = getCurrentPackageName();
   const resolvedRegistry = registry ?? resolveRegistryForPackage(pkgName);
   try {
-    const output = execSync(
-      `npm view ${pkgName} version --registry=${resolvedRegistry}`,
-      { timeout, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+    // Async execFile so the hook dispatcher's event loop is not blocked while
+    // the registry is queried — a synchronous execSync here would freeze all
+    // sibling Stop handlers for up to `timeout` ms.
+    const { stdout } = await execFileAsync(
+      'npm',
+      ['view', pkgName, 'version', `--registry=${resolvedRegistry}`],
+      { timeout, encoding: 'utf-8' },
     );
-    const version = output.trim();
+    const version = stdout.trim();
     if (!version) return null;
     return version;
   } catch (e) {
@@ -243,17 +250,17 @@ export async function doUpdate(): Promise<void> {
   try {
     const pkgName = getCurrentPackageName();
     const registry = resolveRegistryForPackage(pkgName);
-    execSync(
-      `npm install -g ${pkgName} --registry=${registry}`,
-      { timeout: INSTALL_TIMEOUT, stdio: 'pipe' },
+    await execFileAsync(
+      'npm',
+      ['install', '-g', pkgName, `--registry=${registry}`],
+      { timeout: INSTALL_TIMEOUT },
     );
     log.success(`Updated teamai to v${result.latest}`);
 
     // Refresh hooks using new version's code (spawn new process so updated code is loaded)
     try {
-      execSync('teamai hooks inject --silent', {
+      await execFileAsync('teamai', ['hooks', 'inject', '--silent'], {
         timeout: 15_000,
-        stdio: 'pipe',
       });
       log.success('Refreshed hooks with new version');
     } catch (e) {


### PR DESCRIPTION
## Problem

The Stop `hook-dispatch` runs `updateHandler`, whose first post-install version check shells out to `npm view` via a **synchronous `execSync`** (up to 5s). Combined with Node startup (~3s) this approaches CodeBuddy's 10s hook timeout.

The recently-merged `process.exit(0)` hard-exit (#214) prevents a hung socket from blocking the host — but as its own comment notes, it **also kills all in-process fire-and-forget work before it finishes**. So the version check (and dashboard / local-agent sync) may never complete.

## Fix — two layers

**1. `update.ts`: `execSync` → `promisify(execFile)`** (3 call sites: npm view / npm install / hooks inject)

A synchronous exec froze the dispatcher's event loop, blocking every sibling Stop handler for its full duration. Async frees the loop so handlers run truly concurrently.

**2. `hook-dispatch`: foreground / background split**

Stop handlers are split by whether they produce output the host injects back into the session:

| Handler | Produces output? | Mode |
|---|---|---|
| `votes-sync` | yes (adoption nudge) | foreground |
| `contribute-check` | yes (hint) | foreground |
| `update` | no | **background** |
| `dashboard-report` | no | **background** |
| `local-agent` | no (on Stop) | **background** |

Foreground handlers run inline. Background handlers run in a **detached, `unref`'d child process** (`hook-dispatch … --bg-only`), fed the already-consumed STDIN via a pipe. The parent returns in ~0.3s regardless of registry latency, and because the child is detached it **survives the caller's `process.exit(0)`** and finishes independently. `--bg-only` never spawns again, preventing recursion.

This is complementary to #214: the hard-exit stops a hang from blocking the host; detaching ensures the best-effort work the hard-exit would otherwise kill still runs to completion.

Note: CodeBuddy per-hook `timeout` rendering (originally part of this investigation) is already handled by #214, so it is **not** included here.

## Test Plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — **1814 passed** (incl. new foreground/background split + `hasBackground` tests, and the `execFile`-migrated `update.test.ts`)
- [x] `npm run build`
- [x] **E2E**: with an unreachable npm registry (`TEAMAI_NPM_REGISTRY=http://10.255.255.1:9999`), the Stop main process returns in **0.315s** while the detached `--bg-only` child stays alive **past `process.exit(0)`** and exits cleanly after the 5s npm-view timeout (no zombie).
- [x] **E2E**: `--bg-only` child does not spawn a further child (recursion guard verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)