### PR TITLE
fix(local-agent): CloudStudio sandbox — dedupe card + keep workspace bind prompt

### DIFF
--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -590,8 +590,14 @@ Configurable environment variables:
 | `TEAMAI_REPORT_PATHS` | JSON `{ "report", "sync", "ack" }`, overrides the three paths |
 | `TEAMAI_REPORT_AGENTS` | Comma-separated list of agents that report (default `workbuddy,codebuddy`) |
 | `TEAMAI_SKILL_DOWNLOAD_HOSTS` | Allowlist of hosts for skill `download_url` (empty = allow all) |
+| `TEAMAI_ALLOW_SANDBOX_REPORT` | Set to `1` to force report/sync inside a CloudStudio sandbox (see note below) |
 
 > **Privacy:** The install path and machine id are only hashed locally to derive `local_agent_id` — they are never reported.
+
+> **CloudStudio sandbox:** When WorkBuddy runs teamai hooks inside a CloudStudio container, that container has a
+> different machine id than the macOS host and would report a duplicate agent card. Report/sync is therefore skipped
+> automatically inside a CloudStudio sandbox (detected via `X_IDE_IS_CLOUDSTUDIO=TRUE` or the `/var/run/cloudstudio`
+> directory). Set `TEAMAI_ALLOW_SANDBOX_REPORT=1` to opt back in if you run teamai exclusively inside CloudStudio.
 
 ### Codebase Knowledge Graph
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -588,8 +588,14 @@ cat ~/.claude/CLAUDE.md
 | `TEAMAI_REPORT_PATHS` | JSON `{ "report", "sync", "ack" }`，覆盖三个路径 |
 | `TEAMAI_REPORT_AGENTS` | 参与上报的 agent，逗号分隔（默认 `workbuddy,codebuddy`） |
 | `TEAMAI_SKILL_DOWNLOAD_HOSTS` | skill `download_url` host 白名单（空 = 全部放行） |
+| `TEAMAI_ALLOW_SANDBOX_REPORT` | 设为 `1` 可强制在 CloudStudio 沙箱内 report/sync（见下方说明） |
 
 > **隐私**：install path 和 machine id 仅在本地哈希以派生 `local_agent_id`，不会上报。
+
+> **CloudStudio 沙箱**：当 WorkBuddy 在 CloudStudio 容器内运行 teamai hook 时，该容器的 machine id 与 macOS
+> 宿主不同，会上报一张重复的 agent 卡片。因此在 CloudStudio 沙箱内会自动跳过 report/sync（通过
+> `X_IDE_IS_CLOUDSTUDIO=TRUE` 或 `/var/run/cloudstudio` 目录检测）。若你只在 CloudStudio 内使用 teamai，可设
+> `TEAMAI_ALLOW_SANDBOX_REPORT=1` 重新开启上报。
 
 ### 代码知识图谱
 

--- a/src/__tests__/local-agent.test.ts
+++ b/src/__tests__/local-agent.test.ts
@@ -805,4 +805,54 @@ describe('local-agent: CloudStudio sandbox suppression', () => {
     expect(result).toBe(false);
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it('still emits binding hint (stdout) but skips HTTP report inside sandbox', async () => {
+    process.env.X_IDE_IS_CLOUDSTUDIO = 'TRUE';
+    process.env.TEAMAI_BIND_PROMPT_ENABLED = '1';
+    await setupConfig();
+    const projectDir = path.join(tmpDir, 'sandbox-unbound-project');
+    await fse.ensureDir(projectDir);
+    const { execFileSync } = await import('node:child_process');
+    execFileSync('git', ['init'], { cwd: projectDir, stdio: 'ignore' });
+
+    let reportCalled = false;
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/api/projects/mine')) {
+        return new Response(JSON.stringify({
+          ok: true,
+          projects: [{ id: 100, name: 'alpha' }],
+        }));
+      }
+      if (url.includes('/report')) reportCalled = true;
+      return new Response(JSON.stringify({ ok: true }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const stdoutChunks: string[] = [];
+    const origWrite = process.stdout.write;
+    process.stdout.write = ((chunk: string | Buffer) => {
+      stdoutChunks.push(typeof chunk === 'string' ? chunk : chunk.toString());
+      return true;
+    }) as typeof process.stdout.write;
+
+    let result: boolean;
+    try {
+      const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+      result = await reportAndSyncLocalAgent({
+        cwd: projectDir,
+        tool: 'claude',
+        event: { type: 'prompt_submit', timestamp: new Date().toISOString(), sessionId: 'test-session', tool: 'claude' },
+      });
+    } finally {
+      process.stdout.write = origWrite;
+    }
+
+    const output = stdoutChunks.join('');
+    // Binding hint must still be injected via stdout even inside the sandbox.
+    expect(output).toContain('hookSpecificOutput');
+    expect(output).toContain('绑定到「alpha」项目');
+    // But the HTTP report/sync must be skipped, and the function returns false.
+    expect(reportCalled).toBe(false);
+    expect(result).toBe(false);
+  });
 });

--- a/src/__tests__/local-agent.test.ts
+++ b/src/__tests__/local-agent.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import fse from 'fs-extra';
@@ -741,5 +742,67 @@ describe('local-agent: full-snapshot workspace reporting', () => {
 
     expect(pruned).toBe(true);
     expect(Object.keys(config!.workspaceBindings)).not.toContain(wsSkipDead);
+  });
+});
+
+describe('local-agent: CloudStudio sandbox suppression', () => {
+  afterEach(() => {
+    delete process.env.X_IDE_IS_CLOUDSTUDIO;
+    delete process.env.TEAMAI_ALLOW_SANDBOX_REPORT;
+  });
+
+  it('returns false without fetching when X_IDE_IS_CLOUDSTUDIO=TRUE', async () => {
+    process.env.X_IDE_IS_CLOUDSTUDIO = 'TRUE';
+    await setupConfig();
+
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ ok: true })));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    const result = await reportAndSyncLocalAgent({ tool: 'claude', cwd: tmpDir });
+
+    expect(result).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('proceeds with normal reporting when TEAMAI_ALLOW_SANDBOX_REPORT=1 overrides sandbox', async () => {
+    process.env.X_IDE_IS_CLOUDSTUDIO = 'TRUE';
+    process.env.TEAMAI_ALLOW_SANDBOX_REPORT = '1';
+    await setupConfig();
+
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ ok: true })));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ tool: 'claude', cwd: tmpDir });
+
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
+  it('proceeds with normal reporting when no sandbox env is set', async () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    await setupConfig();
+
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ ok: true })));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ tool: 'claude', cwd: tmpDir });
+
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
+  it('returns false without fetching when /var/run/cloudstudio exists', async () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    await setupConfig();
+
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ ok: true })));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    const result = await reportAndSyncLocalAgent({ tool: 'claude', cwd: tmpDir });
+
+    expect(result).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -1574,24 +1574,31 @@ async function processCommands(
 }
 
 export async function reportAndSyncLocalAgent(context: LocalAgentContext): Promise<boolean> {
-  if (isCloudStudioSandbox() && process.env.TEAMAI_ALLOW_SANDBOX_REPORT !== '1') {
-    log.debug(
-      '[local-agent] CloudStudio sandbox detected; skipping report/sync ' +
-        '(set TEAMAI_ALLOW_SANDBOX_REPORT=1 to override)',
-    );
-    return false;
-  }
   const config = await loadLocalAgentConfig();
   if (!config) return false;
 
-  const workspacePath = await resolveWorkspacePath(context.cwd);
-  if (isBindPromptEnabled() && workspacePath) {
-    if (context.event?.type === 'session_start') {
-      await ensureWorkspaceBinding(config, workspacePath);
+  // Binding prompt is injected via stdout hook context (not HTTP), so it must run
+  // even inside the CloudStudio sandbox — the sandbox guard below only skips the
+  // HTTP report/sync that would produce a duplicate card. Resolve the workspace
+  // only when the prompt is enabled, so the default-off path forks no git process.
+  if (isBindPromptEnabled()) {
+    const workspacePath = await resolveWorkspacePath(context.cwd);
+    if (workspacePath) {
+      if (context.event?.type === 'session_start') {
+        await ensureWorkspaceBinding(config, workspacePath);
+      }
+      if (context.event?.type === 'prompt_submit') {
+        await emitBindingHint(config, workspacePath);
+      }
     }
-    if (context.event?.type === 'prompt_submit') {
-      await emitBindingHint(config, workspacePath);
-    }
+  }
+
+  if (isCloudStudioSandbox() && process.env.TEAMAI_ALLOW_SANDBOX_REPORT !== '1') {
+    log.debug(
+      '[local-agent] CloudStudio sandbox detected; skipping HTTP report/sync ' +
+        '(binding prompt still runs; set TEAMAI_ALLOW_SANDBOX_REPORT=1 to override)',
+    );
+    return false;
   }
 
   const tag = localAgentTag(context);

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -254,6 +254,24 @@ function resolveLocalAgentId(context: LocalAgentContext): string {
 }
 
 /**
+ * Detect whether we are running inside a CloudStudio container sandbox.
+ *
+ * WorkBuddy can spawn a CloudStudio Linux container that runs its own teamai
+ * hooks. That container has a different machine_id than the macOS host, so it
+ * derives a second local_agent_id and reports a duplicate agent card. Both
+ * signals below are absent on a normal Linux user machine, so this never
+ * suppresses reporting for legitimate standalone Linux users.
+ */
+function isCloudStudioSandbox(): boolean {
+  if (process.env.X_IDE_IS_CLOUDSTUDIO === 'TRUE') return true;
+  try {
+    return fs.existsSync('/var/run/cloudstudio');
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Build the unified log tag for local-agent debug output: `[<id6>] [<tool>]` —
  * the last 6 chars of the derived agent id plus the agent name (tool), so every
  * line (HTTP request/response, report/sync, command ack) reads the same way.
@@ -1556,6 +1574,13 @@ async function processCommands(
 }
 
 export async function reportAndSyncLocalAgent(context: LocalAgentContext): Promise<boolean> {
+  if (isCloudStudioSandbox() && process.env.TEAMAI_ALLOW_SANDBOX_REPORT !== '1') {
+    log.debug(
+      '[local-agent] CloudStudio sandbox detected; skipping report/sync ' +
+        '(set TEAMAI_ALLOW_SANDBOX_REPORT=1 to override)',
+    );
+    return false;
+  }
   const config = await loadLocalAgentConfig();
   if (!config) return false;
 


### PR DESCRIPTION
## Summary

Two related fixes for how the HTTP local-agent behaves inside the CloudStudio sandbox (where WorkBuddy runs workspace tasks).

**Commit 1 — skip duplicate report inside sandbox (`d4f5f8f`)**
WorkBuddy runs teamai hooks both on the macOS host and inside a spawned CloudStudio Linux container. The container has a different `machine_id`, so it derives a second `local_agent_id` and reports a duplicate agent card. Detect the sandbox (`X_IDE_IS_CLOUDSTUDIO=TRUE` or `/var/run/cloudstudio`) and short-circuit the HTTP report/sync. `TEAMAI_ALLOW_SANDBOX_REPORT=1` opts back in.

**Commit 2 — keep the workspace bind prompt working in the sandbox (`748fb89`)**
The sandbox guard above returned *before* the workspace binding prompt, so workspace tasks (which run inside the sandbox) never triggered the bind prompt — while ad-hoc tasks on the host still did. This was a regression introduced by commit 1's early return.

Fix: move the binding prompt ahead of the guard. The prompt is injected via **stdout hook context**, not the HTTP report that produces the duplicate card, so the guard still suppresses only the card-producing report/sync. The workspace path is resolved only when the prompt is enabled, so the default-off path forks no `git` process.

## Behavior

| Scenario | Bind prompt | HTTP report |
|---|---|---|
| Ad-hoc task (host, no sandbox) | triggers | reports |
| Workspace task (inside sandbox) | triggers | skipped (no duplicate card) |

## Test Plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/__tests__/local-agent.test.ts` — 30/30 pass (incl. new regression test: sandbox still emits bind hint but skips HTTP report)
- [x] `npm run build` — success
- [x] Real CLI end-to-end via `dist/index.js` `hook-dispatch` (the entry WorkBuddy calls) against a fake backend: confirmed bind hint is injected both inside and outside the sandbox, and `POST /report` fires only outside the sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)