### PR TITLE
fix(local-agent): create tool root dir for workspace resource install

### DIFF
--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -31,6 +31,7 @@ import { normalizeAgentType } from './utils/tool-names.js';
 import { logHttpRequest, logHttpResponse } from './utils/http-log.js';
 import { reconcilePlugins, teardownAllPlugins, parseGetConfig, substituteVars, unresolvedPlaceholders, type ReconcileDeps, type PluginState } from './plugin-lifecycle.js';
 import {
+  resolveBaseDir,
   TEAMAI_HOME,
   TEAMAI_TOKEN_PATH,
   TEAMAI_CLAUDEMD_START,
@@ -1339,6 +1340,32 @@ async function installDownloadedResource(input: {
     }
     const teamConfig = { ...fullTeamConfig, toolPaths: { [tool]: toolPath } };
     const localConfig = createResourceLocalConfig(input.config, input.scope, repoPath, input.workspacePath);
+    // Ensure the tool root directory exists before dispatch so isToolInstalled
+    // gate does not skip the resource when the workspace is freshly bound.
+    // Restricted to project scope: user-scope installs use $HOME as baseDir and
+    // should continue to rely on isToolInstalled as the gate.
+    if (localConfig.scope === 'project') {
+      try {
+        const baseDir = resolveBaseDir(localConfig);
+        const resourceToolPath =
+          input.kind === 'skill' ? toolPath.skills :
+          input.kind === 'rule'  ? toolPath.rules  :
+          // Default branch covers the 'claudemd' kind; if a new CommandResourceKind
+          // is added, revisit this mapping so it doesn't silently fall through to claudemd.
+          toolPath.claudemd;
+        if (resourceToolPath && resourceToolPath.includes('/')) {
+          const rootSegment = resourceToolPath.split('/')[0];
+          await ensureDir(path.join(baseDir, rootSegment));
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes('resolveBaseDir')) {
+          log.warn(`Cannot resolve base dir to pre-create tool root: ${msg}`);
+        } else {
+          log.debug(`Failed to pre-create tool root directory: ${msg}`);
+        }
+      }
+    }
     const now = new Date().toISOString();
     let displayName = input.command.display_name ?? input.slug;
     // On-disk skill directory name (SKILL.md name when it differs from slug).


### PR DESCRIPTION
## Problem

PR #216 normalized the backend `"workspace"` scope to internal project scope, fixing resources being installed under `~/` instead of the project. But it did **not** touch the `ResourceHandler.isToolInstalled` gate.

For a freshly bound workspace that has no tool directory yet (e.g. `.codebuddy/`), that gate returns false and **every** skill, rule and claudemd is silently skipped on explicit backend-driven install — so nothing lands until the user manually `mkdir .codebuddy`. Rules never synced at all for the same reason.

The gate is correct for `teamai pull` batch sync (don't create dirs for tools the user hasn't installed), but wrong for local-agent explicit installs where the backend has explicitly pushed the resource to this workspace.

## Fix

In `installDownloadedResource()`, **project scope only**, pre-create the target tool's root directory before dispatch so `isToolInstalled` passes and the resource lands. Details:

- User scope is untouched — it keeps relying on `isToolInstalled` (so we never create `~/.codebuddy` for an uninstalled tool).
- `teamai pull` path is untouched (shared handlers, signatures unchanged).
- Guards the bare-file claudemd target (workbuddy's `AGENTS.md`) so no spurious directory is created.
- Failures degrade gracefully (warn on missing projectRoot config, debug on fs errors); install is never aborted.

One file changed, +27 lines.

## Test Plan

All executed and passing:

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run` — 1823 tests passed
- [x] `npm run build` — success
- [x] **Real-CLI e2e** — drove the built CLI via `hook-dispatch session-start --tool codebuddy` against a mock backend, into a fresh workspace containing only `.git` (no `.codebuddy`), with project-scope `install_skill` + `install_rule` + `install_claudemd` commands:
  - **After fix**: `.codebuddy/skills/<slug>/SKILL.md`, `.codebuddy/rules/<slug>.md`, and `.codebuddy/CODEBUDDY.md` (prompt content injected between teamai markers) all land correctly.
  - **Before fix (control, change stashed + rebuilt)**: all three fail to land, `.codebuddy` is never created — reproducing the reported bug and confirming the fix is causal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)