### PR TITLE
fix(local-agent): attribute reported workspaces to their owning tool

### DIFF
--- a/src/__tests__/local-agent.test.ts
+++ b/src/__tests__/local-agent.test.ts
@@ -574,8 +574,8 @@ describe('local-agent: full-snapshot workspace reporting', () => {
     await fse.ensureDir(wsA);
     await fse.ensureDir(wsB);
     await setupConfig({
-      [wsA]: { projectId: 11, projectName: 'A', boundAt: 'x' },
-      [wsB]: { projectId: 22, projectName: 'B', boundAt: 'x' },
+      [wsA]: { projectId: 11, projectName: 'A', boundAt: 'x', ideType: 'codebuddy' },
+      [wsB]: { projectId: 22, projectName: 'B', boundAt: 'x', ideType: 'codebuddy' },
     });
 
     const { buildReportPayload, loadLocalAgentConfig } = await import('../local-agent.js');
@@ -610,8 +610,8 @@ describe('local-agent: full-snapshot workspace reporting', () => {
     );
     await fse.ensureDir(wsEmpty);
     await setupConfig({
-      [wsFull]: { projectId: 7, projectName: 'full', boundAt: 'x' },
-      [wsEmpty]: { projectId: 8, projectName: 'empty', boundAt: 'x' },
+      [wsFull]: { projectId: 7, projectName: 'full', boundAt: 'x', ideType: 'codebuddy' },
+      [wsEmpty]: { projectId: 8, projectName: 'empty', boundAt: 'x', ideType: 'codebuddy' },
     });
 
     const { buildReportPayload, loadLocalAgentConfig } = await import('../local-agent.js');
@@ -675,7 +675,7 @@ describe('local-agent: full-snapshot workspace reporting', () => {
     await fse.ensureDir(wsA);
     execFileSync('git', ['init'], { cwd: cwdDir, stdio: 'ignore' });
     await setupConfig({
-      [wsA]: { projectId: 5, projectName: 'A', boundAt: 'x' },
+      [wsA]: { projectId: 5, projectName: 'A', boundAt: 'x', ideType: 'codebuddy' },
     });
 
     const { buildReportPayload, loadLocalAgentConfig } = await import('../local-agent.js');
@@ -714,7 +714,7 @@ describe('local-agent: full-snapshot workspace reporting', () => {
     const wsSkip = path.join(tmpDir, 'ws-skip');
     await fse.ensureDir(wsSkip);
     await setupConfig({
-      [wsSkip]: { projectId: 0, projectName: '__skipped__', boundAt: 'x' },
+      [wsSkip]: { projectId: 0, projectName: '__skipped__', boundAt: 'x', ideType: 'codebuddy' },
     });
 
     const { buildReportPayload, loadLocalAgentConfig } = await import('../local-agent.js');
@@ -741,5 +741,134 @@ describe('local-agent: full-snapshot workspace reporting', () => {
 
     expect(pruned).toBe(true);
     expect(Object.keys(config!.workspaceBindings)).not.toContain(wsSkipDead);
+  });
+
+  it('filters by tool: workbuddy report only includes workbuddy-owned binding', async () => {
+    const wsCb = path.join(tmpDir, 'ws-cb');
+    const wsWb = path.join(tmpDir, 'ws-wb');
+    await fse.ensureDir(wsCb);
+    await fse.ensureDir(wsWb);
+    await setupConfig({
+      [wsCb]: { projectId: 10, projectName: 'cb', boundAt: 'x', ideType: 'codebuddy' },
+      [wsWb]: { projectId: 20, projectName: 'wb', boundAt: 'x', ideType: 'workbuddy' },
+    });
+
+    const { buildReportPayload, loadLocalAgentConfig } = await import('../local-agent.js');
+    const config = await loadLocalAgentConfig();
+
+    const wbPayload = await buildReportPayload(config!, { tool: 'workbuddy' }) as {
+      workspaces?: Array<Record<string, unknown>>;
+    };
+    expect(wbPayload.workspaces).toHaveLength(1);
+    expect(wbPayload.workspaces![0].path).toBe(wsWb);
+    expect(wbPayload.workspaces![0].ide_type).toBe('workbuddy');
+
+    const cbPayload = await buildReportPayload(config!, { tool: 'codebuddy' }) as {
+      workspaces?: Array<Record<string, unknown>>;
+    };
+    expect(cbPayload.workspaces).toHaveLength(1);
+    expect(cbPayload.workspaces![0].path).toBe(wsCb);
+    expect(cbPayload.workspaces![0].ide_type).toBe('codebuddy');
+  });
+
+  it('includes unattributed cwd binding as current tool and excludes unattributed non-cwd binding', async () => {
+    const { execFileSync } = await import('node:child_process');
+    const cwdDir = path.join(tmpDir, 'cwd-no-type');
+    const wsOther = path.join(tmpDir, 'ws-other-no-type');
+    await fse.ensureDir(cwdDir);
+    await fse.ensureDir(wsOther);
+    execFileSync('git', ['init'], { cwd: cwdDir, stdio: 'ignore' });
+    await setupConfig({
+      [cwdDir]: { projectId: 30, projectName: 'cwd-ws', boundAt: 'x' },
+      [wsOther]: { projectId: 31, projectName: 'other-ws', boundAt: 'x' },
+    });
+
+    const { buildReportPayload, loadLocalAgentConfig } = await import('../local-agent.js');
+    const config = await loadLocalAgentConfig();
+    const payload = await buildReportPayload(config!, { tool: 'codebuddy', cwd: cwdDir }) as {
+      workspaces?: Array<Record<string, unknown>>;
+    };
+
+    const realCwd = fse.realpathSync(cwdDir);
+    // Only the cwd binding is included; the unattributed non-cwd binding is skipped.
+    expect(payload.workspaces).toHaveLength(1);
+    expect(payload.workspaces![0].path).toBe(realCwd);
+    expect(payload.workspaces![0].ide_type).toBe('codebuddy');
+    // wsOther has no ideType and is not cwd, so it is excluded.
+    const paths = (payload.workspaces ?? []).map((w) => w.path as string);
+    expect(paths).not.toContain(wsOther);
+  });
+
+  it('stampWorkspaceTool writes ideType to cwd binding and returns true', async () => {
+    const wsCwd = path.join(tmpDir, 'stamp-ws');
+    await fse.ensureDir(wsCwd);
+    await setupConfig({
+      [wsCwd]: { projectId: 40, projectName: 'stamp', boundAt: 'x' },
+    });
+
+    const { stampWorkspaceTool, loadLocalAgentConfig } = await import('../local-agent.js');
+    const config = await loadLocalAgentConfig();
+
+    const changed = stampWorkspaceTool(config!, wsCwd, 'codebuddy');
+    expect(changed).toBe(true);
+    expect(config!.workspaceBindings[wsCwd].ideType).toBe('codebuddy');
+
+    // Calling again with same tool is idempotent.
+    const changedAgain = stampWorkspaceTool(config!, wsCwd, 'codebuddy');
+    expect(changedAgain).toBe(false);
+  });
+
+  it('stampWorkspaceTool returns false when currentPath is null or undefined', async () => {
+    const wsCwd = path.join(tmpDir, 'stamp-null-ws');
+    await fse.ensureDir(wsCwd);
+    await setupConfig({
+      [wsCwd]: { projectId: 41, projectName: 'stamp-null', boundAt: 'x' },
+    });
+
+    const { stampWorkspaceTool, loadLocalAgentConfig } = await import('../local-agent.js');
+    const config = await loadLocalAgentConfig();
+
+    expect(stampWorkspaceTool(config!, null, 'codebuddy')).toBe(false);
+    expect(stampWorkspaceTool(config!, undefined, 'codebuddy')).toBe(false);
+    // Config must be untouched.
+    expect(config!.workspaceBindings[wsCwd].ideType).toBeUndefined();
+  });
+
+  it('stampWorkspaceTool returns false when currentPath has no binding in config', async () => {
+    await setupConfig({});
+
+    const { stampWorkspaceTool, loadLocalAgentConfig } = await import('../local-agent.js');
+    const config = await loadLocalAgentConfig();
+
+    const missingPath = path.join(tmpDir, 'no-such-binding');
+    expect(stampWorkspaceTool(config!, missingPath, 'codebuddy')).toBe(false);
+  });
+
+  it('buildSyncPayload filters by tool matching ideType', async () => {
+    const wsCb = path.join(tmpDir, 'sync-cb');
+    const wsWb = path.join(tmpDir, 'sync-wb');
+    await fse.ensureDir(wsCb);
+    await fse.ensureDir(wsWb);
+    await setupConfig({
+      [wsCb]: { projectId: 50, projectName: 'sync-cb', boundAt: 'x', ideType: 'codebuddy' },
+      [wsWb]: { projectId: 51, projectName: 'sync-wb', boundAt: 'x', ideType: 'workbuddy' },
+    });
+
+    const { buildSyncPayload, loadLocalAgentConfig } = await import('../local-agent.js');
+    const config = await loadLocalAgentConfig();
+
+    const cbPayload = await buildSyncPayload(config!, { tool: 'codebuddy' }) as {
+      workspaces?: Array<Record<string, unknown>>;
+    };
+    expect(cbPayload.workspaces).toHaveLength(1);
+    expect(cbPayload.workspaces![0].path).toBe(wsCb);
+    expect(cbPayload.workspaces![0].ide_type).toBe('codebuddy');
+
+    const wbPayload = await buildSyncPayload(config!, { tool: 'workbuddy' }) as {
+      workspaces?: Array<Record<string, unknown>>;
+    };
+    expect(wbPayload.workspaces).toHaveLength(1);
+    expect(wbPayload.workspaces![0].path).toBe(wsWb);
+    expect(wbPayload.workspaces![0].ide_type).toBe('workbuddy');
   });
 });

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -1620,7 +1620,11 @@ export async function reportAndSyncLocalAgent(context: LocalAgentContext): Promi
   }
 
   const pruned = await pruneDeadWorkspaceBindings(config);
-  const stamped = stampWorkspaceTool(config, workspacePath, context.tool ?? 'workbuddy');
+  // Resolve the current workspace independently here rather than reusing an
+  // earlier local, so tool attribution does not depend on the binding-prompt
+  // block above keeping a `workspacePath` in scope.
+  const currentPath = await resolveWorkspacePath(context.cwd);
+  const stamped = stampWorkspaceTool(config, currentPath, context.tool ?? 'workbuddy');
   if (pruned || stamped) {
     await saveLocalAgentConfig(config);
   }

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -66,6 +66,9 @@ interface WorkspaceBinding {
   projectId: number;
   projectName?: string;
   boundAt: string;
+  /** Normalized owning tool (via normalizeAgentType). Optional for back-compat with existing config.json;
+   * absent means "not yet attributed". */
+  ideType?: string;
 }
 
 export interface LocalAgentConfig {
@@ -982,6 +985,49 @@ export async function pruneDeadWorkspaceBindings(config: LocalAgentConfig): Prom
   return changed;
 }
 
+/**
+ * Stamps the workspace binding's owning tool when the hook fires from that tool's own process.
+ * Because hooks are invoked from within the tool's process, cwd === binding.path is the
+ * authoritative signal that this binding belongs to the triggering tool.
+ *
+ * Returns true if the binding was modified (caller should persist config), false otherwise.
+ */
+export function stampWorkspaceTool(
+  config: LocalAgentConfig,
+  currentPath: string | null | undefined,
+  tool: string,
+): boolean {
+  if (!currentPath) return false;
+  const binding = config.workspaceBindings[currentPath];
+  if (!binding) return false;
+  const normalized = normalizeAgentType(tool);
+  if (binding.ideType === normalized) return false;
+  binding.ideType = normalized;
+  return true;
+}
+
+/**
+ * Select the workspace paths that belong to the current tool for reporting.
+ *
+ * A binding belongs to the current tool when its stamped ideType matches, or —
+ * for the not-yet-attributed current cwd — when it is the workspace the hook
+ * fired from. An empty/absent ideType on a non-cwd binding is treated as
+ * unattributed and excluded (it self-heals once its owning tool reports from it).
+ */
+function selectToolWorkspaces(
+  config: LocalAgentConfig,
+  currentPath: string | null | undefined,
+  currentTool: string,
+): string[] {
+  const paths = new Set<string>(Object.keys(config.workspaceBindings));
+  if (currentPath) paths.add(currentPath);
+  return Array.from(paths).filter((wsPath) => {
+    const b = config.workspaceBindings[wsPath];
+    const wsTool = (b?.ideType || undefined) ?? (wsPath === currentPath ? currentTool : undefined);
+    return wsTool === currentTool;
+  });
+}
+
 export async function buildReportPayload(
   config: LocalAgentConfig,
   context: LocalAgentContext,
@@ -1030,19 +1076,17 @@ export async function buildReportPayload(
   };
 
   const currentPath = await resolveWorkspacePath(context.cwd);
-  const workspacePaths = new Set<string>(Object.keys(config.workspaceBindings));
-  if (currentPath) {
-    workspacePaths.add(currentPath);
-  }
-  if (workspacePaths.size > 0) {
-    payload.workspaces = await Promise.all(
-      Array.from(workspacePaths).map(async (wsPath) => {
+  const currentTool = normalizeAgentType(tool);
+  const targetPaths = selectToolWorkspaces(config, currentPath, currentTool);
+  if (targetPaths.length > 0) {
+    const workspaceResults = await Promise.all(
+      targetPaths.map(async (wsPath) => {
         const wsScope = await scanScope(wsPath);
         const wsBinding = config.workspaceBindings[wsPath];
         const workspace: Record<string, unknown> = {
           path: wsPath,
           name: path.basename(wsPath),
-          ide_type: normalizeAgentType(tool),
+          ide_type: currentTool,
           project_id: wsBinding?.projectId,
         };
         if (wsScope.skills.length > 0) workspace.skills = wsScope.skills;
@@ -1050,12 +1094,13 @@ export async function buildReportPayload(
         return workspace;
       }),
     );
+    payload.workspaces = workspaceResults;
   }
 
   return payload;
 }
 
-async function buildSyncPayload(
+export async function buildSyncPayload(
   config: LocalAgentConfig,
   context: LocalAgentContext,
 ): Promise<Record<string, unknown>> {
@@ -1065,17 +1110,15 @@ async function buildSyncPayload(
     status: context.status ?? 'running',
   };
   const currentPath = await resolveWorkspacePath(context.cwd);
-  const workspacePaths = new Set<string>(Object.keys(config.workspaceBindings));
-  if (currentPath) {
-    workspacePaths.add(currentPath);
-  }
-  if (workspacePaths.size > 0) {
-    payload.workspaces = Array.from(workspacePaths).map((wsPath) => {
+  const currentTool = normalizeAgentType(context.tool ?? 'workbuddy');
+  const targetPaths = selectToolWorkspaces(config, currentPath, currentTool);
+  if (targetPaths.length > 0) {
+    payload.workspaces = targetPaths.map((wsPath) => {
       const wsBinding = config.workspaceBindings[wsPath];
       return {
         path: wsPath,
         name: path.basename(wsPath),
-        ide_type: normalizeAgentType(context.tool ?? 'workbuddy'),
+        ide_type: currentTool,
         project_id: wsBinding?.projectId,
       };
     });
@@ -1577,7 +1620,8 @@ export async function reportAndSyncLocalAgent(context: LocalAgentContext): Promi
   }
 
   const pruned = await pruneDeadWorkspaceBindings(config);
-  if (pruned) {
+  const stamped = stampWorkspaceTool(config, workspacePath, context.tool ?? 'workbuddy');
+  if (pruned || stamped) {
     await saveLocalAgentConfig(config);
   }
 


### PR DESCRIPTION
## Problem

CodeBuddy and WorkBuddy share `~/.teamai/local-agent/config.json`. Its `workspaceBindings` only mapped `path -> project` with no record of which tool owns a path. On report, `buildReportPayload` / `buildSyncPayload` stamped **every** workspace's `ide_type` with the tool that triggered the current hook.

Because each tool is a distinct backend instance (`local_agent_id` derives from `agent_type` + the per-tool install dir) and report is a full-snapshot (`消失即删`), a WorkBuddy hook relabeled CodeBuddy workspaces as `workbuddy` on the WB instance — and vice versa. Bidirectional cross-tool pollution.

Direct evidence from logs: WorkBuddy reporting tagged multiple `/Users/.../CodeBuddy/...` workspaces as `"ide_type": "workbuddy"`.

## Fix

- Add `WorkspaceBinding.ideType` to record the owning tool (optional, back-compat with existing configs).
- `stampWorkspaceTool`: a hook fires from its own tool's process, so `cwd === binding.path` is the authoritative signal that the binding belongs to the triggering tool. Stamped and persisted alongside the existing prune write in `reportAndSyncLocalAgent`.
- `selectToolWorkspaces` (shared by report and sync): report only the workspaces owned by the current tool, with their real `ide_type`.

### Documented tradeoffs

- An unattributed **non-cwd** binding (legacy config, pre-`ideType`) is skipped until its owning tool reports from it and self-heals — correctness over completeness. The self-heal window is short (every hook from the owning dir re-stamps).
- `ideType` is single-valued: if one path is opened by two tools in turn, the later one wins. Multi-tool co-ownership is out of scope.
- An empty-string `ideType` is treated as unattributed so it can still self-heal.

## Test Plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — **1829 passed** (incl. tool-filter, cwd-stamp, empty/missing-binding, sync-filter cases)
- [x] `npm run build` — success
- [x] E2E via real `teamai hook-dispatch session-start`:
  - `codebuddy` triggered → reports only `repo-cb` with `ide_type=codebuddy`
  - `workbuddy` triggered → reports only `repo-wb` with `ide_type=workbuddy`
  - blank-`ideType` cwd binding self-heals to the triggering tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)