### PR TITLE
fix(pull): refresh CLAUDE.md recall block on the "Already synced" fast-path

### DIFF
--- a/src/__tests__/pull-skip-sync.test.ts
+++ b/src/__tests__/pull-skip-sync.test.ts
@@ -65,10 +65,11 @@ vi.mock('../roles.js', () => ({
   }),
 }));
 
-import { pull } from '../pull.js';
+import { pull, compileRecallRulesBlock } from '../pull.js';
 import { loadLocalConfigForScope, loadTeamConfig, detectProjectConfig, loadStateForScope, saveStateForScope } from '../config.js';
 import { getHeadRev } from '../utils/git.js';
 import { log } from '../utils/logger.js';
+import { TEAMAI_RECALL_RULES_START, TEAMAI_RECALL_RULES_END } from '../types.js';
 import type { TeamaiConfig, LocalConfig } from '../types.js';
 
 describe('pull skip-sync when repo HEAD unchanged', () => {
@@ -258,5 +259,135 @@ describe('pull skip-sync when repo HEAD unchanged', () => {
     expect(log.debug).toHaveBeenCalledWith(
       expect.stringContaining('Rev check failed'),
     );
+  });
+});
+
+// Regression: a CLI upgrade that ships a new recall block must reach CLAUDE.md
+// even when the repo HEAD is unchanged (the "Already synced" fast-path). Before
+// the fix, the fast-path refreshed rules/agents but skipped the CLAUDE.md recall
+// block, so the block stayed frozen at the old wording (e.g. MUST vs SHOULD)
+// until the user ran `teamai pull --force`.
+describe('pull skip-sync refreshes CLAUDE.md recall block (CLI upgrade)', () => {
+  let tmpDir: string;
+  let homeDir: string;
+  let repoPath: string;
+  let claudeMdPath: string;
+
+  // A stale recall block, as an older CLI version would have written it.
+  const STALE_RECALL_BLOCK = [
+    TEAMAI_RECALL_RULES_START,
+    '<!-- DO NOT EDIT: This section is auto-managed by teamai -->',
+    '',
+    '## Team Knowledge Recall (teamai)',
+    '',
+    '**Before** starting any task, you **MUST** first invoke the `teamai-recall` subagent.',
+    TEAMAI_RECALL_RULES_END,
+  ].join('\n');
+
+  beforeEach(async () => {
+    tmpDir = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-recall-refresh-'));
+    homeDir = path.join(tmpDir, 'home');
+    repoPath = path.join(tmpDir, 'team-repo');
+    claudeMdPath = path.join(homeDir, '.claude', 'CLAUDE.md');
+
+    await fse.ensureDir(path.join(repoPath, 'rules'));
+    await fse.ensureDir(path.join(repoPath, 'skills', 'common'));
+    await fse.ensureDir(path.join(repoPath, 'learnings', 'common'));
+    await fse.ensureDir(path.join(repoPath, 'manifest'));
+    await fse.writeFile(path.join(repoPath, 'manifest', 'roles.yaml'), 'version: 1\n');
+    // Tier-1 tool must have its agents dir present for injection to fire.
+    await fse.ensureDir(path.join(homeDir, '.claude', 'agents'));
+    await fse.ensureDir(path.join(homeDir, '.claude', 'rules'));
+    await fse.ensureDir(path.join(homeDir, '.claude', 'skills'));
+    // Seed a CLAUDE.md holding the stale (pre-upgrade) recall block.
+    await fse.writeFile(claudeMdPath, `# CLAUDE.md\n\n${STALE_RECALL_BLOCK}\n`);
+
+    vi.stubEnv('HOME', homeDir);
+
+    const teamConfig: TeamaiConfig = {
+      team: 'test',
+      description: '',
+      repo: 'https://git.woa.com/test/repo.git',
+      provider: 'tgit' as const,
+      reviewers: [],
+      sharing: {
+        skills: {},
+        rules: { enforced: [] },
+        docs: { localDir: '' },
+        env: { injectShellProfile: true },
+      },
+      toolPaths: {
+        // Tier-1: both agents + claudemd configured → recall block injected.
+        claude: { skills: '.claude/skills', rules: '.claude/rules', agents: '.claude/agents', claudemd: '.claude/CLAUDE.md' },
+      },
+    };
+
+    const localConfig: LocalConfig = {
+      repo: { localPath: repoPath, remote: 'https://git.woa.com/test/repo.git' },
+      username: 'testuser',
+      updatePolicy: 'auto',
+      primaryRole: 'hai',
+      additionalRoles: [],
+      resourceProfileVersion: 1,
+      scope: 'user',
+      recallEnabled: true,
+    };
+
+    vi.mocked(loadLocalConfigForScope).mockResolvedValue(localConfig);
+    vi.mocked(loadTeamConfig).mockResolvedValue(teamConfig);
+    vi.mocked(detectProjectConfig).mockResolvedValue(null);
+    vi.mocked(getHeadRev).mockResolvedValue('abc1234');
+    vi.mocked(loadStateForScope).mockResolvedValue({
+      lastPull: '2026-04-01',
+      lastPullRev: 'abc1234', // matches HEAD → triggers "Already synced" fast-path
+      lastPush: null,
+      pushedRules: [],
+      pushedSkills: [],
+      pushedEnvVars: [],
+      lastUpdateCheck: null,
+      availableUpdate: null,
+    });
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+    await fse.remove(tmpDir);
+  });
+
+  it('replaces the stale recall block with the current one on the fast-path', async () => {
+    await pull({});
+
+    // Confirm we actually took the fast-path (repo HEAD unchanged).
+    expect(log.success).toHaveBeenCalledWith(
+      expect.stringContaining('Already synced at abc1234, skipping'),
+    );
+
+    const updated = await fse.readFile(claudeMdPath, 'utf8');
+    // Stale block gone, current block present — verbatim from the CLI source.
+    expect(updated).not.toContain('you **MUST** first invoke the `teamai-recall` subagent');
+    expect(updated).toContain(compileRecallRulesBlock());
+    // Exactly one managed block (replace, not append).
+    expect(updated.split(TEAMAI_RECALL_RULES_START).length - 1).toBe(1);
+    expect(updated.split(TEAMAI_RECALL_RULES_END).length - 1).toBe(1);
+  });
+
+  it('does not touch CLAUDE.md when recall is disabled for the scope', async () => {
+    vi.mocked(loadLocalConfigForScope).mockResolvedValue({
+      repo: { localPath: repoPath, remote: 'https://git.woa.com/test/repo.git' },
+      username: 'testuser',
+      updatePolicy: 'auto',
+      primaryRole: 'hai',
+      additionalRoles: [],
+      resourceProfileVersion: 1,
+      scope: 'user',
+      recallEnabled: false,
+    } as LocalConfig);
+
+    await pull({});
+
+    const after = await fse.readFile(claudeMdPath, 'utf8');
+    // Untouched: the stale block remains exactly as seeded.
+    expect(after).toContain('you **MUST** first invoke the `teamai-recall` subagent');
   });
 });

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -309,6 +309,9 @@ async function pullForScope(
             try { const { deployBuiltinAgents } = await import('./builtin-agents.js'); await deployBuiltinAgents(cfg, localConfig, { skipRecall }); } catch {}
             try { const { deployBuiltinRules } = await import('./builtin-rules.js'); await deployBuiltinRules(cfg, localConfig, { skipRecall }); } catch {}
             try { const { deployBuiltinSkills } = await import('./builtin-skills.js'); await deployBuiltinSkills(cfg, localConfig, { reportingOnly, skipRecall }); } catch {}
+            // Also refresh the CLAUDE.md recall block so a CLI upgrade that ships
+            // a new block reaches CLAUDE.md even when the repo HEAD is unchanged.
+            await injectRecallBlockIntoTools(cfg, localConfig, scopeLabel);
           }
         }
         return;
@@ -716,40 +719,8 @@ async function pullForScope(
   }
 
   // Step 3.8: Inject teamai-recall subagent rules block (Phase 1)
-  //
-  // Only injected for Tier-1 tools that have BOTH `agents` and `claudemd`
-  // configured. Tools without subagent support (cursor / codex / openclaw /
-  // workbuddy) are skipped — for them the recall flow runs purely via the
-  // TodoWrite hint hook and the manual `teamai recall` command.
-  if (!options.dryRun && isRecallEnabled(localConfig, freshConfig)) {
-    try {
-      const baseDir = resolveBaseDir(localConfig);
-      const recallBlock = compileRecallRulesBlock();
-      let injected = 0;
-      for (const [tool, toolPath] of Object.entries(freshConfig.toolPaths)) {
-        if (!toolPath.claudemd || !toolPath.agents) continue;
-        if (!await ResourceHandler.isToolInstalled(toolPath.agents, baseDir)) continue;
-
-        const claudeMdPath = path.join(baseDir, toolPath.claudemd);
-        try {
-          await injectClaudeMdSection(
-            claudeMdPath,
-            TEAMAI_RECALL_RULES_START,
-            TEAMAI_RECALL_RULES_END,
-            recallBlock,
-          );
-          injected++;
-          log.debug(`Injected recall rules into ${tool} CLAUDE.md`);
-        } catch (e) {
-          log.warn(`Failed to inject recall rules into ${tool} CLAUDE.md: ${(e as Error).message}`);
-        }
-      }
-      if (injected > 0) {
-        log.debug(`[${scopeLabel}] Injected recall rules into ${injected} tool(s) CLAUDE.md`);
-      }
-    } catch (e) {
-      log.debug(`[${scopeLabel}] Recall rules injection skipped: ${(e as Error).message}`);
-    }
+  if (!options.dryRun) {
+    await injectRecallBlockIntoTools(freshConfig, localConfig, scopeLabel);
   }
 
   // Step 4: Deploy CLI built-in skills
@@ -917,6 +888,55 @@ export function compileClaudemd(contents: string[]): string | null {
         '',
         TEAMAI_CLAUDEMD_END,
     ].join('\n');
+}
+
+/**
+ * Inject (or replace) the teamai-recall block into every Tier-1 tool's CLAUDE.md.
+ *
+ * Only injected for Tier-1 tools that have BOTH `agents` and `claudemd`
+ * configured. Tools without subagent support (cursor / codex / openclaw /
+ * workbuddy) are skipped — for them the recall flow runs purely via the
+ * TodoWrite hint hook and the manual `teamai recall` command.
+ *
+ * Extracted so both the full-sync path (Step 3.8) and the "Already synced"
+ * rev fast-path can call it — otherwise a CLI upgrade that ships a new recall
+ * block never reaches CLAUDE.md when the team repo HEAD is unchanged.
+ * No-op when recall is disabled for this scope.
+ */
+export async function injectRecallBlockIntoTools(
+    config: TeamaiConfig,
+    localConfig: LocalConfig,
+    scopeLabel: string,
+): Promise<void> {
+    if (!isRecallEnabled(localConfig, config)) return;
+    try {
+        const baseDir = resolveBaseDir(localConfig);
+        const recallBlock = compileRecallRulesBlock();
+        let injected = 0;
+        for (const [tool, toolPath] of Object.entries(config.toolPaths)) {
+            if (!toolPath.claudemd || !toolPath.agents) continue;
+            if (!await ResourceHandler.isToolInstalled(toolPath.agents, baseDir)) continue;
+
+            const claudeMdPath = path.join(baseDir, toolPath.claudemd);
+            try {
+                await injectClaudeMdSection(
+                    claudeMdPath,
+                    TEAMAI_RECALL_RULES_START,
+                    TEAMAI_RECALL_RULES_END,
+                    recallBlock,
+                );
+                injected++;
+                log.debug(`Injected recall rules into ${tool} CLAUDE.md`);
+            } catch (e) {
+                log.warn(`Failed to inject recall rules into ${tool} CLAUDE.md: ${(e as Error).message}`);
+            }
+        }
+        if (injected > 0) {
+            log.debug(`[${scopeLabel}] Injected recall rules into ${injected} tool(s) CLAUDE.md`);
+        }
+    } catch (e) {
+        log.debug(`[${scopeLabel}] Recall rules injection skipped: ${(e as Error).message}`);
+    }
 }
 
 /**


### PR DESCRIPTION
## Problem

Upgrading the CLI does not update the `teamai-recall` block in `CLAUDE.md` on a normal `teamai pull` — the block stays frozen at the old wording (e.g. the recall keyword that changed from **MUST** to **SHOULD** in v0.17.2). It only updates when the user runs `teamai pull --force`.

**Root cause:** when the team repo HEAD is unchanged, `pullForScope` takes the "Already synced, skipping" fast-path. That path was extended to re-deploy built-in agents/rules/skills so a CLI upgrade self-heals — but it never called the Step 3.8 CLAUDE.md recall-block injection before `return`. So `rules/teamai-recall.md` updated correctly while the `CLAUDE.md` managed block did not. This hits the most common upgrade scenario (CLI upgraded, but the team repo has no new commits that day).

## Fix

- Extract the Step 3.8 injection loop into `injectRecallBlockIntoTools()` (recall-enabled gate + Tier-1 tool gate preserved, zero behavior change on the normal path).
- Call it from both the full-sync path and the fast-path, mirroring the existing `reconcileHooksAllScopes` self-heal pattern. No-op when recall is disabled for the scope.

## Test Plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 1836 tests pass (146 files)
- [x] New e2e regression in `pull-skip-sync.test.ts`:
  - stale `MUST` block is replaced with the current block on the fast-path (replace, not append)
  - `CLAUDE.md` left untouched when recall is disabled
  - verified the test fails when the fix is reverted (guards the real bug)
- [x] Real-CLI e2e reproduction (v0.17.0 → fixed build): seeded a stale `MUST` block, ran a normal `pull` that took the `Already synced` fast-path → `CLAUDE.md` correctly updated to `SHOULD`; confirmed the unpatched 0.17.4 binary still shows `MUST` in the same scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)