### PR TITLE
fix(hooks): don't create root dirs for uninstalled tools on hooks inject/remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ hooks:
 
 ```bash
 teamai hooks list      # list effective hooks
-teamai hooks inject    # force-reconcile into all tools
+teamai hooks inject    # re-reconcile into every installed tool
 teamai hooks remove    # remove all teamai-managed hooks
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -79,7 +79,7 @@ hooks:
 
 ```bash
 teamai hooks list      # 查看生效的 hooks
-teamai hooks inject    # 强制重新注入到所有工具
+teamai hooks inject    # 重新注入到每个已安装的工具
 teamai hooks remove    # 移除所有 teamai 管理的 hooks
 ```
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -706,6 +706,8 @@ teamai hooks inject    # Re-inject
 teamai hooks remove    # Remove
 ```
 
+Both commands only touch tools you actually have installed (i.e. whose `~/.<tool>/` root directory already exists). They never create root directories for tools listed in `toolPaths` but not installed, so uninstalled tools such as `.tclaude` / `.tcodex` are left untouched.
+
 ### Team Hooks Declaration
 
 A team can declare custom hooks in the repo's `hooks/hooks.yaml`; `teamai pull` automatically distributes them to all members' AI tools:

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -704,6 +704,8 @@ teamai hooks inject    # 重新注入
 teamai hooks remove    # 移除
 ```
 
+这两个命令只会操作你实际已安装的工具（即 `~/.<tool>/` 根目录已存在的工具）。对于 `toolPaths` 中已配置但未安装的工具，命令不会为其凭空创建根目录，因此像 `.tclaude` / `.tcodex` 这类未安装的工具会被完全跳过。
+
 ### 团队 Hooks 声明
 
 团队可在仓库 `hooks/hooks.yaml` 中声明自定义 hooks，`teamai pull` 自动分发到所有成员的 AI 工具：

--- a/src/__tests__/hooks-cmd.test.ts
+++ b/src/__tests__/hooks-cmd.test.ts
@@ -90,7 +90,7 @@ describe('hooksInject', () => {
             expect.any(String),
             TEAM_DEFS,
             expect.stringContaining('managed-hooks.json'),
-            { builtinOverride: undefined, force: true },
+            { builtinOverride: undefined },
         );
         expect(mockedLog.success).toHaveBeenCalledWith(expect.stringContaining('Hooks injected'));
     });
@@ -119,8 +119,8 @@ describe('hooksInject', () => {
         }
 
         expect(mockedReconcile).toHaveBeenCalledTimes(2);
-        expect(mockedReconcile).toHaveBeenNthCalledWith(1, mockTeamConfig.toolPaths, '/path/to/project', TEAM_DEFS, expect.any(String), { builtinOverride: undefined, force: true });
-        expect(mockedReconcile).toHaveBeenNthCalledWith(2, mockTeamConfig.toolPaths, '/home/testuser', TEAM_DEFS, expect.any(String), { builtinOverride: undefined, force: true });
+        expect(mockedReconcile).toHaveBeenNthCalledWith(1, mockTeamConfig.toolPaths, '/path/to/project', TEAM_DEFS, expect.any(String), { builtinOverride: undefined });
+        expect(mockedReconcile).toHaveBeenNthCalledWith(2, mockTeamConfig.toolPaths, '/home/testuser', TEAM_DEFS, expect.any(String), { builtinOverride: undefined });
 
         // #85: the user-home target must be reconciled against the USER's own
         // manifest, not the project's — otherwise `pull`'s per-scope reconcile
@@ -242,7 +242,7 @@ describe('hooksRemove', () => {
             expect.any(String),
             [],
             expect.stringContaining('managed-hooks.json'),
-            { removeAll: true, force: true },
+            { removeAll: true },
         );
         expect(mockedLog.success).toHaveBeenCalledWith(expect.stringContaining('Hooks removed'));
     });

--- a/src/__tests__/hooks-team-e2e.test.ts
+++ b/src/__tests__/hooks-team-e2e.test.ts
@@ -51,6 +51,12 @@ beforeEach(() => {
   home = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-hooks-e2e-home-'));
   repo = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-hooks-e2e-repo-'));
   writeConfig();
+  // Pre-create the tool root dirs the assertions cover so they are detected as
+  // installed. `hooks inject`/`remove` only reconciles installed tools, so
+  // uninstalled tools (e.g. .tclaude) are intentionally left untouched.
+  for (const tool of ['.claude', '.cursor', '.codex']) {
+    fs.mkdirSync(path.join(home, tool), { recursive: true });
+  }
 });
 
 afterEach(() => {
@@ -129,6 +135,25 @@ describe('teamai hooks — unified A+B end-to-end', () => {
     const claude = readJson('.claude/settings.json') as unknown as { hooks: Record<string, unknown[]> };
     for (const entries of Object.values(claude.hooks)) {
       expect(entries).toHaveLength(0);
+    }
+  });
+
+  // Regression: `hooks inject` must NOT materialize root directories for tools
+  // the user never installed. Doing so used to make uninstalled tools (e.g.
+  // .tclaude / .tcodex / .codex-internal, all present in default toolPaths)
+  // look installed, so later `pull`s pushed skills into them.
+  it('does not create root directories for uninstalled tools', async () => {
+    writeHooksYaml(TEAM_HOOK);
+    // .claude is pre-created (installed) by beforeEach; .tclaude/.tcodex are not.
+    await run(['hooks', 'inject', '--silent']);
+
+    // Installed tool got its settings written.
+    expect(fs.existsSync(path.join(home, '.claude', 'settings.json'))).toBe(true);
+
+    // Uninstalled tools from the default toolPaths were left completely alone —
+    // no root directory, no settings file conjured out of thin air.
+    for (const tool of ['.tclaude', '.tcodex', '.codex-internal']) {
+      expect(fs.existsSync(path.join(home, tool))).toBe(false);
     }
   });
 });

--- a/src/__tests__/hooks-wrapper.test.ts
+++ b/src/__tests__/hooks-wrapper.test.ts
@@ -56,9 +56,7 @@ describe('reconcileHooksToAllTools — wrapper creation on main inject path', ()
         [tool]: { settings: settingsFile },
       };
 
-      await reconcileHooksToAllTools(toolPaths, tmp, [], path.join(tmp, 'managed-hooks.json'), {
-        force: true,
-      });
+      await reconcileHooksToAllTools(toolPaths, tmp, [], path.join(tmp, 'managed-hooks.json'), {});
 
       const wrapperPath = path.join(tmp, '.teamai', 'bin', 'teamai');
       expect(await fse.pathExists(wrapperPath)).toBe(true);
@@ -76,9 +74,7 @@ describe('reconcileHooksToAllTools — wrapper creation on main inject path', ()
     await fse.ensureDir(path.join(tmp, '.claude'));
 
     await expect(
-      reconcileHooksToAllTools(toolPaths, tmp, [], path.join(tmp, 'managed-hooks.json'), {
-        force: true,
-      }),
+      reconcileHooksToAllTools(toolPaths, tmp, [], path.join(tmp, 'managed-hooks.json'), {}),
     ).resolves.not.toThrow();
   });
 });
@@ -120,9 +116,7 @@ describe('reconcileHooksToAllTools — wrapper creation on main inject path', ()
         [tool]: { settings: settingsFile },
       };
 
-      await reconcileHooksToAllTools(toolPaths, tmp, [], path.join(tmp, 'managed-hooks.json'), {
-        force: true,
-      });
+      await reconcileHooksToAllTools(toolPaths, tmp, [], path.join(tmp, 'managed-hooks.json'), {});
 
       const wrapperPath = path.join(tmp, '.teamai', 'bin', 'teamai');
       expect(await fse.pathExists(wrapperPath)).toBe(true);
@@ -140,9 +134,7 @@ describe('reconcileHooksToAllTools — wrapper creation on main inject path', ()
     await fse.ensureDir(path.join(tmp, '.claude'));
 
     await expect(
-      reconcileHooksToAllTools(toolPaths, tmp, [], path.join(tmp, 'managed-hooks.json'), {
-        force: true,
-      }),
+      reconcileHooksToAllTools(toolPaths, tmp, [], path.join(tmp, 'managed-hooks.json'), {}),
     ).resolves.not.toThrow();
   });
 });

--- a/src/hooks-cmd.ts
+++ b/src/hooks-cmd.ts
@@ -90,7 +90,7 @@ export async function hooksInject(options: GlobalOptions): Promise<void> {
         silent: options.silent,
     });
     for (const { baseDir, manifestPath } of resolveHookScopeTargets(localConfig)) {
-        await reconcileHooksToAllTools(teamConfig.toolPaths, baseDir, teamDefs, manifestPath, { builtinOverride: builtin, force: true });
+        await reconcileHooksToAllTools(teamConfig.toolPaths, baseDir, teamDefs, manifestPath, { builtinOverride: builtin });
     }
 
     if (!options.silent) {
@@ -156,7 +156,7 @@ export async function hooksRemove(_options: GlobalOptions): Promise<void> {
     const { localConfig, teamConfig } = await autoDetectInit();
 
     for (const { baseDir, manifestPath } of resolveHookScopeTargets(localConfig)) {
-        await reconcileHooksToAllTools(teamConfig.toolPaths, baseDir, [], manifestPath, { removeAll: true, force: true });
+        await reconcileHooksToAllTools(teamConfig.toolPaths, baseDir, [], manifestPath, { removeAll: true });
     }
 
     log.success('Hooks removed from all AI tool settings');

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -543,7 +543,7 @@ export async function reconcileHooksToAllTools(
   baseDir: string,
   teamDefs: HookDef[],
   manifestPath: string,
-  opts: { removeAll?: boolean; builtinOverride?: BuiltinHookOverride; force?: boolean; filterAgents?: string[] } = {},
+  opts: { removeAll?: boolean; builtinOverride?: BuiltinHookOverride; filterAgents?: string[] } = {},
 ): Promise<void> {
   const wrapperTools = ['workbuddy', 'codebuddy'];
   const activeTools = Object.keys(toolPaths).filter(t => !opts.filterAgents || opts.filterAgents.includes(t));
@@ -553,11 +553,13 @@ export async function reconcileHooksToAllTools(
   for (const [tool, paths] of Object.entries(toolPaths)) {
     if (opts.filterAgents && !opts.filterAgents.includes(tool)) continue;
     if (!paths.settings) continue;
-    if (opts.filterAgents && !opts.filterAgents.includes(tool)) continue;
-    if (!opts.force) {
-      const toolRoot = path.join(baseDir, paths.settings.split('/')[0]);
-      if (!await pathExists(toolRoot)) continue;
-    }
+    // Only reconcile hooks for tools the user actually has installed. Without
+    // this gate, `hooks inject`/`remove` would create root directories for
+    // every configured tool (e.g. ~/.tclaude, ~/.tcodex) via reconcileHooks's
+    // ensureDir — making uninstalled tools look installed and pulling skills
+    // into them on later `pull`s.
+    const toolRoot = path.join(baseDir, paths.settings.split('/')[0]);
+    if (!await pathExists(toolRoot)) continue;
     const settingsPath = path.join(baseDir, paths.settings);
     try {
       await reconcileHooks(settingsPath, tool, teamDefs, {


### PR DESCRIPTION
## Problem

`teamai hooks inject` / `hooks remove` were silently creating root directories for AI tools the user never installed.

The default `toolPaths` includes internal agents like `tclaude`, `tcodex`, `codex-internal`. When a user ran `hooks inject`, empty `~/.tclaude/`, `~/.tcodex/`, `~/.codex-internal/` directories appeared out of nowhere — each with a `settings.json`/`hooks.json` and empty `skills/rules/agents/` subdirs. Worse: once those root dirs existed, `isToolInstalled` treated the tools as installed, so subsequent `teamai pull`s copied skills into them too.

## Root cause

`hooks inject`/`remove` passed `force: true` to `reconcileHooksToAllTools` (introduced in #135 to make clean-env E2E tests pass). `force` skipped the `pathExists(toolRoot)` gate, and `reconcileHooks` then created the root dir via `ensureDir` for **every** configured tool.

```ts
// before — force bypassed the installed check entirely
if (!opts.force) {
  const toolRoot = path.join(baseDir, paths.settings.split('/')[0]);
  if (!await pathExists(toolRoot)) continue;
}
```

`force`'s only effect was bypassing this gate, so it's removed entirely. Hooks are now reconciled only into tools whose root directory already exists — consistent with skill/rule/agent sync and with `injectHooksToAllTools` (the `pull`/`init` path, which already gated correctly).

## Changes

- `src/hooks.ts`: drop the `force` option; always gate each tool on root-dir existence
- `src/hooks-cmd.ts`: stop passing `force: true` from `inject`/`remove`
- Tests: pre-create installed tool dirs where they previously relied on `force`; add an e2e regression asserting uninstalled tool dirs are never created
- Docs: clarify `inject`/`remove` only touch installed tools (README + usage-guide, both languages)

## Test Plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 1836 passed
- [x] `npx vitest run --config vitest.e2e.config.ts` — 56 passed, 23 skipped
- [x] New regression test `does not create root directories for uninstalled tools` (hooks-team-e2e) passes
- [x] Real CLI e2e in a clean `$HOME`: only `.claude` (pre-installed) exists after `hooks inject`; `.tclaude` / `.tcodex` / `.codex-internal` / `.cursor` / `.codex` / `.codebuddy` are **not** created, and `.claude/settings.json` is written correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)