### PR TITLE
perf(hooks): run post-tool-use local-agent sync in background

### DIFF
--- a/src/__tests__/hook-handlers.test.ts
+++ b/src/__tests__/hook-handlers.test.ts
@@ -11,6 +11,7 @@ const mockTrackFromParsed = vi.fn().mockResolvedValue(undefined);
 const mockTrackSlashFromParsed = vi.fn().mockResolvedValue(undefined);
 const mockContributeCheckForSession = vi.fn().mockResolvedValue({ hint: null });
 const mockDoUpdate = vi.fn().mockResolvedValue(undefined);
+const mockReportAndSyncFromHook = vi.fn().mockResolvedValue(null);
 
 vi.mock('../pull.js', () => ({
   pull: mockPull,
@@ -53,7 +54,12 @@ vi.mock('../utils/logger.js', () => ({
   log: { info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
+vi.mock('../local-agent.js', () => ({
+  reportAndSyncFromHook: mockReportAndSyncFromHook,
+}));
+
 import { buildHandlerRegistry, type HandlerRegistration } from '../hook-handlers.js';
+import { createDispatcher } from '../hook-dispatch.js';
 
 // ── Tests ────────────────────────────────────────────────
 
@@ -160,6 +166,46 @@ describe('hook-handlers registry', () => {
     expect(skillHandlers).toContain('track');
   });
 
+  // Perf regression: post-tool-use fires on every tool call, so its local-agent
+  // report/sync (two HTTP round-trips) must run detached — never in the
+  // foreground where it stalls the host's hook completion by ~300ms–seconds
+  // depending on network latency. Mirrors the `stop` event, which already
+  // backgrounds local-agent-sync.
+  it('post-tool-use wildcard local-agent-sync is a background handler', () => {
+    const registry = buildHandlerRegistry();
+    const localAgent = registry.find(
+      (r) => r.event === 'post-tool-use' && r.matcher === '*' && r.handler.name === 'local-agent-sync',
+    );
+    expect(localAgent).toBeDefined();
+    expect(localAgent!.background).toBe(true);
+  });
+
+  // post-tool-use dashboard-report stays foreground: it is a fast local file
+  // append with no network I/O, so detaching it would add spawn overhead for
+  // no benefit.
+  it('post-tool-use wildcard dashboard-report stays foreground', () => {
+    const registry = buildHandlerRegistry();
+    const dashboard = registry.find(
+      (r) => r.event === 'post-tool-use' && r.matcher === '*' && r.handler.name === 'dashboard-report',
+    );
+    expect(dashboard).toBeDefined();
+    expect(dashboard!.background).not.toBe(true);
+  });
+
+  // prompt-submit local-agent-sync must NOT be backgrounded: when the org
+  // binding prompt is enabled (TEAMAI_BIND_PROMPT_ENABLED=1) it writes the
+  // binding hint to STDOUT for the host to inject back into the session, and a
+  // detached child's STDOUT is discarded. Guards against a copy-paste of the
+  // post-tool-use change onto prompt-submit.
+  it('prompt-submit wildcard local-agent-sync stays foreground', () => {
+    const registry = buildHandlerRegistry();
+    const localAgent = registry.find(
+      (r) => r.event === 'prompt-submit' && r.matcher === '*' && r.handler.name === 'local-agent-sync',
+    );
+    expect(localAgent).toBeDefined();
+    expect(localAgent!.background).not.toBe(true);
+  });
+
   it('post-tool-use Bash/Grep/WebSearch/WebFetch have no registered handlers', () => {
     const registry = buildHandlerRegistry();
     for (const matcher of ['Bash', 'Grep', 'WebSearch', 'WebFetch']) {
@@ -189,5 +235,43 @@ describe('hook-handlers registry', () => {
     const pull = registry.find((r) => r.handler.name === 'pull');
     const dashboard = registry.find((r) => r.handler.name === 'dashboard-report');
     expect(pull!.timeoutMs).toBeGreaterThan(dashboard!.timeoutMs!);
+  });
+});
+
+// End-to-end: wire the real handler registry through the real dispatcher and
+// assert the foreground/background split that actually governs host latency.
+// The registry declares `background: true`; the dispatcher must honor it by
+// keeping local-agent-sync OUT of the foreground pass (so the host's hook
+// returns without waiting on the two HTTP round-trips) while still running it
+// in the detached background pass (so report/sync are not silently dropped).
+describe('post-tool-use dispatch — local-agent runs detached, never blocks host', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const stdin = { tool_name: 'Bash', tool_input: { command: 'ls' }, cwd: '/tmp/proj' };
+
+  it('hasBackground is true for the post-tool-use wildcard', () => {
+    const dispatcher = createDispatcher({ handlers: buildHandlerRegistry() });
+    expect(dispatcher.hasBackground('post-tool-use', '*')).toBe(true);
+  });
+
+  it('foreground pass does NOT invoke local-agent-sync (host is not blocked on HTTP)', async () => {
+    const dispatcher = createDispatcher({ handlers: buildHandlerRegistry() });
+    await dispatcher.dispatch('post-tool-use', '*', stdin, 'claude', 'foreground');
+    expect(mockReportAndSyncFromHook).not.toHaveBeenCalled();
+  });
+
+  it('background pass DOES invoke local-agent-sync (report/sync still happen)', async () => {
+    const dispatcher = createDispatcher({ handlers: buildHandlerRegistry() });
+    await dispatcher.dispatch('post-tool-use', '*', stdin, 'claude', 'background');
+    expect(mockReportAndSyncFromHook).toHaveBeenCalledOnce();
+  });
+
+  it('foreground pass still runs the fast local dashboard-report handler', async () => {
+    const dispatcher = createDispatcher({ handlers: buildHandlerRegistry() });
+    await dispatcher.dispatch('post-tool-use', '*', stdin, 'claude', 'foreground');
+    // dashboard-report parses the event and appends locally — it must stay inline.
+    expect(mockParseHookEvent).toHaveBeenCalled();
   });
 });

--- a/src/hook-handlers.ts
+++ b/src/hook-handlers.ts
@@ -325,7 +325,7 @@ export function buildHandlerRegistry(): HandlerRegistration[] {
     { event: 'post-tool-use', matcher: '*', handler: dashboardReportHandler, timeoutMs: DASHBOARD_TIMEOUT_MS },
     { event: 'post-tool-use', matcher: 'Skill', handler: trackHandler, timeoutMs: TRACK_TIMEOUT_MS },
     { event: 'post-tool-use', matcher: 'TodoWrite', handler: todowriteHintHandler, timeoutMs: TODOWRITE_HINT_TIMEOUT_MS },
-    { event: 'post-tool-use', matcher: '*', handler: localAgentHandler, timeoutMs: LOCAL_AGENT_TIMEOUT_MS },
+    { event: 'post-tool-use', matcher: '*', handler: localAgentHandler, timeoutMs: LOCAL_AGENT_TIMEOUT_MS, background: true },
 
     // ─── UserPromptSubmit ─────────────────────────────
     { event: 'prompt-submit', matcher: '*', handler: trackSlashHandler, timeoutMs: TRACK_TIMEOUT_MS },


### PR DESCRIPTION
## Problem

Users reported teamai hooks being slow (often >1s). Profiling confirmed it: the **PostToolUse hook fires on every single tool call**, and its `local-agent-sync` handler ran two blocking HTTP round-trips (`report` + `sync`) in the **foreground**.

Measured hot-path latency (`hook-dispatch post-tool-use`, HTTP source configured):

| Scenario | Before (foreground) | After (background) |
|---|---|---|
| Normal endpoint | ~500ms | **~195ms** |
| Slow endpoint (2s/req) | ~4340ms | **~195ms** (unaffected) |

Other hooks (`stop`, `TodoWrite`, `Skill`) were already ~190ms — only `post-tool-use *` and `prompt-submit *` carried the foreground HTTP cost.

## Fix

Mark the `post-tool-use` wildcard `local-agent-sync` handler `background: true`, so the dispatcher runs it in the **detached child process** — exactly how the `Stop` event already treats `local-agent-sync`. The foreground pass now returns as soon as the fast local `dashboard-report` append completes; the two HTTP round-trips happen in the background and never block the host's hook completion.

## Why this is safe

`local-agent`'s only two STDOUT side-channels (the outputs the host injects back into the session) are:

- `ensureWorkspaceBinding` (`local-agent.ts:814`) — fires **only on `session_start`**
- `emitBindingHint` (`local-agent.ts:869`) — fires **only on `prompt_submit`**

Both are gated behind `TEAMAI_BIND_PROMPT_ENABLED` (off by default). `PostToolUse` maps to event type `tool_use` (`dashboard-collector.ts:405`), which hits **neither** branch. `reportAndSyncFromHook` always returns `null`, and `processCommands` is pure side-effect (no STDOUT). So detaching loses no host-visible output.

**`prompt-submit` is deliberately left foreground** — when the binding prompt is enabled it writes to STDOUT for the host to inject back, which a detached child (STDOUT `ignore`d) would silently drop. A regression test guards against copy-pasting this change onto `prompt-submit`.

## Test Plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 146 files / 1843 tests pass (incl. hooks-golden: on-disk hook rendering unchanged, since `background` is a runtime-only registry property)
- [x] New unit + e2e tests in `hook-handlers.test.ts`:
  - registry: `post-tool-use *` local-agent-sync is `background: true`
  - registry: `post-tool-use *` dashboard-report stays foreground
  - registry: `prompt-submit *` local-agent-sync stays foreground (regression guard)
  - dispatch e2e: foreground pass does NOT invoke local-agent-sync; background pass DOES
- [x] **Real CLI e2e** (built `dist`, spy server with 2s/request latency):
  - foreground hook returns in ~195ms (before: ~4340ms)
  - detached child still issues `POST /report` + `POST /sync` to the backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)