### PR TITLE
fix(init): re-clone when existing team-repo is not a git repository

### DIFF
--- a/src/__tests__/git.test.ts
+++ b/src/__tests__/git.test.ts
@@ -25,6 +25,7 @@ vi.mock('simple-git', () => ({
 vi.mock('fs-extra', () => ({
   default: {
     ensureDir: vi.fn(),
+    pathExists: vi.fn(),
   },
 }));
 
@@ -46,7 +47,7 @@ vi.mock('../utils/logger.js', () => ({
   },
 }));
 
-import { generateBranchName, pushRepoBranch, checkoutMaster, pushRepoDirectly, initRepo, configureGitUser, getHeadRev, resetToCleanMaster, isMetadataOnlyDiff } from '../utils/git.js';
+import { generateBranchName, pushRepoBranch, checkoutMaster, pushRepoDirectly, initRepo, configureGitUser, getHeadRev, resetToCleanMaster, isMetadataOnlyDiff, isGitRepo } from '../utils/git.js';
 import fse from 'fs-extra';
 
 describe('generateBranchName', () => {
@@ -73,6 +74,33 @@ describe('generateBranchName', () => {
     expect(month).toBeLessThanOrEqual(12);
     expect(day).toBeGreaterThanOrEqual(1);
     expect(day).toBeLessThanOrEqual(31);
+  });
+});
+
+describe('isGitRepo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns false when the path does not exist', async () => {
+    (fse.pathExists as any).mockResolvedValue(false);
+    expect(await isGitRepo('/nope')).toBe(false);
+    // Should short-circuit after the first (path) check
+    expect((fse.pathExists as any)).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns false when the path exists but has no .git entry', async () => {
+    (fse.pathExists as any)
+      .mockResolvedValueOnce(true) // path exists
+      .mockResolvedValueOnce(false); // .git missing
+    expect(await isGitRepo('/repo')).toBe(false);
+  });
+
+  it('returns true when the path is a git repo', async () => {
+    (fse.pathExists as any)
+      .mockResolvedValueOnce(true) // path exists
+      .mockResolvedValueOnce(true); // .git present
+    expect(await isGitRepo('/repo')).toBe(true);
   });
 });
 

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -135,6 +135,8 @@ vi.mock('../roles.js', () => ({
 // Track pathExists calls to simulate directory states
 let pathExistsFn: (p: string) => boolean = () => false;
 
+const mockRemove = vi.fn();
+
 vi.mock('../utils/fs.js', () => ({
   ensureDir: vi.fn(),
   writeFile: vi.fn(),
@@ -146,6 +148,7 @@ vi.mock('../utils/fs.js', () => ({
     return p;
   },
   readFileSafe: vi.fn().mockResolvedValue(null),
+  remove: (p: string) => mockRemove(p),
 }));
 
 vi.mock('../types.js', async (importOriginal) => {
@@ -179,6 +182,7 @@ const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as
 import { init } from '../init.js';
 import { RepoNotFoundError } from '../providers/types.js';
 import { saveLocalConfig } from '../config.js';
+import fse from 'fs-extra';
 
 describe('init', () => {
   const HOME = process.env.HOME ?? '';
@@ -237,6 +241,55 @@ describe('init', () => {
       expect(mockGfRepoClone).toHaveBeenCalled();
       expect(mockGit.init).not.toHaveBeenCalled();
       expect(mockGit.addRemote).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('stale non-git directory', () => {
+    it('should remove and re-clone when team-repo exists but is not a git repo', async () => {
+      // team-repo dir exists on disk...
+      let removed = false;
+      pathExistsFn = (p: string) => {
+        if (p === localPath) return !removed; // exists until we remove it, then clone recreates handled below
+        return false;
+      };
+      mockRemove.mockImplementation((p: string) => {
+        if (p === localPath) removed = true;
+      });
+      // ...but it has no .git entry → isGitRepo() returns false.
+      // isGitRepo calls fse.pathExists twice: dir exists (true), .git missing (false).
+      (fse.pathExists as any)
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false);
+
+      mockGfRepoClone.mockImplementation(() => {
+        removed = false; // clone recreates the directory
+      });
+
+      // Answers: configure reviewers (n), primary role (1), no additional roles
+      questionAnswers = ['n', '1', ''];
+
+      await init({ repo: 'https://git.woa.com/HyperAI/teamai-test.git', scope: 'user' });
+
+      // Stale dir removed, then a real clone performed.
+      expect(mockRemove).toHaveBeenCalledWith(localPath);
+      expect(mockGfRepoClone).toHaveBeenCalledWith('HyperAI/teamai-test', localPath);
+      expect(mockExit).not.toHaveBeenCalled();
+    });
+
+    it('should reuse the existing clone when team-repo is a valid git repo', async () => {
+      pathExistsFn = (p: string) => p === localPath; // dir exists
+      // isGitRepo: dir exists (true), .git present (true)
+      (fse.pathExists as any)
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(true);
+
+      questionAnswers = ['n'];
+
+      await init({ repo: 'https://git.woa.com/HyperAI/teamai-test.git', scope: 'user' });
+
+      // Valid clone → no removal, no re-clone.
+      expect(mockRemove).not.toHaveBeenCalled();
+      expect(mockGfRepoClone).not.toHaveBeenCalled();
     });
   });
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -2,10 +2,10 @@ import YAML from 'yaml';
 import path from 'node:path';
 import { saveLocalConfig, loadTeamConfig, saveLocalConfigForScope, loadLocalConfigForScope, loadStateForScope, saveStateForScope } from './config.js';
 import { reconcileTeamHooksForConfig } from './hooks.js';
-import { configureGitUser, initRepo } from './utils/git.js';
+import { configureGitUser, initRepo, isGitRepo } from './utils/git.js';
 import { pushRepoDirectly } from './utils/git.js';
 import { getProvider, detectProvider, RepoNotFoundError } from './providers/index.js';
-import { ensureDir, writeFile, pathExists, expandHome, readFileSafe } from './utils/fs.js';
+import { ensureDir, writeFile, pathExists, expandHome, readFileSafe, remove } from './utils/fs.js';
 import { log, spinner } from './utils/logger.js';
 import { TEAMAI_HOME, type GlobalOptions, type LocalConfig, type Scope, getTeamaiHome, getConfigPath } from './types.js';
 import { describeRoles, loadRolesManifest } from './roles.js';
@@ -305,13 +305,20 @@ export async function init(options: GlobalOptions & { repo?: string; scope?: str
 
   // Step 3: Clone or link repo
   const defaultLocalPath = path.join(teamaiHome, 'team-repo');
-  let localPath: string;
+  const localPath = expandHome(defaultLocalPath);
 
-  if (await pathExists(expandHome(defaultLocalPath))) {
-    localPath = expandHome(defaultLocalPath);
-    log.info(`Repo already exists at ${localPath}, using existing clone`);
+  if (await pathExists(localPath)) {
+    if (await isGitRepo(localPath)) {
+      log.info(`Repo already exists at ${localPath}, using existing clone`);
+    } else {
+      // The path exists but isn't a git repo — typically a leftover from a
+      // previous non-git source (e.g. an HTTP repo). Reusing it would make the
+      // subsequent git commands fail ("not a git repository"). Remove it so we
+      // fall through to a fresh clone below.
+      log.warn(`Existing ${localPath} is not a git repository, re-cloning`);
+      await remove(localPath);
+    }
   } else {
-    localPath = expandHome(defaultLocalPath);
     log.info(`Clone path: ${localPath}`);
   }
 

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import path from 'node:path';
 import fse from 'fs-extra';
 import simpleGit, { type SimpleGit } from 'simple-git';
 import { log } from './logger.js';
@@ -14,6 +15,20 @@ export function createGit(basePath?: string): SimpleGit {
     return simpleGit({ baseDir: basePath });
   }
   return simpleGit();
+}
+
+/**
+ * Check whether localPath is a valid git repository (has a `.git` entry).
+ *
+ * Returns false if the path does not exist, or exists but is not a git repo
+ * (e.g. a leftover directory from a previous non-git source such as an HTTP
+ * repo). Callers use this to avoid running git commands against a non-repo.
+ */
+export async function isGitRepo(localPath: string): Promise<boolean> {
+  if (!(await fse.pathExists(localPath))) {
+    return false;
+  }
+  return fse.pathExists(path.join(localPath, '.git'));
 }
 
 /**


### PR DESCRIPTION
## Problem

`teamai init` reused any existing `~/.teamai/team-repo` directory based purely on its **presence**, assuming it was a prior git clone. When the directory was a leftover from a **non-git source** (e.g. a previous HTTP `init`), it contained no `.git`, so the subsequent `git config --local user.name` crashed with:

```
GitError: fatal: --local can only be used inside a git repository
    commands: [ 'config', '--local', 'user.name', '<user>' ]
```

This is a hard, uncaught crash — the user cannot switch from an HTTP source to a git-repo source without manually deleting `~/.teamai/team-repo` first.

## Fix

- Add an `isGitRepo()` helper in `src/utils/git.ts` that checks for a `.git` entry.
- In `init.ts`, when the target path exists but is **not** a git repo, log a warning, `remove()` it, and fall through to a fresh clone. Valid clones are still reused unchanged.

## Test Plan

- [x] `npx tsc --noEmit` — no errors
- [x] `npx vitest run` — 1765 passed, 0 failed (added unit tests for `isGitRepo` and both init paths: stale-non-git → re-clone, valid-repo → reuse)
- [x] **Real E2E (old binary)**: reproduced the exact reported crash against a stale non-git `team-repo`
- [x] **Real E2E (fixed binary)**: same stale state now prints `⚠ Existing ... is not a git repository, re-cloning` → `✔ Team repo cloned` → `✔ teamai initialized successfully!`; afterwards `git config --local user.name` succeeds and the dir is a valid git repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)