### PR TITLE
feat(local-agent): enable binding prompt by default

### DIFF
--- a/src/__tests__/local-agent.test.ts
+++ b/src/__tests__/local-agent.test.ts
@@ -23,7 +23,7 @@ beforeEach(async () => {
   origHome = process.env.HOME;
   process.env.HOME = tmpDir;
   origPpid = process.ppid;
-  // Bind prompt is off by default — start each test from that baseline.
+  // Bind prompt is on by default — start each test from that baseline.
   delete process.env.TEAMAI_BIND_PROMPT_ENABLED;
   // Clean hint markers
   const markerPath = path.join(os.tmpdir(), `teamai-bind-hint-${process.ppid}`);
@@ -232,10 +232,11 @@ describe('local-agent: emitBindingHint via reportAndSyncLocalAgent', () => {
     expect(ctx).toContain('teamai bind-project --skip');
   });
 
-  it('does NOT emit hint by default when TEAMAI_BIND_PROMPT_ENABLED is unset', async () => {
-    // No process.env.TEAMAI_BIND_PROMPT_ENABLED — bind prompt is off by default.
+  it('does NOT emit hint when TEAMAI_BIND_PROMPT_ENABLED is explicitly disabled', async () => {
+    // Explicitly disable the bind prompt via TEAMAI_BIND_PROMPT_ENABLED=0.
+    process.env.TEAMAI_BIND_PROMPT_ENABLED = '0';
     await setupConfig();
-    const projectDir = path.join(tmpDir, 'default-off-project');
+    const projectDir = path.join(tmpDir, 'disabled-project');
     await fse.ensureDir(projectDir);
     const { execFileSync } = await import('node:child_process');
     execFileSync('git', ['init'], { cwd: projectDir, stdio: 'ignore' });

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -816,12 +816,15 @@ async function ensureWorkspaceBinding(
 
 /**
  * The organization-binding prompt (TTY prompt + injected hook context) is
- * off by default. Enable it explicitly with `TEAMAI_BIND_PROMPT_ENABLED=1`.
- * The manual `teamai bind-project` command is always available regardless.
+ * on by default. Disable it explicitly with `TEAMAI_BIND_PROMPT_ENABLED=0`
+ * (or `false`). The manual `teamai bind-project` command is always available
+ * regardless.
  */
 function isBindPromptEnabled(): boolean {
   const flag = process.env.TEAMAI_BIND_PROMPT_ENABLED;
-  return flag === '1' || flag === 'true';
+  if (flag === undefined) return true;
+  const normalized = flag.toLowerCase();
+  return normalized !== '0' && normalized !== 'false';
 }
 
 async function emitBindingHint(
@@ -1650,7 +1653,7 @@ export async function reportAndSyncLocalAgent(context: LocalAgentContext): Promi
   // Binding prompt is injected via stdout hook context (not HTTP), so it must run
   // even inside the CloudStudio sandbox — the sandbox guard below only skips the
   // HTTP report/sync that would produce a duplicate card. Resolve the workspace
-  // only when the prompt is enabled, so the default-off path forks no git process.
+  // only when the prompt is enabled, so the disabled path forks no git process.
   if (isBindPromptEnabled()) {
     const workspacePath = await resolveWorkspacePath(context.cwd);
     if (workspacePath) {


### PR DESCRIPTION
## 改动内容

将 `TEAMAI_BIND_PROMPT_ENABLED` 的默认值从 `false` 翻转为 `true`。

## 背景

当前 organization-binding prompt（TTY prompt + injected hook context）默认关闭，需要显式设置 `TEAMAI_BIND_PROMPT_ENABLED=1` 才能开启。这使得新用户默认无法感知项目绑定功能，需要额外配置才能获得引导。

## 改动详情

- `isBindPromptEnabled()` 在环境变量未设置时默认返回 `true`（开启）
- 仍可通过 `TEAMAI_BIND_PROMPT_ENABLED=0`（或 `false`）显式关闭，保持 opt-out 能力
- `teamai bind-project` 手动命令不受影响，始终可用

## 文件变更

- `src/local-agent.ts`：修改 `isBindPromptEnabled()` 默认行为 + 更新函数 doc 和调用点注释
- `src/__tests__/local-agent.test.ts`：将原"默认关闭不发 hint"测试改为"显式 \`=0\` 关闭不发 hint"

## 测试

`src/__tests__/local-agent.test.ts` 全部 36 个测试通过。