### PR TITLE
fix(import-mr): tolerate malformed frontmatter in AI learning output

### DIFF
--- a/src/__tests__/import-mr.test.ts
+++ b/src/__tests__/import-mr.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../utils/logger.js', () => ({
+  log: { info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), dim: vi.fn() },
+  spinner: vi.fn(() => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+  })),
+}));
+
+import { parseLearningDraft } from '../import-mr.js';
+
+describe('parseLearningDraft', () => {
+  it('parses well-formed frontmatter', () => {
+    const raw = '---\ntitle: "Hello"\ntags: [a, b]\n---\n\n# Body\n';
+    const { data, content } = parseLearningDraft(raw);
+    expect(data['title']).toBe('Hello');
+    expect(data['tags']).toEqual(['a', 'b']);
+    expect(content).toContain('# Body');
+  });
+
+  it('does not throw on markdown that breaks YAML alias parsing (regression: CI exit 1)', () => {
+    // A line starting with '*' is a YAML alias reference and makes js-yaml throw.
+    const raw = '---\n\n*说明:本次 MR 是 8 个 GitHub PR 的 squash 同步*\n---\n';
+    expect(() => parseLearningDraft(raw)).not.toThrow();
+    const { data } = parseLearningDraft(raw);
+    expect(data).toEqual({});
+  });
+
+  it('strips a wrapping markdown code fence', () => {
+    const raw = '```markdown\n---\ntitle: "X"\n---\n\nbody\n```';
+    const { data } = parseLearningDraft(raw);
+    expect(data['title']).toBe('X');
+  });
+
+  it('drops conversational text before the frontmatter', () => {
+    const raw = 'Sure, here is the learning:\n\n---\ntitle: "Y"\n---\n\nbody';
+    const { data } = parseLearningDraft(raw);
+    expect(data['title']).toBe('Y');
+  });
+});

--- a/src/import-mr.ts
+++ b/src/import-mr.ts
@@ -94,6 +94,36 @@ ${diff3000}`;
 }
 
 /**
+ * Parses the AI-generated learning draft, tolerating malformed frontmatter.
+ *
+ * The LLM output may wrap content in markdown code fences, prepend
+ * conversational text, or contain markdown (e.g. '*italic*' lines) that
+ * gray-matter/js-yaml would misread as YAML. This normalizes the content and
+ * parses it defensively so a parse failure never crashes the caller.
+ *
+ * @param raw  Raw string returned by the AI
+ * @returns    Normalized content plus parsed frontmatter data (empty object on parse failure)
+ */
+export function parseLearningDraft(raw: string): { content: string; data: Record<string, unknown> } {
+  let content = raw
+    .replace(/^```(?:markdown|md|yaml)?\s*\n/m, '')
+    .replace(/\n```\s*$/, '');
+  // AI may emit conversational text before the frontmatter; start at the first `---`
+  const frontmatterStart = content.indexOf('---');
+  if (frontmatterStart > 0) {
+    content = content.slice(frontmatterStart);
+  }
+  try {
+    const parsed = matter(content);
+    return { content, data: parsed.data };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.warn(`⚠️  Failed to parse learning frontmatter, using fallback: ${message}`);
+    return { content, data: {} };
+  }
+}
+
+/**
  * Interactively asks the user to confirm an action.
  *
  * @param question  Prompt text (no trailing space needed)
@@ -176,17 +206,9 @@ export async function importFromMR(opts: {
   }
 
   // ── 步骤 3：解析 learning 草稿 + dedup ─────────────────
-  // AI 可能用 markdown 代码块包裹输出，先剥离
-  learningContent = learningContent
-    .replace(/^```(?:markdown|md|yaml)?\s*\n/m, '')
-    .replace(/\n```\s*$/, '');
-  // AI 可能在 frontmatter 前输出对话性废话，截取从第一个 `---` 开始的内容
-  const frontmatterStart = learningContent.indexOf('---');
-  if (frontmatterStart > 0) {
-    learningContent = learningContent.slice(frontmatterStart);
-  }
-  const parsed = matter(learningContent);
-  const learningTitle = (parsed.data['title'] as string | undefined) ?? mr.title;
+  const { content: normalizedContent, data: frontmatter } = parseLearningDraft(learningContent);
+  learningContent = normalizedContent;
+  const learningTitle = (frontmatter['title'] as string | undefined) ?? mr.title;
 
   const draftKeywords = extractKeywords(learningContent);
   const supersededEntries = await findSupersededLearnings(draftKeywords, learningsDir);
@@ -203,7 +225,7 @@ export async function importFromMR(opts: {
   // ── 步骤 4：打印摘要 ────────────────────────────────────
   log.info(`✅ Learning draft generated: ${learningTitle}`);
 
-  const tags = parsed.data['tags'] as string[] | undefined;
+  const tags = frontmatter['tags'] as string[] | undefined;
   if (tags && tags.length > 0) {
     log.info(`   Tags: ${tags.join(', ')}`);
   }


### PR DESCRIPTION
## Problem

The CI pipeline's `teamai ci extract-mr` step crashed with exit 1, failing the whole pipeline. Root cause:

After the AI analysis completes, the LLM's Markdown output is parsed as YAML frontmatter via `gray-matter` (`src/import-mr.ts`). When the output contains a line starting with `*` (a markdown italic, e.g. `*说明:本次 MR 是 8 个 GitHub PR…*`), `js-yaml` interprets `*foo` as a **YAML alias reference**, has no matching anchor, and throws an uncaught `YAMLException`:

```
YAMLException: unidentified alias "说明:本次" at line 3, column 7
    at readAlias (.../js-yaml/lib/js-yaml/loader.js:1298:5)
Node.js v22.19.0
```

The `matter()` call had no `try/catch`, so the exception propagated all the way up and killed the process.

## Fix

Extract the preprocessing + parse into a defensive `parseLearningDraft()` helper that catches parse failures and falls back to empty frontmatter (title falls back to the MR title). Any AI output — however malformed as YAML — now flows through instead of crashing.

## Test Plan

- [x] `npm run build` passes
- [x] `npx tsc --noEmit` passes
- [x] New regression test `src/__tests__/import-mr.test.ts` (4 cases incl. the exact CI-failing alias string) passes
- [x] `src/__tests__/ci-extract-mr.test.ts` still passes (7/7)
- [x] Reproduced with the verbatim failing string from the CI log — no longer throws

🤖 Generated with [Claude Code](https://claude.com/claude-code)