### PR TITLE
fix(local-agent): workspace path casing conflict causes report 500 and persistent "Not connected"

### DIFF
--- a/src/__tests__/local-agent.test.ts
+++ b/src/__tests__/local-agent.test.ts
@@ -586,11 +586,13 @@ describe('local-agent: full-snapshot workspace reporting', () => {
       workspaces?: Array<Record<string, unknown>>;
     };
 
+    const rA = fse.realpathSync(wsA);
+    const rB = fse.realpathSync(wsB);
     expect(payload.workspaces).toHaveLength(2);
     const paths = (payload.workspaces ?? []).map((w) => w.path as string);
-    expect(new Set(paths)).toEqual(new Set([wsA, wsB]));
-    const wsAEntry = (payload.workspaces ?? []).find((w) => w.path === wsA);
-    const wsBEntry = (payload.workspaces ?? []).find((w) => w.path === wsB);
+    expect(new Set(paths)).toEqual(new Set([rA, rB]));
+    const wsAEntry = (payload.workspaces ?? []).find((w) => w.path === rA);
+    const wsBEntry = (payload.workspaces ?? []).find((w) => w.path === rB);
     expect(wsAEntry?.project_id).toBe(11);
     expect(wsBEntry?.project_id).toBe(22);
     // Empty directories — no skills or rules installed.
@@ -622,10 +624,12 @@ describe('local-agent: full-snapshot workspace reporting', () => {
       workspaces?: Array<Record<string, unknown>>;
     };
 
-    const wsFullEntry = (payload.workspaces ?? []).find((w) => w.path === wsFull) as
+    const rFull = fse.realpathSync(wsFull);
+    const rEmpty = fse.realpathSync(wsEmpty);
+    const wsFullEntry = (payload.workspaces ?? []).find((w) => w.path === rFull) as
       | (Record<string, unknown> & { skills?: Array<{ slug: string }> })
       | undefined;
-    const wsEmptyEntry = (payload.workspaces ?? []).find((w) => w.path === wsEmpty);
+    const wsEmptyEntry = (payload.workspaces ?? []).find((w) => w.path === rEmpty);
 
     expect(wsFullEntry?.skills).toBeDefined();
     expect(wsFullEntry?.skills?.map((s) => s.slug)).toContain('demo-skill');
@@ -648,7 +652,7 @@ describe('local-agent: full-snapshot workspace reporting', () => {
     const pruned = await pruneDeadWorkspaceBindings(config!);
 
     expect(pruned).toBe(true);
-    expect(Object.keys(config!.workspaceBindings)).toEqual([wsLive]);
+    expect(Object.keys(config!.workspaceBindings)).toEqual([fse.realpathSync(wsLive)]);
   });
 
   it('returns false when all directories exist', async () => {
@@ -687,12 +691,13 @@ describe('local-agent: full-snapshot workspace reporting', () => {
     };
 
     const realCwd = fse.realpathSync(cwdDir);
+    const rA = fse.realpathSync(wsA);
     expect(payload.workspaces).toHaveLength(2);
     const allPaths = (payload.workspaces ?? []).map((w) => w.path as string);
-    expect(allPaths).toContain(wsA);
+    expect(allPaths).toContain(rA);
     expect(allPaths).toContain(realCwd);
     const cwdEntry = (payload.workspaces ?? []).find((w) => w.path === realCwd);
-    const wsAEntry = (payload.workspaces ?? []).find((w) => w.path === wsA);
+    const wsAEntry = (payload.workspaces ?? []).find((w) => w.path === rA);
     expect(cwdEntry?.project_id).toBeUndefined();
     expect(wsAEntry?.project_id).toBe(5);
   });
@@ -725,7 +730,7 @@ describe('local-agent: full-snapshot workspace reporting', () => {
       workspaces?: Array<Record<string, unknown>>;
     };
 
-    const entry = (payload.workspaces ?? []).find((w) => w.path === wsSkip);
+    const entry = (payload.workspaces ?? []).find((w) => w.path === fse.realpathSync(wsSkip));
     expect(entry).toBeDefined();
     expect(entry?.project_id).toBe(0);
   });
@@ -762,15 +767,65 @@ describe('local-agent: full-snapshot workspace reporting', () => {
       workspaces?: Array<Record<string, unknown>>;
     };
     expect(wbPayload.workspaces).toHaveLength(1);
-    expect(wbPayload.workspaces![0].path).toBe(wsWb);
+    expect(wbPayload.workspaces![0].path).toBe(fse.realpathSync(wsWb));
     expect(wbPayload.workspaces![0].ide_type).toBe('workbuddy');
 
     const cbPayload = await buildReportPayload(config!, { tool: 'codebuddy' }) as {
       workspaces?: Array<Record<string, unknown>>;
     };
     expect(cbPayload.workspaces).toHaveLength(1);
-    expect(cbPayload.workspaces![0].path).toBe(wsCb);
+    expect(cbPayload.workspaces![0].path).toBe(fse.realpathSync(wsCb));
     expect(cbPayload.workspaces![0].ide_type).toBe('codebuddy');
+  });
+
+  it('collapses two path aliases of the same physical workspace into one entry', async () => {
+    // Real directory + a symlink alias pointing at it. Both are valid strings
+    // for the same physical workspace (mirrors macOS case-insensitive aliasing).
+    const realWs = path.join(tmpDir, 'ws-real');
+    const aliasWs = path.join(tmpDir, 'ws-alias');
+    await fse.ensureDir(realWs);
+    await fse.symlink(realWs, aliasWs, 'dir');
+
+    // Config stores the two aliases as distinct keys, as a pre-migration install would.
+    await setupConfig({
+      [realWs]: { projectId: 11, projectName: 'real', boundAt: 'x', ideType: 'codebuddy' },
+      [aliasWs]: { projectId: 11, projectName: 'alias', boundAt: 'x', ideType: 'codebuddy' },
+    });
+
+    const { buildReportPayload, loadLocalAgentConfig } = await import('../local-agent.js');
+    const config = await loadLocalAgentConfig();
+
+    // After canonicalization migration, only one binding key remains.
+    const canonical = fse.realpathSync(realWs);
+    expect(Object.keys(config!.workspaceBindings)).toEqual([canonical]);
+
+    const payload = await buildReportPayload(config!, { tool: 'codebuddy' }) as {
+      workspaces?: Array<Record<string, unknown>>;
+    };
+    expect(payload.workspaces).toHaveLength(1);
+    expect(payload.workspaces![0].path).toBe(canonical);
+    expect(payload.workspaces![0].project_id).toBe(11);
+  });
+
+  it('warns and keeps first binding when aliases have conflicting project ids', async () => {
+    const realWs = path.join(tmpDir, 'ws-conflict-real');
+    const aliasWs = path.join(tmpDir, 'ws-conflict-alias');
+    await fse.ensureDir(realWs);
+    await fse.symlink(realWs, aliasWs, 'dir');
+
+    // Order in the object literal determines iteration order; realWs (id 11) is first.
+    await setupConfig({
+      [realWs]: { projectId: 11, projectName: 'real', boundAt: 'x', ideType: 'codebuddy' },
+      [aliasWs]: { projectId: 22, projectName: 'alias', boundAt: 'x', ideType: 'codebuddy' },
+    });
+
+    const { loadLocalAgentConfig } = await import('../local-agent.js');
+    const config = await loadLocalAgentConfig();
+
+    const canonical = fse.realpathSync(realWs);
+    expect(Object.keys(config!.workspaceBindings)).toEqual([canonical]);
+    // First-seen non-zero projectId wins.
+    expect(config!.workspaceBindings[canonical].projectId).toBe(11);
   });
 
   it('includes unattributed cwd binding as current tool and excludes unattributed non-cwd binding', async () => {
@@ -810,13 +865,14 @@ describe('local-agent: full-snapshot workspace reporting', () => {
 
     const { stampWorkspaceTool, loadLocalAgentConfig } = await import('../local-agent.js');
     const config = await loadLocalAgentConfig();
+    const realWsCwd = fse.realpathSync(wsCwd);
 
-    const changed = stampWorkspaceTool(config!, wsCwd, 'codebuddy');
+    const changed = stampWorkspaceTool(config!, realWsCwd, 'codebuddy');
     expect(changed).toBe(true);
-    expect(config!.workspaceBindings[wsCwd].ideType).toBe('codebuddy');
+    expect(config!.workspaceBindings[realWsCwd].ideType).toBe('codebuddy');
 
     // Calling again with same tool is idempotent.
-    const changedAgain = stampWorkspaceTool(config!, wsCwd, 'codebuddy');
+    const changedAgain = stampWorkspaceTool(config!, realWsCwd, 'codebuddy');
     expect(changedAgain).toBe(false);
   });
 
@@ -829,11 +885,12 @@ describe('local-agent: full-snapshot workspace reporting', () => {
 
     const { stampWorkspaceTool, loadLocalAgentConfig } = await import('../local-agent.js');
     const config = await loadLocalAgentConfig();
+    const realWsCwd = fse.realpathSync(wsCwd);
 
     expect(stampWorkspaceTool(config!, null, 'codebuddy')).toBe(false);
     expect(stampWorkspaceTool(config!, undefined, 'codebuddy')).toBe(false);
     // Config must be untouched.
-    expect(config!.workspaceBindings[wsCwd].ideType).toBeUndefined();
+    expect(config!.workspaceBindings[realWsCwd].ideType).toBeUndefined();
   });
 
   it('stampWorkspaceTool returns false when currentPath has no binding in config', async () => {
@@ -863,14 +920,14 @@ describe('local-agent: full-snapshot workspace reporting', () => {
       workspaces?: Array<Record<string, unknown>>;
     };
     expect(cbPayload.workspaces).toHaveLength(1);
-    expect(cbPayload.workspaces![0].path).toBe(wsCb);
+    expect(cbPayload.workspaces![0].path).toBe(fse.realpathSync(wsCb));
     expect(cbPayload.workspaces![0].ide_type).toBe('codebuddy');
 
     const wbPayload = await buildSyncPayload(config!, { tool: 'workbuddy' }) as {
       workspaces?: Array<Record<string, unknown>>;
     };
     expect(wbPayload.workspaces).toHaveLength(1);
-    expect(wbPayload.workspaces![0].path).toBe(wsWb);
+    expect(wbPayload.workspaces![0].path).toBe(fse.realpathSync(wsWb));
     expect(wbPayload.workspaces![0].ide_type).toBe('workbuddy');
   });
 });

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -352,6 +352,46 @@ function getManifestScope(
   return manifest.scopes[key];
 }
 
+/**
+ * Canonicalize a workspace path to its physical on-disk form via realpath.
+ * On case-insensitive filesystems (macOS) this collapses casing variants of the
+ * same physical directory to one identity; it also resolves symlinks. Falls back
+ * to the resolved absolute path when the target does not exist (dead binding) or
+ * realpath fails for any other reason.
+ */
+async function canonicalizeWorkspacePath(value: string): Promise<string> {
+  const absolute = path.resolve(value);
+  try {
+    return await fs.promises.realpath(absolute);
+  } catch {
+    return absolute;
+  }
+}
+
+function mergeWorkspaceBindings(
+  existing: WorkspaceBinding | undefined,
+  incoming: WorkspaceBinding,
+  canonicalKey: string,
+): WorkspaceBinding {
+  if (!existing) return incoming;
+  // pick base = whichever has a non-zero projectId; prefer existing on tie
+  const existingReal = existing.projectId !== 0;
+  const incomingReal = incoming.projectId !== 0;
+  if (existingReal && incomingReal && existing.projectId !== incoming.projectId) {
+    log.warn(
+      `local-agent: workspace ${canonicalKey} has conflicting project bindings ` +
+        `(${existing.projectId} vs ${incoming.projectId}); keeping ${existing.projectId}`,
+    );
+  }
+  const base = existingReal || !incomingReal ? { ...existing } : { ...incoming };
+  // A physical workspace tracks one owning tool (same single-owner model as
+  // stampWorkspaceTool). Only backfill ideType when the base lacks one; if two
+  // aliases were stamped by different tools, the base's ideType wins — the
+  // other tool re-stamps itself on its next report from the canonical path.
+  if (!base.ideType) base.ideType = existing.ideType ?? incoming.ideType;
+  return base;
+}
+
 export async function loadLocalAgentConfig(): Promise<LocalAgentConfig | null> {
   const fileConfig = await readJson<LocalAgentConfig>(getConfigPath());
   if (fileConfig?.endpoint) {
@@ -365,6 +405,20 @@ export async function loadLocalAgentConfig(): Promise<LocalAgentConfig | null> {
       if ('groupId' in binding && !('projectId' in (binding as Record<string, unknown>))) {
         delete config.workspaceBindings[wsPath];
       }
+    }
+    // Migrate: canonicalize binding keys to their physical on-disk path so
+    // case-only / symlink aliases of the same workspace collapse to one entry.
+    const migrated: Record<string, WorkspaceBinding> = {};
+    let migrationChanged = false;
+    for (const [wsPath, binding] of Object.entries(config.workspaceBindings)) {
+      const canonicalKey = await canonicalizeWorkspacePath(wsPath);
+      if (canonicalKey !== wsPath) migrationChanged = true;
+      if (migrated[canonicalKey]) migrationChanged = true;
+      migrated[canonicalKey] = mergeWorkspaceBindings(migrated[canonicalKey], binding, canonicalKey);
+    }
+    config.workspaceBindings = migrated;
+    if (migrationChanged) {
+      await saveLocalAgentConfig(config);
     }
     return config;
   }
@@ -878,9 +932,9 @@ async function resolveWorkspacePath(cwd?: string): Promise<string | undefined> {
   try {
     const { stdout } = await execFileAsync('git', ['-C', absolute, 'rev-parse', '--show-toplevel']);
     const root = stdout.trim();
-    return root ? path.resolve(root) : absolute;
+    return await canonicalizeWorkspacePath(root || absolute);
   } catch {
-    return absolute;
+    return await canonicalizeWorkspacePath(absolute);
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #242. On case-insensitive filesystems (macOS), a single physical WorkBuddy workspace could be represented with different path casing (e.g. `.../WorkBuddy/project` vs `.../Workbuddy/project`). TeamAI treated these as distinct workspace identities, so the reported workspace list contained a duplicate entry whose `project_id` resolved to `undefined` — causing `POST /api/local-agent/report` to return **500** and leaving the existing local-agent card stuck at **Not connected** even though hooks were firing and auth/project discovery succeeded.

## Root cause (`src/local-agent.ts`)

- `resolveWorkspacePath()` used `path.resolve()` but never `fs.realpath()`, so the runtime-resolved path casing could differ from the casing stored as a `workspaceBindings` key.
- `selectToolWorkspaces()` dedups with `Set<string>` and looks up bindings by exact string, so the casing variant became a second workspace with no binding → `project_id: undefined` → server 500.

## Fix

Canonicalize workspace paths to their physical on-disk form via `fs.realpath`, at both sources so the existing dedup becomes correct without touching `selectToolWorkspaces()`:

- Add `canonicalizeWorkspacePath()` — `path.resolve` + `fs.promises.realpath`, falling back to the absolute path for missing/dead bindings.
- `resolveWorkspacePath()` now canonicalizes the git root / cwd.
- `loadLocalAgentConfig()` migrates existing `workspaceBindings` keys to canonical paths, merges duplicate aliases (preferring the non-zero `projectId`, backfilling `ideType`), warns (in English) on conflicting non-zero project IDs while keeping the first, and persists the migrated config — **no user action required**.

## Acceptance criteria (from the issue)

- [x] Different string paths resolving to the same physical workspace produce one workspace entry.
- [x] Existing installations are migrated automatically (no manual `config.json` edit).
- [x] `POST /api/local-agent/report` succeeds after migration.
- [x] No duplicate local-agent card is created (`local_agent_id` unchanged).

## Test Plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npx vitest run` — **1779/1779 passing** (local-agent suite 38/38, incl. 2 new symlink-alias regression tests covering alias merge + conflicting project-id resolution).
- [x] `npm run build` — success.
- [x] **Real-CLI e2e**: ran `teamai hook-dispatch prompt-submit --tool workbuddy` from a symlink-aliased cwd against a 2-key config → config migrated to a single canonical realpath key; conflicting project IDs emitted `⚠ local-agent: workspace … has conflicting project bindings (7 vs 22); keeping 7`; migration persisted to disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)