### PR TITLE
feat(uninstall): support --agent <tool> to uninstall a single tool (#230)

### DIFF
--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -953,7 +953,11 @@ What gets removed:
 
 ### Uninstall a single tool (`--agent <tool>`)
 
-`--agent <tool>` removes only that tool's teamai resources (hooks, CLAUDE.md block, skills, rules, built-in agents). The tool name is a key of `toolPaths` (e.g. `claude`, `codex`, `codebuddy`). Shared resources (the env block, docs directory, and `~/.teamai/`) are removed **only when the target is the last tool still using teamai** — otherwise they are kept for the remaining tools. An unknown tool name aborts without deleting anything and lists the available tools.
+`--agent <tool>` removes only that tool's teamai resources (hooks, CLAUDE.md block, skills, rules, built-in agents). The tool name is a key of `toolPaths` (e.g. `claude`, `codex`, `codebuddy`) and is matched case-insensitively. An unknown tool name aborts without deleting anything, lists the available tools, and exits with a non-zero status.
+
+Shared resources (the env block, docs directory, and `~/.teamai/`) are removed **only when the target itself has teamai resources AND is the last tool still using teamai** — otherwise they are kept for the remaining tools. (So targeting a tool that has no teamai resources of its own is a no-op and leaves shared resources in place, even if it happens to be the only tool.)
+
+The exclusion is durable: `uninstall --agent <tool>` drops the tool from `enabledAgents` and records it in `disabledAgents`, so a later `pull` (or another tool's session-start hook) will not resurrect its skills, rules, agents, CLAUDE.md block, or hooks. Running `init --agent <tool>` again clears the exclusion and re-enables sync for that tool.
 
 To rejoin after uninstalling:
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -938,6 +938,9 @@ teamai uninstall
 
 # Skip confirmation and uninstall directly (for scripts/CI)
 teamai uninstall --force
+
+# Uninstall only one tool's resources (mirrors `init --agent`)
+teamai uninstall --agent claude
 ```
 
 What gets removed:
@@ -947,6 +950,10 @@ What gets removed:
 - Team-synced rules
 - The env block in your shell profile
 - The `~/.teamai/` directory
+
+### Uninstall a single tool (`--agent <tool>`)
+
+`--agent <tool>` removes only that tool's teamai resources (hooks, CLAUDE.md block, skills, rules, built-in agents). The tool name is a key of `toolPaths` (e.g. `claude`, `codex`, `codebuddy`). Shared resources (the env block, docs directory, and `~/.teamai/`) are removed **only when the target is the last tool still using teamai** — otherwise they are kept for the remaining tools. An unknown tool name aborts without deleting anything and lists the available tools.
 
 To rejoin after uninstalling:
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -951,7 +951,11 @@ teamai uninstall --agent claude
 
 ### 只卸载单个工具（`--agent <tool>`）
 
-`--agent <tool>` 只移除该工具的 teamai 资源（hooks、CLAUDE.md 块、skills、rules、内置 agents）。工具名即 `toolPaths` 的键（如 `claude`、`codex`、`codebuddy`）。跨工具共享资源（shell profile env 块、docs 目录、`~/.teamai/`）**仅当该工具是最后一个仍在使用 teamai 的工具时**才一并移除，否则会为其余工具保留。传入未知工具名会直接报错并列出可用工具，不执行任何删除。
+`--agent <tool>` 只移除该工具的 teamai 资源（hooks、CLAUDE.md 块、skills、rules、内置 agents）。工具名即 `toolPaths` 的键（如 `claude`、`codex`、`codebuddy`），匹配大小写不敏感。传入未知工具名会直接报错并列出可用工具、不执行任何删除，并以非零状态码退出。
+
+跨工具共享资源（shell profile env 块、docs 目录、`~/.teamai/`）**仅当该工具自身存在 teamai 资源、且它是最后一个仍在使用 teamai 的工具时**才一并移除，否则会为其余工具保留。（因此，定向卸载一个自身没有任何 teamai 资源的工具是 no-op，即便它恰好是唯一的工具，也不会删除共享资源。）
+
+该排除是持久的：`uninstall --agent <tool>` 会把该工具从 `enabledAgents` 移除并记入 `disabledAgents`，因此之后的 `pull`（或其他工具的 session-start hook）不会再把它的 skills、rules、agents、CLAUDE.md 块或 hooks 重新装回。重新执行 `init --agent <tool>` 会清除该排除、恢复对该工具的同步。
 
 卸载后如需重新加入：
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -936,6 +936,9 @@ teamai uninstall
 
 # 跳过确认直接卸载（适合脚本/CI）
 teamai uninstall --force
+
+# 只卸载某一个工具的资源（与 init --agent 对称）
+teamai uninstall --agent claude
 ```
 
 移除内容：
@@ -945,6 +948,10 @@ teamai uninstall --force
 - 团队同步的 rules
 - Shell profile 中的 env 块
 - `~/.teamai/` 目录
+
+### 只卸载单个工具（`--agent <tool>`）
+
+`--agent <tool>` 只移除该工具的 teamai 资源（hooks、CLAUDE.md 块、skills、rules、内置 agents）。工具名即 `toolPaths` 的键（如 `claude`、`codex`、`codebuddy`）。跨工具共享资源（shell profile env 块、docs 目录、`~/.teamai/`）**仅当该工具是最后一个仍在使用 teamai 的工具时**才一并移除，否则会为其余工具保留。传入未知工具名会直接报错并列出可用工具，不执行任何删除。
 
 卸载后如需重新加入：
 

--- a/src/__tests__/hooks-hasteamaihooks.test.ts
+++ b/src/__tests__/hooks-hasteamaihooks.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { hasTeamaiHooks } from '../hooks.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-hasteamaihooks-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('hasTeamaiHooks', () => {
+  it('returns true when file contains a teamai built-in hook (description prefix)', async () => {
+    const settingsPath = path.join(tmpDir, 'settings.json');
+    fs.writeFileSync(settingsPath, JSON.stringify({
+      hooks: {
+        SessionStart: [
+          {
+            matcher: '*',
+            hooks: [{ type: 'command', command: 'teamai hook-dispatch' }],
+            description: '[teamai] hook-dispatch',
+          },
+        ],
+      },
+    }));
+
+    expect(await hasTeamaiHooks(settingsPath, 'claude')).toBe(true);
+  });
+
+  it('returns false when file has only user hooks and manifest has stale record (P2#2 regression)', async () => {
+    const settingsPath = path.join(tmpDir, 'settings.json');
+    fs.writeFileSync(settingsPath, JSON.stringify({
+      hooks: {
+        SessionStart: [
+          { matcher: '*', hooks: [{ type: 'command', command: 'echo hi' }] },
+        ],
+      },
+    }));
+
+    const manifestPath = path.join(tmpDir, 'managed-hooks.json');
+    fs.writeFileSync(manifestPath, JSON.stringify({
+      claude: [{ id: 'x', event: 'SessionStart', command: 'teamai pull' }],
+    }));
+
+    // stale manifest entry — command not present in file → must return false
+    expect(await hasTeamaiHooks(settingsPath, 'claude', manifestPath)).toBe(false);
+  });
+
+  it('returns true for codex format when manifest command exists in hooks file', async () => {
+    const hooksPath = path.join(tmpDir, 'hooks.json');
+    const teamCmd = 'teamai-custom-team-hook';
+    fs.writeFileSync(hooksPath, JSON.stringify({
+      hooks: {
+        SessionStart: [
+          { hooks: [{ type: 'command', command: teamCmd }] },
+        ],
+      },
+    }));
+
+    const manifestPath = path.join(tmpDir, 'managed-hooks.json');
+    fs.writeFileSync(manifestPath, JSON.stringify({
+      codex: [{ id: 'y', event: 'SessionStart', command: teamCmd }],
+    }));
+
+    expect(await hasTeamaiHooks(hooksPath, 'codex', manifestPath)).toBe(true);
+  });
+});

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -952,3 +952,73 @@ describe('ensureSkillFrontmatter', () => {
     expect(pushedContent).toMatch(/^---\nname: bare-skill\ndescription: Bare Skill\n---\n/);
   });
 });
+
+describe('SkillsHandler.pullItem honors disabledAgents', () => {
+  let tmpDir: string;
+  let homeDir: string;
+  let handler: SkillsHandler;
+  let teamConfig: TeamaiConfig;
+  let localConfig: LocalConfig;
+  let sourcePath: string;
+
+  beforeEach(async () => {
+    tmpDir = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-skills-pull-disabled-'));
+    homeDir = path.join(tmpDir, 'home');
+    const repoPath = path.join(tmpDir, 'team-repo');
+
+    // Both tools installed (root dirs exist) so isToolInstalled alone wouldn't skip either.
+    await fse.ensureDir(path.join(homeDir, '.claude', 'skills'));
+    await fse.ensureDir(path.join(homeDir, '.codex', 'skills'));
+
+    // Team-repo source skill to pull.
+    sourcePath = path.join(repoPath, 'skills', 'team-skill');
+    await fse.ensureDir(sourcePath);
+    await fse.writeFile(path.join(sourcePath, 'SKILL.md'), '---\nname: team-skill\ndescription: X\n---\n');
+
+    vi.stubEnv('HOME', homeDir);
+    handler = new SkillsHandler();
+
+    teamConfig = {
+      team: 'test',
+      description: '',
+      repo: 'https://git.woa.com/test/repo.git',
+      provider: 'tgit' as const,
+      reviewers: [],
+      sharing: { skills: {}, rules: { enforced: [] }, docs: { localDir: '' }, env: { injectShellProfile: true } },
+      toolPaths: {
+        claude: { skills: '.claude/skills', rules: '.claude/rules' },
+        codex: { skills: '.codex/skills', rules: '.codex/rules' },
+      },
+    };
+
+    localConfig = {
+      repo: { localPath: repoPath, remote: 'https://git.woa.com/test/repo.git' },
+      username: 'testuser',
+      updatePolicy: 'auto',
+      additionalRoles: [],
+      scope: 'user',
+      disabledAgents: ['claude'],
+    };
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await fse.remove(tmpDir);
+  });
+
+  it('skips a disabled tool but still syncs the others', async () => {
+    const item = {
+      name: 'team-skill',
+      type: 'skills' as const,
+      sourcePath,
+      relativePath: 'skills/team-skill',
+    };
+
+    await handler.pullItem(item, teamConfig, localConfig);
+
+    // claude is disabled → not written, even though ~/.claude exists
+    expect(await fse.pathExists(path.join(homeDir, '.claude', 'skills', 'team-skill'))).toBe(false);
+    // codex is not disabled → synced normally
+    expect(await fse.pathExists(path.join(homeDir, '.codex', 'skills', 'team-skill'))).toBe(true);
+  });
+});

--- a/src/__tests__/uninstall.test.ts
+++ b/src/__tests__/uninstall.test.ts
@@ -13,9 +13,10 @@ vi.mock('../config.js', () => ({
 
 const mockReconcileHooks = vi.fn();
 
-vi.mock('../hooks.js', () => ({
-  reconcileHooks: (...args: unknown[]) => mockReconcileHooks(...args),
-}));
+vi.mock('../hooks.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../hooks.js')>();
+  return { ...actual, reconcileHooks: (...args: unknown[]) => mockReconcileHooks(...args) };
+});
 
 vi.mock('../utils/logger.js', () => ({
   log: {
@@ -650,6 +651,191 @@ describe('uninstall', () => {
     expect(internalResult).toContain('# Internal Config');
     expect(internalResult).not.toContain(TEAMAI_CULTURE_START);
     expect(internalResult).not.toContain(TEAMAI_CLAUDEMD_START);
+  });
+
+  it('--agent claude 且只有 claude 一个工具 → 全删含共享', async () => {
+    const { homeDir, repoPath, teamaiHome } = await setupFixture(tmpDir);
+    vi.stubEnv('HOME', homeDir);
+    vi.stubEnv('SHELL', '/bin/zsh');
+
+    const teamConfig = makeTeamConfig();
+    const localConfig = makeLocalConfig(homeDir, repoPath);
+    mockAutoDetectInit.mockResolvedValue({ localConfig, teamConfig });
+
+    await uninstall({ force: true, agent: 'claude' });
+
+    // claude team-skill removed
+    expect(await fse.pathExists(path.join(homeDir, '.claude', 'skills', 'team-skill'))).toBe(false);
+    // ~/.teamai removed (claude was the last tool)
+    expect(await fse.pathExists(teamaiHome)).toBe(false);
+    // reconcileHooks called with claude + removeAll
+    expect(mockReconcileHooks).toHaveBeenCalledWith(
+      path.join(homeDir, '.claude', 'settings.json'),
+      'claude',
+      [],
+      expect.objectContaining({ removeAll: true }),
+    );
+  });
+
+  it('--agent claude 但 codex 仍有资源 → 保留共享', async () => {
+    const { homeDir, repoPath, teamaiHome } = await setupFixture(tmpDir);
+    vi.stubEnv('HOME', homeDir);
+    vi.stubEnv('SHELL', '/bin/zsh');
+
+    // Set up codex with a team-skill so discoverToolResources finds resources
+    await fse.ensureDir(path.join(homeDir, '.codex', 'skills', 'team-skill'));
+    await fse.writeFile(path.join(homeDir, '.codex', 'skills', 'team-skill', 'SKILL.md'), '# Team Skill');
+
+    const teamConfig = makeTeamConfig({
+      toolPaths: {
+        claude: {
+          skills: '.claude/skills',
+          rules: '.claude/rules',
+          settings: '.claude/settings.json',
+          claudemd: '.claude/CLAUDE.md',
+          agents: '.claude/agents',
+        },
+        codex: {
+          skills: '.codex/skills',
+          rules: '.codex/rules',
+        },
+      },
+    });
+    const localConfig = makeLocalConfig(homeDir, repoPath);
+    mockAutoDetectInit.mockResolvedValue({ localConfig, teamConfig });
+
+    await uninstall({ force: true, agent: 'claude' });
+
+    // claude team-skill removed
+    expect(await fse.pathExists(path.join(homeDir, '.claude', 'skills', 'team-skill'))).toBe(false);
+    // ~/.teamai NOT removed (codex still has resources)
+    expect(await fse.pathExists(teamaiHome)).toBe(true);
+    // codex team-skill still exists
+    expect(await fse.pathExists(path.join(homeDir, '.codex', 'skills', 'team-skill'))).toBe(true);
+  });
+
+  it('--agent unknown → 报错不删', async () => {
+    const { homeDir, repoPath, teamaiHome } = await setupFixture(tmpDir);
+    vi.stubEnv('HOME', homeDir);
+    vi.stubEnv('SHELL', '/bin/zsh');
+
+    const teamConfig = makeTeamConfig();
+    const localConfig = makeLocalConfig(homeDir, repoPath);
+    mockAutoDetectInit.mockResolvedValue({ localConfig, teamConfig });
+
+    await uninstall({ force: true, agent: 'nonexistent' });
+
+    // claude team-skill still exists
+    expect(await fse.pathExists(path.join(homeDir, '.claude', 'skills', 'team-skill'))).toBe(true);
+    // ~/.teamai still exists
+    expect(await fse.pathExists(teamaiHome)).toBe(true);
+    // reconcileHooks not called
+    expect(mockReconcileHooks).not.toHaveBeenCalled();
+  });
+
+  it('--agent 卸载最后一个工具时移除共享资源（已剥离 hooks 的工具不算占用）', async () => {
+    const { homeDir, repoPath, teamaiHome } = await setupFixture(tmpDir);
+    vi.stubEnv('HOME', homeDir);
+    vi.stubEnv('SHELL', '/bin/zsh');
+
+    // claude settings.json has only a non-teamai user hook (simulates hooks already stripped)
+    await fse.writeJson(path.join(homeDir, '.claude', 'settings.json'), {
+      hooks: { SessionStart: [{ matcher: '*', hooks: [{ type: 'command', command: 'echo hi' }] }] },
+    });
+    // Remove all teamai resources from claude so it has zero teamai presence
+    await fse.remove(path.join(homeDir, '.claude', 'skills', 'team-skill'));
+    await fse.remove(path.join(homeDir, '.claude', 'skills', 'teamai-share-learnings'));
+    await fse.remove(path.join(homeDir, '.claude', 'skills', 'team-wiki-codebase'));
+    await fse.remove(path.join(homeDir, '.claude', 'rules', 'team-rule.md'));
+    await fse.remove(path.join(homeDir, '.claude', 'rules', 'teamai-recall.md'));
+    await fse.remove(path.join(homeDir, '.claude', 'agents', 'teamai-recall.md'));
+    await fse.remove(path.join(homeDir, '.claude', 'CLAUDE.md'));
+
+    // codex has one team-skill
+    await fse.ensureDir(path.join(homeDir, '.codex', 'skills', 'team-skill'));
+    await fse.writeFile(path.join(homeDir, '.codex', 'skills', 'team-skill', 'SKILL.md'), '# Team Skill');
+
+    const teamConfig = makeTeamConfig({
+      toolPaths: {
+        claude: {
+          skills: '.claude/skills',
+          rules: '.claude/rules',
+          settings: '.claude/settings.json',
+          claudemd: '.claude/CLAUDE.md',
+          agents: '.claude/agents',
+        },
+        codex: {
+          skills: '.codex/skills',
+          rules: '.codex/rules',
+        },
+      },
+    });
+    const localConfig = makeLocalConfig(homeDir, repoPath);
+    mockAutoDetectInit.mockResolvedValue({ localConfig, teamConfig });
+
+    await uninstall({ force: true, agent: 'codex' });
+
+    // codex team-skill removed
+    expect(await fse.pathExists(path.join(homeDir, '.codex', 'skills', 'team-skill'))).toBe(false);
+    // ~/.teamai removed — claude's settings.json has no teamai hooks, so it doesn't block shared removal
+    expect(await fse.pathExists(teamaiHome)).toBe(false);
+  });
+
+  it('未检测到配置 + --agent → 返回不删', async () => {
+    const homeDir = path.join(tmpDir, 'no-config-home');
+    const teamaiHome = path.join(homeDir, '.teamai');
+    await fse.ensureDir(teamaiHome);
+    vi.stubEnv('HOME', homeDir);
+
+    mockAutoDetectInit.mockRejectedValue(new Error('no config'));
+
+    await uninstall({ force: true, agent: 'claude' });
+
+    // ~/.teamai still exists (minimal uninstall was skipped)
+    expect(await fse.pathExists(teamaiHome)).toBe(true);
+  });
+
+  it('目标工具无 teamai 资源 → no-op 不删共享', async () => {
+    const { homeDir, repoPath, teamaiHome } = await setupFixture(tmpDir);
+    vi.stubEnv('HOME', homeDir);
+    vi.stubEnv('SHELL', '/bin/zsh');
+
+    // Strip all teamai resources from claude so it has zero teamai presence
+    await fse.writeJson(path.join(homeDir, '.claude', 'settings.json'), {
+      hooks: { SessionStart: [{ matcher: '*', hooks: [{ type: 'command', command: 'echo hi' }] }] },
+    });
+    await fse.remove(path.join(homeDir, '.claude', 'skills', 'team-skill'));
+    await fse.remove(path.join(homeDir, '.claude', 'skills', 'teamai-share-learnings'));
+    await fse.remove(path.join(homeDir, '.claude', 'skills', 'team-wiki-codebase'));
+    await fse.remove(path.join(homeDir, '.claude', 'rules', 'team-rule.md'));
+    await fse.remove(path.join(homeDir, '.claude', 'rules', 'teamai-recall.md'));
+    await fse.remove(path.join(homeDir, '.claude', 'agents', 'teamai-recall.md'));
+    await fse.remove(path.join(homeDir, '.claude', 'CLAUDE.md'));
+
+    const teamConfig = makeTeamConfig();
+    const localConfig = makeLocalConfig(homeDir, repoPath);
+    mockAutoDetectInit.mockResolvedValue({ localConfig, teamConfig });
+
+    await uninstall({ force: true, agent: 'claude' });
+
+    // ~/.teamai must still exist — target had no teamai resources
+    expect(await fse.pathExists(teamaiHome)).toBe(true);
+    expect(mockReconcileHooks).not.toHaveBeenCalled();
+  });
+
+  it('--agent 大小写不敏感', async () => {
+    const { homeDir, repoPath } = await setupFixture(tmpDir);
+    vi.stubEnv('HOME', homeDir);
+    vi.stubEnv('SHELL', '/bin/zsh');
+
+    const teamConfig = makeTeamConfig();
+    const localConfig = makeLocalConfig(homeDir, repoPath);
+    mockAutoDetectInit.mockResolvedValue({ localConfig, teamConfig });
+
+    await uninstall({ force: true, agent: 'Claude' });
+
+    // Should have matched 'claude' and removed team-skill
+    expect(await fse.pathExists(path.join(homeDir, '.claude', 'skills', 'team-skill'))).toBe(false);
   });
 
   it('仅含 teamai section 的 CLAUDE.md 被整文件删除', async () => {

--- a/src/__tests__/uninstall.test.ts
+++ b/src/__tests__/uninstall.test.ts
@@ -6,9 +6,13 @@ import fse from 'fs-extra';
 // ─── Mocks ─────────────────────────────────────────────
 
 const mockAutoDetectInit = vi.fn();
+const mockSaveLocalConfig = vi.fn();
+const mockSaveLocalConfigForScope = vi.fn();
 
 vi.mock('../config.js', () => ({
   autoDetectInit: (...args: unknown[]) => mockAutoDetectInit(...args),
+  saveLocalConfig: (...args: unknown[]) => mockSaveLocalConfig(...args),
+  saveLocalConfigForScope: (...args: unknown[]) => mockSaveLocalConfigForScope(...args),
 }));
 
 const mockReconcileHooks = vi.fn();
@@ -184,6 +188,8 @@ describe('uninstall', () => {
     tmpDir = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-uninstall-test-'));
     mockAutoDetectInit.mockReset();
     mockReconcileHooks.mockReset();
+    mockSaveLocalConfig.mockReset();
+    mockSaveLocalConfigForScope.mockReset();
   });
 
   afterEach(async () => {
@@ -712,6 +718,48 @@ describe('uninstall', () => {
     expect(await fse.pathExists(teamaiHome)).toBe(true);
     // codex team-skill still exists
     expect(await fse.pathExists(path.join(homeDir, '.codex', 'skills', 'team-skill'))).toBe(true);
+    // Exclusion persisted so the next pull won't resurrect claude: added to
+    // disabledAgents (user scope → saveLocalConfig).
+    expect(mockSaveLocalConfig).toHaveBeenCalledTimes(1);
+    const savedCfg = mockSaveLocalConfig.mock.calls[0][0] as LocalConfig;
+    expect(savedCfg.disabledAgents).toContain('claude');
+    // No prior whitelist existed → enabledAgents must stay undefined, NOT collapse
+    // to [] (which the hook path reads as "whitelist nothing" and would wrongly
+    // stop hook sync for the remaining tools too).
+    expect(savedCfg.enabledAgents).toBeUndefined();
+  });
+
+  it('--agent 卸载在已有 enabledAgents 白名单时只移除目标工具', async () => {
+    const { homeDir, repoPath } = await setupFixture(tmpDir);
+    vi.stubEnv('HOME', homeDir);
+    vi.stubEnv('SHELL', '/bin/zsh');
+
+    await fse.ensureDir(path.join(homeDir, '.codex', 'skills', 'team-skill'));
+    await fse.writeFile(path.join(homeDir, '.codex', 'skills', 'team-skill', 'SKILL.md'), '# Team Skill');
+
+    const teamConfig = makeTeamConfig({
+      toolPaths: {
+        claude: {
+          skills: '.claude/skills',
+          rules: '.claude/rules',
+          settings: '.claude/settings.json',
+          claudemd: '.claude/CLAUDE.md',
+          agents: '.claude/agents',
+        },
+        codex: { skills: '.codex/skills', rules: '.codex/rules' },
+      },
+    });
+    const localConfig = makeLocalConfig(homeDir, repoPath);
+    localConfig.enabledAgents = ['claude', 'codex'];
+    mockAutoDetectInit.mockResolvedValue({ localConfig, teamConfig });
+
+    await uninstall({ force: true, agent: 'claude' });
+
+    expect(mockSaveLocalConfig).toHaveBeenCalledTimes(1);
+    const savedCfg = mockSaveLocalConfig.mock.calls[0][0] as LocalConfig;
+    // Existing whitelist is pruned of the target only; codex stays enabled.
+    expect(savedCfg.enabledAgents).toEqual(['codex']);
+    expect(savedCfg.disabledAgents).toContain('claude');
   });
 
   it('--agent unknown → 报错不删', async () => {
@@ -723,6 +771,8 @@ describe('uninstall', () => {
     const localConfig = makeLocalConfig(homeDir, repoPath);
     mockAutoDetectInit.mockResolvedValue({ localConfig, teamConfig });
 
+    const prevExitCode = process.exitCode;
+    process.exitCode = undefined;
     await uninstall({ force: true, agent: 'nonexistent' });
 
     // claude team-skill still exists
@@ -731,6 +781,9 @@ describe('uninstall', () => {
     expect(await fse.pathExists(teamaiHome)).toBe(true);
     // reconcileHooks not called
     expect(mockReconcileHooks).not.toHaveBeenCalled();
+    // Unknown tool sets a non-zero exit code (so scripts/CI see the failure)
+    expect(process.exitCode).toBe(2);
+    process.exitCode = prevExitCode;
   });
 
   it('--agent 卸载最后一个工具时移除共享资源（已剥离 hooks 的工具不算占用）', async () => {
@@ -779,6 +832,9 @@ describe('uninstall', () => {
     expect(await fse.pathExists(path.join(homeDir, '.codex', 'skills', 'team-skill'))).toBe(false);
     // ~/.teamai removed — claude's settings.json has no teamai hooks, so it doesn't block shared removal
     expect(await fse.pathExists(teamaiHome)).toBe(false);
+    // Last-tool uninstall deletes ~/.teamai, so there is no config to persist to.
+    expect(mockSaveLocalConfig).not.toHaveBeenCalled();
+    expect(mockSaveLocalConfigForScope).not.toHaveBeenCalled();
   });
 
   it('未检测到配置 + --agent → 返回不删', async () => {

--- a/src/builtin-agents.ts
+++ b/src/builtin-agents.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { ensureDir, pathExists, copyFile } from './utils/fs.js';
 import { log } from './utils/logger.js';
 import type { TeamaiConfig, LocalConfig } from './types.js';
-import { resolveBaseDir } from './types.js';
+import { resolveBaseDir, isAgentDisabled } from './types.js';
 import { ResourceHandler } from './resources/base.js';
 
 // ─── Built-in agents deployment ──────────────────────────
@@ -87,6 +87,7 @@ export async function deployBuiltinAgents(
       log.debug(`Skipping built-in agent deployment for ${tool}: tool not installed`);
       continue;
     }
+    if (localConfig && isAgentDisabled(localConfig, tool)) continue;
 
     const targetAgentsDir = path.join(baseDir, toolPath.agents);
     try {

--- a/src/builtin-rules.ts
+++ b/src/builtin-rules.ts
@@ -3,7 +3,7 @@ import { ensureDir, writeFile, pathExists } from './utils/fs.js';
 import { log } from './utils/logger.js';
 import { ResourceHandler } from './resources/base.js';
 import type { TeamaiConfig, LocalConfig } from './types.js';
-import { resolveBaseDir } from './types.js';
+import { resolveBaseDir, isAgentDisabled } from './types.js';
 import fs from 'node:fs/promises';
 
 // ─── Built-in rules deployment ──────────────────────────
@@ -63,6 +63,7 @@ export async function deployBuiltinRules(
             log.debug(`Skipping built-in rules for ${tool}: tool not installed`);
             continue;
         }
+        if (localConfig && isAgentDisabled(localConfig, tool)) continue;
 
         const rulesDir = path.join(baseDir, toolPath.rules);
         if (!await pathExists(rulesDir)) continue;

--- a/src/builtin-skills.ts
+++ b/src/builtin-skills.ts
@@ -5,7 +5,7 @@ import fse from 'fs-extra';
 import { pathExists } from './utils/fs.js';
 import { log } from './utils/logger.js';
 import type { TeamaiConfig, LocalConfig } from './types.js';
-import { resolveBaseDir } from './types.js';
+import { resolveBaseDir, isAgentDisabled } from './types.js';
 import { ResourceHandler } from './resources/base.js';
 import { ensureSkillFrontmatter } from './resources/skills.js';
 
@@ -108,6 +108,7 @@ export async function deployBuiltinSkills(teamConfig: TeamaiConfig, localConfig?
       log.debug(`Skipping built-in skill deployment for ${tool}: tool not installed`);
       continue;
     }
+    if (localConfig && isAgentDisabled(localConfig, tool)) continue;
 
     const targetSkillsDir = path.join(baseDir, toolPath.skills);
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -641,7 +641,14 @@ export async function reconcileTeamHooksForConfig(
     : await resolveTeamHooks(teamConfig, localConfig.repo.localPath, { auto: opts.auto, silent: opts.silent });
   const baseDir = resolveBaseDir(localConfig);
   const manifestPath = getManagedHooksPath(localConfig.scope, localConfig.projectRoot);
-  const filterAgents = opts.filterAgents ?? localConfig.enabledAgents;
+  let filterAgents = opts.filterAgents ?? localConfig.enabledAgents;
+  const disabled = localConfig.disabledAgents;
+  if (disabled && disabled.length > 0) {
+    // Exclusion always applies, even when there is no whitelist. When no
+    // whitelist exists, start from the full configured tool set.
+    const universe = filterAgents ?? Object.keys(teamConfig.toolPaths);
+    filterAgents = universe.filter((t) => !disabled.includes(t));
+  }
   await reconcileHooksToAllTools(teamConfig.toolPaths, baseDir, teamDefs, manifestPath, {
     removeAll: opts.removeAll,
     builtinOverride: builtin,

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -498,6 +498,58 @@ export async function getHookStatus(settingsPath: string, tool?: string): Promis
 }
 
 /**
+ * Report whether a tool settings/hooks file currently holds ANY teamai-managed
+ * hook entry (built-in A or team B). Unlike getHookStatus (which checks the full
+ * built-in set is present), this returns true if even one teamai entry remains.
+ * Used by `uninstall --agent` to decide whether a tool still has teamai hooks.
+ * Manifest records must still exist in the file to count — stale manifest entries
+ * (user hand-stripped the hook) are ignored.
+ */
+export async function hasTeamaiHooks(
+  settingsPath: string,
+  tool: string,
+  manifestPath?: string,
+): Promise<boolean> {
+  const manifest = manifestPath ? await readManifest(manifestPath) : null;
+  // Manifest records are only a signal when the recorded command still exists in
+  // the settings file. A stale manifest entry (user hand-stripped the hook) must
+  // NOT count as "still using teamai" — intersect manifest with actual content.
+  const priorTeamCommands = new Set((manifest?.[tool] ?? []).map((r) => r.command));
+
+  const expanded = expandHome(settingsPath);
+  const format = detectFormat(tool);
+
+  if (format === 'cursor') {
+    const j = await readJson<CursorHooksJson>(expanded);
+    if (!j?.hooks) return false;
+    return Object.values(j.hooks).some((entries) =>
+      (entries ?? []).some((e) => isTeamaiHookCommand(e.command) || priorTeamCommands.has(e.command)),
+    );
+  }
+
+  if (format === 'codex') {
+    const j = await readJson<CodexHooksJson>(expanded);
+    if (!j?.hooks) return false;
+    return Object.values(j.hooks).some((entries) =>
+      (entries ?? []).some((e) => {
+        const cmd = e.hooks?.[0]?.command ?? '';
+        return TEAMAI_COMMAND_MARKERS.some((m) => cmd.includes(m)) || priorTeamCommands.has(cmd);
+      }),
+    );
+  }
+
+  const s = await readJson<ClaudeSettingsJson>(expanded);
+  if (!s?.hooks) return false;
+  return Object.values(s.hooks).some((entries) =>
+    (entries ?? []).some((e) => {
+      if (isBuiltinClaudeEntry(e) || isTeamClaudeEntry(e)) return true;
+      const cmd = e.hooks?.[0]?.command ?? '';
+      return priorTeamCommands.has(cmd);
+    }),
+  );
+}
+
+/**
  * Inject teamai built-in hooks into all AI tool settings.
  * Only writes to tools whose root directory already exists on disk,
  * preventing creation of config dirs for tools the user hasn't installed.

--- a/src/index.ts
+++ b/src/index.ts
@@ -424,6 +424,7 @@ program
   .command('uninstall')
   .description('Remove all teamai-managed resources and hooks from this machine')
   .option('--force', 'Skip confirmation prompt')
+  .option('--agent <name>', 'Only uninstall this agent\'s resources; shared resources go only if it is the last tool')
   .action(async (cmdOpts) => {
     const globalOpts = program.opts() as GlobalOptions;
     const { uninstall } = await import('./uninstall.js');

--- a/src/init.ts
+++ b/src/init.ts
@@ -179,6 +179,7 @@ export async function initHttp(
     const existing = await loadLocalConfigForScope(scope, projectRoot);
     const prev = existing?.enabledAgents ?? [];
     localConfig.enabledAgents = [...new Set([...prev, options.agent])];
+    localConfig.disabledAgents = (existing?.disabledAgents ?? []).filter((t) => t !== options.agent);
   }
 
   await ensureDir(teamaiHome);
@@ -517,6 +518,7 @@ export async function init(options: GlobalOptions & { repo?: string; scope?: str
     const existing = await loadLocalConfigForScope(scope, projectRoot);
     const prev = existing?.enabledAgents ?? [];
     localConfig.enabledAgents = [...new Set([...prev, options.agent])];
+    localConfig.disabledAgents = (existing?.disabledAgents ?? []).filter((t) => t !== options.agent);
   }
 
   await ensureDir(teamaiHome);

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -23,6 +23,7 @@ import {
   resolveBaseDir,
   getTeamaiHome,
   isRecallEnabled,
+  isAgentDisabled,
 } from './types.js';
 import type { CultureFrontmatter } from './types.js';
 import { loadRolesManifest, resolveRoleResourceNamespaces, type ResourceNamespaces } from './roles.js';
@@ -178,6 +179,7 @@ export async function cleanupInactiveNamespaceSkills(
   const baseDir = resolveBaseDir(localConfig);
 
   for (const [tool, toolPath] of Object.entries(teamConfig.toolPaths)) {
+    if (isAgentDisabled(localConfig, tool)) continue;
     if (!toolPath.skills) continue;
     if (!await ResourceHandler.isToolInstalled(toolPath.skills, baseDir)) continue;
     if (!await pathExists(path.join(baseDir, toolPath.skills))) continue;
@@ -494,10 +496,11 @@ async function pullForScope(
       const tombstones = await handler.readTombstones(localConfig);
       if (tombstones.size === 0) continue;
 
-      for (const [_tool, toolPath] of Object.entries(freshConfig.toolPaths)) {
+      for (const [tool, toolPath] of Object.entries(freshConfig.toolPaths)) {
         const dir = toolPath[toolPathField];
         if (!dir) continue;
         if (!await ResourceHandler.isToolInstalled(dir, baseDir)) continue;
+        if (isAgentDisabled(localConfig, tool)) continue;
 
         for (const name of tombstones) {
           const localPath = path.join(baseDir, dir, ext ? `${name}${ext}` : name);
@@ -524,6 +527,7 @@ async function pullForScope(
     const baseDir = resolveBaseDir(localConfig);
 
     for (const [tool, toolPath] of Object.entries(freshConfig.toolPaths)) {
+      if (isAgentDisabled(localConfig, tool)) continue;
       if (!toolPath.skills) continue;
       if (!await ResourceHandler.isToolInstalled(toolPath.skills, baseDir)) continue;
       const skillsDir = path.join(baseDir, toolPath.skills);
@@ -658,6 +662,7 @@ async function pullForScope(
           if (compiled) {
             const baseDir = resolveBaseDir(localConfig);
             for (const [tool, toolPath] of Object.entries(freshConfig.toolPaths)) {
+              if (isAgentDisabled(localConfig, tool)) continue;
               if (!toolPath.claudemd) continue;
               if (toolPath.rules && !await ResourceHandler.isToolInstalled(toolPath.rules, baseDir)) continue;
 
@@ -688,6 +693,7 @@ async function pullForScope(
         if (compiled) {
           const baseDir = resolveBaseDir(localConfig);
           for (const [tool, toolPath] of Object.entries(freshConfig.toolPaths)) {
+            if (isAgentDisabled(localConfig, tool)) continue;
             if (!toolPath.claudemd) continue;
             if (toolPath.rules && !await ResourceHandler.isToolInstalled(toolPath.rules, baseDir)) continue;
             const claudeMdPath = path.join(baseDir, toolPath.claudemd);
@@ -902,6 +908,7 @@ export async function injectRecallBlockIntoTools(
         const recallBlock = compileRecallRulesBlock();
         let injected = 0;
         for (const [tool, toolPath] of Object.entries(config.toolPaths)) {
+            if (isAgentDisabled(localConfig, tool)) continue;
             if (!toolPath.claudemd || !toolPath.agents) continue;
             if (!await ResourceHandler.isToolInstalled(toolPath.agents, baseDir)) continue;
 
@@ -1061,7 +1068,13 @@ async function autoMigrateHooksIfNeeded(): Promise<void> {
   const { injectHooksToAllTools } = await import('./hooks.js');
   const { localConfig, teamConfig } = await autoDetectInit();
   const baseDir = resolveBaseDir(localConfig);
-  await injectHooksToAllTools(teamConfig.toolPaths, baseDir, localConfig.enabledAgents);
+  const disabled = localConfig.disabledAgents;
+  let hookFilter = localConfig.enabledAgents;
+  if (disabled && disabled.length > 0) {
+    const universe = hookFilter ?? Object.keys(teamConfig.toolPaths);
+    hookFilter = universe.filter((t) => !disabled.includes(t));
+  }
+  await injectHooksToAllTools(teamConfig.toolPaths, baseDir, hookFilter);
   log.debug('Hooks migrated to dispatch format');
 }
 

--- a/src/resources/agents.ts
+++ b/src/resources/agents.ts
@@ -3,7 +3,7 @@ import { ResourceHandler } from './base.js';
 import type { ResourceItem, ResourceItemStatus, TeamaiConfig, LocalConfig } from '../types.js';
 import { listFiles, pathExists, copyFile, ensureDir, remove, fileContentEqual, getFileMtime, writeFile, readFileSafe } from '../utils/fs.js';
 import { log } from '../utils/logger.js';
-import { resolveBaseDir } from '../types.js';
+import { resolveBaseDir, isAgentDisabled } from '../types.js';
 import { BUILTIN_AGENT_NAMES } from '../builtin-agents.js';
 import {
   parseAgentYaml,
@@ -266,7 +266,7 @@ export class AgentsHandler extends ResourceHandler {
 
     if (isLegacy) {
       // Legacy: copy .md to tools that support agents
-      await this.pullLegacyMd(item, teamConfig, baseDir);
+      await this.pullLegacyMd(item, teamConfig, baseDir, localConfig);
       return;
     }
 
@@ -297,6 +297,7 @@ export class AgentsHandler extends ResourceHandler {
         log.debug(`Skipping agent sync for ${tool}: tool not installed`);
         continue;
       }
+      if (isAgentDisabled(localConfig, tool)) continue;
 
       const destDir = path.join(baseDir, toolPath.agents);
       try {
@@ -357,6 +358,7 @@ export class AgentsHandler extends ResourceHandler {
     item: ResourceItem,
     teamConfig: TeamaiConfig,
     baseDir: string,
+    localConfig: LocalConfig,
   ): Promise<void> {
     const legacyTools = new Set(['claude', 'claude-internal', 'tclaude', 'codebuddy']);
 
@@ -370,6 +372,7 @@ export class AgentsHandler extends ResourceHandler {
         log.debug(`Skipping legacy agent sync for ${tool}: tool not installed`);
         continue;
       }
+      if (isAgentDisabled(localConfig, tool)) continue;
 
       const destDir = path.join(baseDir, toolPath.agents);
       try {

--- a/src/resources/rules.ts
+++ b/src/resources/rules.ts
@@ -3,7 +3,7 @@ import { ResourceHandler } from './base.js';
 import type { ResourceItem, ResourceItemStatus, TeamaiConfig, LocalConfig } from '../types.js';
 import { listFilesRecursive, pathExists, copyFile, ensureDir, remove, fileContentEqual, getFileMtime, listDirs, readFileSafe, writeFile } from '../utils/fs.js';
 import { log } from '../utils/logger.js';
-import { TEAMAI_RULES_START, TEAMAI_RULES_END, resolveBaseDir } from '../types.js';
+import { TEAMAI_RULES_START, TEAMAI_RULES_END, resolveBaseDir, isAgentDisabled } from '../types.js';
 import { EXCLUDED_RULE_NAMES } from '../builtin-rules.js';
 
 export class RulesHandler extends ResourceHandler {
@@ -120,6 +120,7 @@ export class RulesHandler extends ResourceHandler {
   async pullItem(item: ResourceItem, teamConfig: TeamaiConfig, localConfig: LocalConfig): Promise<void> {
     const baseDir = resolveBaseDir(localConfig);
     for (const [tool, toolPath] of Object.entries(teamConfig.toolPaths)) {
+      if (isAgentDisabled(localConfig, tool)) continue;
       if (!toolPath.rules) continue;
 
       // Skip tools that are not installed

--- a/src/resources/skills.ts
+++ b/src/resources/skills.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { ResourceHandler } from './base.js';
 import type { ResourceItem, ResourceItemStatus, TeamaiConfig, LocalConfig } from '../types.js';
-import { resolveBaseDir, getPushignorePath } from '../types.js';
+import { resolveBaseDir, getPushignorePath, isAgentDisabled } from '../types.js';
 import { listDirs, pathExists, copyDir, remove, dirTeamSubsetEqual, getDirLatestMtime, readFileSafe, writeFile } from '../utils/fs.js';
 import { log } from '../utils/logger.js';
 import { BUILTIN_SKILL_NAMES } from '../builtin-skills.js';
@@ -431,6 +431,7 @@ export class SkillsHandler extends ResourceHandler {
     const baseDir = resolveBaseDir(localConfig);
 
     for (const [tool, toolPath] of Object.entries(teamConfig.toolPaths)) {
+      if (isAgentDisabled(localConfig, tool)) continue;
       if (!toolPath.skills) continue;
 
       // Skip tools that are not installed

--- a/src/types.ts
+++ b/src/types.ts
@@ -225,6 +225,8 @@ export const LocalConfigSchema = z.object({
   recallEnabled: z.boolean().optional(),
   /** When set, only inject hooks into these agents. Additive across multiple init --agent runs. */
   enabledAgents: z.array(z.string()).optional(),
+  /** Tools explicitly excluded from all teamai sync (set by `uninstall --agent`). Removed again by `init --agent`. */
+  disabledAgents: z.array(z.string()).optional(),
 });
 
 export type LocalConfig = z.infer<typeof LocalConfigSchema>;
@@ -954,6 +956,11 @@ export function resolveBaseDir(localConfig: LocalConfig): string {
     return localConfig.projectRoot;
   }
   return process.env.HOME!;
+}
+
+/** True when `tool` is in localConfig.disabledAgents (excluded from teamai sync). */
+export function isAgentDisabled(localConfig: { disabledAgents?: string[] }, tool: string): boolean {
+  return localConfig.disabledAgents?.includes(tool) ?? false;
 }
 
 /**

--- a/src/uninstall.ts
+++ b/src/uninstall.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { autoDetectInit } from './config.js';
-import { reconcileHooks } from './hooks.js';
+import { reconcileHooks, hasTeamaiHooks } from './hooks.js';
 import { removeOpenClawHooks, OPENCLAW_HOOK_DIR } from './openclaw-hooks.js';
 import {
   TEAMAI_RULES_START,
@@ -43,6 +43,7 @@ import { askConfirmation } from './utils/prompt.js';
 
 interface UninstallOptions extends GlobalOptions {
   force?: boolean;
+  agent?: string;
 }
 
 interface RemovalPlan {
@@ -70,8 +71,31 @@ interface RemovalPlan {
   teamaiHomeExists: boolean;
   /** Managed-hooks manifest path (for team-hook cleanup). */
   managedHooksPath: string;
+  /** Whether shared resources (docs / ~/.teamai / shell profile) are part of this removal. */
+  includeShared: boolean;
   /** Scope being uninstalled (issue #73: surfaced to the user). */
   scope: Scope;
+}
+
+/** Per-tool findings collected during discovery (tool-specific resources only). */
+interface ToolResources {
+  hookFiles: Array<{ path: string; tool: string }>;
+  openclawHookDirs: Array<{ hooksDir: string; tool: string }>;
+  claudeMdFiles: string[];
+  skillDirs: string[];
+  ruleFiles: string[];
+  agentFiles: string[];
+}
+
+function hasToolResources(r: ToolResources): boolean {
+  return (
+    r.hookFiles.length > 0 ||
+    r.openclawHookDirs.length > 0 ||
+    r.claudeMdFiles.length > 0 ||
+    r.skillDirs.length > 0 ||
+    r.ruleFiles.length > 0 ||
+    r.agentFiles.length > 0
+  );
 }
 
 // ─── Helpers ───────────────────────────────────────────
@@ -139,40 +163,96 @@ async function collectTeamRuleNames(repoPath: string): Promise<Set<string>> {
 
 // ─── Discovery ─────────────────────────────────────────
 
+async function discoverToolResources(
+  tool: string,
+  toolPath: TeamaiConfig['toolPaths'][string],
+  baseDir: string,
+  teamSkillNames: Set<string>,
+  teamRuleNames: Set<string>,
+  managedHooksPath: string,
+): Promise<ToolResources> {
+  const res: ToolResources = {
+    hookFiles: [], openclawHookDirs: [], claudeMdFiles: [],
+    skillDirs: [], ruleFiles: [], agentFiles: [],
+  };
+
+  // (a) Hooks — settings.json / hooks.json
+  if (toolPath.settings) {
+    const settingsPath = path.join(baseDir, toolPath.settings);
+    if (await pathExists(settingsPath) && await hasTeamaiHooks(settingsPath, tool, managedHooksPath)) {
+      res.hookFiles.push({ path: settingsPath, tool });
+    }
+  } else {
+    // OpenClaw-style agents (no settings file) inject a HOOK.md + handler.ts
+    // under <base>/.<tool>/hooks/<OPENCLAW_HOOK_DIR>. Mirror that for removal.
+    const hooksDir = path.join(baseDir, `.${tool}`, 'hooks');
+    if (await pathExists(path.join(hooksDir, OPENCLAW_HOOK_DIR))) {
+      res.openclawHookDirs.push({ hooksDir, tool });
+    }
+  }
+
+  // (b) CLAUDE.md teamai section blocks
+  if (toolPath.claudemd) {
+    const claudeMdPath = path.join(baseDir, toolPath.claudemd);
+    const content = await readFileSafe(claudeMdPath);
+    if (content && CLAUDEMD_MARKER_PAIRS.some(([start]) => content.includes(start))) {
+      res.claudeMdFiles.push(claudeMdPath);
+    }
+  }
+
+  // (c) Skills — only those matching team repo
+  if (toolPath.skills) {
+    const skillsDir = path.join(baseDir, toolPath.skills);
+    if (await pathExists(skillsDir)) {
+      const dirs = await listDirs(skillsDir);
+      for (const dir of dirs) {
+        if (teamSkillNames.has(dir)) {
+          res.skillDirs.push(path.join(skillsDir, dir));
+        }
+      }
+    }
+  }
+
+  // (d) Rules — team-synced rules plus CLI built-in rules (teamRuleNames
+  // now includes BUILTIN_RULE_NAMES). User-authored rules are left alone.
+  if (toolPath.rules) {
+    const rulesDir = path.join(baseDir, toolPath.rules);
+    if (await pathExists(rulesDir)) {
+      const files = await listFilesRecursive(rulesDir);
+      for (const file of files) {
+        if (!file.endsWith('.md')) continue;
+        const ruleName = file.replace(/\.md$/, '');
+        if (teamRuleNames.has(ruleName)) {
+          res.ruleFiles.push(path.join(rulesDir, file));
+        }
+      }
+    }
+  }
+
+  // (d2) Built-in agents — CLI-deployed subagents (e.g. teamai-recall).
+  // Not synced from the team repo, so match by BUILTIN_AGENT_NAMES.
+  if (toolPath.agents) {
+    const agentsDir = path.join(baseDir, toolPath.agents);
+    if (await pathExists(agentsDir)) {
+      for (const name of BUILTIN_AGENT_NAMES) {
+        const agentFile = path.join(agentsDir, `${name}.md`);
+        if (await pathExists(agentFile)) {
+          res.agentFiles.push(agentFile);
+        }
+      }
+    }
+  }
+
+  return res;
+}
+
 async function buildRemovalPlan(
   localConfig: LocalConfig,
   teamConfig: TeamaiConfig,
+  agentFilter?: string,
 ): Promise<RemovalPlan> {
   const baseDir = resolveBaseDir(localConfig);
   const teamaiHome = getTeamaiHome(localConfig.scope, localConfig.projectRoot);
-
-  const plan: RemovalPlan = {
-    hookFiles: [],
-    openclawHookDirs: [],
-    claudeMdFiles: [],
-    skillDirs: [],
-    ruleFiles: [],
-    agentFiles: [],
-    mcpServers: [],
-    shellProfile: null,
-    docsDir: null,
-    teamaiHome,
-    teamaiHomeExists: await pathExists(teamaiHome),
-    managedHooksPath: getManagedHooksPath(localConfig.scope, localConfig.projectRoot),
-    scope: localConfig.scope,
-  };
-
-  // MCP servers are tracked in managed-mcp.json (same ownership model as hooks).
-  const mcpManifestPath = expandHome(
-    managedMcpManifestPath(localConfig.scope, localConfig.projectRoot),
-  );
-  const mcpManifest = (await readJson<ManagedMcpManifest>(mcpManifestPath)) ?? {};
-  for (const [toolKey, records] of Object.entries(mcpManifest)) {
-    for (const rec of records ?? []) {
-      if (rec?.name) plan.mcpServers.push(`${toolKey}/${rec.name}`);
-    }
-  }
-  plan.mcpServers.sort();
 
   // Discover team repo resource names for targeted removal. CLI built-in
   // resources (recall agent/rule, share-learnings skill, …) are deployed by
@@ -202,98 +282,103 @@ async function buildRemovalPlan(
     } catch { /* best effort */ }
   }
 
+  // Discover per-tool resources
+  const managedHooksPath = getManagedHooksPath(localConfig.scope, localConfig.projectRoot);
+  const perTool = new Map<string, ToolResources>();
   for (const [tool, toolPath] of Object.entries(teamConfig.toolPaths)) {
-    // (a) Hooks — settings.json / hooks.json
-    if (toolPath.settings) {
-      const settingsPath = path.join(baseDir, toolPath.settings);
-      if (await pathExists(settingsPath)) {
-        plan.hookFiles.push({ path: settingsPath, tool });
-      }
-    } else {
-      // OpenClaw-style agents (no settings file) inject a HOOK.md + handler.ts
-      // under <base>/.<tool>/hooks/<OPENCLAW_HOOK_DIR>. Mirror that for removal.
-      const hooksDir = path.join(baseDir, `.${tool}`, 'hooks');
-      if (await pathExists(path.join(hooksDir, OPENCLAW_HOOK_DIR))) {
-        plan.openclawHookDirs.push({ hooksDir, tool });
-      }
-    }
-
-    // (b) CLAUDE.md teamai section blocks
-    if (toolPath.claudemd) {
-      const claudeMdPath = path.join(baseDir, toolPath.claudemd);
-      const content = await readFileSafe(claudeMdPath);
-      if (content && CLAUDEMD_MARKER_PAIRS.some(([start]) => content.includes(start))) {
-        plan.claudeMdFiles.push(claudeMdPath);
-      }
-    }
-
-    // (c) Skills — only those matching team repo
-    if (toolPath.skills) {
-      const skillsDir = path.join(baseDir, toolPath.skills);
-      if (await pathExists(skillsDir)) {
-        const dirs = await listDirs(skillsDir);
-        for (const dir of dirs) {
-          if (teamSkillNames.has(dir)) {
-            plan.skillDirs.push(path.join(skillsDir, dir));
-          }
-        }
-      }
-    }
-
-    // (d) Rules — team-synced rules plus CLI built-in rules (teamRuleNames
-    // now includes BUILTIN_RULE_NAMES). User-authored rules are left alone.
-    if (toolPath.rules) {
-      const rulesDir = path.join(baseDir, toolPath.rules);
-      if (await pathExists(rulesDir)) {
-        const files = await listFilesRecursive(rulesDir);
-        for (const file of files) {
-          if (!file.endsWith('.md')) continue;
-          const ruleName = file.replace(/\.md$/, '');
-          if (teamRuleNames.has(ruleName)) {
-            plan.ruleFiles.push(path.join(rulesDir, file));
-          }
-        }
-      }
-    }
-
-    // (d2) Built-in agents — CLI-deployed subagents (e.g. teamai-recall).
-    // Not synced from the team repo, so match by BUILTIN_AGENT_NAMES.
-    if (toolPath.agents) {
-      const agentsDir = path.join(baseDir, toolPath.agents);
-      if (await pathExists(agentsDir)) {
-        for (const name of BUILTIN_AGENT_NAMES) {
-          const agentFile = path.join(agentsDir, `${name}.md`);
-          if (await pathExists(agentFile)) {
-            plan.agentFiles.push(agentFile);
-          }
-        }
-      }
-    }
+    perTool.set(
+      tool,
+      await discoverToolResources(tool, toolPath, baseDir, teamSkillNames, teamRuleNames, managedHooksPath),
+    );
   }
 
-  // (e) Shell profile env block
-  const shellProfilePath = teamConfig.sharing.env.shellProfilePath
-    ? expandHome(teamConfig.sharing.env.shellProfilePath)
-    : detectShellProfile();
-  if (shellProfilePath) {
-    const profileContent = await readFileSafe(shellProfilePath);
-    if (profileContent && profileContent.includes(TEAMAI_ENV_START)) {
-      plan.shellProfile = shellProfilePath;
-    }
-  }
-
-  // (f) Docs directory
-  const docsLocalDir = teamConfig.sharing.docs.localDir;
-  let docsDir: string;
-  if (localConfig.scope === 'project' && localConfig.projectRoot) {
-    docsDir = docsLocalDir.startsWith('~/')
-      ? path.join(localConfig.projectRoot, docsLocalDir.substring(2))
-      : expandHome(docsLocalDir);
+  // Decide which tools to merge and whether to include shared resources
+  let includeShared: boolean;
+  let toolsToMerge: string[];
+  if (agentFilter) {
+    toolsToMerge = [agentFilter];
+    const targetRes = perTool.get(agentFilter);
+    const targetHasResources = targetRes ? hasToolResources(targetRes) : false;
+    // Other tools still have teamai resources → keep shared resources.
+    const othersHaveResources = [...perTool.entries()]
+      .some(([t, r]) => t !== agentFilter && hasToolResources(r));
+    // Remove shared resources only when the target itself has resources AND is
+    // the last tool using teamai. Targeting a tool with no teamai resources is a
+    // no-op for shared resources (plan will be empty → "没有需要卸载的内容").
+    includeShared = targetHasResources && !othersHaveResources;
   } else {
-    docsDir = expandHome(docsLocalDir);
+    toolsToMerge = [...perTool.keys()];
+    includeShared = true;
   }
-  if (await pathExists(docsDir)) {
-    plan.docsDir = docsDir;
+
+  const plan: RemovalPlan = {
+    hookFiles: [],
+    openclawHookDirs: [],
+    claudeMdFiles: [],
+    skillDirs: [],
+    ruleFiles: [],
+    agentFiles: [],
+    mcpServers: [],
+    shellProfile: null,
+    docsDir: null,
+    teamaiHome,
+    teamaiHomeExists: includeShared && await pathExists(teamaiHome),
+    managedHooksPath,
+    includeShared,
+    scope: localConfig.scope,
+  };
+
+  // Merge tool-specific resources for selected tools
+  for (const tool of toolsToMerge) {
+    const res = perTool.get(tool);
+    if (!res) continue;
+    plan.hookFiles.push(...res.hookFiles);
+    plan.openclawHookDirs.push(...res.openclawHookDirs);
+    plan.claudeMdFiles.push(...res.claudeMdFiles);
+    plan.skillDirs.push(...res.skillDirs);
+    plan.ruleFiles.push(...res.ruleFiles);
+    plan.agentFiles.push(...res.agentFiles);
+  }
+
+  if (includeShared) {
+    // (d3) teamai-managed MCP servers, tracked in managed-mcp.json (same
+    // ownership model as hooks). These live under ~/.teamai, so they are shared
+    // resources: only removed when the target is the last tool using teamai.
+    const mcpManifestPath = expandHome(
+      managedMcpManifestPath(localConfig.scope, localConfig.projectRoot),
+    );
+    const mcpManifest = (await readJson<ManagedMcpManifest>(mcpManifestPath)) ?? {};
+    for (const [toolKey, records] of Object.entries(mcpManifest)) {
+      for (const rec of records ?? []) {
+        if (rec?.name) plan.mcpServers.push(`${toolKey}/${rec.name}`);
+      }
+    }
+    plan.mcpServers.sort();
+
+    // (e) Shell profile env block
+    const shellProfilePath = teamConfig.sharing.env.shellProfilePath
+      ? expandHome(teamConfig.sharing.env.shellProfilePath)
+      : detectShellProfile();
+    if (shellProfilePath) {
+      const profileContent = await readFileSafe(shellProfilePath);
+      if (profileContent && profileContent.includes(TEAMAI_ENV_START)) {
+        plan.shellProfile = shellProfilePath;
+      }
+    }
+
+    // (f) Docs directory
+    const docsLocalDir = teamConfig.sharing.docs.localDir;
+    let docsDir: string;
+    if (localConfig.scope === 'project' && localConfig.projectRoot) {
+      docsDir = docsLocalDir.startsWith('~/')
+        ? path.join(localConfig.projectRoot, docsLocalDir.substring(2))
+        : expandHome(docsLocalDir);
+    } else {
+      docsDir = expandHome(docsLocalDir);
+    }
+    if (await pathExists(docsDir)) {
+      plan.docsDir = docsDir;
+    }
   }
 
   return plan;
@@ -316,10 +401,16 @@ function isPlanEmpty(plan: RemovalPlan): boolean {
   );
 }
 
-function printSummary(plan: RemovalPlan): void {
+function printSummary(plan: RemovalPlan, agentFilter?: string): void {
   const cn = plan.scope === 'project' ? '项目级' : '用户级';
   console.log('');
   console.log(`⚠  正在卸载 ${plan.scope} scope（${cn}）— ${plan.teamaiHome}`);
+  if (agentFilter) {
+    const sharedNote = plan.includeShared
+      ? '（最后一个工具，共享资源一并移除）'
+      : '（保留其他工具的共享资源）';
+    console.log(`⚠  仅卸载工具: ${agentFilter}${sharedNote}`);
+  }
   console.log('⚠  以下 teamai 资源将被移除:');
   console.log('');
 
@@ -546,14 +637,24 @@ export async function uninstall(opts: UninstallOptions): Promise<void> {
 
   if (localConfig && teamConfig) {
     // Full uninstall with discovery
-    const plan = await buildRemovalPlan(localConfig, teamConfig);
+    let agentKey: string | undefined = opts.agent;
+    if (opts.agent) {
+      const tools = Object.keys(teamConfig.toolPaths);
+      const matched = tools.find((t) => t.toLowerCase() === opts.agent!.toLowerCase());
+      if (!matched) {
+        log.error(`未知工具 "${opts.agent}"。可用工具: ${tools.join(', ')}`);
+        return;
+      }
+      agentKey = matched; // normalize to canonical toolPaths key
+    }
+    const plan = await buildRemovalPlan(localConfig, teamConfig, agentKey);
 
     if (isPlanEmpty(plan)) {
       log.info('没有需要卸载的内容');
       return;
     }
 
-    printSummary(plan);
+    printSummary(plan, agentKey);
 
     if (opts.dryRun) {
       log.info('Dry run — 未做任何更改');
@@ -570,14 +671,19 @@ export async function uninstall(opts: UninstallOptions): Promise<void> {
 
     // MCP cleanup must run before executeRemoval deletes ~/.teamai/: ownership is
     // tracked in managed-mcp.json inside that directory. Hooks already do this
-    // inside executeRemoval for the same reason.
-    try {
-      const { reconcileMcpForConfig } = await import('./mcp-reconcile.js');
-      const { changes } = await reconcileMcpForConfig(teamConfig, localConfig, { removeAll: true });
-      const removed = changes.filter((c) => c.action === 'removed');
-      if (removed.length > 0) log.info(`Removed ${removed.length} teamai-managed MCP server(s)`);
-    } catch (e) {
-      log.warn(`Failed to remove MCP servers: ${(e as Error).message}`);
+    // inside executeRemoval for the same reason. MCP servers are shared
+    // resources (see buildRemovalPlan), so only reconcile them away when this
+    // uninstall includes shared resources — a targeted non-last-tool uninstall
+    // must leave the remaining tools' MCP servers intact.
+    if (plan.includeShared) {
+      try {
+        const { reconcileMcpForConfig } = await import('./mcp-reconcile.js');
+        const { changes } = await reconcileMcpForConfig(teamConfig, localConfig, { removeAll: true });
+        const removed = changes.filter((c) => c.action === 'removed');
+        if (removed.length > 0) log.info(`Removed ${removed.length} teamai-managed MCP server(s)`);
+      } catch (e) {
+        log.warn(`Failed to remove MCP servers: ${(e as Error).message}`);
+      }
     }
 
     await executeRemoval(plan);
@@ -585,6 +691,10 @@ export async function uninstall(opts: UninstallOptions): Promise<void> {
     log.success('teamai 卸载完成');
   } else {
     // Minimal uninstall — just try to remove ~/.teamai/
+    if (opts.agent) {
+      log.warn('未检测到有效配置，无法按 --agent 定向卸载指定工具');
+      return;
+    }
     const homeDir = process.env.HOME;
     if (!homeDir) {
       log.error('无法确定用户主目录（HOME 环境变量未设置）');

--- a/src/uninstall.ts
+++ b/src/uninstall.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { autoDetectInit } from './config.js';
+import { autoDetectInit, saveLocalConfig, saveLocalConfigForScope } from './config.js';
 import { reconcileHooks, hasTeamaiHooks } from './hooks.js';
 import { removeOpenClawHooks, OPENCLAW_HOOK_DIR } from './openclaw-hooks.js';
 import {
@@ -407,9 +407,9 @@ function printSummary(plan: RemovalPlan, agentFilter?: string): void {
   console.log(`⚠  正在卸载 ${plan.scope} scope（${cn}）— ${plan.teamaiHome}`);
   if (agentFilter) {
     const sharedNote = plan.includeShared
-      ? '（最后一个工具，共享资源一并移除）'
-      : '（保留其他工具的共享资源）';
-    console.log(`⚠  仅卸载工具: ${agentFilter}${sharedNote}`);
+      ? ' (last tool — shared resources removed too)'
+      : ' (shared resources kept for remaining tools)';
+    console.log(`⚠  Uninstalling tool only: ${agentFilter}${sharedNote}`);
   }
   console.log('⚠  以下 teamai 资源将被移除:');
   console.log('');
@@ -642,7 +642,8 @@ export async function uninstall(opts: UninstallOptions): Promise<void> {
       const tools = Object.keys(teamConfig.toolPaths);
       const matched = tools.find((t) => t.toLowerCase() === opts.agent!.toLowerCase());
       if (!matched) {
-        log.error(`未知工具 "${opts.agent}"。可用工具: ${tools.join(', ')}`);
+        log.error(`Unknown tool "${opts.agent}". Available tools: ${tools.join(', ')}`);
+        process.exitCode = 2;
         return;
       }
       agentKey = matched; // normalize to canonical toolPaths key
@@ -688,11 +689,35 @@ export async function uninstall(opts: UninstallOptions): Promise<void> {
 
     await executeRemoval(plan);
 
+    // Persist the exclusion so the next pull (or another tool's session-start
+    // hook) does not resurrect this tool's resources. Only meaningful when the
+    // shared ~/.teamai home survives (non-last-tool uninstall); on a last-tool
+    // uninstall the home is deleted and there is nothing to persist.
+    if (agentKey && !plan.includeShared) {
+      const cfg = localConfig!;
+      // Only prune an existing whitelist. Leaving `enabledAgents` undefined
+      // (meaning "all tools") as-is is important: collapsing it to [] would be
+      // read by the hook path as "whitelist nothing" and stop hook sync for the
+      // remaining tools too. The disabledAgents exclusion below is what actually
+      // keeps the uninstalled tool out on the next pull.
+      if (cfg.enabledAgents) {
+        cfg.enabledAgents = cfg.enabledAgents.filter((t) => t !== agentKey);
+      }
+      const prevDisabled = cfg.disabledAgents ?? [];
+      cfg.disabledAgents = [...new Set([...prevDisabled, agentKey])];
+      if (cfg.scope === 'project') {
+        await saveLocalConfigForScope(cfg, cfg.scope, cfg.projectRoot);
+      } else {
+        await saveLocalConfig(cfg);
+      }
+    }
+
     log.success('teamai 卸载完成');
   } else {
     // Minimal uninstall — just try to remove ~/.teamai/
     if (opts.agent) {
-      log.warn('未检测到有效配置，无法按 --agent 定向卸载指定工具');
+      log.warn('No valid teamai configuration detected; cannot target a specific tool with --agent');
+      process.exitCode = 2;
       return;
     }
     const homeDir = process.env.HOME;


### PR DESCRIPTION
## Summary

Closes #230. Adds `--agent <tool>` to `teamai uninstall`, mirroring `init --agent`, so a user can uninstall a single AI tool's teamai resources instead of everything on the machine — and makes that removal **durable across pulls**.

- **Tool-specific resources** (removed for the target tool): hooks (settings.json / OpenClaw hook dir), CLAUDE.md teamai block, team-synced skills, rules, built-in agents (e.g. `teamai-recall`).
- **Shared resources** (env shell-profile block, docs directory, `~/.teamai/`): removed **only when the target itself has teamai resources AND is the last tool still using teamai**; otherwise kept for the remaining tools.
- **Durable exclusion**: a single-tool uninstall records the tool in `disabledAgents` so the next `pull` (or another tool's session-start hook) does not resurrect it. `init --agent` clears the exclusion again — symmetric.
- **Unknown tool / `--agent` without config** → aborts without deleting anything, lists the available tools, and exits with a non-zero status.
- **No `--agent`** → behavior is exactly as before (full uninstall).

## Implementation

- `src/uninstall.ts`: extract per-tool discovery into `discoverToolResources()`; `buildRemovalPlan(…, agentFilter?)` merges only the selected tool(s) and computes `includeShared` (false when other tools still hold teamai resources). On a non-last-tool uninstall (shared `~/.teamai` survives), the tool is recorded in `disabledAgents` and pruned from any existing `enabledAgents` whitelist. Unknown-tool and no-config `--agent` paths set `process.exitCode = 2`.
- `src/types.ts`: new `disabledAgents` field + `isAgentDisabled()` predicate.
- **Honor `disabledAgents` on every sync write-back** so an excluded tool is never re-hydrated: hooks (`reconcileTeamHooksForConfig` effective filter + auto-migrate inject in `pull.ts`), the `pull.ts` resource/CLAUDE.md loops (tombstone, culture, claudemd, recall, cleanup), `resources/{skills,rules,agents}` `pullItem`, and `builtin-{agents,rules,skills}` deploy.
- `src/init.ts`: `init --agent` removes the tool from `disabledAgents` (reverses the exclusion).
- `src/hooks.ts`: `hasTeamaiHooks(settingsPath, tool, manifestPath?)` — true iff a settings file actually contains a teamai-managed hook (built-in or team), across claude/codex/cursor formats + managed-hooks manifest. Discovery gates the hook file on this instead of mere file existence.
- `src/index.ts`: register the `--agent <name>` option.

### Note on `hasTeamaiHooks` and the full-uninstall path

Gating `hookFiles` on `hasTeamaiHooks` also applies to the no-`--agent` path. It cannot under-remove (each `reconcile*Format`'s `isManaged` predicate is a subset of what `hasTeamaiHooks` matches); the only behavior lost is the empty-camelCase-key cleanup pass no longer running on files that hold no teamai hooks. Low impact.

### Note on the `enabledAgents` whitelist

When no whitelist existed (`enabledAgents` unset = "all tools"), the uninstall leaves it **undefined** rather than collapsing it to `[]` — the hook path reads `[]` as "whitelist nothing", which would otherwise stop hook sync for the *remaining* tools too. Covered by a regression test + the e2e round-trip below.

## Test Plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — full suite green (1791 tests). `uninstall.test.ts`: single-tool full removal, keep-shared when another tool present, unknown-tool error + `exitCode === 2`, no-config+`--agent` guard, last-tool-with-stripped-hooks regression, **disabledAgents persisted on non-last-tool uninstall**, **enabledAgents whitelist pruned (not collapsed) when it exists**. `skills.test.ts`: **`pullItem` skips a disabled tool but still syncs the others**.
- [x] Real CLI e2e (built `dist/index.js`, isolated `$HOME` with claude+codex tools):
  1. `uninstall --agent claude` (codex present) → claude skill/rule/hooks removed, `.teamai` + codex kept; `disabledAgents: [claude]` written, `enabledAgents` left unset ✅
  2. `uninstall --agent codex` (now last tool) → codex skill **and** `.teamai` removed ✅ (regression fixed)
  3. `uninstall --agent <unknown>` → English error + available-tools list, nothing deleted, `exit 2` ✅
  4. **Durability round-trip** — `pull → uninstall --agent claude → new team-repo commit → pull` with codex configured **with hooks**: claude's skill/rule/hooks stay gone, codex's hooks **and** newly-synced rule are kept (i.e. the excluded tool is not resurrected, and sync for remaining tools is unaffected) ✅
  5. `uninstall` (no `--agent`) → full removal of both tools + shared, unchanged ✅
- [x] Docs updated bilingually (`docs/usage-guide.md` + `.zh-CN.md`): the extra shared-removal condition, case-insensitive tool matching, and the durable-exclusion guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
