### PR TITLE
fix(hooks): gate git-only hook prompts to git-provider users

### DIFF
--- a/src/__tests__/hook-handlers.test.ts
+++ b/src/__tests__/hook-handlers.test.ts
@@ -58,7 +58,7 @@ vi.mock('../local-agent.js', () => ({
   reportAndSyncFromHook: mockReportAndSyncFromHook,
 }));
 
-import { buildHandlerRegistry, type HandlerRegistration } from '../hook-handlers.js';
+import { buildHandlerRegistry, filterHandlersForConfig, type HandlerRegistration } from '../hook-handlers.js';
 import { createDispatcher } from '../hook-dispatch.js';
 
 // ── Tests ────────────────────────────────────────────────
@@ -235,6 +235,34 @@ describe('hook-handlers registry', () => {
     const pull = registry.find((r) => r.handler.name === 'pull');
     const dashboard = registry.find((r) => r.handler.name === 'dashboard-report');
     expect(pull!.timeoutMs).toBeGreaterThan(dashboard!.timeoutMs!);
+  });
+
+  it('marks contribute-check, mr-hint, and votes-sync as gitOnly', () => {
+    const registry = buildHandlerRegistry();
+    const gitOnly = registry.filter((r) => r.gitOnly === true).map((r) => r.handler.name);
+    expect(gitOnly).toContain('contribute-check');
+    expect(gitOnly).toContain('mr-hint');
+    expect(gitOnly).toContain('votes-sync');
+  });
+
+  it('filterHandlersForConfig drops gitOnly handlers for http source', () => {
+    const registry = buildHandlerRegistry();
+    const filtered = filterHandlersForConfig(registry, { repo: { kind: 'http' } } as never);
+    const names = filtered.map((r) => r.handler.name);
+    expect(names).not.toContain('contribute-check');
+    expect(names).not.toContain('mr-hint');
+    expect(names).not.toContain('votes-sync');
+    // Non-git-only handlers survive
+    expect(names).toContain('pull');
+    expect(names).toContain('local-agent-sync');
+  });
+
+  it('filterHandlersForConfig keeps all handlers for git source and when uninitialized', () => {
+    const registry = buildHandlerRegistry();
+    const full = registry.length;
+    expect(filterHandlersForConfig(registry, { repo: { kind: 'git' } } as never).length).toBe(full);
+    expect(filterHandlersForConfig(registry, { repo: {} } as never).length).toBe(full);
+    expect(filterHandlersForConfig(registry, null).length).toBe(full);
   });
 });
 

--- a/src/hook-dispatch-cli.ts
+++ b/src/hook-dispatch-cli.ts
@@ -17,7 +17,7 @@
 import { spawn } from 'node:child_process';
 
 import { createDispatcher, type Dispatcher } from './hook-dispatch.js';
-import { buildHandlerRegistry } from './hook-handlers.js';
+import { buildHandlerRegistry, filterHandlersForConfig } from './hook-handlers.js';
 import { log, setStderrOnly } from './utils/logger.js';
 
 /** Read STDIN fully. Returns empty string if STDIN is a TTY. */
@@ -127,7 +127,13 @@ export async function hookDispatchCli(
   const stdin = parseStdin(raw, event);
   if (stdin === null) return;
 
-  const dispatcher = createDispatcher({ handlers: buildHandlerRegistry() });
+  // Provider-config gate: HTTP-only teams must not receive git-provider-only
+  // hook prompts (contribute / mr-hint / votes). Filter keyed on teamai's own
+  // configured source, independent of the cwd's git remote.
+  const { loadLocalConfig } = await import('./config.js');
+  const localConfig = await loadLocalConfig();
+  const handlers = filterHandlersForConfig(buildHandlerRegistry(), localConfig);
+  const dispatcher = createDispatcher({ handlers });
 
   // Detached child: run the fire-and-forget handlers, then exit. No output is
   // wired back to the host (the parent already returned).

--- a/src/hook-handlers.ts
+++ b/src/hook-handlers.ts
@@ -12,6 +12,7 @@
 import path from 'node:path';
 
 import type { HookHandler } from './hook-dispatch.js';
+import type { LocalConfig } from './types.js';
 import { deriveSessionId } from './utils/session-id.js';
 import { normalizeToolName } from './utils/tool-names.js';
 
@@ -24,6 +25,13 @@ export interface HandlerRegistration {
   timeoutMs: number;
   /** Fire-and-forget: run detached so it can't delay host hook completion. */
   background?: boolean;
+  /**
+   * Git-provider-only handler. When teamai is configured with an HTTP source
+   * (localConfig.repo.kind === 'http'), these are filtered out at the dispatch
+   * boundary so HTTP consumers never see prompts for git-only workflows
+   * (contribute / import-from-mr / votes push). See filterHandlersForConfig.
+   */
+  gitOnly?: boolean;
 }
 
 // ─── Timeout constants ──────────────────────────────────
@@ -306,7 +314,7 @@ export function buildHandlerRegistry(): HandlerRegistration[] {
     // ─── SessionStart ─────────────────────────────────
     { event: 'session-start', matcher: '*', handler: pullHandler, timeoutMs: PULL_TIMEOUT_MS },
     { event: 'session-start', matcher: '*', handler: dashboardReportHandler, timeoutMs: DASHBOARD_TIMEOUT_MS },
-    { event: 'session-start', matcher: '*', handler: mrHintHandler, timeoutMs: MR_HINT_TIMEOUT_MS },
+    { event: 'session-start', matcher: '*', handler: mrHintHandler, timeoutMs: MR_HINT_TIMEOUT_MS, gitOnly: true },
     { event: 'session-start', matcher: '*', handler: localAgentHandler, timeoutMs: LOCAL_AGENT_TIMEOUT_MS },
 
     // ─── Stop ─────────────────────────────────────────
@@ -316,8 +324,8 @@ export function buildHandlerRegistry(): HandlerRegistration[] {
     // run detached to avoid pushing the Stop hook past the host's hook timeout
     // (CodeBuddy: 10s).
     { event: 'stop', matcher: '*', handler: updateHandler, timeoutMs: UPDATE_TIMEOUT_MS, background: true },
-    { event: 'stop', matcher: '*', handler: votesSyncHandler, timeoutMs: VOTES_SYNC_TIMEOUT_MS },
-    { event: 'stop', matcher: '*', handler: contributeCheckHandler, timeoutMs: CONTRIBUTE_CHECK_TIMEOUT_MS },
+    { event: 'stop', matcher: '*', handler: votesSyncHandler, timeoutMs: VOTES_SYNC_TIMEOUT_MS, gitOnly: true },
+    { event: 'stop', matcher: '*', handler: contributeCheckHandler, timeoutMs: CONTRIBUTE_CHECK_TIMEOUT_MS, gitOnly: true },
     { event: 'stop', matcher: '*', handler: dashboardReportHandler, timeoutMs: DASHBOARD_TIMEOUT_MS, background: true },
     { event: 'stop', matcher: '*', handler: localAgentHandler, timeoutMs: LOCAL_AGENT_TIMEOUT_MS, background: true },
 
@@ -332,4 +340,34 @@ export function buildHandlerRegistry(): HandlerRegistration[] {
     { event: 'prompt-submit', matcher: '*', handler: dashboardReportHandler, timeoutMs: DASHBOARD_TIMEOUT_MS },
     { event: 'prompt-submit', matcher: '*', handler: localAgentHandler, timeoutMs: LOCAL_AGENT_TIMEOUT_MS },
   ];
+}
+
+/**
+ * Apply the provider-config gate to a handler registry.
+ *
+ * HTTP-only teams (localConfig.repo.kind === 'http') must not receive prompts
+ * for git-provider-only features. This drops every `gitOnly` handler when the
+ * team source is HTTP. When localConfig is null (teamai not initialized) or the
+ * source is git (kind === 'git' or undefined for backward compatibility), the
+ * full registry is returned unchanged.
+ *
+ * The gate is keyed on teamai's own configured source, NOT on the current
+ * working directory's git remote — an HTTP-only user working inside a
+ * github/tgit checkout must still see no git-only prompts.
+ *
+ * Fail-open by design: a null localConfig means either teamai is not
+ * initialized or the config failed to parse (loadLocalConfig swallows parse
+ * errors and returns null). In both cases the full registry is kept, so a
+ * corrupted config degrades to "all hooks run" rather than silently disabling
+ * them. This is intentionally NOT a hard security gate — HTTP write ops are
+ * still enforced at execution time by assertNotReadOnly().
+ */
+export function filterHandlersForConfig(
+  registry: HandlerRegistration[],
+  localConfig: LocalConfig | null,
+): HandlerRegistration[] {
+  if (localConfig?.repo.kind === 'http') {
+    return registry.filter((reg) => reg.gitOnly !== true);
+  }
+  return registry;
 }


### PR DESCRIPTION
## Problem

Git-provider-only hook features leak their prompts/context injections to HTTP (`repo.kind === 'http'`) users. The follow-up commands are correctly blocked by `assertNotReadOnly()`, but the **prompt itself still appears**, steering HTTP users toward workflows they can't use.

Root cause: all hooks funnel through one dispatcher (`hook-dispatch-cli.ts` → `buildHandlerRegistry()`), and every handler is registered with a `*` matcher that fires for all users regardless of `localConfig.repo.kind`. The only HTTP gate (`assertNotReadOnly`) runs at command *execution* time — after the hint has already been shown.

Fixes #246. Fixes #245 (mr-hint should only prompt when a git provider is configured).

## Affected features (3, verified exhaustive)

| Feature | Entry | Nature |
|---------|-------|--------|
| **contribute-check** | `hook-handlers.ts` → `contribute-check.ts` | Injects a `/teamai-share-learnings` prompt — a skill HTTP users don't even have installed (correctly withheld via `reportingOnly`). |
| **mr-hint** | `hook-handlers.ts` → `mr-hint.ts` | Promotes `teamai import --from-mr`. Its only guard was "does the *cwd* have a git remote?" — never checked `repo.kind`, so any HTTP user inside a git repo got it. |
| **votes-sync** | `hook-handlers.ts` | The "declare referenced-doc-ids" nudge was injected unconditionally; the underlying `syncVotesToTeam` git write silently no-ops for HTTP users. |

## Fix

A declarative provider-config gate at the dispatch boundary:

- `gitOnly?: boolean` flag on `HandlerRegistration`; the three handlers above marked `gitOnly: true`.
- Pure `filterHandlersForConfig(registry, localConfig)` — drops `gitOnly` handlers when `repo.kind === 'http'`; keeps all for git / undefined / uninitialized.
- `hook-dispatch-cli.ts` loads `localConfig` once and filters before building the dispatcher (covers both the foreground pass and the detached background child).

**Keyed on teamai's own `repo.kind`, not the cwd's git remote** — an HTTP-only user sees no git prompts even inside a github/tgit checkout. This also fixes mr-hint's previously-flawed cwd-remote guard.

**Fail-open by design:** if config is missing or unparseable (`loadLocalConfig()` → null), the full registry is kept — a corrupted config degrades to "all hooks run" rather than silently disabling them. This is not a security gate; HTTP write ops remain enforced at execution time by `assertNotReadOnly()`.

## Test Plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 1792 tests pass, incl. 3 new gate tests (gitOnly marking, http filters all 3, git/null keep full registry)
- [x] `npm run build` — succeeds
- [x] Real-CLI e2e: drove the built `hook-dispatch stop` under an isolated HOME. git config → contribute hint emitted (score 61); http config → handler filtered out before it runs (no scoring, no output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


