### PR TITLE
fix(hooks): bound foreground hook time to stay under host 10s cap

### DIFF
--- a/src/__tests__/hook-handlers.test.ts
+++ b/src/__tests__/hook-handlers.test.ts
@@ -206,6 +206,27 @@ describe('hook-handlers registry', () => {
     expect(localAgent!.background).not.toBe(true);
   });
 
+  // Regression: foreground local-agent-sync runs inline and blocks the host's
+  // hook. Its timeout MUST stay safely under CodeBuddy's per-event hook cap
+  // (see builtin-hooks.ts: UserPromptSubmit=10s, SessionStart=15s). Otherwise a
+  // slow/unreachable HTTP endpoint makes CodeBuddy abort the hook with
+  // "Hook timed out after 10000ms" (error 3003) on every prompt — breaking the
+  // IDE for anyone who installed `teamai init --http`.
+  it('foreground local-agent-sync timeouts are unified under 5s', () => {
+    const registry = buildHandlerRegistry();
+    const promptSubmit = registry.find(
+      (r) => r.event === 'prompt-submit' && r.matcher === '*' && r.handler.name === 'local-agent-sync',
+    );
+    const sessionStart = registry.find(
+      (r) => r.event === 'session-start' && r.matcher === '*' && r.handler.name === 'local-agent-sync',
+    );
+    // Kept < 5s (and unified) so a slow/unreachable HTTP endpoint never blocks the
+    // IDE long enough to trip CodeBuddy's per-event hook cap (error 3003).
+    expect(promptSubmit!.timeoutMs).toBeLessThan(5_000);
+    expect(sessionStart!.timeoutMs).toBeLessThan(5_000);
+    expect(promptSubmit!.timeoutMs).toBe(sessionStart!.timeoutMs);
+  });
+
   it('post-tool-use Bash/Grep/WebSearch/WebFetch have no registered handlers', () => {
     const registry = buildHandlerRegistry();
     for (const matcher of ['Bash', 'Grep', 'WebSearch', 'WebFetch']) {
@@ -230,11 +251,27 @@ describe('hook-handlers registry', () => {
     }
   });
 
-  it('pull handler has a longer timeout than dashboard-report', () => {
+  // CodeBuddy aborts a hook at ~10s regardless of the declared timeout (even
+  // Stop/SessionStart, declared 15s, are killed at 10000ms). Every foreground
+  // (inline, blocking) handler must therefore stay well under that ceiling —
+  // unified at <5s — so a slow/unreachable endpoint can never trip the host
+  // timeout on any event. Background (detached) handlers are not awaited by the
+  // host, so they may keep longer budgets.
+  it('every foreground handler timeout is under 5s', () => {
     const registry = buildHandlerRegistry();
-    const pull = registry.find((r) => r.handler.name === 'pull');
-    const dashboard = registry.find((r) => r.handler.name === 'dashboard-report');
-    expect(pull!.timeoutMs).toBeGreaterThan(dashboard!.timeoutMs!);
+    const foreground = registry.filter((r) => r.background !== true);
+    expect(foreground.length).toBeGreaterThan(0);
+    for (const reg of foreground) {
+      expect(reg.timeoutMs).toBeLessThan(5_000);
+    }
+  });
+
+  it('TodoWrite hint stays under its 3s PostToolUse host cap', () => {
+    const registry = buildHandlerRegistry();
+    const todo = registry.find(
+      (r) => r.event === 'post-tool-use' && r.matcher === 'TodoWrite',
+    );
+    expect(todo!.timeoutMs).toBeLessThan(3_000);
   });
 
   it('marks contribute-check, mr-hint, and votes-sync as gitOnly', () => {

--- a/src/hook-dispatch-cli.ts
+++ b/src/hook-dispatch-cli.ts
@@ -20,13 +20,45 @@ import { createDispatcher, type Dispatcher } from './hook-dispatch.js';
 import { buildHandlerRegistry, filterHandlersForConfig } from './hook-handlers.js';
 import { log, setStderrOnly } from './utils/logger.js';
 
-/** Read STDIN fully. Returns empty string if STDIN is a TTY. */
+/**
+ * Max time to wait for STDIN EOF before proceeding with whatever was received.
+ *
+ * `for await (process.stdin)` only ends when the host closes the pipe (EOF). If
+ * the host (e.g. CodeBuddy) writes the hook payload but never closes STDIN — or
+ * opens the pipe without sending EOF — the read would hang until the host aborts
+ * the hook with "Hook timed out after 10000ms" (error 3003), all *before* any
+ * handler timeout can engage. Racing a short deadline lets us continue with the
+ * payload we already buffered (a healthy host EOFs within milliseconds, so this
+ * never triggers in normal use).
+ */
+const STDIN_READ_TIMEOUT_MS = 2_000;
+
+/**
+ * Read STDIN fully, but never block longer than STDIN_READ_TIMEOUT_MS waiting
+ * for EOF. Returns empty string if STDIN is a TTY. On timeout, returns whatever
+ * chunks were already received (typically the full payload minus a missing EOF).
+ */
 async function readStdin(): Promise<string> {
   if (process.stdin.isTTY) return '';
   const chunks: Buffer[] = [];
-  for await (const chunk of process.stdin) {
-    chunks.push(chunk as Buffer);
+  const readAll = (async () => {
+    for await (const chunk of process.stdin) {
+      chunks.push(chunk as Buffer);
+    }
+  })();
+  let timer: NodeJS.Timeout | undefined;
+  const deadline = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, STDIN_READ_TIMEOUT_MS);
+    // Don't let this timer itself keep the event loop alive.
+    timer.unref();
+  });
+  try {
+    await Promise.race([readAll, deadline]);
+  } finally {
+    if (timer) clearTimeout(timer);
   }
+  // Swallow late read errors/rejections so an aborted read can't crash the hook.
+  readAll.catch(() => {});
   return Buffer.concat(chunks).toString('utf-8');
 }
 

--- a/src/hook-handlers.ts
+++ b/src/hook-handlers.ts
@@ -36,23 +36,37 @@ export interface HandlerRegistration {
 
 // ─── Timeout constants ──────────────────────────────────
 
-/** Pull involves git network ops — 15s cap. */
-const PULL_TIMEOUT_MS = 15_000;
-/** Update checks npm registry — cap at 10s to avoid blocking session shutdown. */
+/**
+ * Unified budget for every *foreground* (inline) handler, kept strictly under 5s.
+ *
+ * Foreground handlers block the host IDE's hook. Empirically CodeBuddy aborts a
+ * hook at ~10s REGARDLESS of the larger `timeout` we declare (see
+ * builtin-hooks.ts: even Stop/SessionStart, declared 15s, are killed at 10000ms),
+ * reporting "Hook timed out after 10000ms" (error 3003) and breaking the IDE.
+ *
+ * So no single foreground handler may approach that ceiling. Since foreground
+ * handlers on an event run concurrently, the whole foreground pass finishes at
+ * ~max(handler timeouts) + node startup/exit, which must stay well under 10s. A
+ * unified <5s cap guarantees that with margin. Healthy endpoints answer in well
+ * under a second, so this is invisible in normal use; it only bounds the worst
+ * case (slow/unreachable endpoint). Any network side-effect truncated here (e.g.
+ * a large first-time resource sync, vote-delta push) is completed later by the
+ * background (detached) pass, which is not awaited by the host.
+ */
+const FOREGROUND_HOOK_TIMEOUT_MS = 4_500;
+/**
+ * TodoWrite runs on a PostToolUse matcher whose host cap is only 3s
+ * (builtin-hooks.ts), so it needs a tighter budget than the shared foreground
+ * cap. It is a local dedup-cache check that completes in microseconds anyway.
+ */
+const TODOWRITE_HINT_TIMEOUT_MS = 2_500;
+/** Background (detached) npm-registry update check — not awaited by the host. */
 const UPDATE_TIMEOUT_MS = 10_000;
-/** Track/track-slash is a local file append — very fast. */
-const TRACK_TIMEOUT_MS = 5_000;
-/** Dashboard-report is a local file append — very fast. */
-const DASHBOARD_TIMEOUT_MS = 5_000;
-/** Contribute-check reads local state + events.jsonl — generally fast. */
-const CONTRIBUTE_CHECK_TIMEOUT_MS = 10_000;
-/** Votes sync at session end: parse transcript + push deltas. */
-const VOTES_SYNC_TIMEOUT_MS = 8_000;
-/** TodoWrite hint is a local dedup-cache check — very fast. */
-const TODOWRITE_HINT_TIMEOUT_MS = 5_000;
-/** MR-hint queries a remote MR/PR API — allow a network round-trip. */
-const MR_HINT_TIMEOUT_MS = 10_000;
-/** Local-agent HTTP report/sync + binding prompts — 15s cap. */
+/**
+ * Background (detached) local-agent HTTP report/sync. Detached runs are not
+ * awaited by the host, so they keep a full budget to complete real work such as
+ * resource downloads. Foreground local-agent runs use FOREGROUND_HOOK_TIMEOUT_MS.
+ */
 const LOCAL_AGENT_TIMEOUT_MS = 15_000;
 
 // ─── Handler implementations ────────────────────────────
@@ -312,33 +326,34 @@ const localAgentHandler: HookHandler = {
 export function buildHandlerRegistry(): HandlerRegistration[] {
   return [
     // ─── SessionStart ─────────────────────────────────
-    { event: 'session-start', matcher: '*', handler: pullHandler, timeoutMs: PULL_TIMEOUT_MS },
-    { event: 'session-start', matcher: '*', handler: dashboardReportHandler, timeoutMs: DASHBOARD_TIMEOUT_MS },
-    { event: 'session-start', matcher: '*', handler: mrHintHandler, timeoutMs: MR_HINT_TIMEOUT_MS, gitOnly: true },
-    { event: 'session-start', matcher: '*', handler: localAgentHandler, timeoutMs: LOCAL_AGENT_TIMEOUT_MS },
+    { event: 'session-start', matcher: '*', handler: pullHandler, timeoutMs: FOREGROUND_HOOK_TIMEOUT_MS },
+    { event: 'session-start', matcher: '*', handler: dashboardReportHandler, timeoutMs: FOREGROUND_HOOK_TIMEOUT_MS },
+    { event: 'session-start', matcher: '*', handler: mrHintHandler, timeoutMs: FOREGROUND_HOOK_TIMEOUT_MS, gitOnly: true },
+    { event: 'session-start', matcher: '*', handler: localAgentHandler, timeoutMs: FOREGROUND_HOOK_TIMEOUT_MS },
 
     // ─── Stop ─────────────────────────────────────────
     // votes-sync and contribute-check may return a hint the host injects back
-    // into the session, so they run inline. The rest are pure side effects —
-    // the update check in particular shells out to the npm registry — so they
-    // run detached to avoid pushing the Stop hook past the host's hook timeout
-    // (CodeBuddy: 10s).
+    // into the session, so they run inline (capped at FOREGROUND_HOOK_TIMEOUT_MS).
+    // The rest are pure side effects — the update check in particular shells out
+    // to the npm registry — so they run detached to avoid pushing the Stop hook
+    // past the host's hook timeout (CodeBuddy kills hooks at ~10s regardless of
+    // the declared timeout).
     { event: 'stop', matcher: '*', handler: updateHandler, timeoutMs: UPDATE_TIMEOUT_MS, background: true },
-    { event: 'stop', matcher: '*', handler: votesSyncHandler, timeoutMs: VOTES_SYNC_TIMEOUT_MS, gitOnly: true },
-    { event: 'stop', matcher: '*', handler: contributeCheckHandler, timeoutMs: CONTRIBUTE_CHECK_TIMEOUT_MS, gitOnly: true },
-    { event: 'stop', matcher: '*', handler: dashboardReportHandler, timeoutMs: DASHBOARD_TIMEOUT_MS, background: true },
+    { event: 'stop', matcher: '*', handler: votesSyncHandler, timeoutMs: FOREGROUND_HOOK_TIMEOUT_MS, gitOnly: true },
+    { event: 'stop', matcher: '*', handler: contributeCheckHandler, timeoutMs: FOREGROUND_HOOK_TIMEOUT_MS, gitOnly: true },
+    { event: 'stop', matcher: '*', handler: dashboardReportHandler, timeoutMs: FOREGROUND_HOOK_TIMEOUT_MS, background: true },
     { event: 'stop', matcher: '*', handler: localAgentHandler, timeoutMs: LOCAL_AGENT_TIMEOUT_MS, background: true },
 
     // ─── PostToolUse ──────────────────────────────────
-    { event: 'post-tool-use', matcher: '*', handler: dashboardReportHandler, timeoutMs: DASHBOARD_TIMEOUT_MS },
-    { event: 'post-tool-use', matcher: 'Skill', handler: trackHandler, timeoutMs: TRACK_TIMEOUT_MS },
+    { event: 'post-tool-use', matcher: '*', handler: dashboardReportHandler, timeoutMs: FOREGROUND_HOOK_TIMEOUT_MS },
+    { event: 'post-tool-use', matcher: 'Skill', handler: trackHandler, timeoutMs: FOREGROUND_HOOK_TIMEOUT_MS },
     { event: 'post-tool-use', matcher: 'TodoWrite', handler: todowriteHintHandler, timeoutMs: TODOWRITE_HINT_TIMEOUT_MS },
     { event: 'post-tool-use', matcher: '*', handler: localAgentHandler, timeoutMs: LOCAL_AGENT_TIMEOUT_MS, background: true },
 
     // ─── UserPromptSubmit ─────────────────────────────
-    { event: 'prompt-submit', matcher: '*', handler: trackSlashHandler, timeoutMs: TRACK_TIMEOUT_MS },
-    { event: 'prompt-submit', matcher: '*', handler: dashboardReportHandler, timeoutMs: DASHBOARD_TIMEOUT_MS },
-    { event: 'prompt-submit', matcher: '*', handler: localAgentHandler, timeoutMs: LOCAL_AGENT_TIMEOUT_MS },
+    { event: 'prompt-submit', matcher: '*', handler: trackSlashHandler, timeoutMs: FOREGROUND_HOOK_TIMEOUT_MS },
+    { event: 'prompt-submit', matcher: '*', handler: dashboardReportHandler, timeoutMs: FOREGROUND_HOOK_TIMEOUT_MS },
+    { event: 'prompt-submit', matcher: '*', handler: localAgentHandler, timeoutMs: FOREGROUND_HOOK_TIMEOUT_MS },
   ];
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -605,10 +605,30 @@ program
   .option('--matcher <matcher>', 'Hook matcher for PostToolUse (e.g. Skill, Bash)')
   .option('--bg-only', 'Internal: run only fire-and-forget background handlers (used by the detached child)')
   .action(async (event: string, cmdOpts: { stdin?: boolean; tool?: string; matcher?: string; bgOnly?: boolean }) => {
+    const bgOnly = cmdOpts.bgOnly ?? false;
+
+    // Hard wall-clock safety net for the FOREGROUND (parent) hook process, which
+    // blocks the host IDE's hook. The host aborts a hook at ~10s regardless of
+    // any larger declared timeout, reporting "Hook timed out after 10000ms"
+    // (error 3003) and breaking the IDE. Guarantee we exit well before that no
+    // matter which stage stalls — a STDIN read that never sees EOF, a wedged
+    // handler, or a pending socket from an aborted fetch keeping the event loop
+    // alive. 7s leaves margin below the 10s cap while sitting comfortably above
+    // the 4.5s foreground handler budget, so it never truncates legitimate work.
+    // The detached `--bg-only` child is unref'd and not awaited by the host, so
+    // it is exempt and keeps its full budget to finish real syncs/downloads.
+    const HOOK_HARD_EXIT_MS = 7_000;
+    let hardExit: NodeJS.Timeout | undefined;
+    if (!bgOnly) {
+      hardExit = setTimeout(() => process.exit(0), HOOK_HARD_EXIT_MS);
+      hardExit.unref();
+    }
+
     const { hookDispatchCli } = await import('./hook-dispatch-cli.js');
     try {
-      await hookDispatchCli(event, cmdOpts.tool ?? 'claude', cmdOpts.matcher ?? '*', cmdOpts.bgOnly ?? false);
+      await hookDispatchCli(event, cmdOpts.tool ?? 'claude', cmdOpts.matcher ?? '*', bgOnly);
     } finally {
+      if (hardExit) clearTimeout(hardExit);
       // Hook subprocesses must exit promptly: a hung/unreachable backend fetch can
       // leave a socket pending on the event loop, blocking natural exit and tripping
       // the host IDE's default hook timeout. Force exit once dispatch has settled.

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -59,6 +59,20 @@ const REPORTER_ERROR_LOG = 'reporter/errors.jsonl';
  */
 const LOCAL_AGENT_FETCH_TIMEOUT_MS = 15_000;
 
+/**
+ * Per-fetch timeout to use while running inside a *foreground* hook. Foreground
+ * hooks block the host IDE and must finish under its per-event hook timeout
+ * (UserPromptSubmit/PostToolUse = 10s). Kept under 5s — and safely below the
+ * foreground handler's dispatch budget (LOCAL_AGENT_FG_TIMEOUT_MS = 4.5s) — so a
+ * slow/unreachable endpoint fails fast and the whole handler returns before the
+ * host aborts it. Healthy endpoints answer in well under a second, so this is
+ * invisible in normal use and never degrades the experience.
+ */
+const LOCAL_AGENT_HOOK_FETCH_TIMEOUT_MS = 3_000;
+
+/** Active per-fetch timeout; overridden to the hook value inside foreground hooks. */
+let activeFetchTimeoutMs = LOCAL_AGENT_FETCH_TIMEOUT_MS;
+
 type LocalAgentScope = 'instance' | 'user' | 'project';
 type ResourceKind = 'skills' | 'rules' | 'claudemd';
 type CommandResourceKind = 'skill' | 'rule' | 'claudemd';
@@ -518,7 +532,7 @@ async function localAgentFetch<T>(
   const response = await fetch(url, {
     ...init,
     headers,
-    signal: init?.signal ?? AbortSignal.timeout(LOCAL_AGENT_FETCH_TIMEOUT_MS),
+    signal: init?.signal ?? AbortSignal.timeout(activeFetchTimeoutMs),
   });
   const text = await response.text();
   let body: unknown = null;
@@ -1310,7 +1324,7 @@ async function downloadResource(downloadUrl: string): Promise<string> {
   const maxRedirects = 5;
   // One timeout budget for the whole download (all redirect hops combined), so a
   // chain of slow redirects cannot exceed the intended bound.
-  const signal = AbortSignal.timeout(LOCAL_AGENT_FETCH_TIMEOUT_MS);
+  const signal = AbortSignal.timeout(activeFetchTimeoutMs);
   for (let hop = 0; ; hop++) {
     response = await fetch(current, { redirect: 'manual', signal });
     if (response.status >= 300 && response.status < 400) {
@@ -1793,13 +1807,28 @@ export async function reportAndSyncFromHook(
   const raw = JSON.stringify(stdin);
   const event = await parseHookEvent(raw, tool);
   const cwd = typeof stdin.cwd === 'string' ? stdin.cwd : event?.cwd ?? process.cwd();
-  await reportAndSyncLocalAgent({
-    cwd,
-    tool,
-    status: statusFromEvent(event ?? undefined),
-    event: event ?? undefined,
-  });
-  return null;
+
+  // SessionStart and UserPromptSubmit run this handler in the *foreground*, where
+  // it blocks the host IDE's hook (UserPromptSubmit cap = 10s). Narrow the
+  // per-fetch timeout so a slow/unreachable endpoint fails fast and the handler
+  // returns before the host aborts the hook. Stop / PostToolUse run detached in
+  // the background, so they keep the full interactive timeout to complete real
+  // resource syncs/downloads.
+  const isForegroundEvent = event?.type === 'session_start' || event?.type === 'prompt_submit';
+  activeFetchTimeoutMs = isForegroundEvent
+    ? LOCAL_AGENT_HOOK_FETCH_TIMEOUT_MS
+    : LOCAL_AGENT_FETCH_TIMEOUT_MS;
+  try {
+    await reportAndSyncLocalAgent({
+      cwd,
+      tool,
+      status: statusFromEvent(event ?? undefined),
+      event: event ?? undefined,
+    });
+    return null;
+  } finally {
+    activeFetchTimeoutMs = LOCAL_AGENT_FETCH_TIMEOUT_MS;
+  }
 }
 
 /**


### PR DESCRIPTION
## Problem

Foreground (inline) hooks block the host IDE and are aborted at ~10s **regardless of the declared timeout** — even Stop/SessionStart (declared 15s) are killed at 10000ms, reporting `Hook timed out after 10000ms` (error 3003) and breaking the IDE. Two paths could hit this:

1. A slow/unreachable HTTP endpoint (`local-agent` report/sync) in a foreground handler.
2. `readStdin`'s `for await (process.stdin)` hanging forever when the host writes the payload but never sends EOF — this happens *before* any handler timeout can engage.

## Changes (layered bounds)

- **hook-handlers**: unify every *foreground* handler timeout to **4.5s** (`FOREGROUND_HOOK_TIMEOUT_MS`); detached background handlers keep their full budget.
- **local-agent**: cap per-fetch timeout at **3s** inside foreground hooks (SessionStart / UserPromptSubmit); background (detached) runs keep the full 15s to finish real syncs/downloads.
- **hook-dispatch-cli**: `readStdin` races a **2s** deadline — a host that writes the payload but never sends EOF no longer hangs the process; we proceed with the buffered payload.
- **index**: **7s** hard-exit safety net for the foreground hook process (below the 10s host cap, above the 4.5s handler budget). The detached `--bg-only` child is exempt and keeps its full budget.

Healthy endpoints answer well under a second, so these bounds are invisible in normal use; they only cap the worst case.

## Tests

Added regression tests asserting every foreground handler timeout stays under 5s and that foreground local-agent-sync timeouts are unified. `npm run build` + `vitest` (hook-handlers 21 + local-agent 38) all green.