### PR TITLE
feat(mcp): distribute team MCP servers as a seventh resource type

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,36 @@ teamai hooks inject    # re-reconcile into every installed tool
 teamai hooks remove    # remove all teamai-managed hooks
 ```
 
+### Team MCP Servers
+
+Declare MCP servers once in `mcp/mcp.yaml` and `teamai pull` writes them into each
+tool's own MCP config — `~/.claude.json`, `~/.cursor/mcp.json`, `~/.codebuddy/mcp.json`,
+`~/.codex/config.toml` — in that tool's native format:
+
+```yaml
+servers:
+  - name: gpu-analysis
+    description: GPU inventory and pricing queries
+    transport: http            # stdio | http | sse
+    url: https://example.com/api/mcp
+    headers:
+      Authorization: Bearer ${GPU_ANALYSIS_TOKEN}
+    timeout: 600000
+```
+
+Secrets are never committed: write `${VAR}` and the value is resolved at inject time
+from your environment or the team's `env/env.yaml` channel. A server whose variables
+cannot be resolved is skipped with a hint rather than installed in a broken state.
+
+```bash
+teamai mcp list        # servers, secret status, and where they are installed
+teamai mcp inject      # apply to every installed tool (--dry-run, --force)
+teamai mcp remove      # remove all teamai-managed servers
+```
+
+Servers you added yourself are never touched, and a team server that collides with
+one of your names is skipped instead of overwriting it.
+
 ### Cross-team Skill Subscription
 
 Subscribe to other teams' public skill repos:

--- a/README.md
+++ b/README.md
@@ -85,33 +85,20 @@ teamai hooks remove    # remove all teamai-managed hooks
 
 ### Team MCP Servers
 
-Declare MCP servers once in `mcp/mcp.yaml` and `teamai pull` writes them into each
-tool's own MCP config — `~/.claude.json`, `~/.cursor/mcp.json`, `~/.codebuddy/mcp.json`,
-`~/.codex/config.toml` — in that tool's native format:
+Declare once in `mcp/mcp.yaml`; `teamai pull` writes each tool's native config. Use `${VAR}` for secrets.
 
 ```yaml
 servers:
   - name: gpu-analysis
-    description: GPU inventory and pricing queries
     transport: http            # stdio | http | sse
     url: https://example.com/api/mcp
     headers:
       Authorization: Bearer ${GPU_ANALYSIS_TOKEN}
-    timeout: 600000
 ```
-
-Secrets are never committed: write `${VAR}` and the value is resolved at inject time
-from your environment or the team's `env/env.yaml` channel. A server whose variables
-cannot be resolved is skipped with a hint rather than installed in a broken state.
 
 ```bash
-teamai mcp list        # servers, secret status, and where they are installed
-teamai mcp inject      # apply to every installed tool (--dry-run, --force)
-teamai mcp remove      # remove all teamai-managed servers
+teamai mcp list | inject | remove
 ```
-
-Servers you added yourself are never touched, and a team server that collides with
-one of your names is skipped instead of overwriting it.
 
 ### Cross-team Skill Subscription
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -83,6 +83,34 @@ teamai hooks inject    # 重新注入到每个已安装的工具
 teamai hooks remove    # 移除所有 teamai 管理的 hooks
 ```
 
+### 团队 MCP Server
+
+在 `mcp/mcp.yaml` 中声明一次，`teamai pull` 会按各工具的原生格式写入它们各自的 MCP
+配置文件——`~/.claude.json`、`~/.cursor/mcp.json`、`~/.codebuddy/mcp.json`、
+`~/.codex/config.toml`：
+
+```yaml
+servers:
+  - name: gpu-analysis
+    description: GPU 存量与价格查询
+    transport: http            # stdio | http | sse
+    url: https://example.com/api/mcp
+    headers:
+      Authorization: Bearer ${GPU_ANALYSIS_TOKEN}
+    timeout: 600000
+```
+
+密钥不入库：只写 `${VAR}`，注入时从环境变量或团队 `env/env.yaml` 通道解析。变量无法
+解析的 server 会被跳过并给出提示，而不是装成一个连不上的残缺配置。
+
+```bash
+teamai mcp list        # 查看 server、密钥状态与安装位置
+teamai mcp inject      # 注入到所有已安装工具（支持 --dry-run、--force）
+teamai mcp remove      # 移除所有 teamai 管理的 server
+```
+
+你自己添加的 server 不会被改动；团队 server 与你的同名时会跳过而非覆盖。
+
 ### 跨团队 Skill 订阅
 
 订阅其他团队的公开 skill 仓库：

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -85,31 +85,20 @@ teamai hooks remove    # 移除所有 teamai 管理的 hooks
 
 ### 团队 MCP Server
 
-在 `mcp/mcp.yaml` 中声明一次，`teamai pull` 会按各工具的原生格式写入它们各自的 MCP
-配置文件——`~/.claude.json`、`~/.cursor/mcp.json`、`~/.codebuddy/mcp.json`、
-`~/.codex/config.toml`：
+在 `mcp/mcp.yaml` 中声明一次，`teamai pull` 按各工具原生格式写入。密钥用 `${VAR}`。
 
 ```yaml
 servers:
   - name: gpu-analysis
-    description: GPU 存量与价格查询
     transport: http            # stdio | http | sse
     url: https://example.com/api/mcp
     headers:
       Authorization: Bearer ${GPU_ANALYSIS_TOKEN}
-    timeout: 600000
 ```
-
-密钥不入库：只写 `${VAR}`，注入时从环境变量或团队 `env/env.yaml` 通道解析。变量无法
-解析的 server 会被跳过并给出提示，而不是装成一个连不上的残缺配置。
 
 ```bash
-teamai mcp list        # 查看 server、密钥状态与安装位置
-teamai mcp inject      # 注入到所有已安装工具（支持 --dry-run、--force）
-teamai mcp remove      # 移除所有 teamai 管理的 server
+teamai mcp list | inject | remove
 ```
-
-你自己添加的 server 不会被改动；团队 server 与你的同名时会跳过而非覆盖。
 
 ### 跨团队 Skill 订阅
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -423,24 +423,17 @@ Where each tool's servers land:
 | Tool | User scope | Project scope |
 |---|---|---|
 | claude | `~/.claude.json` | `<project>/.mcp.json` |
-| tclaude | `~/.tclaude/.claude.json` | shares `<project>/.mcp.json` with claude |
 | cursor | `~/.cursor/mcp.json` | `<project>/.cursor/mcp.json` |
 | codebuddy / workbuddy | `~/.<tool>/mcp.json` | `<project>/.<tool>/mcp.json` |
 | codex | `~/.codex/config.toml` | not supported |
 
-tclaude ships Claude Code with `customUserDataDir: .tclaude`, so its config lives at `~/.tclaude/.claude.json` rather than alongside `~/.claude.json`.
+Codex supports `stdio` and `http`; `sse` is skipped. Ownership is tracked in `~/.teamai/managed-mcp.json` — hand-added servers are left alone; name collisions skip unless `--force`.
 
-Codex takes `stdio` and `http` but has no `sse` transport, so only `sse` servers are skipped there rather than written as config that would fail at session start.
+**Secrets.** Write `${VAR}`, never a literal. Values resolve from the environment, then from `env/env.yaml` → `~/.teamai/env`. Unresolved variables skip the server with a hint.
 
-**Secrets.** Write `${VAR}` instead of a literal token. Values resolve from your process environment first, then from the values the team's `env/env.yaml` channel wrote to `~/.teamai/env`. A server with an unresolved variable is skipped with a hint — a server that cannot connect would otherwise fail on every session start.
+Where the tool can keep secrets off disk, teamai does: Claude project `.mcp.json` keeps the placeholder (Claude expands it); Codex writes `bearer_token_env_var` / `env_http_headers` (variable name only). Elsewhere the value is resolved into a `0600` file. In project scope, tools that cannot expand `${VAR}` skip secret-bearing servers instead of writing plaintext into a committed file.
 
-Where a tool can keep the secret out of its own config file, teamai lets it. Codex names the variable rather than storing its value, so `Authorization: Bearer ${TOKEN}` becomes `bearer_token_env_var = "TOKEN"` and any other whole-value placeholder becomes an `env_http_headers` entry; the token itself never reaches `config.toml`. A placeholder that codex cannot name — one embedded in a longer string, or in the URL — is resolved as usual.
-
-**Secrets in project scope.** Project-scope config files live inside the repo and get committed, so a resolved token there would land in version control. Claude Code expands `${VAR}` itself, so `<project>/.mcp.json` receives the placeholder verbatim and the secret stays out of git. No other tool expands it, so in project scope a server that references a variable is skipped for those tools with an explanatory message; distribute such a server at user scope instead. Servers with no secrets are unaffected and install everywhere.
-
-**Approving project servers.** Claude Code treats a `.mcp.json` arriving from a repo as untrusted and lists its servers as `⏸ Pending approval` until you accept them once in an interactive `claude` session. This is Claude's own prompt, not something teamai suppresses.
-
-**What is safe.** teamai only ever rewrites the specific server keys it installed, tracked in `~/.teamai/managed-mcp.json`. Servers you added by hand are left untouched, and a team server whose name collides with one of yours is skipped unless you pass `--force`. Unrelated content in the target file — your Claude OAuth session, your Codex model settings and comments — is preserved byte for byte.
+Claude Code may show project `.mcp.json` servers as pending approval until you accept them once in an interactive session.
 
 ```bash
 teamai mcp list              # servers, secret status, and where they are installed
@@ -448,7 +441,6 @@ teamai mcp inject            # apply now; --dry-run to preview, --force to overr
 teamai mcp remove            # remove every teamai-managed server
 ```
 
-MCP servers are read when a session starts, so changes take effect in your next session.
 
 ---
 
@@ -763,7 +755,7 @@ teamai hooks inject    # Re-inject
 teamai hooks remove    # Remove
 ```
 
-Both commands only touch tools you actually have installed (i.e. whose `~/.<tool>/` root directory already exists). They never create root directories for tools listed in `toolPaths` but not installed, so uninstalled tools such as `.tclaude` / `.tcodex` are left untouched.
+Both commands only touch tools you actually have installed (i.e. whose `~/.<tool>/` root directory already exists). They never create root directories for tools listed in `toolPaths` but not installed.
 
 ### Team Hooks Declaration
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -430,9 +430,11 @@ Where each tool's servers land:
 
 tclaude ships Claude Code with `customUserDataDir: .tclaude`, so its config lives at `~/.tclaude/.claude.json` rather than alongside `~/.claude.json`.
 
-Codex models MCP servers as launched processes, so `http` and `sse` servers are skipped there rather than written as config that would fail at session start.
+Codex takes `stdio` and `http` but has no `sse` transport, so only `sse` servers are skipped there rather than written as config that would fail at session start.
 
 **Secrets.** Write `${VAR}` instead of a literal token. Values resolve from your process environment first, then from the values the team's `env/env.yaml` channel wrote to `~/.teamai/env`. A server with an unresolved variable is skipped with a hint — a server that cannot connect would otherwise fail on every session start.
+
+Where a tool can keep the secret out of its own config file, teamai lets it. Codex names the variable rather than storing its value, so `Authorization: Bearer ${TOKEN}` becomes `bearer_token_env_var = "TOKEN"` and any other whole-value placeholder becomes an `env_http_headers` entry; the token itself never reaches `config.toml`. A placeholder that codex cannot name — one embedded in a longer string, or in the URL — is resolved as usual.
 
 **Secrets in project scope.** Project-scope config files live inside the repo and get committed, so a resolved token there would land in version control. Claude Code expands `${VAR}` itself, so `<project>/.mcp.json` receives the placeholder verbatim and the secret stays out of git. No other tool expands it, so in project scope a server that references a variable is skipped for those tools with an explanatory message; distribute such a server at user scope instead. Servers with no secrets are unaffected and install everywhere.
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -394,6 +394,53 @@ teamai push
 
 Place documentation in the team repo's `docs/` directory; after pushing, team members will automatically receive it on their next `pull`.
 
+### MCP servers
+
+Declare each server once in the team repo's `mcp/mcp.yaml`. On `teamai pull` it is written into every installed tool's own MCP config, translated into that tool's native format.
+
+```yaml
+servers:
+  - name: gpu-analysis
+    description: GPU inventory and pricing queries
+    transport: http                      # stdio | http | sse
+    url: https://example.com/api/mcp
+    headers:
+      Authorization: Bearer ${GPU_ANALYSIS_TOKEN}
+    timeout: 600000
+
+  - name: local-formatter
+    transport: stdio
+    command: npx
+    args: ['-y', '@acme/formatter-mcp']
+    env:
+      FORMATTER_MODE: strict
+    requires: [npx]                      # skipped with a hint when npx is absent
+    tools: [claude, cursor]              # optional; default is every capable tool
+```
+
+Where each tool's servers land:
+
+| Tool | User scope | Project scope |
+|---|---|---|
+| claude | `~/.claude.json` | `<project>/.mcp.json` |
+| cursor | `~/.cursor/mcp.json` | `<project>/.cursor/mcp.json` |
+| codebuddy / workbuddy | `~/.<tool>/mcp.json` | `<project>/.<tool>/mcp.json` |
+| codex | `~/.codex/config.toml` | not supported |
+
+Codex models MCP servers as launched processes, so `http` and `sse` servers are skipped there rather than written as config that would fail at session start.
+
+**Secrets.** Write `${VAR}` instead of a literal token. Values resolve from your process environment first, then from the values the team's `env/env.yaml` channel wrote to `~/.teamai/env`. A server with an unresolved variable is skipped with a hint — a server that cannot connect would otherwise fail on every session start.
+
+**What is safe.** teamai only ever rewrites the specific server keys it installed, tracked in `~/.teamai/managed-mcp.json`. Servers you added by hand are left untouched, and a team server whose name collides with one of yours is skipped unless you pass `--force`. Unrelated content in the target file — your Claude OAuth session, your Codex model settings and comments — is preserved byte for byte.
+
+```bash
+teamai mcp list              # servers, secret status, and where they are installed
+teamai mcp inject            # apply now; --dry-run to preview, --force to override collisions
+teamai mcp remove            # remove every teamai-managed server
+```
+
+MCP servers are read when a session starts, so changes take effect in your next session.
+
 ---
 
 ## Knowledge Capture & Retrieval

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -434,6 +434,10 @@ Codex models MCP servers as launched processes, so `http` and `sse` servers are 
 
 **Secrets.** Write `${VAR}` instead of a literal token. Values resolve from your process environment first, then from the values the team's `env/env.yaml` channel wrote to `~/.teamai/env`. A server with an unresolved variable is skipped with a hint — a server that cannot connect would otherwise fail on every session start.
 
+**Secrets in project scope.** Project-scope config files live inside the repo and get committed, so a resolved token there would land in version control. Claude Code expands `${VAR}` itself, so `<project>/.mcp.json` receives the placeholder verbatim and the secret stays out of git. No other tool expands it, so in project scope a server that references a variable is skipped for those tools with an explanatory message; distribute such a server at user scope instead. Servers with no secrets are unaffected and install everywhere.
+
+**Approving project servers.** Claude Code treats a `.mcp.json` arriving from a repo as untrusted and lists its servers as `⏸ Pending approval` until you accept them once in an interactive `claude` session. This is Claude's own prompt, not something teamai suppresses.
+
 **What is safe.** teamai only ever rewrites the specific server keys it installed, tracked in `~/.teamai/managed-mcp.json`. Servers you added by hand are left untouched, and a team server whose name collides with one of yours is skipped unless you pass `--force`. Unrelated content in the target file — your Claude OAuth session, your Codex model settings and comments — is preserved byte for byte.
 
 ```bash

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -423,9 +423,12 @@ Where each tool's servers land:
 | Tool | User scope | Project scope |
 |---|---|---|
 | claude | `~/.claude.json` | `<project>/.mcp.json` |
+| tclaude | `~/.tclaude/.claude.json` | shares `<project>/.mcp.json` with claude |
 | cursor | `~/.cursor/mcp.json` | `<project>/.cursor/mcp.json` |
 | codebuddy / workbuddy | `~/.<tool>/mcp.json` | `<project>/.<tool>/mcp.json` |
 | codex | `~/.codex/config.toml` | not supported |
+
+tclaude ships Claude Code with `customUserDataDir: .tclaude`, so its config lives at `~/.tclaude/.claude.json` rather than alongside `~/.claude.json`.
 
 Codex models MCP servers as launched processes, so `http` and `sse` servers are skipped there rather than written as config that would fail at session start.
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -421,24 +421,17 @@ servers:
 | 工具 | 用户级 | 项目级 |
 |---|---|---|
 | claude | `~/.claude.json` | `<project>/.mcp.json` |
-| tclaude | `~/.tclaude/.claude.json` | 与 claude 共用 `<project>/.mcp.json` |
 | cursor | `~/.cursor/mcp.json` | `<project>/.cursor/mcp.json` |
 | codebuddy / workbuddy | `~/.<tool>/mcp.json` | `<project>/.<tool>/mcp.json` |
 | codex | `~/.codex/config.toml` | 不支持 |
 
-tclaude 通过 `customUserDataDir: .tclaude` 重定向了 Claude Code 的用户数据目录，因此它的配置在 `~/.tclaude/.claude.json`，而不是与 `~/.claude.json` 并列。
+Codex 支持 `stdio` 与 `http`，`sse` 会被跳过。归属记录在 `~/.teamai/managed-mcp.json`——手动添加的 server 不动；与手写同名则跳过，除非 `--force`。
 
-Codex 支持 `stdio` 与 `http`，但没有 `sse` 传输，因此只有 `sse` 类型在 Codex 上会被跳过，而不是写入一份注定在会话启动时失败的配置。
+**密钥**：写 `${VAR}`，不要写明文。取值优先来自环境变量，其次是 `env/env.yaml` → `~/.teamai/env`。变量无法解析则跳过并提示。
 
-**密钥**：不要写明文 token，写 `${VAR}`。取值优先来自当前进程环境变量，其次是团队 `env/env.yaml` 通道写入 `~/.teamai/env` 的值。变量无法解析的 server 会被跳过并提示——否则它会在每次会话启动时报错。
+能让密钥不落盘的工具会走那条路：Claude 项目级 `.mcp.json` 保留占位符（由 Claude 展开）；Codex 写 `bearer_token_env_var` / `env_http_headers`（只记变量名）。其余情况解析后写入 `0600` 文件。项目级下，不支持 `${VAR}` 展开的工具会跳过带密钥的 server，避免明文进 git。
 
-只要工具本身能让密钥不落到自己的配置文件里，teamai 就会走那条路。Codex 是记变量名而不是存值：`Authorization: Bearer ${TOKEN}` 会写成 `bearer_token_env_var = "TOKEN"`，其他「整个值就是一个占位符」的 header 会写成 `env_http_headers` 项，token 本身不会进入 `config.toml`。Codex 无法用变量名表达的占位符——嵌在更长字符串里的、或者出现在 URL 里的——仍按常规解析。
-
-**项目级的密钥处理**：项目级配置文件位于仓库内、会被提交，因此在那里解析出真实 token 就等于把密钥写进版本库。Claude Code 自己支持 `${VAR}` 展开，所以 `<project>/.mcp.json` 原样保留占位符，密钥不入 git。其他工具不支持展开，因此在项目级，引用了变量的 server 会对这些工具跳过并给出说明——这类 server 请改用用户级分发。不含密钥的 server 不受影响，照常安装到所有工具。
-
-**项目级 server 的批准**：Claude Code 会把来自仓库的 `.mcp.json` 视为不可信，其中的 server 显示为 `⏸ Pending approval`，需要你在交互式 `claude` 会话中确认一次。这是 Claude 自身的安全提示，teamai 不会绕过它。
-
-**安全边界**：teamai 只改写自己装过的那些 server 键，归属记录在 `~/.teamai/managed-mcp.json`。你手动添加的 server 不会被碰；团队 server 与你的重名时会跳过，除非显式加 `--force`。目标文件里的无关内容——Claude 的 OAuth 会话、Codex 的模型设置与注释——逐字节保留。
+Claude Code 可能把来自仓库的 `.mcp.json` 标为待批准，需在交互式会话中确认一次。
 
 ```bash
 teamai mcp list              # 查看 server、密钥状态与安装位置
@@ -446,7 +439,6 @@ teamai mcp inject            # 立即注入；--dry-run 预览，--force 覆盖�
 teamai mcp remove            # 移除所有 teamai 管理的 server
 ```
 
-MCP server 在会话启动时读取，因此变更在你的下一个会话生效。
 
 ---
 
@@ -761,7 +753,7 @@ teamai hooks inject    # 重新注入
 teamai hooks remove    # 移除
 ```
 
-这两个命令只会操作你实际已安装的工具（即 `~/.<tool>/` 根目录已存在的工具）。对于 `toolPaths` 中已配置但未安装的工具，命令不会为其凭空创建根目录，因此像 `.tclaude` / `.tcodex` 这类未安装的工具会被完全跳过。
+这两个命令只会操作你实际已安装的工具（即 `~/.<tool>/` 根目录已存在的工具）。对于 `toolPaths` 中已配置但未安装的工具，命令不会为其凭空创建根目录。
 
 ### 团队 Hooks 声明
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -392,6 +392,53 @@ teamai push
 
 将文档放入团队仓库 `docs/` 目录，push 后团队成员 pull 时自动同步。
 
+### MCP Server
+
+在团队仓库的 `mcp/mcp.yaml` 中声明一次，`teamai pull` 时会按各工具的原生格式写入它们各自的 MCP 配置文件。
+
+```yaml
+servers:
+  - name: gpu-analysis
+    description: GPU 存量与价格查询
+    transport: http                      # stdio | http | sse
+    url: https://example.com/api/mcp
+    headers:
+      Authorization: Bearer ${GPU_ANALYSIS_TOKEN}
+    timeout: 600000
+
+  - name: local-formatter
+    transport: stdio
+    command: npx
+    args: ['-y', '@acme/formatter-mcp']
+    env:
+      FORMATTER_MODE: strict
+    requires: [npx]                      # npx 不存在时跳过并提示
+    tools: [claude, cursor]              # 可选；默认所有支持 MCP 的工具
+```
+
+各工具的落点：
+
+| 工具 | 用户级 | 项目级 |
+|---|---|---|
+| claude | `~/.claude.json` | `<project>/.mcp.json` |
+| cursor | `~/.cursor/mcp.json` | `<project>/.cursor/mcp.json` |
+| codebuddy / workbuddy | `~/.<tool>/mcp.json` | `<project>/.<tool>/mcp.json` |
+| codex | `~/.codex/config.toml` | 不支持 |
+
+Codex 把 MCP server 建模为被拉起的进程，因此 `http` / `sse` 类型在 Codex 上会被跳过，而不是写入一份注定在会话启动时失败的配置。
+
+**密钥**：不要写明文 token，写 `${VAR}`。取值优先来自当前进程环境变量，其次是团队 `env/env.yaml` 通道写入 `~/.teamai/env` 的值。变量无法解析的 server 会被跳过并提示——否则它会在每次会话启动时报错。
+
+**安全边界**：teamai 只改写自己装过的那些 server 键，归属记录在 `~/.teamai/managed-mcp.json`。你手动添加的 server 不会被碰；团队 server 与你的重名时会跳过，除非显式加 `--force`。目标文件里的无关内容——Claude 的 OAuth 会话、Codex 的模型设置与注释——逐字节保留。
+
+```bash
+teamai mcp list              # 查看 server、密钥状态与安装位置
+teamai mcp inject            # 立即注入；--dry-run 预览，--force 覆盖同名
+teamai mcp remove            # 移除所有 teamai 管理的 server
+```
+
+MCP server 在会话启动时读取，因此变更在你的下一个会话生效。
+
 ---
 
 ## 知识沉淀与检索

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -428,9 +428,11 @@ servers:
 
 tclaude 通过 `customUserDataDir: .tclaude` 重定向了 Claude Code 的用户数据目录，因此它的配置在 `~/.tclaude/.claude.json`，而不是与 `~/.claude.json` 并列。
 
-Codex 把 MCP server 建模为被拉起的进程，因此 `http` / `sse` 类型在 Codex 上会被跳过，而不是写入一份注定在会话启动时失败的配置。
+Codex 支持 `stdio` 与 `http`，但没有 `sse` 传输，因此只有 `sse` 类型在 Codex 上会被跳过，而不是写入一份注定在会话启动时失败的配置。
 
 **密钥**：不要写明文 token，写 `${VAR}`。取值优先来自当前进程环境变量，其次是团队 `env/env.yaml` 通道写入 `~/.teamai/env` 的值。变量无法解析的 server 会被跳过并提示——否则它会在每次会话启动时报错。
+
+只要工具本身能让密钥不落到自己的配置文件里，teamai 就会走那条路。Codex 是记变量名而不是存值：`Authorization: Bearer ${TOKEN}` 会写成 `bearer_token_env_var = "TOKEN"`，其他「整个值就是一个占位符」的 header 会写成 `env_http_headers` 项，token 本身不会进入 `config.toml`。Codex 无法用变量名表达的占位符——嵌在更长字符串里的、或者出现在 URL 里的——仍按常规解析。
 
 **项目级的密钥处理**：项目级配置文件位于仓库内、会被提交，因此在那里解析出真实 token 就等于把密钥写进版本库。Claude Code 自己支持 `${VAR}` 展开，所以 `<project>/.mcp.json` 原样保留占位符，密钥不入 git。其他工具不支持展开，因此在项目级，引用了变量的 server 会对这些工具跳过并给出说明——这类 server 请改用用户级分发。不含密钥的 server 不受影响，照常安装到所有工具。
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -432,6 +432,10 @@ Codex 把 MCP server 建模为被拉起的进程，因此 `http` / `sse` 类型�
 
 **密钥**：不要写明文 token，写 `${VAR}`。取值优先来自当前进程环境变量，其次是团队 `env/env.yaml` 通道写入 `~/.teamai/env` 的值。变量无法解析的 server 会被跳过并提示——否则它会在每次会话启动时报错。
 
+**项目级的密钥处理**：项目级配置文件位于仓库内、会被提交，因此在那里解析出真实 token 就等于把密钥写进版本库。Claude Code 自己支持 `${VAR}` 展开，所以 `<project>/.mcp.json` 原样保留占位符，密钥不入 git。其他工具不支持展开，因此在项目级，引用了变量的 server 会对这些工具跳过并给出说明——这类 server 请改用用户级分发。不含密钥的 server 不受影响，照常安装到所有工具。
+
+**项目级 server 的批准**：Claude Code 会把来自仓库的 `.mcp.json` 视为不可信，其中的 server 显示为 `⏸ Pending approval`，需要你在交互式 `claude` 会话中确认一次。这是 Claude 自身的安全提示，teamai 不会绕过它。
+
 **安全边界**：teamai 只改写自己装过的那些 server 键，归属记录在 `~/.teamai/managed-mcp.json`。你手动添加的 server 不会被碰；团队 server 与你的重名时会跳过，除非显式加 `--force`。目标文件里的无关内容——Claude 的 OAuth 会话、Codex 的模型设置与注释——逐字节保留。
 
 ```bash

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -421,9 +421,12 @@ servers:
 | 工具 | 用户级 | 项目级 |
 |---|---|---|
 | claude | `~/.claude.json` | `<project>/.mcp.json` |
+| tclaude | `~/.tclaude/.claude.json` | 与 claude 共用 `<project>/.mcp.json` |
 | cursor | `~/.cursor/mcp.json` | `<project>/.cursor/mcp.json` |
 | codebuddy / workbuddy | `~/.<tool>/mcp.json` | `<project>/.<tool>/mcp.json` |
 | codex | `~/.codex/config.toml` | 不支持 |
+
+tclaude 通过 `customUserDataDir: .tclaude` 重定向了 Claude Code 的用户数据目录，因此它的配置在 `~/.tclaude/.claude.json`，而不是与 `~/.claude.json` 并列。
 
 Codex 把 MCP server 建模为被拉起的进程，因此 `http` / `sse` 类型在 Codex 上会被跳过，而不是写入一份注定在会话启动时失败的配置。
 

--- a/src/__tests__/mcp-reconcile.test.ts
+++ b/src/__tests__/mcp-reconcile.test.ts
@@ -344,19 +344,70 @@ servers:
     expect(await fse.pathExists(path.join(homeDir, '.codebuddy', 'mcp.json'))).toBe(false);
   });
 
-  it('skips http servers for codex, which cannot express them', async () => {
+  // Verified against codex-cli 0.142.5: it speaks streamable HTTP, and names the
+  // env var for a bearer token rather than storing the value.
+  it('writes an http server into codex config.toml, naming the token env var', async () => {
     await fse.ensureDir(path.join(homeDir, '.codex', 'skills'));
+    process.env.REMOTE_TOKEN = 'super-secret-value';
     await writeMcpYaml(`
 servers:
   - name: remote
     transport: http
     url: https://example.com/mcp
+    headers:
+      Authorization: Bearer \${REMOTE_TOKEN}
+      X-Trace: \${TRACE_ID}
+      X-Team: literal-value
+    timeout: 600000
+    tools: [codex]
+`);
+    process.env.TRACE_ID = 'trace-1';
+
+    await reconcileMcpForConfig(teamConfig, localConfig);
+    const toml = await fse.readFile(path.join(homeDir, '.codex', 'config.toml'), 'utf-8');
+
+    expect(toml).toContain('url = "https://example.com/mcp"');
+    expect(toml).toContain('bearer_token_env_var = "REMOTE_TOKEN"');
+    expect(toml).toContain('env_http_headers = { "X-Trace" = "TRACE_ID" }');
+    expect(toml).toContain('http_headers = { "X-Team" = "literal-value" }');
+    expect(toml).toContain('startup_timeout_sec = 600');
+    // The point of naming the variable: the value never reaches the file.
+    expect(toml).not.toContain('super-secret-value');
+    expect(toml).not.toContain('trace-1');
+    delete process.env.REMOTE_TOKEN;
+    delete process.env.TRACE_ID;
+  });
+
+  it('resolves a codex placeholder it cannot name, such as one inside the url', async () => {
+    await fse.ensureDir(path.join(homeDir, '.codex', 'skills'));
+    process.env.REGION = 'eu';
+    await writeMcpYaml(`
+servers:
+  - name: regional
+    transport: http
+    url: https://\${REGION}.example.com/mcp
+    tools: [codex]
+`);
+
+    await reconcileMcpForConfig(teamConfig, localConfig);
+    const toml = await fse.readFile(path.join(homeDir, '.codex', 'config.toml'), 'utf-8');
+    expect(toml).toContain('url = "https://eu.example.com/mcp"');
+    delete process.env.REGION;
+  });
+
+  it('still skips sse for codex, which has no such transport', async () => {
+    await fse.ensureDir(path.join(homeDir, '.codex', 'skills'));
+    await writeMcpYaml(`
+servers:
+  - name: streamy
+    transport: sse
+    url: https://example.com/sse
     tools: [codex]
 `);
 
     const { changes } = await reconcileMcpForConfig(teamConfig, localConfig);
     expect(changes).toContainEqual(
-      expect.objectContaining({ tool: 'codex', server: 'remote', action: 'skipped' }),
+      expect.objectContaining({ tool: 'codex', server: 'streamy', action: 'skipped' }),
     );
     expect(await fse.pathExists(path.join(homeDir, '.codex', 'config.toml'))).toBe(false);
   });

--- a/src/__tests__/mcp-reconcile.test.ts
+++ b/src/__tests__/mcp-reconcile.test.ts
@@ -19,13 +19,13 @@ vi.mock('../utils/logger.js', () => ({
   })),
 }));
 
-import { reconcileMcpForConfig, spliceCodexBlock, codexServerNames } from '../mcp-reconcile.js';
+import { reconcileMcpForConfig, resolveMcpTargets, spliceCodexBlock, codexServerNames } from '../mcp-reconcile.js';
 import type { TeamaiConfig, LocalConfig } from '../types.js';
 
 const TOOL_PATHS = {
   claude: { skills: '.claude/skills', settings: '.claude/settings.json', mcp: '.claude.json', mcpProject: '.mcp.json' },
-  cursor: { skills: '.cursor/skills', settings: '.cursor/hooks.json', mcp: '.cursor/mcp.json' },
-  codebuddy: { skills: '.codebuddy/skills', settings: '.codebuddy/settings.json', mcp: '.codebuddy/mcp.json' },
+  cursor: { skills: '.cursor/skills', settings: '.cursor/hooks.json', mcp: '.cursor/mcp.json', mcpProject: '.cursor/mcp.json' },
+  codebuddy: { skills: '.codebuddy/skills', settings: '.codebuddy/settings.json', mcp: '.codebuddy/mcp.json', mcpProject: '.codebuddy/mcp.json' },
   codex: { skills: '.codex/skills', settings: '.codex/hooks.json', mcp: '.codex/config.toml' },
   tclaude: { skills: '.tclaude/skills', settings: '.tclaude/settings.json', mcp: '.tclaude/.claude.json' },
 };
@@ -249,6 +249,86 @@ servers:
       expect.objectContaining({ tool: 'tclaude', server: 'gpu', action: 'added' }),
     );
     expect(await fse.pathExists(path.join(homeDir, '.tclaude', '.claude.json'))).toBe(true);
+  });
+
+  // Regression: project scope used to fall back to the user-scope path, which
+  // put files where codex/tclaude would never look for them.
+  it('never falls back to the user-scope path in project scope', async () => {
+    const projectRoot = path.join(tmpDir, 'proj');
+    for (const d of ['.claude', '.cursor', '.codebuddy', '.tclaude', '.codex']) {
+      await fse.ensureDir(path.join(projectRoot, d, 'skills'));
+    }
+    const projectConfig = {
+      ...localConfig,
+      scope: 'project',
+      projectRoot,
+    } as unknown as LocalConfig;
+
+    await writeMcpYaml(`
+servers:
+  - name: s1
+    transport: stdio
+    command: echo
+`);
+
+    const targets = await resolveMcpTargets(teamConfig, projectConfig);
+    const byTool = Object.fromEntries(targets.map((t) => [t.tool, t.file]));
+
+    expect(byTool.claude).toBe(path.join(projectRoot, '.mcp.json'));
+    expect(byTool.cursor).toBe(path.join(projectRoot, '.cursor', 'mcp.json'));
+    expect(byTool.codebuddy).toBe(path.join(projectRoot, '.codebuddy', 'mcp.json'));
+    // No project-scope MCP support: codex has no such concept, and tclaude reads
+    // the <root>/.mcp.json that the claude target already writes.
+    expect(byTool.codex).toBeUndefined();
+    expect(byTool.tclaude).toBeUndefined();
+
+    await reconcileMcpForConfig(teamConfig, projectConfig);
+    expect(await fse.pathExists(path.join(projectRoot, '.codex', 'config.toml'))).toBe(false);
+    expect(await fse.pathExists(path.join(projectRoot, '.tclaude', '.claude.json'))).toBe(false);
+    expect(await fse.pathExists(path.join(projectRoot, '.mcp.json'))).toBe(true);
+  });
+
+  it('refuses to write a secret in plaintext into a committed project file', async () => {
+    const projectRoot = path.join(tmpDir, 'proj2');
+    for (const d of ['.claude', '.cursor']) {
+      await fse.ensureDir(path.join(projectRoot, d, 'skills'));
+    }
+    const projectConfig = { ...localConfig, scope: 'project', projectRoot } as unknown as LocalConfig;
+    process.env.SECRET_TOKEN = 'super-secret-value';
+
+    await writeMcpYaml(`
+servers:
+  - name: with-secret
+    transport: http
+    url: https://example.com/mcp
+    headers:
+      Authorization: Bearer \${SECRET_TOKEN}
+  - name: no-secret
+    transport: http
+    url: https://example.com/open
+`);
+
+    const { changes } = await reconcileMcpForConfig(teamConfig, projectConfig);
+
+    // Claude expands ${VAR} itself, so the placeholder is passed through intact.
+    const claudeDoc = await fse.readJson(path.join(projectRoot, '.mcp.json'));
+    expect(claudeDoc.mcpServers['with-secret'].headers.Authorization).toBe('Bearer ${SECRET_TOKEN}');
+
+    // Cursor cannot, so the server is dropped rather than resolved to plaintext.
+    const cursorDoc = await fse.readJson(path.join(projectRoot, '.cursor', 'mcp.json'));
+    expect(cursorDoc.mcpServers['with-secret']).toBeUndefined();
+    expect(cursorDoc.mcpServers['no-secret']).toBeDefined();
+
+    const skipped = changes.find((c) => c.tool === 'cursor' && c.server === 'with-secret');
+    expect(skipped?.action).toBe('skipped');
+    expect(skipped?.reason).toMatch(/plaintext/);
+
+    // Belt and braces: the secret must not appear anywhere under the project.
+    for (const f of ['.mcp.json', '.cursor/mcp.json']) {
+      const raw = await fse.readFile(path.join(projectRoot, f), 'utf-8');
+      expect(raw).not.toContain('super-secret-value');
+    }
+    delete process.env.SECRET_TOKEN;
   });
 
   it('skips tools that are not installed', async () => {

--- a/src/__tests__/mcp-reconcile.test.ts
+++ b/src/__tests__/mcp-reconcile.test.ts
@@ -27,6 +27,7 @@ const TOOL_PATHS = {
   cursor: { skills: '.cursor/skills', settings: '.cursor/hooks.json', mcp: '.cursor/mcp.json' },
   codebuddy: { skills: '.codebuddy/skills', settings: '.codebuddy/settings.json', mcp: '.codebuddy/mcp.json' },
   codex: { skills: '.codex/skills', settings: '.codex/hooks.json', mcp: '.codex/config.toml' },
+  tclaude: { skills: '.tclaude/skills', settings: '.tclaude/settings.json', mcp: '.tclaude/.claude.json' },
 };
 
 describe('MCP reconcile', () => {
@@ -203,6 +204,51 @@ servers:
 
     const after = await fse.readJson(path.join(homeDir, '.claude.json'));
     expect(after.mcpServers.temp).toBeUndefined();
+  });
+
+  // tclaude relocates Claude Code's user data dir via customUserDataDir, so its
+  // MCP file is ~/.tclaude/.claude.json — a nested path, not ~/.tclaude.json.
+  it('writes tclaude servers to ~/.tclaude/.claude.json in claude format', async () => {
+    const tclaudeJson = path.join(homeDir, '.tclaude', '.claude.json');
+    await fse.ensureDir(path.join(homeDir, '.tclaude', 'skills'));
+    await fse.writeJson(tclaudeJson, { numStartups: 7, projects: { '/p': { trustLevel: 'trusted' } } });
+
+    await writeMcpYaml(`
+servers:
+  - name: gpu
+    transport: http
+    url: https://example.com/mcp
+    tools: [tclaude]
+`);
+
+    await reconcileMcpForConfig(teamConfig, localConfig);
+
+    const after = await fse.readJson(tclaudeJson);
+    expect(after.mcpServers.gpu).toEqual({ type: 'http', url: 'https://example.com/mcp' });
+    // Pre-existing tclaude state survives.
+    expect(after.numStartups).toBe(7);
+    expect(after.projects).toEqual({ '/p': { trustLevel: 'trusted' } });
+    // The sibling path must not be created by mistake.
+    expect(await fse.pathExists(path.join(homeDir, '.tclaude.json'))).toBe(false);
+  });
+
+  it('detects tclaude as installed from its skills dir, not its MCP file', async () => {
+    // ~/.tclaude exists but .claude.json does not yet — a fresh install.
+    await fse.ensureDir(path.join(homeDir, '.tclaude', 'skills'));
+
+    await writeMcpYaml(`
+servers:
+  - name: gpu
+    transport: http
+    url: https://example.com/mcp
+    tools: [tclaude]
+`);
+
+    const { changes } = await reconcileMcpForConfig(teamConfig, localConfig);
+    expect(changes).toContainEqual(
+      expect.objectContaining({ tool: 'tclaude', server: 'gpu', action: 'added' }),
+    );
+    expect(await fse.pathExists(path.join(homeDir, '.tclaude', '.claude.json'))).toBe(true);
   });
 
   it('skips tools that are not installed', async () => {

--- a/src/__tests__/mcp-reconcile.test.ts
+++ b/src/__tests__/mcp-reconcile.test.ts
@@ -1,0 +1,364 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import os from 'node:os';
+import fse from 'fs-extra';
+
+vi.mock('../utils/logger.js', () => ({
+  log: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    dim: vi.fn(),
+  },
+  spinner: vi.fn(() => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+  })),
+}));
+
+import { reconcileMcpForConfig, spliceCodexBlock, codexServerNames } from '../mcp-reconcile.js';
+import type { TeamaiConfig, LocalConfig } from '../types.js';
+
+const TOOL_PATHS = {
+  claude: { skills: '.claude/skills', settings: '.claude/settings.json', mcp: '.claude.json', mcpProject: '.mcp.json' },
+  cursor: { skills: '.cursor/skills', settings: '.cursor/hooks.json', mcp: '.cursor/mcp.json' },
+  codebuddy: { skills: '.codebuddy/skills', settings: '.codebuddy/settings.json', mcp: '.codebuddy/mcp.json' },
+  codex: { skills: '.codex/skills', settings: '.codex/hooks.json', mcp: '.codex/config.toml' },
+};
+
+describe('MCP reconcile', () => {
+  let tmpDir: string;
+  let homeDir: string;
+  let repoPath: string;
+  let teamConfig: TeamaiConfig;
+  let localConfig: LocalConfig;
+
+  async function writeMcpYaml(body: string): Promise<void> {
+    await fse.ensureDir(path.join(repoPath, 'mcp'));
+    await fse.writeFile(path.join(repoPath, 'mcp', 'mcp.yaml'), body);
+  }
+
+  beforeEach(async () => {
+    tmpDir = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-mcp-test-'));
+    homeDir = path.join(tmpDir, 'home');
+    repoPath = path.join(tmpDir, 'team-repo');
+
+    // Only claude + cursor are "installed".
+    await fse.ensureDir(path.join(homeDir, '.claude', 'skills'));
+    await fse.ensureDir(path.join(homeDir, '.cursor', 'skills'));
+    await fse.ensureDir(path.join(homeDir, '.teamai'));
+
+    vi.stubEnv('HOME', homeDir);
+
+    teamConfig = {
+      team: 't',
+      description: '',
+      repo: 'r',
+      provider: 'tgit',
+      reviewers: [],
+      sharing: {
+        skills: {},
+        rules: { enforced: [] },
+        docs: { localDir: '~/.teamai/docs' },
+        env: { injectShellProfile: false },
+      },
+      toolPaths: TOOL_PATHS,
+    } as unknown as TeamaiConfig;
+
+    localConfig = {
+      repo: { localPath: repoPath, remote: 'r' },
+      username: 'u',
+      scope: 'user',
+      additionalRoles: [],
+    } as unknown as LocalConfig;
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await fse.remove(tmpDir);
+  });
+
+  it('preserves every unrelated key in ~/.claude.json', async () => {
+    const claudeJson = path.join(homeDir, '.claude.json');
+    const original = {
+      oauthAccount: { emailAddress: 'me@example.com', accountUuid: 'abc-123' },
+      projects: { '/some/project': { trustLevel: 'trusted', allowedTools: ['Bash'] } },
+      numStartups: 42,
+      mcpServers: { 'my-own': { command: 'my-server' } },
+    };
+    await fse.writeJson(claudeJson, original);
+
+    await writeMcpYaml(`
+servers:
+  - name: team-server
+    transport: http
+    url: https://example.com/mcp
+`);
+
+    await reconcileMcpForConfig(teamConfig, localConfig);
+
+    const after = await fse.readJson(claudeJson);
+    expect(after.oauthAccount).toEqual(original.oauthAccount);
+    expect(after.projects).toEqual(original.projects);
+    expect(after.numStartups).toBe(42);
+    // User's own server survives alongside the team one.
+    expect(after.mcpServers['my-own']).toEqual({ command: 'my-server' });
+    expect(after.mcpServers['team-server']).toEqual({
+      type: 'http',
+      url: 'https://example.com/mcp',
+    });
+  });
+
+  it('is idempotent — a second run does not rewrite the file', async () => {
+    await writeMcpYaml(`
+servers:
+  - name: s1
+    transport: http
+    url: https://example.com/mcp
+`);
+
+    const first = await reconcileMcpForConfig(teamConfig, localConfig);
+    expect(first.wrote).toBe(true);
+
+    const claudeJson = path.join(homeDir, '.claude.json');
+    const mtimeBefore = (await fse.stat(claudeJson)).mtimeMs;
+
+    const second = await reconcileMcpForConfig(teamConfig, localConfig);
+    expect(second.wrote).toBe(false);
+    expect((await fse.stat(claudeJson)).mtimeMs).toBe(mtimeBefore);
+  });
+
+  it('does not overwrite a user-owned server with a colliding name', async () => {
+    const cursorMcp = path.join(homeDir, '.cursor', 'mcp.json');
+    await fse.writeJson(cursorMcp, { mcpServers: { shared: { url: 'https://mine.example/mcp' } } });
+
+    await writeMcpYaml(`
+servers:
+  - name: shared
+    transport: http
+    url: https://team.example/mcp
+    tools: [cursor]
+`);
+
+    const { changes } = await reconcileMcpForConfig(teamConfig, localConfig);
+
+    const after = await fse.readJson(cursorMcp);
+    expect(after.mcpServers.shared.url).toBe('https://mine.example/mcp');
+    expect(changes).toContainEqual(
+      expect.objectContaining({ tool: 'cursor', server: 'shared', action: 'skipped' }),
+    );
+  });
+
+  it('skips a server whose ${VAR} cannot be resolved instead of injecting it broken', async () => {
+    await writeMcpYaml(`
+servers:
+  - name: needs-token
+    transport: http
+    url: https://example.com/mcp
+    headers:
+      Authorization: Bearer \${DEFINITELY_UNSET_TOKEN_XYZ}
+`);
+
+    const { changes } = await reconcileMcpForConfig(teamConfig, localConfig);
+
+    expect(await fse.pathExists(path.join(homeDir, '.claude.json'))).toBe(false);
+    expect(changes.every((c) => c.action === 'skipped')).toBe(true);
+    expect(changes[0].reason).toContain('DEFINITELY_UNSET_TOKEN_XYZ');
+  });
+
+  it('resolves ${VAR} from the team env file', async () => {
+    await fse.writeFile(path.join(homeDir, '.teamai', 'env'), 'TEAM_TOKEN=s3cret\n');
+    await writeMcpYaml(`
+servers:
+  - name: with-token
+    transport: http
+    url: https://example.com/mcp
+    headers:
+      Authorization: Bearer \${TEAM_TOKEN}
+    tools: [claude]
+`);
+
+    await reconcileMcpForConfig(teamConfig, localConfig);
+
+    const after = await fse.readJson(path.join(homeDir, '.claude.json'));
+    expect(after.mcpServers['with-token'].headers.Authorization).toBe('Bearer s3cret');
+  });
+
+  it('removes a server once it disappears from mcp.yaml', async () => {
+    await writeMcpYaml(`
+servers:
+  - name: temp
+    transport: http
+    url: https://example.com/mcp
+    tools: [claude]
+`);
+    await reconcileMcpForConfig(teamConfig, localConfig);
+    expect((await fse.readJson(path.join(homeDir, '.claude.json'))).mcpServers.temp).toBeDefined();
+
+    await writeMcpYaml('servers: []\n');
+    await reconcileMcpForConfig(teamConfig, localConfig);
+
+    const after = await fse.readJson(path.join(homeDir, '.claude.json'));
+    expect(after.mcpServers.temp).toBeUndefined();
+  });
+
+  it('skips tools that are not installed', async () => {
+    await writeMcpYaml(`
+servers:
+  - name: s1
+    transport: http
+    url: https://example.com/mcp
+`);
+    await reconcileMcpForConfig(teamConfig, localConfig);
+
+    // codebuddy has no ~/.codebuddy directory in this fixture.
+    expect(await fse.pathExists(path.join(homeDir, '.codebuddy', 'mcp.json'))).toBe(false);
+  });
+
+  it('skips http servers for codex, which cannot express them', async () => {
+    await fse.ensureDir(path.join(homeDir, '.codex', 'skills'));
+    await writeMcpYaml(`
+servers:
+  - name: remote
+    transport: http
+    url: https://example.com/mcp
+    tools: [codex]
+`);
+
+    const { changes } = await reconcileMcpForConfig(teamConfig, localConfig);
+    expect(changes).toContainEqual(
+      expect.objectContaining({ tool: 'codex', server: 'remote', action: 'skipped' }),
+    );
+    expect(await fse.pathExists(path.join(homeDir, '.codex', 'config.toml'))).toBe(false);
+  });
+
+  it('writes a stdio server into codex config.toml without destroying user comments', async () => {
+    await fse.ensureDir(path.join(homeDir, '.codex', 'skills'));
+    const configToml = path.join(homeDir, '.codex', 'config.toml');
+    await fse.writeFile(
+      configToml,
+      '# my important comment\nmodel = "gpt-5"\n\n[projects."/x"]\ntrust_level = "trusted"\n',
+    );
+
+    await writeMcpYaml(`
+servers:
+  - name: local-tool
+    transport: stdio
+    command: my-mcp
+    args: ['--flag']
+    tools: [codex]
+`);
+
+    await reconcileMcpForConfig(teamConfig, localConfig);
+
+    const after = await fse.readFile(configToml, 'utf-8');
+    expect(after).toContain('# my important comment');
+    expect(after).toContain('trust_level = "trusted"');
+    expect(after).toContain('[mcp_servers.local-tool]');
+    expect(after).toContain('command = "my-mcp"');
+  });
+
+  it('leaves an unparseable config file alone rather than clobbering it', async () => {
+    const claudeJson = path.join(homeDir, '.claude.json');
+    await fse.writeFile(claudeJson, '{ this is not valid json');
+
+    await writeMcpYaml(`
+servers:
+  - name: s1
+    transport: http
+    url: https://example.com/mcp
+    tools: [claude]
+`);
+
+    await reconcileMcpForConfig(teamConfig, localConfig);
+    expect(await fse.readFile(claudeJson, 'utf-8')).toBe('{ this is not valid json');
+  });
+
+  it('enforces the allowedHosts policy', async () => {
+    teamConfig.sharing.mcp = { autoApply: true, allowedCommands: [], allowedHosts: ['*.trusted.com'] };
+    await writeMcpYaml(`
+servers:
+  - name: sketchy
+    transport: http
+    url: https://evil.example/mcp
+    tools: [claude]
+`);
+
+    const { changes } = await reconcileMcpForConfig(teamConfig, localConfig);
+    expect(changes[0]).toMatchObject({ action: 'skipped' });
+    expect(changes[0].reason).toContain('allowedHosts');
+  });
+});
+
+describe('spliceCodexBlock', () => {
+  it('replaces a block and its nested env sub-table, leaving neighbours intact', () => {
+    const src = [
+      '# header comment',
+      'model = "gpt-5"',
+      '',
+      '[mcp_servers.a]',
+      'command = "old"',
+      '',
+      '[mcp_servers.a.env]',
+      'OLD = "1"',
+      '',
+      '[projects."/x"]',
+      'trust_level = "trusted"',
+      '',
+    ].join('\n');
+
+    const out = spliceCodexBlock(src, 'a', '[mcp_servers.a]\ncommand = "new"\n');
+
+    expect(out).toContain('# header comment');
+    expect(out).toContain('command = "new"');
+    expect(out).not.toContain('OLD = "1"');
+    expect(out).toContain('[projects."/x"]');
+    expect(out).toContain('trust_level = "trusted"');
+  });
+
+  it('deletes a block when passed null', () => {
+    const src = '[mcp_servers.a]\ncommand = "x"\n\n[projects."/y"]\ntrust_level = "trusted"\n';
+    const out = spliceCodexBlock(src, 'a', null);
+    expect(out).not.toContain('mcp_servers.a');
+    expect(out).toContain('[projects."/y"]');
+  });
+
+  // Regression: the end-of-input branch was originally written as \z, which JS
+  // reads as a literal "z", so a trailing block could never be matched.
+  it('deletes a block sitting at end-of-file', () => {
+    const src = 'model = "gpt-5"\n\n[mcp_servers.last]\ncommand = "x"\n';
+    const out = spliceCodexBlock(src, 'last', null);
+    expect(out).not.toContain('mcp_servers.last');
+    expect(out).toContain('model = "gpt-5"');
+  });
+
+  it('deletes a trailing block including its env sub-table', () => {
+    const src = '[projects."/y"]\nt = 1\n\n[mcp_servers.last]\ncommand = "x"\n\n[mcp_servers.last.env]\nA = "1"\n';
+    const out = spliceCodexBlock(src, 'last', null);
+    expect(out).not.toContain('mcp_servers.last');
+    expect(out).not.toContain('A = "1"');
+    expect(out).toContain('[projects."/y"]');
+  });
+
+  it('replaces a trailing block in place', () => {
+    const src = 'model = "x"\n\n[mcp_servers.last]\ncommand = "old"\n';
+    const out = spliceCodexBlock(src, 'last', '[mcp_servers.last]\ncommand = "new"\n');
+    expect(out).toContain('command = "new"');
+    expect(out).not.toContain('command = "old"');
+  });
+
+  it('appends when the block is absent', () => {
+    const src = 'model = "gpt-5"\n';
+    const out = spliceCodexBlock(src, 'newone', '[mcp_servers.newone]\ncommand = "x"\n');
+    expect(out).toContain('model = "gpt-5"');
+    expect(out).toContain('[mcp_servers.newone]');
+  });
+
+  it('lists existing server names', () => {
+    const src = '[mcp_servers.a]\n\n[mcp_servers.b]\n\n[mcp_servers.b.env]\nX = "1"\n';
+    expect(codexServerNames(src).sort()).toEqual(['a', 'b']);
+  });
+});

--- a/src/__tests__/tclaude-tcodex.test.ts
+++ b/src/__tests__/tclaude-tcodex.test.ts
@@ -15,6 +15,8 @@ describe('tclaude/tcodex adapter integration', () => {
         settings: '.tclaude/settings.json',
         claudemd: '.tclaude/CLAUDE.md',
         agents: '.tclaude/agents',
+        // customUserDataDir relocates Claude Code's user data dir into .tclaude/
+        mcp: '.tclaude/.claude.json',
       });
     });
 

--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -65,6 +65,7 @@ describe('TeamaiConfigSchema', () => {
       settings: '.codebuddy/settings.json',
       claudemd: '.codebuddy/CODEBUDDY.md',
       mcp: '.codebuddy/mcp.json',
+      mcpProject: '.codebuddy/mcp.json',
     });
   });
 

--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -64,6 +64,7 @@ describe('TeamaiConfigSchema', () => {
       agents: '.codebuddy/agents',
       settings: '.codebuddy/settings.json',
       claudemd: '.codebuddy/CODEBUDDY.md',
+      mcp: '.codebuddy/mcp.json',
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -504,6 +504,41 @@ hooksCmd
     await hooksRemove(globalOpts);
   });
 
+// ─── MCP commands ───────────────────────────────────────
+
+const mcpCmd = program
+  .command('mcp')
+  .description('Manage team MCP servers across AI tools');
+
+mcpCmd
+  .command('list')
+  .description('List team MCP servers and their per-tool install status')
+  .action(async () => {
+    const globalOpts = program.opts() as GlobalOptions;
+    const { mcpList } = await import('./mcp-cmd.js');
+    await mcpList(globalOpts);
+  });
+
+mcpCmd
+  .command('inject')
+  .description('Inject team MCP servers into all AI tool configs')
+  .option('--dry-run', 'Show what would change without writing')
+  .option('--force', 'Overwrite servers that collide with user-owned entries')
+  .action(async (cmdOpts) => {
+    const globalOpts = program.opts() as GlobalOptions;
+    const { mcpInject } = await import('./mcp-cmd.js');
+    await mcpInject({ ...globalOpts, ...cmdOpts });
+  });
+
+mcpCmd
+  .command('remove')
+  .description('Remove all teamai-managed MCP servers from AI tool configs')
+  .action(async () => {
+    const globalOpts = program.opts() as GlobalOptions;
+    const { mcpRemove } = await import('./mcp-cmd.js');
+    await mcpRemove(globalOpts);
+  });
+
 // ─── Usage tracking commands ────────────────────────────
 
 program

--- a/src/mcp-cmd.ts
+++ b/src/mcp-cmd.ts
@@ -1,0 +1,104 @@
+import path from 'node:path';
+import { autoDetectInit } from './config.js';
+import { parseTeamMcpServers } from './resources/mcp.js';
+import {
+  reconcileMcpForConfig,
+  resolveMcpTargets,
+  buildVarTable,
+  type McpChange,
+} from './mcp-reconcile.js';
+import { referencedVars } from './resources/mcp-format.js';
+import { log } from './utils/logger.js';
+import type { GlobalOptions } from './types.js';
+import { managedMcpManifestPath } from './types.js';
+import { readJson } from './utils/fs.js';
+import type { ManagedMcpManifest } from './types.js';
+
+function displayPath(p: string): string {
+  const home = process.env.HOME;
+  if (home && (p === home || p.startsWith(home + path.sep))) return `~${p.slice(home.length)}`;
+  return p;
+}
+
+/** Print team MCP servers, their secret requirements, and where they are installed. */
+export async function mcpList(_options: GlobalOptions): Promise<void> {
+  const { localConfig, teamConfig } = await autoDetectInit();
+  const servers = await parseTeamMcpServers(localConfig.repo.localPath);
+
+  if (servers.length === 0) {
+    log.info('No team MCP servers defined (mcp/mcp.yaml not found or empty)');
+    return;
+  }
+
+  const targets = await resolveMcpTargets(teamConfig, localConfig);
+  const vars = await buildVarTable(localConfig);
+  const manifest = (await readJson<ManagedMcpManifest>(
+    managedMcpManifestPath(localConfig.scope, localConfig.projectRoot),
+  )) ?? {};
+
+  console.log(`Team MCP servers — mcp/mcp.yaml (${servers.length}):`);
+  console.log('');
+  for (const s of servers) {
+    const endpoint = s.transport === 'stdio' ? `${s.command} ${(s.args ?? []).join(' ')}`.trim() : s.url;
+    console.log(`  ${s.name}  [${s.transport}]`);
+    if (s.description) console.log(`    ${s.description}`);
+    console.log(`    endpoint: ${endpoint}`);
+
+    const needed = referencedVars(s);
+    if (needed.length > 0) {
+      const missing = needed.filter((v) => !vars[v]);
+      const state = missing.length === 0 ? 'all set' : `MISSING: ${missing.join(', ')}`;
+      console.log(`    secrets:  ${needed.join(', ')} (${state})`);
+    }
+
+    const installedIn = targets
+      .filter((t) => (manifest[`${t.tool}${t.projectScope ? ':project' : ''}`] ?? []).some((r) => r.name === s.name))
+      .map((t) => t.tool);
+    console.log(`    installed: ${installedIn.length > 0 ? installedIn.join(', ') : '(none)'}`);
+    console.log('');
+  }
+
+  console.log('MCP-capable tools detected:');
+  if (targets.length === 0) {
+    console.log('  (none)');
+  } else {
+    for (const t of targets) console.log(`  ${t.tool.padEnd(16)} ${displayPath(t.file)}`);
+  }
+}
+
+function reportChanges(changes: McpChange[]): void {
+  const applied = changes.filter((c) => c.action !== 'skipped');
+  const skipped = changes.filter((c) => c.action === 'skipped');
+
+  for (const c of applied) console.log(`  ${c.action.padEnd(8)} ${c.tool}/${c.server}`);
+  for (const c of skipped) console.log(`  skipped  ${c.tool}/${c.server} — ${c.reason}`);
+
+  if (applied.length === 0 && skipped.length === 0) console.log('  (no changes)');
+}
+
+export async function mcpInject(
+  options: GlobalOptions & { dryRun?: boolean; force?: boolean },
+): Promise<void> {
+  const { localConfig, teamConfig } = await autoDetectInit();
+  const { changes, wrote } = await reconcileMcpForConfig(teamConfig, localConfig, {
+    dryRun: options.dryRun,
+    force: options.force,
+  });
+
+  console.log(options.dryRun ? 'MCP inject (dry run):' : 'MCP inject:');
+  reportChanges(changes);
+
+  if (wrote) log.success('MCP servers updated. Restart your AI tool session to load them.');
+  else if (!options.dryRun) log.info('Already up to date.');
+}
+
+export async function mcpRemove(_options: GlobalOptions): Promise<void> {
+  const { localConfig, teamConfig } = await autoDetectInit();
+  const { changes, wrote } = await reconcileMcpForConfig(teamConfig, localConfig, { removeAll: true });
+
+  console.log('MCP remove:');
+  reportChanges(changes);
+
+  if (wrote) log.success('teamai-managed MCP servers removed.');
+  else log.info('Nothing to remove.');
+}

--- a/src/mcp-reconcile.ts
+++ b/src/mcp-reconcile.ts
@@ -341,7 +341,7 @@ export async function reconcileMcpForConfig(
 
       // Pass ${VAR} through where the tool expands it itself, so the secret
       // never lands on disk; otherwise resolve and require every var to exist.
-      const passthrough = supportsEnvExpansion(target.format, target.projectScope);
+      const passthrough = supportsEnvExpansion(target.format, target.projectScope, raw);
       let def = raw;
       if (!passthrough) {
         // A project-scope file lives in the repo and gets committed. Resolving a

--- a/src/mcp-reconcile.ts
+++ b/src/mcp-reconcile.ts
@@ -180,7 +180,12 @@ export async function resolveMcpTargets(
     const format = detectMcpFormat(tool);
     if (!format) continue;
 
-    const rel = projectScope ? (paths.mcpProject ?? paths.mcp) : paths.mcp;
+    // No fallback between scopes: a tool's project-scope location is a
+    // different thing from its user-scope one, not a default for it. Absent
+    // `mcpProject` means the tool has no project-scope MCP support (codex), or
+    // is already covered by a sibling target writing the shared file (tclaude
+    // reads the <root>/.mcp.json that `claude` writes).
+    const rel = projectScope ? paths.mcpProject : paths.mcp;
     if (!rel) continue;
 
     const probe = paths.skills ?? paths.settings ?? paths.agents;
@@ -339,6 +344,21 @@ export async function reconcileMcpForConfig(
       const passthrough = supportsEnvExpansion(target.format, target.projectScope);
       let def = raw;
       if (!passthrough) {
+        // A project-scope file lives in the repo and gets committed. Resolving a
+        // placeholder for a tool that cannot expand ${VAR} would put the secret
+        // into version control, so refuse rather than leak it.
+        const referenced = referencedVars(raw);
+        if (target.projectScope && referenced.length > 0) {
+          changes.push({
+            tool: target.tool,
+            server: raw.name,
+            action: 'skipped',
+            reason:
+              `${target.tool} cannot expand \${VAR}, so ${referenced.join(', ')} would be ` +
+              `written in plaintext to a committed file — distribute this server at user scope instead`,
+          });
+          continue;
+        }
         const { def: resolved, missing } = resolvePlaceholders(raw, vars);
         if (missing.length > 0) {
           changes.push({

--- a/src/mcp-reconcile.ts
+++ b/src/mcp-reconcile.ts
@@ -1,0 +1,485 @@
+import path from 'node:path';
+import fse from 'fs-extra';
+import type {
+  LocalConfig,
+  TeamaiConfig,
+  McpServerDef,
+  ManagedMcpManifest,
+  ManagedMcpRecord,
+} from './types.js';
+import {
+  getMcpSharing,
+  getTeamaiHome,
+  managedMcpManifestPath,
+  resolveBaseDir,
+} from './types.js';
+import {
+  detectMcpFormat,
+  supportsTransport,
+  supportsEnvExpansion,
+  renderJsonEntry,
+  renderCodexBlock,
+  resolvePlaceholders,
+  referencedVars,
+  entryHash,
+  type McpFormat,
+} from './resources/mcp-format.js';
+import { parseTeamMcpServers } from './resources/mcp.js';
+import {
+  readJson,
+  writeJsonAtomic,
+  readFileSafe,
+  pathExists,
+  expandHome,
+} from './utils/fs.js';
+import { log } from './utils/logger.js';
+
+// ─── Reconcile engine ────────────────────────────────────────
+//
+//  Injects team MCP servers into each tool's own config file, idempotently.
+//
+//  The files here are NOT owned by teamai — ~/.claude.json also holds the OAuth
+//  session and all per-project state, and ~/.codex/config.toml holds model and
+//  trust settings. So every write is key-level surgery on an existing document,
+//  never a regenerate-from-scratch, and never a whole-file TOML round-trip
+//  (which would silently drop the user's comments).
+//
+//  Ownership lives in ~/.teamai/managed-mcp.json rather than a marker inside the
+//  entry, because MCP entries have no field we can safely stamp. Only keys the
+//  manifest claims are ever rewritten or removed; anything the user added by
+//  hand is left strictly alone.
+
+export interface McpReconcileOptions {
+  /** Remove all teamai-managed servers instead of injecting the desired set. */
+  removeAll?: boolean;
+  /** Report intended changes without touching disk. */
+  dryRun?: boolean;
+  /** Overwrite user-owned servers that collide by name. */
+  force?: boolean;
+}
+
+export interface McpChange {
+  tool: string;
+  server: string;
+  action: 'added' | 'updated' | 'removed' | 'skipped';
+  reason?: string;
+}
+
+export interface McpReconcileResult {
+  changes: McpChange[];
+  /** True when any file was actually written. */
+  wrote: boolean;
+}
+
+// ─── Manifest ────────────────────────────────────────────────
+
+async function readManifest(manifestPath: string): Promise<ManagedMcpManifest> {
+  const data = await readJson<ManagedMcpManifest>(expandHome(manifestPath));
+  return data && typeof data === 'object' ? data : {};
+}
+
+// ─── Secret lookup ───────────────────────────────────────────
+
+/**
+ * Build the ${VAR} lookup table: process env first, then values the team's env
+ * channel already wrote to <teamaiHome>/env (KEY=value per line).
+ */
+export async function buildVarTable(localConfig: LocalConfig): Promise<Record<string, string>> {
+  const table: Record<string, string> = {};
+  const envFile = path.join(getTeamaiHome(localConfig.scope, localConfig.projectRoot), 'env');
+  const content = await readFileSafe(envFile);
+  if (content) {
+    for (const line of content.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) continue;
+      const eq = trimmed.indexOf('=');
+      if (eq <= 0) continue;
+      table[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim();
+    }
+  }
+  // process.env wins: it lets a user override a team-provided value locally.
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v !== undefined) table[k] = v;
+  }
+  return table;
+}
+
+// ─── Security gate ───────────────────────────────────────────
+
+function hostAllowed(url: string, allowedHosts: string[]): boolean {
+  if (allowedHosts.length === 0) return true;
+  let host: string;
+  try {
+    host = new URL(url).hostname;
+  } catch {
+    return false;
+  }
+  return allowedHosts.some((pattern) =>
+    pattern.startsWith('*.')
+      ? host === pattern.slice(2) || host.endsWith(pattern.slice(1))
+      : host === pattern,
+  );
+}
+
+/** Reject a server that the team's security policy disallows. Returns a reason, or null when OK. */
+function policyViolation(def: McpServerDef, sharing: ReturnType<typeof getMcpSharing>): string | null {
+  if (def.transport === 'stdio') {
+    const { allowedCommands } = sharing;
+    if (allowedCommands.length > 0 && def.command && !allowedCommands.includes(def.command)) {
+      return `command "${def.command}" is not in sharing.mcp.allowedCommands`;
+    }
+  } else if (def.url && !hostAllowed(def.url, sharing.allowedHosts)) {
+    return `host is not in sharing.mcp.allowedHosts`;
+  }
+  return null;
+}
+
+/** True when every executable in `requires` is on PATH. */
+async function requirementsMet(def: McpServerDef): Promise<string | null> {
+  if (!def.requires?.length) return null;
+  const { execFile } = await import('node:child_process');
+  const { promisify } = await import('node:util');
+  const run = promisify(execFile);
+  for (const bin of def.requires) {
+    try {
+      await run('command', ['-v', bin], { shell: '/bin/sh' });
+    } catch {
+      return `required executable "${bin}" not found on PATH`;
+    }
+  }
+  return null;
+}
+
+// ─── Tool targeting ──────────────────────────────────────────
+
+interface McpTarget {
+  tool: string;
+  format: McpFormat;
+  /** Absolute path of the config file to edit. */
+  file: string;
+  projectScope: boolean;
+}
+
+/**
+ * Resolve which tools to write, and where.
+ *
+ * Installation is detected from the tool's skills/settings path, NOT its MCP
+ * path: Claude's project-scope MCP file is <root>/.mcp.json, whose first path
+ * segment is the file itself, so the usual directory probe would report "not
+ * installed" for a perfectly good Claude install.
+ */
+export async function resolveMcpTargets(
+  teamConfig: TeamaiConfig,
+  localConfig: LocalConfig,
+): Promise<McpTarget[]> {
+  const baseDir = resolveBaseDir(localConfig);
+  const projectScope = localConfig.scope === 'project';
+  const targets: McpTarget[] = [];
+
+  for (const [tool, paths] of Object.entries(teamConfig.toolPaths)) {
+    const format = detectMcpFormat(tool);
+    if (!format) continue;
+
+    const rel = projectScope ? (paths.mcpProject ?? paths.mcp) : paths.mcp;
+    if (!rel) continue;
+
+    const probe = paths.skills ?? paths.settings ?? paths.agents;
+    if (!probe) continue;
+    const toolRoot = path.join(baseDir, probe.split('/')[0]);
+    if (!await pathExists(toolRoot)) {
+      log.debug(`Skipping MCP sync for ${tool}: tool not installed`);
+      continue;
+    }
+
+    targets.push({ tool, format, file: path.join(baseDir, rel), projectScope });
+  }
+  return targets;
+}
+
+// ─── JSON target I/O ─────────────────────────────────────────
+
+interface JsonDoc {
+  data: Record<string, unknown>;
+  servers: Record<string, unknown>;
+}
+
+/**
+ * Read a JSON MCP config. Returns null when the file exists but cannot be
+ * parsed — we abandon the injection rather than risk clobbering a file we do
+ * not understand (it may hold the user's OAuth session).
+ */
+async function readJsonDoc(file: string): Promise<JsonDoc | null> {
+  if (!await pathExists(file)) return { data: {}, servers: {} };
+  const raw = await readFileSafe(file);
+  if (raw === null) return null;
+  if (raw.trim() === '') return { data: {}, servers: {} };
+  try {
+    const data = JSON.parse(raw) as Record<string, unknown>;
+    if (typeof data !== 'object' || data === null || Array.isArray(data)) return null;
+    const servers = (data.mcpServers as Record<string, unknown>) ?? {};
+    if (typeof servers !== 'object' || servers === null || Array.isArray(servers)) return null;
+    return { data, servers: { ...servers } };
+  } catch {
+    return null;
+  }
+}
+
+// ─── Codex TOML target I/O ───────────────────────────────────
+
+/**
+ * Replace or delete a `[mcp_servers.<name>]` block by text surgery, leaving the
+ * rest of config.toml byte-identical (comments included).
+ */
+export function spliceCodexBlock(source: string, name: string, block: string | null): string {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  // The block runs from its header to the next table header that is not one of
+  // its own sub-tables (e.g. [mcp_servers.<name>.env]), or to end-of-input.
+  // End-of-input must be spelled `(?![\s\S])`: JS has no \z, and under the `m`
+  // flag `$` only means end-of-line, which would truncate the match early.
+  const re = new RegExp(
+    String.raw`^\[mcp_servers\.${escaped}\]\s*$[\s\S]*?(?=^\[(?!mcp_servers\.${escaped}[.\]])|(?![\s\S]))`,
+    'm',
+  );
+  const match = source.match(re);
+
+  if (match) {
+    if (block === null) {
+      const cleaned = source.replace(re, '');
+      return cleaned.replace(/\n{3,}/g, '\n\n');
+    }
+    return source.replace(re, block.endsWith('\n') ? block + '\n' : block + '\n\n');
+  }
+
+  if (block === null) return source;
+  const sep = source.length === 0 || source.endsWith('\n\n') ? '' : source.endsWith('\n') ? '\n' : '\n\n';
+  return source + sep + block;
+}
+
+/** Extract the names of all `[mcp_servers.X]` tables present in a config.toml. */
+export function codexServerNames(source: string): string[] {
+  const names = new Set<string>();
+  for (const m of source.matchAll(/^\[mcp_servers\.([A-Za-z0-9_-]+)\]\s*$/gm)) names.add(m[1]);
+  return [...names];
+}
+
+// ─── Main entry ──────────────────────────────────────────────
+
+/**
+ * Reconcile one scope's tool configs to the team's desired MCP server set.
+ * Idempotent: unchanged servers produce no write at all.
+ */
+export async function reconcileMcpForConfig(
+  teamConfig: TeamaiConfig,
+  localConfig: LocalConfig,
+  options: McpReconcileOptions = {},
+): Promise<McpReconcileResult> {
+  const changes: McpChange[] = [];
+  let wrote = false;
+
+  const sharing = getMcpSharing(teamConfig);
+  const removeAll = options.removeAll === true;
+
+  const teamDefs = removeAll ? [] : await parseTeamMcpServers(localConfig.repo.localPath);
+  if (!removeAll && teamDefs.length > 0 && !sharing.autoApply) {
+    log.info(`${teamDefs.length} team MCP server(s) available. Run \`teamai mcp inject\` to apply.`);
+    return { changes, wrote };
+  }
+
+  const excluded = new Set(localConfig.excludedSkills ?? []);
+  const targets = await resolveMcpTargets(teamConfig, localConfig);
+  if (targets.length === 0) return { changes, wrote };
+
+  const manifestPath = managedMcpManifestPath(localConfig.scope, localConfig.projectRoot);
+  const manifest = await readManifest(manifestPath);
+
+  // An empty desired set still has to run: it is how servers dropped from
+  // mcp.yaml get cleaned out of the tools we previously injected them into.
+  const nothingOwned = Object.values(manifest).every((r) => r.length === 0);
+  if (teamDefs.length === 0 && nothingOwned) return { changes, wrote };
+
+  const vars = await buildVarTable(localConfig);
+
+  for (const target of targets) {
+    const manifestKey = `${target.tool}${target.projectScope ? ':project' : ''}`;
+    const owned = manifest[manifestKey] ?? [];
+    const ownedNames = new Set(owned.map((r) => r.name));
+    const nextRecords: ManagedMcpRecord[] = [];
+
+    // Which of this team's servers apply to this tool, and in what rendered form.
+    const desired = new Map<string, { entry: unknown; hash: string; block?: string }>();
+
+    for (const raw of teamDefs) {
+      if (raw.tools && !raw.tools.includes(target.tool)) continue;
+      if (excluded.has(raw.name)) {
+        changes.push({ tool: target.tool, server: raw.name, action: 'skipped', reason: 'excluded by user' });
+        continue;
+      }
+      if (!supportsTransport(target.format, raw.transport)) {
+        changes.push({
+          tool: target.tool,
+          server: raw.name,
+          action: 'skipped',
+          reason: `${target.tool} does not support ${raw.transport} transport`,
+        });
+        continue;
+      }
+      const violation = policyViolation(raw, sharing);
+      if (violation) {
+        changes.push({ tool: target.tool, server: raw.name, action: 'skipped', reason: violation });
+        continue;
+      }
+      const missingBin = await requirementsMet(raw);
+      if (missingBin) {
+        changes.push({ tool: target.tool, server: raw.name, action: 'skipped', reason: missingBin });
+        continue;
+      }
+
+      // Pass ${VAR} through where the tool expands it itself, so the secret
+      // never lands on disk; otherwise resolve and require every var to exist.
+      const passthrough = supportsEnvExpansion(target.format, target.projectScope);
+      let def = raw;
+      if (!passthrough) {
+        const { def: resolved, missing } = resolvePlaceholders(raw, vars);
+        if (missing.length > 0) {
+          changes.push({
+            tool: target.tool,
+            server: raw.name,
+            action: 'skipped',
+            reason: `unresolved variable(s): ${missing.join(', ')}`,
+          });
+          continue;
+        }
+        def = resolved;
+      } else if (referencedVars(raw).length > 0) {
+        log.debug(`${raw.name}: passing ${referencedVars(raw).join(', ')} through to ${target.tool}`);
+      }
+
+      if (target.format === 'codex') {
+        const block = renderCodexBlock(def);
+        desired.set(raw.name, { entry: block, hash: entryHash(block), block });
+      } else {
+        const entry = renderJsonEntry(target.format, def);
+        desired.set(raw.name, { entry, hash: entryHash(entry) });
+      }
+    }
+
+    if (target.format === 'codex') {
+      wrote = await applyCodex(target, desired, ownedNames, nextRecords, changes, options) || wrote;
+    } else {
+      wrote = await applyJson(target, desired, owned, ownedNames, nextRecords, changes, options) || wrote;
+    }
+
+    if (nextRecords.length > 0) manifest[manifestKey] = nextRecords;
+    else delete manifest[manifestKey];
+  }
+
+  if (!options.dryRun && wrote) {
+    await writeJsonAtomic(manifestPath, manifest);
+  }
+  return { changes, wrote };
+}
+
+// ─── Appliers ────────────────────────────────────────────────
+
+async function applyJson(
+  target: McpTarget,
+  desired: Map<string, { entry: unknown; hash: string }>,
+  owned: ManagedMcpRecord[],
+  ownedNames: Set<string>,
+  nextRecords: ManagedMcpRecord[],
+  changes: McpChange[],
+  options: McpReconcileOptions,
+): Promise<boolean> {
+  const doc = await readJsonDoc(target.file);
+  if (!doc) {
+    log.warn(`Could not parse ${target.file} — skipping MCP injection for ${target.tool}`);
+    return false;
+  }
+
+  const ownedHash = new Map(owned.map((r) => [r.name, r.hash]));
+  let dirty = false;
+
+  for (const [name, { entry, hash }] of desired) {
+    const existing = doc.servers[name];
+    if (existing !== undefined && !ownedNames.has(name) && !options.force) {
+      changes.push({
+        tool: target.tool,
+        server: name,
+        action: 'skipped',
+        reason: 'a server with this name already exists and is not managed by teamai',
+      });
+      continue;
+    }
+    nextRecords.push({ name, hash });
+    if (existing !== undefined && ownedHash.get(name) === hash) continue;
+    doc.servers[name] = entry;
+    dirty = true;
+    changes.push({ tool: target.tool, server: name, action: existing === undefined ? 'added' : 'updated' });
+  }
+
+  for (const name of ownedNames) {
+    if (desired.has(name)) continue;
+    if (doc.servers[name] !== undefined) {
+      delete doc.servers[name];
+      dirty = true;
+    }
+    changes.push({ tool: target.tool, server: name, action: 'removed' });
+  }
+
+  if (!dirty || options.dryRun) return false;
+
+  // Key-level surgery: every unrelated top-level key is carried over untouched.
+  doc.data.mcpServers = doc.servers;
+  await writeJsonAtomic(target.file, doc.data);
+  return true;
+}
+
+async function applyCodex(
+  target: McpTarget,
+  desired: Map<string, { entry: unknown; hash: string; block?: string }>,
+  ownedNames: Set<string>,
+  nextRecords: ManagedMcpRecord[],
+  changes: McpChange[],
+  options: McpReconcileOptions,
+): Promise<boolean> {
+  let source = (await readFileSafe(target.file)) ?? '';
+  const present = new Set(codexServerNames(source));
+  let dirty = false;
+
+  for (const [name, { hash, block }] of desired) {
+    if (present.has(name) && !ownedNames.has(name) && !options.force) {
+      changes.push({
+        tool: target.tool,
+        server: name,
+        action: 'skipped',
+        reason: 'a server with this name already exists and is not managed by teamai',
+      });
+      continue;
+    }
+    nextRecords.push({ name, hash });
+    const next = spliceCodexBlock(source, name, block!);
+    if (next === source) continue;
+    source = next;
+    dirty = true;
+    changes.push({ tool: target.tool, server: name, action: present.has(name) ? 'updated' : 'added' });
+  }
+
+  for (const name of ownedNames) {
+    if (desired.has(name)) continue;
+    const next = spliceCodexBlock(source, name, null);
+    if (next !== source) {
+      source = next;
+      dirty = true;
+    }
+    changes.push({ tool: target.tool, server: name, action: 'removed' });
+  }
+
+  if (!dirty || options.dryRun) return false;
+
+  await fse.ensureDir(path.dirname(target.file));
+  const tmp = `${target.file}.${process.pid}.tmp`;
+  await fse.writeFile(tmp, source, 'utf-8');
+  await fse.chmod(tmp, 0o600);
+  await fse.rename(tmp, target.file);
+  return true;
+}

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -1126,6 +1126,10 @@ export async function pull(options: GlobalOptions): Promise<void> {
   // session start. In project mode user is null, so user hooks are left alone.
   await reconcileHooksAllScopes(projectMode ? null : userConfig, projectConfig, options);
 
+  // 3.6. Reconcile team MCP servers. Outside pullForScope for the same reason as
+  // hooks: mcp.yaml changes must apply even when the rev fast-path short-circuits.
+  await reconcileMcpAllScopes(projectMode ? null : userConfig, projectConfig, options);
+
   // 4. Auto-report usage data to all active scopes. Events live in a single
   //    shared file (~/.teamai/usage.jsonl), so we report to each repo with
   //    skipTruncate=true first, then truncate once at the end.
@@ -1207,6 +1211,39 @@ async function reconcileHooksAllScopes(
       }
     } catch (e) {
       log.debug(`[${localConfig.scope}] Hook reconcile skipped: ${(e as Error).message}`);
+    }
+  }
+}
+
+/**
+ * Reconcile team MCP servers across all active scopes. MCP servers load at
+ * session start, so a change applied here takes effect in the user's next
+ * session — which is exactly when the SessionStart pull hook runs.
+ */
+async function reconcileMcpAllScopes(
+  userConfig: LocalConfig | null,
+  projectConfig: LocalConfig | null,
+  options: GlobalOptions,
+): Promise<void> {
+  if (options.dryRun) return;
+  const scopes = [userConfig, projectConfig].filter((c): c is LocalConfig => !!c);
+  for (const localConfig of scopes) {
+    try {
+      const teamConfig = await loadTeamConfig(localConfig.repo.localPath);
+      if (!teamConfig) continue;
+      const { reconcileMcpForConfig } = await import('./mcp-reconcile.js');
+      const { changes } = await reconcileMcpForConfig(teamConfig, localConfig);
+
+      const applied = changes.filter((c) => c.action !== 'skipped');
+      for (const c of changes) {
+        if (c.action === 'skipped') log.debug(`[mcp] ${c.tool}/${c.server}: skipped — ${c.reason}`);
+      }
+      if (applied.length > 0 && !options.silent) {
+        const servers = [...new Set(applied.map((c) => c.server))];
+        log.info(`MCP: ${applied.length} change(s) across ${servers.length} server(s). Restart your AI tool session to load them.`);
+      }
+    } catch (e) {
+      log.debug(`[${localConfig.scope}] MCP reconcile skipped: ${(e as Error).message}`);
     }
   }
 }

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -5,6 +5,7 @@ import { DocsHandler } from './docs.js';
 import { EnvHandler } from './env.js';
 import { AgentsHandler } from './agents.js';
 import { HooksHandler } from './hooks.js';
+import { McpHandler } from './mcp.js';
 import type { ResourceType } from '../types.js';
 
 const handlers: Record<ResourceType, ResourceHandler> = {
@@ -14,6 +15,7 @@ const handlers: Record<ResourceType, ResourceHandler> = {
   env: new EnvHandler(),
   agents: new AgentsHandler(),
   hooks: new HooksHandler(),
+  mcp: new McpHandler(),
 };
 
 export function getHandler(type: ResourceType): ResourceHandler {
@@ -24,4 +26,4 @@ export function getAllHandlers(): ResourceHandler[] {
   return Object.values(handlers);
 }
 
-export { SkillsHandler, RulesHandler, DocsHandler, EnvHandler, AgentsHandler, HooksHandler };
+export { SkillsHandler, RulesHandler, DocsHandler, EnvHandler, AgentsHandler, HooksHandler, McpHandler };

--- a/src/resources/mcp-format.ts
+++ b/src/resources/mcp-format.ts
@@ -1,0 +1,192 @@
+import crypto from 'node:crypto';
+import type { McpServerDef, McpTransport } from '../types.js';
+
+// ─── Per-tool rendering ──────────────────────────────────────
+//
+//  One McpServerDef renders into three different on-disk shapes:
+//
+//    claude family   { "type": "http", "url", "headers" }
+//    cursor          { "url", "headers" }                     (type omitted)
+//    buddy family    { "transportType": "streamable-http", … } (+ timeout)
+//    codex           [mcp_servers.<name>] TOML table          (stdio only)
+//
+//  Keeping the differences here — rather than in the reconcile engine — is the
+//  same split agents uses between agent-format.ts and its handler.
+
+export type McpFormat = 'claude' | 'cursor' | 'buddy' | 'codex';
+
+const CLAUDE_TOOLS = new Set(['claude', 'claude-internal', 'tclaude']);
+const CURSOR_TOOLS = new Set(['cursor']);
+const CODEX_TOOLS = new Set(['codex', 'codex-internal', 'tcodex']);
+const BUDDY_TOOLS = new Set(['codebuddy', 'workbuddy']);
+
+export function detectMcpFormat(tool: string): McpFormat | null {
+  if (CLAUDE_TOOLS.has(tool)) return 'claude';
+  if (CURSOR_TOOLS.has(tool)) return 'cursor';
+  if (CODEX_TOOLS.has(tool)) return 'codex';
+  if (BUDDY_TOOLS.has(tool)) return 'buddy';
+  return null;
+}
+
+/** Transports each format can actually express. */
+const SUPPORTED_TRANSPORTS: Record<McpFormat, Set<McpTransport>> = {
+  claude: new Set<McpTransport>(['stdio', 'http', 'sse']),
+  cursor: new Set<McpTransport>(['stdio', 'http', 'sse']),
+  buddy: new Set<McpTransport>(['stdio', 'http', 'sse']),
+  // Codex's config.toml models MCP servers as launched processes. Remote
+  // transports are not expressible in a way we can verify, so they are skipped
+  // rather than written as a config that would fail at session start.
+  codex: new Set<McpTransport>(['stdio']),
+};
+
+export function supportsTransport(format: McpFormat, transport: McpTransport): boolean {
+  return SUPPORTED_TRANSPORTS[format].has(transport);
+}
+
+/**
+ * Whether the target file expands ${VAR} itself. Where it does, the placeholder
+ * is written through verbatim and the secret never touches disk.
+ *
+ * Claude Code expands env vars in project-scope .mcp.json. Everything else gets
+ * a resolved value, written with 0600 permissions.
+ */
+export function supportsEnvExpansion(format: McpFormat, projectScope: boolean): boolean {
+  return format === 'claude' && projectScope;
+}
+
+// ─── Placeholder resolution ──────────────────────────────────
+
+const PLACEHOLDER_RE = /\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g;
+
+/** Every ${VAR} referenced anywhere in a def. */
+export function referencedVars(def: McpServerDef): string[] {
+  const found = new Set<string>();
+  const scan = (v: string | undefined): void => {
+    if (!v) return;
+    for (const m of v.matchAll(PLACEHOLDER_RE)) found.add(m[1]);
+  };
+  scan(def.url);
+  scan(def.command);
+  def.args?.forEach(scan);
+  Object.values(def.headers ?? {}).forEach(scan);
+  Object.values(def.env ?? {}).forEach(scan);
+  return [...found];
+}
+
+export interface ResolveResult {
+  def: McpServerDef;
+  /** Vars referenced but not found in the lookup table. */
+  missing: string[];
+}
+
+/**
+ * Substitute ${VAR} throughout a def. Unresolved vars are left as-is and
+ * reported, so the caller can skip the server rather than inject a broken one.
+ */
+export function resolvePlaceholders(def: McpServerDef, vars: Record<string, string>): ResolveResult {
+  const missing = new Set<string>();
+  const sub = (v: string): string =>
+    v.replace(PLACEHOLDER_RE, (whole, name: string) => {
+      const val = vars[name];
+      if (val === undefined || val === '') {
+        missing.add(name);
+        return whole;
+      }
+      return val;
+    });
+  const subMap = (m: Record<string, string> | undefined): Record<string, string> | undefined =>
+    m && Object.fromEntries(Object.entries(m).map(([k, v]) => [k, sub(v)]));
+
+  return {
+    def: {
+      ...def,
+      command: def.command ? sub(def.command) : undefined,
+      args: def.args?.map(sub),
+      url: def.url ? sub(def.url) : undefined,
+      headers: subMap(def.headers),
+      env: subMap(def.env),
+    },
+    missing: [...missing],
+  };
+}
+
+// ─── Renderers ───────────────────────────────────────────────
+
+export type McpJsonEntry = Record<string, unknown>;
+
+function renderClaude(def: McpServerDef): McpJsonEntry {
+  const e: McpJsonEntry = { type: def.transport };
+  if (def.transport === 'stdio') {
+    e.command = def.command;
+    if (def.args?.length) e.args = def.args;
+    if (def.env && Object.keys(def.env).length) e.env = def.env;
+  } else {
+    e.url = def.url;
+    if (def.headers && Object.keys(def.headers).length) e.headers = def.headers;
+  }
+  return e;
+}
+
+function renderCursor(def: McpServerDef): McpJsonEntry {
+  const e: McpJsonEntry = {};
+  if (def.transport === 'stdio') {
+    e.command = def.command;
+    if (def.args?.length) e.args = def.args;
+    if (def.env && Object.keys(def.env).length) e.env = def.env;
+  } else {
+    e.url = def.url;
+    if (def.headers && Object.keys(def.headers).length) e.headers = def.headers;
+  }
+  return e;
+}
+
+function renderBuddy(def: McpServerDef): McpJsonEntry {
+  const e: McpJsonEntry = {};
+  if (def.transport === 'stdio') {
+    e.command = def.command;
+    if (def.args?.length) e.args = def.args;
+    if (def.env && Object.keys(def.env).length) e.env = def.env;
+  } else {
+    e.transportType = def.transport === 'http' ? 'streamable-http' : 'sse';
+    e.url = def.url;
+    if (def.headers && Object.keys(def.headers).length) e.headers = def.headers;
+  }
+  if (def.timeout !== undefined) e.timeout = def.timeout;
+  return e;
+}
+
+/** Render the JSON-shaped entry for a format. Codex is handled separately (TOML). */
+export function renderJsonEntry(format: Exclude<McpFormat, 'codex'>, def: McpServerDef): McpJsonEntry {
+  if (format === 'claude') return renderClaude(def);
+  if (format === 'cursor') return renderCursor(def);
+  return renderBuddy(def);
+}
+
+/**
+ * Render a `[mcp_servers.<name>]` TOML block, including a nested `.env` table.
+ *
+ * Hand-rolled rather than smol-toml's stringify: we only ever splice this text
+ * into an existing config.toml, and a whole-file round-trip through the parser
+ * silently drops every user comment in the file.
+ */
+export function renderCodexBlock(def: McpServerDef): string {
+  const q = (s: string): string => JSON.stringify(s);
+  const lines = [`[mcp_servers.${def.name}]`];
+  lines.push(`command = ${q(def.command ?? '')}`);
+  lines.push(`args = [${(def.args ?? []).map(q).join(', ')}]`);
+  if (def.timeout !== undefined) {
+    lines.push(`startup_timeout_sec = ${Math.ceil(def.timeout / 1000)}`);
+  }
+  const env = def.env ?? {};
+  if (Object.keys(env).length) {
+    lines.push('');
+    lines.push(`[mcp_servers.${def.name}.env]`);
+    for (const [k, v] of Object.entries(env)) lines.push(`${k} = ${q(v)}`);
+  }
+  return lines.join('\n') + '\n';
+}
+
+/** Stable content hash of a rendered entry; drives idempotent rewrites. */
+export function entryHash(rendered: unknown): string {
+  return crypto.createHash('sha1').update(JSON.stringify(rendered)).digest('hex').slice(0, 16);
+}

--- a/src/resources/mcp-format.ts
+++ b/src/resources/mcp-format.ts
@@ -8,7 +8,7 @@ import type { McpServerDef, McpTransport } from '../types.js';
 //    claude family   { "type": "http", "url", "headers" }
 //    cursor          { "url", "headers" }                     (type omitted)
 //    buddy family    { "transportType": "streamable-http", … } (+ timeout)
-//    codex           [mcp_servers.<name>] TOML table          (stdio only)
+//    codex           [mcp_servers.<name>] TOML table          (stdio + http)
 //
 //  Keeping the differences here — rather than in the reconcile engine — is the
 //  same split agents uses between agent-format.ts and its handler.
@@ -33,10 +33,9 @@ const SUPPORTED_TRANSPORTS: Record<McpFormat, Set<McpTransport>> = {
   claude: new Set<McpTransport>(['stdio', 'http', 'sse']),
   cursor: new Set<McpTransport>(['stdio', 'http', 'sse']),
   buddy: new Set<McpTransport>(['stdio', 'http', 'sse']),
-  // Codex's config.toml models MCP servers as launched processes. Remote
-  // transports are not expressible in a way we can verify, so they are skipped
-  // rather than written as a config that would fail at session start.
-  codex: new Set<McpTransport>(['stdio']),
+  // Codex speaks streamable HTTP (`url` + header keys) as well as stdio, but has
+  // no SSE transport, so only that one is skipped.
+  codex: new Set<McpTransport>(['stdio', 'http']),
 };
 
 export function supportsTransport(format: McpFormat, transport: McpTransport): boolean {
@@ -44,14 +43,64 @@ export function supportsTransport(format: McpFormat, transport: McpTransport): b
 }
 
 /**
- * Whether the target file expands ${VAR} itself. Where it does, the placeholder
- * is written through verbatim and the secret never touches disk.
+ * Whether the target file keeps the secret out of itself, letting the ${VAR} be
+ * written through verbatim rather than resolved onto disk.
  *
- * Claude Code expands env vars in project-scope .mcp.json. Everything else gets
- * a resolved value, written with 0600 permissions.
+ * Two tools manage it, by different means. Claude Code expands env vars in a
+ * project-scope .mcp.json. Codex names the variable instead of holding its value
+ * (`bearer_token_env_var`, `env_http_headers`) — but those fields only name a
+ * variable for a whole header value, so a placeholder embedded in a larger
+ * string, or one in the URL, still has to be resolved.
  */
-export function supportsEnvExpansion(format: McpFormat, projectScope: boolean): boolean {
-  return format === 'claude' && projectScope;
+export function supportsEnvExpansion(
+  format: McpFormat,
+  projectScope: boolean,
+  def?: McpServerDef,
+): boolean {
+  if (format === 'claude' && projectScope) return true;
+  if (format === 'codex' && def?.transport === 'http') return codexCanNameEveryVar(def);
+  return false;
+}
+
+/** `Authorization: Bearer ${VAR}` — codex re-adds the "Bearer " prefix itself. */
+const BEARER_PLACEHOLDER_RE = /^Bearer \$\{([A-Za-z_][A-Za-z0-9_]*)\}$/;
+/** A header whose entire value is one placeholder. */
+const WHOLE_PLACEHOLDER_RE = /^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$/;
+
+function codexCanNameEveryVar(def: McpServerDef): boolean {
+  if (def.url?.includes('${')) return false;
+  for (const value of Object.values(def.headers ?? {})) {
+    if (!value.includes('${')) continue;
+    if (!BEARER_PLACEHOLDER_RE.test(value) && !WHOLE_PLACEHOLDER_RE.test(value)) return false;
+  }
+  return true;
+}
+
+interface CodexHeaderPlan {
+  bearerTokenEnvVar?: string;
+  envHttpHeaders: Record<string, string>;
+  httpHeaders: Record<string, string>;
+}
+
+/** Split headers across the three fields codex offers for them. */
+export function planCodexHeaders(headers: Record<string, string> = {}): CodexHeaderPlan {
+  const plan: CodexHeaderPlan = { envHttpHeaders: {}, httpHeaders: {} };
+  for (const [name, value] of Object.entries(headers)) {
+    if (name.toLowerCase() === 'authorization') {
+      const bearer = BEARER_PLACEHOLDER_RE.exec(value);
+      if (bearer) {
+        plan.bearerTokenEnvVar = bearer[1];
+        continue;
+      }
+    }
+    const whole = WHOLE_PLACEHOLDER_RE.exec(value);
+    if (whole) {
+      plan.envHttpHeaders[name] = whole[1];
+      continue;
+    }
+    plan.httpHeaders[name] = value;
+  }
+  return plan;
 }
 
 // ─── Placeholder resolution ──────────────────────────────────
@@ -172,6 +221,25 @@ export function renderJsonEntry(format: Exclude<McpFormat, 'codex'>, def: McpSer
 export function renderCodexBlock(def: McpServerDef): string {
   const q = (s: string): string => JSON.stringify(s);
   const lines = [`[mcp_servers.${def.name}]`];
+
+  if (def.transport === 'http') {
+    const inlineTable = (t: Record<string, string>): string =>
+      `{ ${Object.entries(t).map(([k, v]) => `${q(k)} = ${q(v)}`).join(', ')} }`;
+    lines.push(`url = ${q(def.url ?? '')}`);
+    const plan = planCodexHeaders(def.headers);
+    if (plan.bearerTokenEnvVar) lines.push(`bearer_token_env_var = ${q(plan.bearerTokenEnvVar)}`);
+    if (Object.keys(plan.envHttpHeaders).length > 0) {
+      lines.push(`env_http_headers = ${inlineTable(plan.envHttpHeaders)}`);
+    }
+    if (Object.keys(plan.httpHeaders).length > 0) {
+      lines.push(`http_headers = ${inlineTable(plan.httpHeaders)}`);
+    }
+    if (def.timeout !== undefined) {
+      lines.push(`startup_timeout_sec = ${Math.ceil(def.timeout / 1000)}`);
+    }
+    return lines.join('\n') + '\n';
+  }
+
   lines.push(`command = ${q(def.command ?? '')}`);
   lines.push(`args = [${(def.args ?? []).map(q).join(', ')}]`);
   if (def.timeout !== undefined) {

--- a/src/resources/mcp.ts
+++ b/src/resources/mcp.ts
@@ -1,0 +1,138 @@
+import path from 'node:path';
+import { z } from 'zod';
+import YAML from 'yaml';
+import { ResourceHandler } from './base.js';
+import type { ResourceItem, TeamaiConfig, LocalConfig, McpServerDef } from '../types.js';
+import { pathExists, readFileSafe } from '../utils/fs.js';
+import { log } from '../utils/logger.js';
+
+// ─── Schema for mcp/mcp.yaml ────────────────────────────────
+//
+//  Team-declared MCP servers. Transport names are the tool-neutral MCP spec
+//  names; each tool's own spelling (Claude's `type`, CodeBuddy's
+//  `transportType: streamable-http`, Codex's TOML table) is applied at render
+//  time by mcp-format.ts.
+
+const TeamMcpServerSchema = z
+  .object({
+    name: z.string().regex(/^[A-Za-z0-9_-]+$/, 'name must be alphanumeric with - or _'),
+    description: z.string().optional(),
+    transport: z.enum(['stdio', 'http', 'sse']),
+    command: z.string().optional(),
+    args: z.array(z.string()).optional(),
+    url: z.string().optional(),
+    headers: z.record(z.string(), z.string()).optional(),
+    env: z.record(z.string(), z.string()).optional(),
+    timeout: z.number().int().positive().optional(),
+    requires: z.array(z.string()).optional(),
+    tools: z.array(z.string()).optional(),
+  })
+  .refine((s) => (s.transport === 'stdio' ? !!s.command : true), {
+    message: 'stdio transport requires `command`',
+  })
+  .refine((s) => (s.transport === 'stdio' ? true : !!s.url), {
+    message: 'http/sse transport requires `url`',
+  });
+
+export const McpYamlSchema = z.object({
+  servers: z.array(TeamMcpServerSchema).default([]),
+});
+
+export type TeamMcpServer = z.infer<typeof TeamMcpServerSchema>;
+export type McpYaml = z.infer<typeof McpYamlSchema>;
+
+/** Absolute path of a team repo's mcp/mcp.yaml. */
+export function teamMcpYamlPath(repoPath: string): string {
+  return path.join(repoPath, 'mcp', 'mcp.yaml');
+}
+
+/**
+ * Parse mcp/mcp.yaml into the validated structure. Returns null when the file is
+ * absent or fails validation, so callers never act on a half-broken server set.
+ */
+export async function parseMcpYaml(repoPath: string): Promise<McpYaml | null> {
+  const content = await readFileSafe(teamMcpYamlPath(repoPath));
+  if (!content) return null;
+  try {
+    return McpYamlSchema.parse(YAML.parse(content));
+  } catch (e) {
+    log.warn(`Invalid mcp.yaml format: ${(e as Error).message} — skipping team MCP servers this run`);
+    return null;
+  }
+}
+
+/** Convert one validated team server into the tool-neutral def model. */
+export function teamMcpToDef(s: TeamMcpServer): McpServerDef {
+  return {
+    name: s.name,
+    description: s.description,
+    transport: s.transport,
+    command: s.command,
+    args: s.args,
+    url: s.url,
+    headers: s.headers,
+    env: s.env,
+    timeout: s.timeout,
+    requires: s.requires,
+    tools: s.tools,
+  };
+}
+
+/** Parse the team repo's mcp/mcp.yaml into defs. Returns [] when absent or invalid. */
+export async function parseTeamMcpServers(repoPath: string): Promise<McpServerDef[]> {
+  const parsed = await parseMcpYaml(repoPath);
+  if (!parsed) return [];
+  return parsed.servers.map(teamMcpToDef);
+}
+
+// ─── Handler ─────────────────────────────────────────────────
+
+export class McpHandler extends ResourceHandler {
+  readonly type = 'mcp' as const;
+
+  /**
+   * MCP servers are contributed by editing mcp/mcp.yaml directly (same as hooks),
+   * so there is nothing to discover on the local side for push.
+   */
+  async scanLocalForPush(): Promise<ResourceItem[]> {
+    return [];
+  }
+
+  async scanTeamForPull(_teamConfig: TeamaiConfig, localConfig: LocalConfig): Promise<ResourceItem[]> {
+    const yamlPath = teamMcpYamlPath(localConfig.repo.localPath);
+    if (!await pathExists(yamlPath)) return [];
+    const servers = await parseTeamMcpServers(localConfig.repo.localPath);
+    return servers.map((s) => ({
+      name: s.name,
+      type: 'mcp' as const,
+      sourcePath: yamlPath,
+      relativePath: path.join('mcp', 'mcp.yaml'),
+    }));
+  }
+
+  async pushItem(): Promise<void> {
+    // Servers live in a single mcp.yaml committed directly; nothing per-item to copy.
+  }
+
+  async pullItem(): Promise<void> {
+    // No-op — reconcileMcpForConfig() in pull.ts injects across all tools/scopes,
+    // bypassing the "Already synced" rev fast-path (same shape as hooks).
+  }
+
+  /**
+   * Remove a server from the team repo's mcp.yaml. Local tool configs are cleaned
+   * up by the next reconcile, which sees the server vanish from the desired set.
+   */
+  async removeItem(name: string, _teamConfig: TeamaiConfig, localConfig: LocalConfig): Promise<string[]> {
+    const yamlPath = teamMcpYamlPath(localConfig.repo.localPath);
+    const parsed = await parseMcpYaml(localConfig.repo.localPath);
+    if (!parsed) return [];
+    const remaining = parsed.servers.filter((s) => s.name !== name);
+    if (remaining.length === parsed.servers.length) return [];
+
+    const { writeFile } = await import('../utils/fs.js');
+    await writeFile(yamlPath, YAML.stringify({ servers: remaining }));
+    await this.addTombstone(name, localConfig);
+    return [yamlPath];
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,9 +13,10 @@ export const ToolPathsSchema = z.object({
   agents: z.string().optional(),
   /** User-scope MCP config file (relative to $HOME). Omitted = tool has no MCP support. */
   mcp: z.string().optional(),
-  /** Project-scope MCP config file, when it differs from `mcp`. Claude Code is the
-   * notable case: user scope is ~/.claude.json but project scope is <root>/.mcp.json,
-   * which breaks the usual `.<tool>/<file>` convention. */
+  /** Project-scope MCP config file. Never defaults from `mcp` — omitting it means
+   * the tool has no project-scope MCP support at all. Claude Code shows why the two
+   * cannot share a value: user scope is ~/.claude.json but project scope is
+   * <root>/.mcp.json, breaking the usual `.<tool>/<file>` convention. */
   mcpProject: z.string().optional(),
 });
 
@@ -177,10 +178,10 @@ export const TeamaiConfigSchema = z.object({
     // already writes and tclaude reads from the same location.
     tclaude: { skills: '.tclaude/skills', rules: '.tclaude/rules', settings: '.tclaude/settings.json', claudemd: '.tclaude/CLAUDE.md', agents: '.tclaude/agents', mcp: '.tclaude/.claude.json' },
     tcodex: { skills: '.tcodex/skills', rules: '.tcodex/rules', settings: '.tcodex/hooks.json', agents: '.tcodex/agents' },
-    cursor: { skills: '.cursor/skills', rules: '.cursor/rules', settings: '.cursor/hooks.json', agents: '.cursor/agents', mcp: '.cursor/mcp.json' },
-    codebuddy: { skills: '.codebuddy/skills', rules: '.codebuddy/rules', settings: '.codebuddy/settings.json', claudemd: '.codebuddy/CODEBUDDY.md', agents: '.codebuddy/agents', mcp: '.codebuddy/mcp.json' },
+    cursor: { skills: '.cursor/skills', rules: '.cursor/rules', settings: '.cursor/hooks.json', agents: '.cursor/agents', mcp: '.cursor/mcp.json', mcpProject: '.cursor/mcp.json' },
+    codebuddy: { skills: '.codebuddy/skills', rules: '.codebuddy/rules', settings: '.codebuddy/settings.json', claudemd: '.codebuddy/CODEBUDDY.md', agents: '.codebuddy/agents', mcp: '.codebuddy/mcp.json', mcpProject: '.codebuddy/mcp.json' },
     openclaw: { skills: '.openclaw/skills', rules: '.openclaw/rules' },
-    workbuddy: { skills: '.workbuddy/skills', rules: '.workbuddy/rules', settings: '.workbuddy/settings.json', claudemd: 'AGENTS.md', mcp: '.workbuddy/mcp.json' },
+    workbuddy: { skills: '.workbuddy/skills', rules: '.workbuddy/rules', settings: '.workbuddy/settings.json', claudemd: 'AGENTS.md', mcp: '.workbuddy/mcp.json', mcpProject: '.workbuddy/mcp.json' },
   }),
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,12 @@ export const ToolPathsSchema = z.object({
   /** Per-tool agents directory (Phase 1: teamai-recall subagent target).
    * Optional — tools without subagent support omit this and agents sync skips them. */
   agents: z.string().optional(),
+  /** User-scope MCP config file (relative to $HOME). Omitted = tool has no MCP support. */
+  mcp: z.string().optional(),
+  /** Project-scope MCP config file, when it differs from `mcp`. Claude Code is the
+   * notable case: user scope is ~/.claude.json but project scope is <root>/.mcp.json,
+   * which breaks the usual `.<tool>/<file>` convention. */
+  mcpProject: z.string().optional(),
 });
 
 // ─── Scope ──────────────────────────────────────────────
@@ -44,6 +50,17 @@ export const SharingConfigSchema = z.object({
   recall: z.object({
     enabled: z.boolean().default(false),
   }).optional(),
+  // Optional (not .default) so existing TeamaiConfig literals stay valid; use
+  // getMcpSharing() for the defaulted view.
+  mcp: z.object({
+    /** Auto-apply team MCP servers during `teamai pull`. When false, pull only
+     *  hints; the user must run `teamai mcp inject` to apply (explicit consent). */
+    autoApply: z.boolean().default(true),
+    /** Allowed stdio commands. Empty = no restriction. */
+    allowedCommands: z.array(z.string()).default([]),
+    /** Allowed http/sse hosts (supports a leading `*.` wildcard). Empty = no restriction. */
+    allowedHosts: z.array(z.string()).default([]),
+  }).optional(),
 });
 
 /** Defaulted view of the optional `sharing.hooks` config. */
@@ -55,6 +72,18 @@ export function getHooksSharing(config: { sharing?: { hooks?: { autoApply?: bool
   return {
     autoApply: h?.autoApply ?? true,
     requireTeamScripts: h?.requireTeamScripts ?? false,
+  };
+}
+
+/** Defaulted view of the optional `sharing.mcp` config. */
+export function getMcpSharing(config: {
+  sharing?: { mcp?: { autoApply?: boolean; allowedCommands?: string[]; allowedHosts?: string[] } };
+}): { autoApply: boolean; allowedCommands: string[]; allowedHosts: string[] } {
+  const m = config.sharing?.mcp;
+  return {
+    autoApply: m?.autoApply ?? true,
+    allowedCommands: m?.allowedCommands ?? [],
+    allowedHosts: m?.allowedHosts ?? [],
   };
 }
 
@@ -133,17 +162,20 @@ export const TeamaiConfigSchema = z.object({
    * can override via `updatePolicy` in local config. Undefined = team has no
    * opinion (preserves legacy behavior). */
   autoUpdate: z.boolean().optional(),
+  // MCP paths are only set for tools whose config location has been verified.
+  // Tools left without `mcp` are skipped by MCP sync rather than guessed at, so a
+  // wrong guess can never create a junk config file on a user's machine.
   toolPaths: z.record(z.string(), ToolPathsSchema).default({
-    claude: { skills: '.claude/skills', rules: '.claude/rules', settings: '.claude/settings.json', claudemd: '.claude/CLAUDE.md', agents: '.claude/agents' },
-    codex: { skills: '.codex/skills', rules: '.codex/rules', settings: '.codex/hooks.json', agents: '.codex/agents' },
+    claude: { skills: '.claude/skills', rules: '.claude/rules', settings: '.claude/settings.json', claudemd: '.claude/CLAUDE.md', agents: '.claude/agents', mcp: '.claude.json', mcpProject: '.mcp.json' },
+    codex: { skills: '.codex/skills', rules: '.codex/rules', settings: '.codex/hooks.json', agents: '.codex/agents', mcp: '.codex/config.toml' },
     'codex-internal': { skills: '.codex-internal/skills', rules: '.codex-internal/rules', settings: '.codex-internal/hooks.json', agents: '.codex-internal/agents' },
     'claude-internal': { skills: '.claude-internal/skills', rules: '.claude-internal/rules', settings: '.claude-internal/settings.json', claudemd: '.claude-internal/CLAUDE.md', agents: '.claude-internal/agents' },
     tclaude: { skills: '.tclaude/skills', rules: '.tclaude/rules', settings: '.tclaude/settings.json', claudemd: '.tclaude/CLAUDE.md', agents: '.tclaude/agents' },
     tcodex: { skills: '.tcodex/skills', rules: '.tcodex/rules', settings: '.tcodex/hooks.json', agents: '.tcodex/agents' },
-    cursor: { skills: '.cursor/skills', rules: '.cursor/rules', settings: '.cursor/hooks.json', agents: '.cursor/agents' },
-    codebuddy: { skills: '.codebuddy/skills', rules: '.codebuddy/rules', settings: '.codebuddy/settings.json', claudemd: '.codebuddy/CODEBUDDY.md', agents: '.codebuddy/agents' },
+    cursor: { skills: '.cursor/skills', rules: '.cursor/rules', settings: '.cursor/hooks.json', agents: '.cursor/agents', mcp: '.cursor/mcp.json' },
+    codebuddy: { skills: '.codebuddy/skills', rules: '.codebuddy/rules', settings: '.codebuddy/settings.json', claudemd: '.codebuddy/CODEBUDDY.md', agents: '.codebuddy/agents', mcp: '.codebuddy/mcp.json' },
     openclaw: { skills: '.openclaw/skills', rules: '.openclaw/rules' },
-    workbuddy: { skills: '.workbuddy/skills', rules: '.workbuddy/rules', settings: '.workbuddy/settings.json', claudemd: 'AGENTS.md' },
+    workbuddy: { skills: '.workbuddy/skills', rules: '.workbuddy/rules', settings: '.workbuddy/settings.json', claudemd: 'AGENTS.md', mcp: '.workbuddy/mcp.json' },
   }),
 });
 
@@ -230,7 +262,7 @@ export interface TagsConfig {
 
 // ─── Resource types ─────────────────────────────────────
 
-export type ResourceType = 'skills' | 'rules' | 'docs' | 'env' | 'agents' | 'hooks';
+export type ResourceType = 'skills' | 'rules' | 'docs' | 'env' | 'agents' | 'hooks' | 'mcp';
 
 export type ResourceItemStatus = 'new' | 'modified';
 
@@ -278,6 +310,56 @@ export interface HookDef {
   tools?: string[];
 }
 
+// ─── MCP server definitions ──────────────────────────────
+//
+//  Team-declared MCP servers (mcp/mcp.yaml) are parsed into this tool-neutral
+//  model, then rendered per tool by resources/mcp-format.ts — the same
+//  "intermediate model → per-tool render" shape agents already uses.
+//
+//  Ownership is tracked out-of-band in ~/.teamai/managed-mcp.json, because an
+//  MCP entry has no free-text field to stamp a marker into (hooks stamp
+//  `[teamai:hook:<id>]` into `description`). This mirrors how hooks already
+//  track Cursor/Codex entries, which have no description either.
+
+export type McpTransport = 'stdio' | 'http' | 'sse';
+
+export interface McpServerDef {
+  /** Server key as written into each tool's config. */
+  name: string;
+  description?: string;
+  transport: McpTransport;
+  /** stdio only. */
+  command?: string;
+  args?: string[];
+  /** http/sse only. */
+  url?: string;
+  /** http/sse only. Values may contain ${VAR} placeholders. */
+  headers?: Record<string, string>;
+  /** Env vars passed to the server process. Values may contain ${VAR} placeholders. */
+  env?: Record<string, string>;
+  /** Request timeout in milliseconds, passed through where the tool supports it. */
+  timeout?: number;
+  /** Executables that must be on PATH; missing ones cause a skip-with-hint. */
+  requires?: string[];
+  /** Restrict to these tools (default = every MCP-capable tool). */
+  tools?: string[];
+}
+
+/** One injected MCP server recorded in the manifest. */
+export interface ManagedMcpRecord {
+  name: string;
+  /** sha1 (first 16 hex) of the rendered entry; drives idempotent rewrites. */
+  hash: string;
+}
+
+/** ~/.teamai/managed-mcp.json — team MCP servers injected per tool+scope key. */
+export type ManagedMcpManifest = Record<string, ManagedMcpRecord[]>;
+
+/** Path of the managed-MCP manifest for a scope. */
+export function managedMcpManifestPath(scope: Scope, projectRoot?: string): string {
+  return path.join(getTeamaiHome(scope, projectRoot), 'managed-mcp.json');
+}
+
 // ─── Global options ─────────────────────────────────────
 
 export interface GlobalOptions {
@@ -302,7 +384,7 @@ export const TEAMAI_STATE_PATH = `${TEAMAI_HOME}/state.json`;
 export const TEAMAI_TOKEN_PATH = `${TEAMAI_HOME}/token`;
 export const TEAMAI_UPDATE_LOCK_PATH = `${TEAMAI_HOME}/.update-lock`;
 
-export const RESOURCE_TYPES: ResourceType[] = ['skills', 'rules', 'docs', 'env', 'agents', 'hooks'];
+export const RESOURCE_TYPES: ResourceType[] = ['skills', 'rules', 'docs', 'env', 'agents', 'hooks', 'mcp'];
 
 export const TEAMAI_RULES_START = '<!-- [teamai:rules:start] -->';
 export const TEAMAI_RULES_END = '<!-- [teamai:rules:end] -->';

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,7 +170,12 @@ export const TeamaiConfigSchema = z.object({
     codex: { skills: '.codex/skills', rules: '.codex/rules', settings: '.codex/hooks.json', agents: '.codex/agents', mcp: '.codex/config.toml' },
     'codex-internal': { skills: '.codex-internal/skills', rules: '.codex-internal/rules', settings: '.codex-internal/hooks.json', agents: '.codex-internal/agents' },
     'claude-internal': { skills: '.claude-internal/skills', rules: '.claude-internal/rules', settings: '.claude-internal/settings.json', claudemd: '.claude-internal/CLAUDE.md', agents: '.claude-internal/agents' },
-    tclaude: { skills: '.tclaude/skills', rules: '.tclaude/rules', settings: '.tclaude/settings.json', claudemd: '.tclaude/CLAUDE.md', agents: '.tclaude/agents' },
+    // tclaude ships Claude Code with `customUserDataDir: .tclaude`, which
+    // relocates the whole user data dir — so its MCP file is
+    // ~/.tclaude/.claude.json, not ~/.tclaude.json. No mcpProject: project scope
+    // for the Claude family is <root>/.mcp.json, which the `claude` target
+    // already writes and tclaude reads from the same location.
+    tclaude: { skills: '.tclaude/skills', rules: '.tclaude/rules', settings: '.tclaude/settings.json', claudemd: '.tclaude/CLAUDE.md', agents: '.tclaude/agents', mcp: '.tclaude/.claude.json' },
     tcodex: { skills: '.tcodex/skills', rules: '.tcodex/rules', settings: '.tcodex/hooks.json', agents: '.tcodex/agents' },
     cursor: { skills: '.cursor/skills', rules: '.cursor/rules', settings: '.cursor/hooks.json', agents: '.cursor/agents', mcp: '.cursor/mcp.json' },
     codebuddy: { skills: '.codebuddy/skills', rules: '.codebuddy/rules', settings: '.codebuddy/settings.json', claudemd: '.codebuddy/CODEBUDDY.md', agents: '.codebuddy/agents', mcp: '.codebuddy/mcp.json' },

--- a/src/uninstall.ts
+++ b/src/uninstall.ts
@@ -542,6 +542,18 @@ export async function uninstall(opts: UninstallOptions): Promise<void> {
     }
 
     await executeRemoval(plan);
+
+    // MCP servers live in tool-owned config files tracked by their own manifest,
+    // so they are cleaned up through the reconcile engine rather than the plan.
+    try {
+      const { reconcileMcpForConfig } = await import('./mcp-reconcile.js');
+      const { changes } = await reconcileMcpForConfig(teamConfig, localConfig, { removeAll: true });
+      const removed = changes.filter((c) => c.action === 'removed');
+      if (removed.length > 0) log.info(`移除 ${removed.length} 个 teamai 管理的 MCP server`);
+    } catch (e) {
+      log.warn(`移除 MCP server 失败: ${(e as Error).message}`);
+    }
+
     log.success('teamai 卸载完成');
   } else {
     // Minimal uninstall — just try to remove ~/.teamai/


### PR DESCRIPTION
## Summary

Closes #251. Adds `mcp` as a seventh resource type: declare servers once in `mcp/mcp.yaml`, and `teamai pull` writes each installed tool's native config.

```yaml
# mcp/mcp.yaml
servers:
  - name: gpu-analysis
    transport: http
    url: https://gpubiz.woa.com/api/ai/mcp
    headers:
      Authorization: Bearer ${GPU_ANALYSIS_TOKEN}
  - name: context7
    transport: stdio
    command: npx
    args: ['-y', '@upstash/context7-mcp']
    requires: [npx]
```

## Why teamai rather than a committed `.mcp.json`

A committed `.mcp.json` only covers Claude Code at project scope, and cannot hold a secret. Other tools each want a different file shape; two of them are files teamai does not own (`~/.claude.json`, `~/.codex/config.toml`).

The engine never rewrites a whole file. It edits only the server keys it installed (`~/.teamai/managed-mcp.json`), writes atomically, and patches Codex at the text level so comments survive. Name collisions with hand-added servers skip unless `--force`.

## Secrets

Write `${VAR}`, never a literal. Resolve from the environment, then from `env/env.yaml` → `~/.teamai/env`.

Where a tool can keep secrets off its own file, teamai does:

- **Claude** project `.mcp.json` keeps the placeholder (Claude expands it).
- **Codex** names the variable (`bearer_token_env_var` / `env_http_headers`) instead of storing the value.

Anything else gets a resolved value at `0600`. In project scope, tools that cannot expand `${VAR}` skip secret-bearing servers rather than writing plaintext into a committed file.

## Fixes from end-to-end runs

Unit tests passed; these came from real tools:

1. **Project scope secret leak** — resolving `${VAR}` for tools that cannot expand it wrote plaintext into repo-tracked files. Now fail-closed.
2. **Project scope dead paths** — no fallback from `mcpProject` to the user-scope path; absent `mcpProject` means no project-scope support.
3. **Codex HTTP** — Codex supports streamable HTTP (`--url` / `bearer_token_env_var`); only `sse` is skipped. The old “skip http” test encoded the wrong assumption.

## Paths

| Tool | User scope | Project scope |
|---|---|---|
| claude | `~/.claude.json` | `<root>/.mcp.json` |
| cursor | `~/.cursor/mcp.json` | `<root>/.cursor/mcp.json` |
| codebuddy / workbuddy | `~/.<tool>/mcp.json` | `<root>/.<tool>/mcp.json` |
| codex | `~/.codex/config.toml` | not supported |

## Test plan

1808 unit tests, `tsc --noEmit`, and `npm run build` pass. Items below were run against a real team repo and a live HTTP MCP server, using each tool's own command.

- [x] User scope: `teamai pull` → Connected via `claude` / `codebuddy mcp list`
- [x] Codex: `codex exec` listed tools from the http server; no plaintext token in `config.toml`; inject-then-remove restores the file byte-for-byte
- [x] Project scope: `.mcp.json` keeps `${VAR}`; Connected in Claude; appears only inside the project (user scope cleared)
- [x] Unsetting the token → HTTP 401 (proves expansion)
- [x] Project-scope secret policy: cursor/codebuddy skip with a reason; no plaintext in the project
- [x] `sse` still skipped for Codex
- [x] `teamai mcp remove` / uninstall leave hand-added servers alone

Claude may show project `.mcp.json` servers as pending approval until accepted once interactively — documented, not bypassed.

## Docs

README kept short; usage-guide (both languages) covers the matrix, secrets, and project-scope policy.