### PR TITLE
feat(init): default to project scope and accept positional repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,16 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### 💥 破坏性变更
 
+- **`teamai init` 默认 scope 改为 project**（#250）：未传 `--scope` 时安装到 `<cwd>/.teamai/` 与 `<cwd>/.claude/...`，不再默认装到 `~/`。恢复旧行为：`teamai init <repo> --scope user`
+  - 远端 `teamai.yaml.scope` 不再锁定本机安装位置（`validateScopeMatch` 已移除）；本地 scope 仅由 CLI 决定
+  - 新建默认 `teamai.yaml` 不再写入 `scope:` 字段
 - **移除 `auto-recall` PostToolUse hook**：不再在 `Bash`/`Grep`/`WebSearch`/`WebFetch` 工具调用后被动、隐式地自动搜索团队知识库——这条链路噪音大、命中率低，且与更早前上线的 `teamai-recall` subagent（任务开始前主动检索，支持 codebase 图谱 drill-down、输出结构化摘要）功能重叠。已安装环境的 hooks 配置会在下次 `teamai pull` / `hooks inject` 时自动清理，无需手动迁移
   - `contribute-check` 的知识空白检测（Phase 2）改为由 `teamai recall`（手动 + `teamai-recall` subagent 均会触发）记录召回质量，缓存格式不变，功能保留
   - `TEAMAI_RECALL_DISABLED=1` 现在控制 `teamai recall` 的质量记录而非 auto-recall hook
 
 ### ✨ 新功能
 
+- **`teamai init <repo>` 位置参数**（#250）：推荐写法；`--repo` 永久保留为等价别名（无 deprecation 警告）
 - **跨 agent skills 视图**：`teamai list` 新增 `--source <repo|local|all>` 和 `--agent <id>` 参数（默认 `--source all`）。`local` / `all` 模式会扫描所有已安装 AI agent 的 skills 目录，每个 skill 标注来源 `[team]` / `[builtin]` / `[source:<name>]` / `[local-only]`。`--verbose` 时展开每个 agent 的 skill 列表与描述摘要。未安装的 agent 不出现在输出里
 - **Known agents 注册表**：内置 28 个 AI agent 路径（Claude Code / Cursor / Codex / Gemini CLI / Aider / Augment / Hermes / Copilot / KiloCode / Kiro / OpenCode / Qoder / Trae / Windsurf / WorkBuddy 等），自动检测哪些已安装。`teamai.yaml` 中显式配置的 `toolPaths` 优先生效
 - **`teamai skill` 子命令组**：

--- a/README.md
+++ b/README.md
@@ -30,19 +30,19 @@ npm install -g teamai-cli
 
 ### Team admin / solo user
 
-Create a shared-experience repo on your git host (GitHub, TGit, or CNB), **grant write access to team members**, then have them run `teamai init --repo https://github.com/yourorg/yourrepo`.
+Create a shared-experience repo on your git host (GitHub, TGit, or CNB), **grant write access to team members**, then have them run `teamai init https://github.com/yourorg/yourrepo`.
 
 > Solo use needs no separate repo setup: `teamai init` checks the target repo and creates it automatically if it doesn't exist.
 
 ### Team members
 
 ```bash
-# User-scope init (default, resources installed under ~/)
-teamai init --repo https://github.com/yourorg/yourrepo
-
-# Project-scope init (resources installed under the project directory)
+# Project-scope init (default, resources installed under the project directory)
 cd /path/to/my-project
-teamai init --repo https://github.com/yourorg/yourrepo --scope project
+teamai init https://github.com/yourorg/yourrepo
+
+# User-scope init (resources installed under ~/)
+teamai init https://github.com/yourorg/yourrepo --scope user
 ```
 
 Once initialized, every AI session automatically pulls the latest skills / rules and other Harness updates published by admins — no manual sync needed.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,19 +30,19 @@ npm install -g teamai-cli
 
 ### 团队管理员 / 个人使用者
 
-在 Git 托管平台（GitHub、TGit 或 CNB）创建共享经验仓库，**授予团队成员写权限**，然后让他们运行 `teamai init --repo https://github.com/yourorg/yourrepo`。
+在 Git 托管平台（GitHub、TGit 或 CNB）创建共享经验仓库，**授予团队成员写权限**，然后让他们运行 `teamai init https://github.com/yourorg/yourrepo`。
 
 > 个人使用无需单独建仓：`teamai init` 会检查目标仓库，不存在时自动创建。
 
 ### 团队成员
 
 ```bash
-# 用户级初始化（默认，资源安装到 ~/ 下）
-teamai init --repo https://github.com/yourorg/yourrepo
-
-# 项目级初始化（资源安装到项目目录下）
+# 项目级初始化（默认，资源安装到项目目录下）
 cd /path/to/my-project
-teamai init --repo https://github.com/yourorg/yourrepo --scope project
+teamai init https://github.com/yourorg/yourrepo
+
+# 用户级初始化（资源安装到 ~/ 下）
+teamai init https://github.com/yourorg/yourrepo --scope user
 ```
 
 初始化完成后，每次开启 AI 会话时都会自动拉取管理员发布的 skills / rules 等 Harness 更新，无需手动同步。

--- a/docs/ci-e2e-setup.md
+++ b/docs/ci-e2e-setup.md
@@ -76,7 +76,7 @@ GitHub repo → **Settings → Secrets and variables → Actions → Variables �
 | `dashboard -p 37210` | spawn Web 服务 + curl 验活 + kill |
 | `uninstall --dry-run` / `uninstall --force` | 卸载预览 + 真卸载 + 重建恢复 |
 | `roles set + pull` | 切换角色后 skill 集变化 |
-| `init --scope project --repo ... --force` | 全新 init（沙盒 cwd + 隔离 HOME） |
+| `init <repo> --force`（默认 project scope） | 全新 init（沙盒 cwd + 隔离 HOME） |
 
 不要 token 的部分：`--version` / `--help` / `tags --help` / `members --help` / `uninstall --help` / 源码 sanity check —— PR from forks 也能跑。
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -10,7 +10,7 @@ TeamAI CLI 通过 provider 抽象层支持多个 git 托管平台。当前实现
 
 ## Provider 自动检测
 
-`teamai init --repo <input>` 根据输入格式自动选择 provider：
+`teamai init <input>`（或等价别名 `teamai init --repo <input>`）根据输入格式自动选择 provider：
 
 ```
 yourorg/yourrepo                        → github（默认）
@@ -45,7 +45,7 @@ sudo apt install gh
 安装后运行 `gh auth login`，或直接让 `teamai init` 触发交互式登录：
 
 ```bash
-teamai init --repo yourorg/yourrepo
+teamai init yourorg/yourrepo
 # 检测到未登录时会自动调起 gh auth login --web
 ```
 
@@ -55,7 +55,7 @@ teamai init --repo yourorg/yourrepo
 
 ```bash
 export GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxx
-teamai init --repo yourorg/yourrepo
+teamai init yourorg/yourrepo
 ```
 
 token 需要 `repo` 权限。`GH_TOKEN` 作为别名也会被识别。
@@ -104,14 +104,14 @@ CNB（[云原生构建](https://cnb.cool)）provider 是对官方 CLI `@cnbcool/
 
 ```bash
 cnb login   # OAuth2 device flow，登录后 `cnb git-credential` 为 git 提供凭据
-teamai init --repo https://cnb.cool/yourorg/yourrepo
+teamai init https://cnb.cool/yourorg/yourrepo
 ```
 
 **方式 2：`CNB_TOKEN` 环境变量（headless / CI）**
 
 ```bash
 export CNB_TOKEN=xxxxxxxx
-teamai init --repo https://cnb.cool/yourorg/yourrepo
+teamai init https://cnb.cool/yourorg/yourrepo
 ```
 
 设置 `CNB_TOKEN` 后无需 `cnb login`。用户名从 `cnb users get-user-info` 解析，也可用 `CNB_USERNAME` 覆盖。

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -76,68 +76,15 @@ teamai --version
 
 Create an empty repository on GitHub, TGit (Tencent's internal Git host), or CNB (cnb.cool) (suggested naming: `TeamAi-<team-name>`), or simply run `teamai init` — if the repo doesn't exist yet, you'll be prompted to create it automatically.
 
-### User Scope
-
-Resources are installed into your home directory (`~/.claude/skills/`, etc.), suited for general team conventions and cross-project skills.
-
-```bash
-# --scope user is the default and can be omitted
-teamai init --repo <group>/TeamAi-<team>
-```
-
-Resulting directory structure:
-
-```
-~/.teamai/
-├── config.yaml          # Local config
-├── team-repo/            # Clone of the team repo
-│   ├── teamai.yaml      # Remote team config (scope: user)
-│   ├── skills/ rules/ docs/ env/ members/
-│   ├── manifest/roles.yaml  # Role definitions (when role-based skills are enabled)
-│   └── learnings/       # Team knowledge base
-~/.claude/skills/        # Team skills (auto-synced)
-~/.claude/rules/         # Team rules (auto-synced)
-```
-
-If the repo has role-based skills enabled (i.e. `manifest/roles.yaml` exists), `teamai init` will also interactively ask you to choose:
-
-- `primaryRole`: the target namespace for skill sync and push by default
-- `additionalRoles`: additional skill namespaces to sync
-
-You can also skip the interactive prompts via CLI flags for a fully non-interactive init (suitable for CI/CD or AI agents):
-
-```bash
-teamai init --repo <group>/TeamAi-<team> --scope user --role hai_dev --force
-```
-
-| Flag | Description |
-|------|------|
-| `--repo <url>` | Team repo URL (required) |
-| `--scope <user\|project>` | Scope, defaults to `user` |
-| `--role <id>` | Directly specify the primary role, skipping the interactive role prompt |
-| `--force` | Overwrite existing config, skipping confirmation prompts |
-
-Example local config:
-
-```yaml
-repo:
-  localPath: ~/.teamai/team-repo
-  remote: https://github.com/group/repo.git
-username: alice
-scope: user
-primaryRole: hai
-additionalRoles:
-  - pm
-resourceProfileVersion: 1
-```
-
-### Project Scope
+### Project Scope (default)
 
 Resources are installed under the project directory (`<project>/.claude/skills/`, etc.), suited for project-specific skills and rules.
 
 ```bash
+# project is the default — --scope can be omitted
 cd /path/to/my-project
-teamai init --repo <group>/TeamAi-<team> --scope project
+teamai init <group>/TeamAi-<team>
+# equivalent alias: teamai init --repo <group>/TeamAi-<team>
 ```
 
 Resulting directory structure:
@@ -152,15 +99,70 @@ Resulting directory structure:
 └── src/
 ```
 
+If the repo has role-based skills enabled (i.e. `manifest/roles.yaml` exists), `teamai init` will also interactively ask you to choose:
+
+- `primaryRole`: the target namespace for skill sync and push by default
+- `additionalRoles`: additional skill namespaces to sync
+
+You can also skip the interactive prompts via CLI flags for a fully non-interactive init (suitable for CI/CD or AI agents):
+
+```bash
+teamai init <group>/TeamAi-<team> --scope project --role hai_dev --force
+```
+
+| Flag | Description |
+|------|------|
+| `[repo]` / `--repo <url>` | Team repo URL (positional preferred; `--repo` is a permanent alias) |
+| `--scope <project\|user>` | Install scope, defaults to `project` (`<cwd>/.teamai`). Use `user` for `~/` |
+| `--role <id>` | Directly specify the primary role, skipping the interactive role prompt |
+| `--force` | Overwrite existing config, skipping confirmation prompts |
+
+Example local config:
+
+```yaml
+repo:
+  localPath: /path/to/my-project/.teamai/team-repo
+  remote: https://github.com/group/repo.git
+username: alice
+scope: project
+projectRoot: /path/to/my-project
+primaryRole: hai
+additionalRoles:
+  - pm
+resourceProfileVersion: 1
+```
+
+### User Scope
+
+Resources are installed into your home directory (`~/.claude/skills/`, etc.), suited for general team conventions and cross-project skills.
+
+```bash
+teamai init <group>/TeamAi-<team> --scope user
+```
+
+Resulting directory structure:
+
+```
+~/.teamai/
+├── config.yaml          # Local config
+├── team-repo/            # Clone of the team repo
+│   ├── teamai.yaml      # Remote team config
+│   ├── skills/ rules/ docs/ env/ members/
+│   ├── manifest/roles.yaml  # Role definitions (when role-based skills are enabled)
+│   └── learnings/       # Team knowledge base
+~/.claude/skills/        # Team skills (auto-synced)
+~/.claude/rules/         # Team rules (auto-synced)
+```
+
 ### How to Choose a Scope?
 
-| Dimension | User Scope (default) | Project Scope |
+| Dimension | Project Scope (default) | User Scope |
 |------|-------------------|---------------|
-| **Install location** | Under `~/` | Under the project directory |
-| **Best for** | General team conventions, cross-project skills | Project-specific skills and rules |
+| **Install location** | Under the project directory | Under `~/` |
+| **Best for** | Project-specific skills and rules | General team conventions, cross-project skills |
 | **Can coexist** | ✅ Yes, both scopes can be active at once | ✅ Yes, both scopes can be active at once |
 
-> **Scope lock-in:** When an admin runs `init` for the first time, the scope is written into the remote `teamai.yaml`. All subsequent member `init` runs must use the same scope.
+> **Local install location** is decided only by `teamai init`'s `--scope` (default `project`). A `scope` field in remote `teamai.yaml`, if present, is ignored.
 
 ---
 
@@ -168,20 +170,20 @@ Resulting directory structure:
 
 Once the admin shares the team repo URL with members:
 
-**User-scoped teams:**
-
-```bash
-npm install -g teamai-cli
-teamai init --repo <group>/TeamAi-<team>
-# Done! AI tools now automatically have access to team resources
-```
-
-**Project-scoped teams:**
+**Project-scoped teams (default):**
 
 ```bash
 npm install -g teamai-cli
 cd /path/to/my-project
-teamai init --repo <group>/TeamAi-<team> --scope project
+teamai init <group>/TeamAi-<team>
+# Done! AI tools now automatically have access to team resources
+```
+
+**User-scoped teams:**
+
+```bash
+npm install -g teamai-cli
+teamai init <group>/TeamAi-<team> --scope user
 ```
 
 **HTTP mode (read-only consumer):**
@@ -894,10 +896,10 @@ An HTTP source reports status and pulls skill commands via hook dispatch on ever
 
 ```yaml
 team: my-team
-scope: user                              # user or project
 description: Team AI resource repo
 repo: https://github.com/group/repo.git
 provider: github
+# scope: ignored if present — local install location is set by `teamai init --scope`
 
 reviewers:
   - reviewer1
@@ -906,7 +908,7 @@ sharing:
   rules:
     enforced: [code-review-guide]
   docs:
-    localDir: ~/.teamai/docs
+    localDir: ./.teamai/docs
   env:
     injectShellProfile: true
 ```
@@ -919,7 +921,7 @@ repo:
   remote: https://github.com/group/repo.git
 username: your-name
 updatePolicy: auto
-scope: user                    # or project
+scope: project                 # project (default from init) or user
 projectRoot: /path/to/project  # project scope only
 ```
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -74,68 +74,15 @@ teamai --version
 
 在 GitHub、TGit（腾讯工蜂）或 CNB（cnb.cool）上创建一个空仓库（命名建议：`TeamAi-<团队名>`），或者直接执行 `teamai init`，不存在时会提示自动创建。
 
-### 用户级（User Scope）
-
-资源安装到用户主目录（`~/.claude/skills/` 等），适用于通用团队规范、跨项目技能。
-
-```bash
-# --scope user 是默认值，可省略
-teamai init --repo <group>/TeamAi-<team>
-```
-
-生成的目录结构：
-
-```
-~/.teamai/
-├── config.yaml          # 本地配置
-├── team-repo/           # 团队仓库克隆
-│   ├── teamai.yaml      # 远端团队配置（scope: user）
-│   ├── skills/ rules/ docs/ env/ members/
-│   ├── manifest/roles.yaml  # 角色定义（启用角色化 skills 时）
-│   └── learnings/       # 团队知识库
-~/.claude/skills/        # 团队 skills（自动同步）
-~/.claude/rules/         # 团队 rules（自动同步）
-```
-
-如果仓库启用了角色化 skills（存在 `manifest/roles.yaml`），`teamai init` 还会交互式要求你选择：
-
-- `primaryRole`：默认 skill 同步和推送的目标 namespace
-- `additionalRoles`：额外需要同步的 skill namespace
-
-也可以通过 CLI 参数跳过交互，实现完全非交互式初始化（适合 CI/CD 或 AI agent）：
-
-```bash
-teamai init --repo <group>/TeamAi-<team> --scope user --role hai_dev --force
-```
-
-| 参数 | 说明 |
-|------|------|
-| `--repo <url>` | 团队仓库地址（必填） |
-| `--scope <user\|project>` | 作用域，默认 `user` |
-| `--role <id>` | 直接指定 primaryRole，跳过角色交互选择 |
-| `--force` | 覆盖已有配置，跳过确认提示 |
-
-本地配置示例：
-
-```yaml
-repo:
-  localPath: ~/.teamai/team-repo
-  remote: https://git.woa.com/group/repo.git
-username: alice
-scope: user
-primaryRole: hai
-additionalRoles:
-  - pm
-resourceProfileVersion: 1
-```
-
-### 项目级（Project Scope）
+### 项目级（Project Scope，默认）
 
 资源安装到项目目录下（`<project>/.claude/skills/` 等），适用于项目特定的技能和规则。
 
 ```bash
+# project 是默认值，可省略 --scope
 cd /path/to/my-project
-teamai init --repo <group>/TeamAi-<team> --scope project
+teamai init <group>/TeamAi-<team>
+# 等价别名：teamai init --repo <group>/TeamAi-<team>
 ```
 
 生成的目录结构：
@@ -150,15 +97,70 @@ teamai init --repo <group>/TeamAi-<team> --scope project
 └── src/
 ```
 
+如果仓库启用了角色化 skills（存在 `manifest/roles.yaml`），`teamai init` 还会交互式要求你选择：
+
+- `primaryRole`：默认 skill 同步和推送的目标 namespace
+- `additionalRoles`：额外需要同步的 skill namespace
+
+也可以通过 CLI 参数跳过交互，实现完全非交互式初始化（适合 CI/CD 或 AI agent）：
+
+```bash
+teamai init <group>/TeamAi-<team> --scope project --role hai_dev --force
+```
+
+| 参数 | 说明 |
+|------|------|
+| `[repo]` / `--repo <url>` | 团队仓库地址（推荐位置参数；`--repo` 为永久别名） |
+| `--scope <project\|user>` | 安装作用域，默认 `project`（`<cwd>/.teamai`）。需要装到 `~/` 时用 `user` |
+| `--role <id>` | 直接指定 primaryRole，跳过角色交互选择 |
+| `--force` | 覆盖已有配置，跳过确认提示 |
+
+本地配置示例：
+
+```yaml
+repo:
+  localPath: /path/to/my-project/.teamai/team-repo
+  remote: https://git.woa.com/group/repo.git
+username: alice
+scope: project
+projectRoot: /path/to/my-project
+primaryRole: hai
+additionalRoles:
+  - pm
+resourceProfileVersion: 1
+```
+
+### 用户级（User Scope）
+
+资源安装到用户主目录（`~/.claude/skills/` 等），适用于通用团队规范、跨项目技能。
+
+```bash
+teamai init <group>/TeamAi-<team> --scope user
+```
+
+生成的目录结构：
+
+```
+~/.teamai/
+├── config.yaml          # 本地配置
+├── team-repo/           # 团队仓库克隆
+│   ├── teamai.yaml      # 远端团队配置
+│   ├── skills/ rules/ docs/ env/ members/
+│   ├── manifest/roles.yaml  # 角色定义（启用角色化 skills 时）
+│   └── learnings/       # 团队知识库
+~/.claude/skills/        # 团队 skills（自动同步）
+~/.claude/rules/         # 团队 rules（自动同步）
+```
+
 ### 如何选择 Scope？
 
-| 维度 | User Scope（默认） | Project Scope |
+| 维度 | Project Scope（默认） | User Scope |
 |------|-------------------|---------------|
-| **资源安装位置** | `~/` 下 | 项目目录下 |
-| **适用场景** | 通用团队规范、跨项目技能 | 项目特定的技能和规则 |
+| **资源安装位置** | 项目目录下 | `~/` 下 |
+| **适用场景** | 项目特定的技能和规则 | 通用团队规范、跨项目技能 |
 | **能否共存** | ✅ 可以同时拥有两个 scope | ✅ 可以同时拥有两个 scope |
 
-> **Scope 锁定：** 管理员首次 init 时 scope 写入远端 `teamai.yaml`，后续成员 init 必须使用相同 scope。
+> **本机安装位置**仅由 `teamai init` 的 `--scope`（默认 `project`）决定。远端 `teamai.yaml` 中若仍有 `scope` 字段会被忽略。
 
 ---
 
@@ -166,20 +168,20 @@ teamai init --repo <group>/TeamAi-<team> --scope project
 
 管理员将团队仓库地址分享给成员后：
 
-**用户级团队：**
-
-```bash
-npm install -g @tencent/teamai-cli --registry=http://r.tnpm.oa.com
-teamai init --repo <group>/TeamAi-<team>
-# 完成！AI 工具已自动获得团队资源
-```
-
-**项目级团队：**
+**项目级团队（默认）：**
 
 ```bash
 npm install -g @tencent/teamai-cli --registry=http://r.tnpm.oa.com
 cd /path/to/my-project
-teamai init --repo <group>/TeamAi-<team> --scope project
+teamai init <group>/TeamAi-<team>
+# 完成！AI 工具已自动获得团队资源
+```
+
+**用户级团队：**
+
+```bash
+npm install -g @tencent/teamai-cli --registry=http://r.tnpm.oa.com
+teamai init <group>/TeamAi-<team> --scope user
 ```
 
 **HTTP 模式（只读消费者）：**
@@ -892,10 +894,10 @@ HTTP 源通过 hook dispatch 在每次 session 中上报状态并拉取 skill �
 
 ```yaml
 team: my-team
-scope: user                              # user 或 project
 description: 团队 AI 资源仓库
 repo: https://git.woa.com/group/repo.git
 provider: tgit
+# scope: 若存在则忽略——本机安装位置由 `teamai init --scope` 决定
 
 reviewers:
   - reviewer1
@@ -904,7 +906,7 @@ sharing:
   rules:
     enforced: [code-review-guide]
   docs:
-    localDir: ~/.teamai/docs
+    localDir: ./.teamai/docs
   env:
     injectShellProfile: true
 ```
@@ -917,7 +919,7 @@ repo:
   remote: https://git.woa.com/group/repo.git
 username: your-name
 updatePolicy: auto
-scope: user                    # 或 project
+scope: project                 # project（init 默认）或 user
 projectRoot: /path/to/project  # 仅 project scope
 ```
 

--- a/src/__tests__/e2e/e2e.test.ts
+++ b/src/__tests__/e2e/e2e.test.ts
@@ -686,8 +686,10 @@ describe('remote commands', () => {
 });
 
 // ─── Init project scope (sandboxed) ──────────────────────
-// Runs in a temp cwd with --scope project so it doesn't touch the
-// user-scope ~/.teamai/ that the rest of the suite depends on.
+// Runs in a temp cwd. Since #250, project is the default scope — we pass the
+// repo as a positional arg (recommended) and omit --scope.
+// HOME is isolated so we don't touch the user-scope ~/.teamai/ that the rest
+// of the suite depends on.
 //
 // GitHub-only: TGit's `gf` CLI authenticates via ~/.netrc, which we lose
 // when we isolate $HOME to a temp dir. `gf auth login` then triggers an
@@ -700,10 +702,13 @@ const PROVIDER_IS_GITHUB =
 
 describe('init project scope (sandboxed)', () => {
   it.skipIf(!CAN_RUN_REMOTE || !PROVIDER_IS_GITHUB)(
-    'teamai init --scope project --repo X --force — creates .teamai/',
+    'teamai init <repo> --force — default project scope creates .teamai/',
     async () => {
       const os = await import('node:os');
-      const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-init-'));
+      // Nested project dir so cwd !== HOME (E1 would otherwise fall back to user)
+      const homeSandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-init-home-'));
+      const sandbox = path.join(homeSandbox, 'project');
+      fs.mkdirSync(sandbox);
 
       try {
         const repoUrl = process.env.TEAMAI_TEST_REPO_URL ?? '';
@@ -718,13 +723,14 @@ describe('init project scope (sandboxed)', () => {
         const stdinAllBlanks = '\n\n\n\n\n';
 
         const result = await runCLIWithEnv(
-          ['init', '--scope', 'project', '--repo', fullUrl, '--role', 'common', '--force'],
+          // Positional repo; omit --scope to exercise the new project default (#250)
+          ['init', fullUrl, '--role', 'common', '--force'],
           {
             // GitHub: gh CLI / REST honors GITHUB_TOKEN
             // TGit: gf CLI honors TGIT_TOKEN
             GITHUB_TOKEN: process.env.TEAMAI_TEST_TOKEN ?? '',
             TGIT_TOKEN: process.env.TEAMAI_TEST_TOKEN ?? '',
-            HOME: sandbox, // isolate from user-scope ~/.teamai
+            HOME: homeSandbox, // isolate from user-scope ~/.teamai
             // Git identity must be set explicitly because HOME override
             // hides the global .gitconfig written by CI setup steps.
             GIT_AUTHOR_NAME: 'TeamAI CI',
@@ -733,11 +739,13 @@ describe('init project scope (sandboxed)', () => {
             GIT_COMMITTER_EMAIL: 'ci@teamai.test',
           },
           stdinAllBlanks,
-          sandbox, // cwd = sandbox, so .teamai/ lands here
+          sandbox, // cwd = project under HOME, so .teamai/ lands here
         );
 
         expect(result.code, `init failed with output:\n${result.output}`).toBe(0);
         expect(fs.existsSync(path.join(sandbox, '.teamai', 'config.yaml'))).toBe(true);
+        // Default scope must not write into HOME/.teamai
+        expect(fs.existsSync(path.join(homeSandbox, '.teamai', 'config.yaml'))).toBe(false);
 
         // Verify the project-scope config has the expected shape
         const cfg = fs.readFileSync(
@@ -746,8 +754,10 @@ describe('init project scope (sandboxed)', () => {
         );
         expect(cfg).toContain('repo:');
         expect(cfg).toContain('localPath');
+        expect(cfg).toMatch(/scope:\s*project/);
+        expect(result.output).toMatch(/Scope: project/);
       } finally {
-        fs.rmSync(sandbox, { recursive: true, force: true });
+        fs.rmSync(homeSandbox, { recursive: true, force: true });
       }
     },
     // init does fixture clone + member push, which is slow on CI runners.

--- a/src/__tests__/http-repo-integration.test.ts
+++ b/src/__tests__/http-repo-integration.test.ts
@@ -45,7 +45,7 @@ describe('teamai init --http (read-only onboarding)', () => {
     server = await startMockServer({ apiKey: API_KEY });
 
     const { init } = await import('../init.js');
-    await init({ http: server.url, force: true });
+    await init({ http: server.url, force: true, scope: 'user' });
 
     // Local config written with kind:http and only the URL (no key).
     const cfg = YAML.parse(fs.readFileSync(path.join(tmpDir, '.teamai', 'config.yaml'), 'utf-8'));
@@ -66,7 +66,7 @@ describe('read-only protection (http kind)', () => {
     server = await startMockServer({ apiKey: API_KEY });
 
     const { init } = await import('../init.js');
-    await init({ http: server.url, force: true });
+    await init({ http: server.url, force: true, scope: 'user' });
 
     const originalCwd = process.cwd();
     process.chdir(tmpDir);

--- a/src/__tests__/init-scope-default.test.ts
+++ b/src/__tests__/init-scope-default.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { resolveInitScope, resolveInitRepo } from '../init.js';
+
+describe('resolveInitScope', () => {
+  const cwd = '/tmp/my-project';
+  const home = '/home/alice';
+
+  it('defaults to project with projectRoot = cwd when scope is omitted', () => {
+    const result = resolveInitScope(undefined, cwd, home);
+    expect(result).toEqual({
+      scope: 'project',
+      projectRoot: cwd,
+      explicit: false,
+    });
+  });
+
+  it('uses user scope when --scope user is explicit', () => {
+    const result = resolveInitScope('user', cwd, home);
+    expect(result).toEqual({
+      scope: 'user',
+      projectRoot: undefined,
+      explicit: true,
+    });
+  });
+
+  it('uses project scope when --scope project is explicit', () => {
+    const result = resolveInitScope('project', cwd, home);
+    expect(result).toEqual({
+      scope: 'project',
+      projectRoot: cwd,
+      explicit: true,
+    });
+  });
+
+  it('throws on invalid scope values', () => {
+    expect(() => resolveInitScope('global', cwd, home)).toThrow(/Invalid scope "global"/);
+    expect(() => resolveInitScope('workspace', cwd, home)).toThrow(/Invalid scope/);
+  });
+
+  it('falls back to user when cwd === home and scope is implicit (E1)', () => {
+    const result = resolveInitScope(undefined, home, home);
+    expect(result.scope).toBe('user');
+    expect(result.projectRoot).toBeUndefined();
+    expect(result.explicit).toBe(false);
+    expect(result.fallbackReason).toMatch(/home directory/);
+  });
+
+  it('treats symlink-equivalent cwd/home as the same path (macOS /var vs /private/var)', () => {
+    // Use the real process HOME/tmpdir pair when they resolve to the same inode
+    // via realpath; otherwise simulate with identical logical paths.
+    const result = resolveInitScope(undefined, '/tmp', '/tmp');
+    // /tmp may realpath to /private/tmp on macOS — both args go through realpath
+    expect(result.scope).toBe('user');
+    expect(result.fallbackReason).toMatch(/home directory/);
+  });
+
+  it('throws when --scope project is explicit and cwd === home (E1)', () => {
+    expect(() => resolveInitScope('project', home, home)).toThrow(
+      /Cannot use --scope project in your home directory/,
+    );
+  });
+
+  it('allows explicit --scope user when cwd === home', () => {
+    const result = resolveInitScope('user', home, home);
+    expect(result).toEqual({
+      scope: 'user',
+      projectRoot: undefined,
+      explicit: true,
+    });
+  });
+});
+
+describe('resolveInitRepo', () => {
+  it('uses positional when only positional is set', () => {
+    expect(resolveInitRepo('owner/repo', undefined)).toBe('owner/repo');
+  });
+
+  it('uses --repo when only --repo is set (no deprecation)', () => {
+    expect(resolveInitRepo(undefined, 'owner/repo')).toBe('owner/repo');
+  });
+
+  it('accepts identical positional and --repo', () => {
+    expect(resolveInitRepo('owner/repo', 'owner/repo')).toBe('owner/repo');
+  });
+
+  it('throws when positional and --repo conflict', () => {
+    expect(() => resolveInitRepo('a/b', 'c/d')).toThrow(/Conflicting repo values/);
+  });
+
+  it('returns undefined when neither is set', () => {
+    expect(resolveInitRepo(undefined, undefined)).toBeUndefined();
+    expect(resolveInitRepo('', '  ')).toBeUndefined();
+  });
+
+  it('trims whitespace', () => {
+    expect(resolveInitRepo('  owner/repo  ', undefined)).toBe('owner/repo');
+    expect(resolveInitRepo(undefined, '  owner/repo  ')).toBe('owner/repo');
+  });
+});

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -83,11 +83,15 @@ vi.mock('../providers/tgit/gf-cli.js', () => {
 vi.mock('../config.js', () => ({
   saveLocalConfig: vi.fn(),
   saveLocalConfigForScope: vi.fn(),
+  loadLocalConfigForScope: vi.fn().mockResolvedValue(null),
   loadTeamConfig: vi.fn().mockResolvedValue(null),
+  loadStateForScope: vi.fn().mockRejectedValue(new Error('no state')),
+  saveStateForScope: vi.fn(),
 }));
 
 vi.mock('../hooks.js', () => ({
   injectHooksToAllTools: vi.fn(),
+  reconcileTeamHooksForConfig: vi.fn(),
 }));
 
 vi.mock('../roles.js', () => ({
@@ -432,10 +436,13 @@ describe('init', () => {
   });
 
   describe('scope path display', () => {
-    it('should display storage paths when scope is not provided via flag', async () => {
+    it('should default to project scope and print summary when --scope is omitted', async () => {
+      const projectLocalPath = path.join(process.cwd(), '.teamai', 'team-repo');
       let cloneDone = false;
       pathExistsFn = (p: string) => {
-        if (p === localPath) return cloneDone;
+        if (p === projectLocalPath) return cloneDone;
+        // Treat cwd as inside a git repo so E2 warn is skipped in this test
+        if (p.endsWith(`${path.sep}.git`) || p.endsWith('/.git')) return true;
         return false;
       };
 
@@ -443,20 +450,25 @@ describe('init', () => {
         cloneDone = true;
       });
 
-      // Answers: scope (user via default), configure reviewers (n), primary role (1)
-      questionAnswers = ['user', 'n', '1'];
+      // Answers: configure reviewers (n), primary role (1) — no scope prompt
+      questionAnswers = ['n', '1'];
 
       const { log } = await import('../utils/logger.js');
+      const { saveLocalConfigForScope } = await import('../config.js');
 
       await init({ repo: 'https://git.woa.com/HyperAI/teamai-test.git' });
 
-      // Verify that path hints were displayed
-      expect(log.info).toHaveBeenCalledWith(expect.stringContaining('user'));
-      expect(log.info).toHaveBeenCalledWith(expect.stringContaining('.teamai/'));
-      expect(log.info).toHaveBeenCalledWith(expect.stringContaining('project'));
+      expect(log.info).toHaveBeenCalledWith(expect.stringMatching(/^Scope: project /));
+      expect(log.info).toHaveBeenCalledWith(expect.stringContaining('config    →'));
+      expect(log.info).toHaveBeenCalledWith(expect.stringContaining('--scope user'));
+      expect(saveLocalConfigForScope).toHaveBeenCalledWith(
+        expect.objectContaining({ scope: 'project', projectRoot: process.cwd() }),
+        'project',
+        process.cwd(),
+      );
     });
 
-    it('should not display storage paths when scope is provided via --scope flag', async () => {
+    it('should print scope summary without interactive Select scope when --scope is provided', async () => {
       let cloneDone = false;
       pathExistsFn = (p: string) => {
         if (p === localPath) return cloneDone;
@@ -475,13 +487,47 @@ describe('init', () => {
 
       await init({ repo: 'https://git.woa.com/HyperAI/teamai-test.git', scope: 'user' });
 
-      // When --scope is provided, the path hints are NOT shown before the prompt
-      // (they appear in the "Scope: user" line only)
-      const infoCalls = vi.mocked(log.info).mock.calls.map(c => c[0]);
-      const pathHintCalls = infoCalls.filter(
-        (msg: string) => msg.includes('user    →') || msg.includes('project →'),
+      expect(log.info).toHaveBeenCalledWith(expect.stringMatching(/^Scope: user$/));
+      const infoCalls = vi.mocked(log.info).mock.calls.map(c => String(c[0]));
+      expect(infoCalls.some((msg) => msg.includes('Select scope:'))).toBe(false);
+      expect(infoCalls.some((msg) => msg.includes('Scope [1/2]'))).toBe(false);
+    });
+
+    it('should ignore remote teamai.yaml.scope and succeed with local project scope', async () => {
+      const projectLocalPath = path.join(process.cwd(), '.teamai', 'team-repo');
+      let cloneDone = false;
+      pathExistsFn = (p: string) => {
+        if (p === projectLocalPath) return cloneDone;
+        if (p.endsWith(`${path.sep}.git`) || p.endsWith('/.git')) return true;
+        return false;
+      };
+
+      mockGfRepoClone.mockImplementation(() => {
+        cloneDone = true;
+      });
+
+      const { loadTeamConfig, saveLocalConfigForScope } = await import('../config.js');
+      vi.mocked(loadTeamConfig).mockResolvedValue({
+        team: 'remote-team',
+        description: '',
+        repo: 'https://git.woa.com/HyperAI/teamai-test.git',
+        provider: 'tgit',
+        scope: 'user',
+        reviewers: [],
+        sharing: { rules: { enforced: [] }, docs: {}, env: { injectShellProfile: true } },
+        toolPaths: {},
+      } as never);
+
+      questionAnswers = ['n', '1'];
+
+      await init({ repo: 'https://git.woa.com/HyperAI/teamai-test.git' });
+
+      expect(mockExit).not.toHaveBeenCalled();
+      expect(saveLocalConfigForScope).toHaveBeenCalledWith(
+        expect.objectContaining({ scope: 'project' }),
+        'project',
+        process.cwd(),
       );
-      expect(pathHintCalls).toHaveLength(0);
     });
   });
 });

--- a/src/__tests__/scope.test.ts
+++ b/src/__tests__/scope.test.ts
@@ -12,7 +12,6 @@ import {
   getStatePath,
   type LocalConfig,
 } from '../types.js';
-import { validateScopeMatch } from '../init.js';
 import {
   detectProjectConfig,
   loadLocalConfigForScope,
@@ -451,33 +450,6 @@ describe('TeamaiConfigSchema with scope', () => {
   it('should reject invalid scope values', () => {
     expect(() => TeamaiConfigSchema.parse({ ...baseTeamConfig, scope: 'global' })).toThrow();
     expect(() => TeamaiConfigSchema.parse({ ...baseTeamConfig, scope: 123 })).toThrow();
-  });
-});
-
-// ─── validateScopeMatch tests ────────────────────────────
-
-describe('validateScopeMatch', () => {
-  it('should allow matching scopes (user/user)', () => {
-    expect(() => validateScopeMatch('user', 'user')).not.toThrow();
-  });
-
-  it('should allow matching scopes (project/project)', () => {
-    expect(() => validateScopeMatch('project', 'project')).not.toThrow();
-  });
-
-  it('should reject mismatched scopes (user remote, project local)', () => {
-    expect(() => validateScopeMatch('user', 'project')).toThrow(/Scope mismatch/);
-    expect(() => validateScopeMatch('user', 'project')).toThrow(/--scope project/);
-  });
-
-  it('should reject mismatched scopes (project remote, user local)', () => {
-    expect(() => validateScopeMatch('project', 'user')).toThrow(/Scope mismatch/);
-    expect(() => validateScopeMatch('project', 'user')).toThrow(/--scope user/);
-  });
-
-  it('should allow any local scope when remote is undefined (legacy repo)', () => {
-    expect(() => validateScopeMatch(undefined, 'user')).not.toThrow();
-    expect(() => validateScopeMatch(undefined, 'project')).not.toThrow();
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,17 +22,18 @@ program
 program
   .command('init')
   .description('Initialize teamai (configure TGit, clone repo, register member)')
-  .option('--repo <repo>', 'Team repo (owner/repo or full URL)')
+  .argument('[repo]', 'Team repo (owner/repo or full URL)')
+  .option('--repo <repo>', 'Team repo (alias of the positional argument)')
   .option('--http <url>', 'Git-free HTTP team repo (read-only consumer; only needs an API key)')
   .option('--token <key>', 'API key for HTTP team repo / status reporting (stored 0600, never committed). Also reads TEAMAI_API_TOKEN.')
-  .option('--scope <scope>', 'Scope: user (default) or project')
+  .option('--scope <scope>', 'Install scope: project (default, <cwd>/.teamai + <cwd>/.claude) or user (~/.teamai + ~/.claude)')
   .option('--role <id>', 'Primary role ID (e.g. hai_dev) for non-interactive setup')
   .option('--agent <name>', 'Only inject hooks into this agent (e.g. claude, codebuddy, workbuddy). Additive on repeated runs.')
   .option('--force', 'Overwrite existing config without confirmation')
-  .action(async (cmdOpts) => {
+  .action(async (repoArg, cmdOpts) => {
     const globalOpts = program.opts() as GlobalOptions;
     const { init } = await import('./init.js');
-    await init({ ...globalOpts, ...cmdOpts });
+    await init({ ...globalOpts, ...cmdOpts, repoPositional: repoArg });
   });
 
 program

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,4 +1,5 @@
 import YAML from 'yaml';
+import fs from 'node:fs';
 import path from 'node:path';
 import { saveLocalConfig, loadTeamConfig, saveLocalConfigForScope, loadLocalConfigForScope, loadStateForScope, saveStateForScope } from './config.js';
 import { reconcileTeamHooksForConfig } from './hooks.js';
@@ -10,6 +11,16 @@ import { log, spinner } from './utils/logger.js';
 import { TEAMAI_HOME, type GlobalOptions, type LocalConfig, type Scope, getTeamaiHome, getConfigPath } from './types.js';
 import { describeRoles, loadRolesManifest } from './roles.js';
 import { askQuestion, askConfirmation, closePrompt } from './utils/prompt.js';
+
+/** Resolve + realpath so macOS /var → /private/var (and similar) compare equal. */
+function resolveRealPath(p: string): string {
+  const resolved = path.resolve(p);
+  try {
+    return fs.realpathSync(resolved);
+  } catch {
+    return resolved;
+  }
+}
 
 function parseRoleSelection(answer: string, max: number): number[] {
   if (!answer.trim()) return [];
@@ -86,17 +97,100 @@ async function promptForRoleProfile(
 }
 
 /**
- * Validate that the local --scope matches the remote repo's declared scope.
- * Legacy repos (scope undefined) allow any local scope.
+ * Resolve init install scope from `--scope` / default.
+ *
+ * - Explicit `user` / `project` → use as-is (`explicit: true`)
+ * - Invalid value → throw
+ * - Omitted → **project** (cwd), unless cwd === home (E1: fall back to user)
+ *
+ * Local install location is decided only by the CLI; remote `teamai.yaml.scope`
+ * is ignored (see issue #250).
  */
-export function validateScopeMatch(remoteScope: Scope | undefined, localScope: Scope): void {
-  if (remoteScope === undefined) return; // legacy repo — no restriction
-  if (remoteScope !== localScope) {
+export function resolveInitScope(
+  rawScope: string | undefined,
+  cwd: string,
+  homeDir: string,
+): { scope: Scope; projectRoot?: string; explicit: boolean; fallbackReason?: string } {
+  const cwdResolved = resolveRealPath(cwd);
+  const homeResolved = resolveRealPath(homeDir);
+  const atHome = cwdResolved === homeResolved;
+
+  if (rawScope !== undefined && rawScope !== '') {
+    if (rawScope !== 'user' && rawScope !== 'project') {
+      throw new Error(`Invalid scope "${rawScope}". Use "project" (default) or "user".`);
+    }
+    if (rawScope === 'project' && atHome) {
+      throw new Error(
+        'Cannot use --scope project in your home directory (paths would collide with user scope). ' +
+        'cd to a project directory first, or omit --scope / use --scope user.',
+      );
+    }
+    return {
+      scope: rawScope,
+      projectRoot: rawScope === 'project' ? cwdResolved : undefined,
+      explicit: true,
+    };
+  }
+
+  // Implicit default: project, with E1 fallback when cwd is $HOME
+  if (atHome) {
+    return {
+      scope: 'user',
+      projectRoot: undefined,
+      explicit: false,
+      fallbackReason:
+        'cwd is your home directory; using user scope to avoid path collision with ~/.teamai',
+    };
+  }
+
+  return {
+    scope: 'project',
+    projectRoot: cwdResolved,
+    explicit: false,
+  };
+}
+
+/**
+ * Merge positional `teamai init <repo>` with `--repo` alias.
+ * `--repo` is permanently kept as an equivalent alias (no deprecation warning).
+ */
+export function resolveInitRepo(
+  positional: string | undefined,
+  repoFlag: string | undefined,
+): string | undefined {
+  const pos = positional?.trim() || undefined;
+  const flag = repoFlag?.trim() || undefined;
+  if (pos && flag && pos !== flag) {
     throw new Error(
-      `Scope mismatch: this repo is configured as "${remoteScope}" scope, ` +
-      `but you are trying to init with --scope ${localScope}. ` +
-      `Please use --scope ${remoteScope}.`,
+      `Conflicting repo values: positional "${pos}" vs --repo "${flag}". Pass only one.`,
     );
+  }
+  return pos ?? flag;
+}
+
+function printScopeSummary(
+  scope: Scope,
+  projectRoot: string | undefined,
+  explicit: boolean,
+): void {
+  const configPath = getConfigPath(scope, projectRoot);
+  const baseDir = scope === 'project' ? (projectRoot ?? process.cwd()) : (process.env.HOME ?? '~');
+  log.info(`Scope: ${scope}${scope === 'project' ? ` (${projectRoot})` : ''}`);
+  log.info(`  config    → ${configPath}`);
+  log.info(`  resources → ${baseDir}/.claude/skills, ...`);
+  if (!explicit && scope === 'project') {
+    log.info('  Tip: run with `--scope user` to install under your home directory (~/)');
+  }
+}
+
+/** Walk up from dir looking for a `.git` entry (file or directory). */
+async function isInsideGitRepo(dir: string): Promise<boolean> {
+  let current = path.resolve(dir);
+  for (;;) {
+    if (await pathExists(path.join(current, '.git'))) return true;
+    const parent = path.dirname(current);
+    if (parent === current) return false;
+    current = parent;
   }
 }
 
@@ -114,11 +208,31 @@ export async function initHttp(
 
   log.info('Initializing teamai (HTTP read-only consumer)...');
 
-  // Step 0: scope
-  let scope: Scope = options.scope === 'project' ? 'project' : 'user';
-  const projectRoot = scope === 'project' ? process.cwd() : undefined;
+  // Step 0: scope (same rules as git init — default project)
+  let scope: Scope;
+  let projectRoot: string | undefined;
+  let explicit: boolean;
+  let fallbackReason: string | undefined;
+  try {
+    ({ scope, projectRoot, explicit, fallbackReason } = resolveInitScope(
+      options.scope,
+      process.cwd(),
+      process.env.HOME ?? '',
+    ));
+  } catch (e) {
+    log.error((e as Error).message);
+    process.exit(1);
+    return;
+  }
+  if (fallbackReason) {
+    log.warn(fallbackReason);
+  }
   const teamaiHome = getTeamaiHome(scope, projectRoot);
-  log.info(`Scope: ${scope}${scope === 'project' ? ` (${projectRoot})` : ''}`);
+  printScopeSummary(scope, projectRoot, explicit);
+
+  if (scope === 'project' && !(await isInsideGitRepo(process.cwd()))) {
+    log.warn(`cwd is not inside a git repository; will create ${teamaiHome}/`);
+  }
 
   // Re-init guard
   const existingConfigPath = getConfigPath(scope, projectRoot);
@@ -218,33 +332,46 @@ export async function initHttp(
   closePrompt();
 }
 
-export async function init(options: GlobalOptions & { repo?: string; scope?: string; role?: string; agent?: string; force?: boolean; http?: string; token?: string }): Promise<void> {
+export async function init(options: GlobalOptions & {
+  repo?: string;
+  repoPositional?: string;
+  scope?: string;
+  role?: string;
+  agent?: string;
+  force?: boolean;
+  http?: string;
+  token?: string;
+}): Promise<void> {
   if (options.http) {
     return initHttp(options.http, options);
   }
   log.info('Initializing teamai...');
 
-  // Step 0: Determine scope (user or project)
-  let scope: Scope = 'user';
-  if (options.scope === 'project' || options.scope === 'user') {
-    scope = options.scope as Scope;
-  } else {
-    const userPath = getTeamaiHome('user');
-    const projectPath = getTeamaiHome('project', process.cwd());
-    log.info('Select scope:');
-    log.info(`  1. user    → ${userPath}/`);
-    log.info(`  2. project → ${projectPath}/`);
-    const scopeAnswer = await askQuestion('Scope [1/2] (default: 1): ', '1');
-    const normalizedScope = scopeAnswer.trim().toLowerCase();
-    if (normalizedScope === '2' || normalizedScope === 'project') {
-      scope = 'project';
-    }
+  // Step 0: Resolve scope (default project; only explicit --scope user → ~/ )
+  let scope: Scope;
+  let projectRoot: string | undefined;
+  let explicit: boolean;
+  let fallbackReason: string | undefined;
+  try {
+    ({ scope, projectRoot, explicit, fallbackReason } = resolveInitScope(
+      options.scope,
+      process.cwd(),
+      process.env.HOME ?? '',
+    ));
+  } catch (e) {
+    log.error((e as Error).message);
+    process.exit(1);
+    return;
   }
-
-  const projectRoot = scope === 'project' ? process.cwd() : undefined;
+  if (fallbackReason) {
+    log.warn(fallbackReason);
+  }
   const teamaiHome = getTeamaiHome(scope, projectRoot);
+  printScopeSummary(scope, projectRoot, explicit);
 
-  log.info(`Scope: ${scope}${scope === 'project' ? ` (${projectRoot})` : ''}`);
+  if (scope === 'project' && !(await isInsideGitRepo(process.cwd()))) {
+    log.warn(`cwd is not inside a git repository; will create ${teamaiHome}/`);
+  }
 
   // Step 0.5: Re-init guard — warn if config already exists
   const existingConfigPath = getConfigPath(scope, projectRoot);
@@ -261,8 +388,15 @@ export async function init(options: GlobalOptions & { repo?: string; scope?: str
     }
   }
 
-  // Step 1: Get repo input first (needed to detect provider)
-  let repoInput = options.repo ?? '';
+  // Step 1: Get repo input (positional or --repo alias; prompt if neither)
+  let repoInput = '';
+  try {
+    repoInput = resolveInitRepo(options.repoPositional, options.repo) ?? '';
+  } catch (e) {
+    log.error((e as Error).message);
+    process.exit(1);
+    return;
+  }
   if (!repoInput) {
     repoInput = await askQuestion('Team repo (e.g. yourteam/yourproject or https://github.com/org/repo): ');
   }
@@ -386,12 +520,13 @@ export async function init(options: GlobalOptions & { repo?: string; scope?: str
   await configureGitUser(localPath, username, username, undefined, emailDomain);
 
   // Step 4: Load team config
+  // Remote teamai.yaml.scope (if present) is ignored — local install location
+  // is decided only by --scope / default (issue #250).
   const teamConfig = await loadTeamConfig(localPath);
   if (!teamConfig) {
     log.warn('teamai.yaml not found in repo. Creating default config...');
     const defaultConfig = YAML.stringify({
       team: 'my-team',
-      scope,
       description: 'TeamAI shared resources',
       repo: repoInfo.httpsUrl,
       provider: providerName,
@@ -410,14 +545,6 @@ export async function init(options: GlobalOptions & { repo?: string; scope?: str
       if (!await pathExists(gitkeep)) {
         await writeFile(gitkeep, '');
       }
-    }
-  } else {
-    // Existing repo — validate that remote scope matches local scope
-    try {
-      validateScopeMatch(teamConfig.scope, scope);
-    } catch (e) {
-      log.error((e as Error).message);
-      process.exit(1);
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,7 +151,10 @@ export const TeamaiConfigSchema = z.object({
   repo: z.string(),
   /** Git hosting provider: 'tgit' | 'github'. Defaults to 'tgit' for backward compatibility. */
   provider: z.enum(['tgit', 'github']).default('tgit'),
-  /** Repo scope set at creation time; undefined = legacy repo (no restriction). */
+  /**
+   * @deprecated Ignored by `teamai init` (issue #250). Local install scope is
+   * decided only by CLI `--scope` / default. Kept optional for old teamai.yaml files.
+   */
   scope: ScopeEnum.optional(),
   reviewers: z.array(z.string()).default([]),
   /** Skills this team makes available to other teams via cross-team subscription. */
@@ -211,6 +214,8 @@ export const LocalConfigSchema = z.object({
   }),
   username: z.string(),
   updatePolicy: z.enum(['auto', 'prompt', 'skip']).optional(),
+  // Read-compat default for historical configs that omit `scope` (pre-project era).
+  // NOT the write default for `teamai init` — init defaults to project (issue #250).
   scope: ScopeEnum.default('user'),
   primaryRole: z.string().min(1).optional(),
   additionalRoles: z.array(z.string()).default([]),


### PR DESCRIPTION
## Summary

- Closes #250: `teamai init` without `--scope` now defaults to **project** (`<cwd>/.teamai` + `<cwd>/.claude/...`); restore previous behavior with `--scope user`.
- Supports positional `teamai init <repo>`; `--repo` remains a permanent equivalent alias (conflict errors if both differ).
- Stops locking local install location to remote `teamai.yaml.scope` (`validateScopeMatch` removed); new default `teamai.yaml` no longer writes `scope:`.
- Adds E1 (cwd === `$HOME` realpath-aware fallback / block) and E2 (warn when not inside a git repo) guards; updates bilingual docs + CHANGELOG breaking note.

## Test plan

- [x] `npx vitest run src/__tests__/init-scope-default.test.ts src/__tests__/init.test.ts src/__tests__/scope.test.ts`
- [x] `npx tsc --noEmit` + `npm run build`
- [x] Real CLI early-path checks: `--help`, conflicting positional/`--repo`, invalid scope, default project summary + tip, E1 fallback/block, `--scope user`, `--repo` alias
- [ ] CI remote e2e: `teamai init <repo> --force` sandboxed case (needs `TEAMAI_TEST_*` / GitHub token)
- [ ] Manual: after authenticated init, `teamai status` / `teamai pull` in the project directory
- [ ] Manual: remote `teamai.yaml` with `scope: user` + local default project → init succeeds, local config is project


Made with [Cursor](https://cursor.com)