### PR TITLE
fix(mcp): reject requires entries with shell metacharacters

### DIFF
--- a/src/__tests__/mcp-reconcile.test.ts
+++ b/src/__tests__/mcp-reconcile.test.ts
@@ -344,6 +344,28 @@ servers:
     expect(await fse.pathExists(path.join(homeDir, '.codebuddy', 'mcp.json'))).toBe(false);
   });
 
+  it('rejects a requires entry with shell metacharacters instead of running it', async () => {
+    const marker = path.join(tmpDir, 'requires-injection-proof');
+    await writeMcpYaml(`
+servers:
+  - name: evil
+    transport: stdio
+    command: echo
+    requires:
+      - "echo; touch ${marker}"
+`);
+
+    const { changes } = await reconcileMcpForConfig(teamConfig, localConfig);
+
+    // The injected command must never have executed.
+    expect(await fse.pathExists(marker)).toBe(false);
+
+    // The server is skipped with an invalid-name reason, not installed.
+    const skipped = changes.find((c) => c.server === 'evil' && c.action === 'skipped');
+    expect(skipped?.reason).toMatch(/invalid name/);
+    expect(changes.some((c) => c.server === 'evil' && c.action === 'added')).toBe(false);
+  });
+
   // Verified against codex-cli 0.142.5: it speaks streamable HTTP, and names the
   // env var for a bearer token rather than storing the value.
   it('writes an http server into codex config.toml, naming the token env var', async () => {

--- a/src/mcp-reconcile.ts
+++ b/src/mcp-reconcile.ts
@@ -134,6 +134,9 @@ function policyViolation(def: McpServerDef, sharing: ReturnType<typeof getMcpSha
   return null;
 }
 
+/** An executable name — no path separators or shell metacharacters. */
+const SAFE_BIN_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
 /** True when every executable in `requires` is on PATH. */
 async function requirementsMet(def: McpServerDef): Promise<string | null> {
   if (!def.requires?.length) return null;
@@ -141,6 +144,13 @@ async function requirementsMet(def: McpServerDef): Promise<string | null> {
   const { promisify } = await import('node:util');
   const run = promisify(execFile);
   for (const bin of def.requires) {
+    // `requires` comes from the team repo's mcp.yaml. `command -v` runs under a
+    // shell (builtin), so an unvalidated name like `npx; rm -rf ~` would be
+    // executed. A bare executable name has no shell metacharacters, so reject
+    // anything else rather than pass it to the shell.
+    if (!SAFE_BIN_RE.test(bin)) {
+      return `required executable "${bin}" has an invalid name`;
+    }
     try {
       await run('command', ['-v', bin], { shell: '/bin/sh' });
     } catch {


### PR DESCRIPTION
## Problem

`requirementsMet` in `src/mcp-reconcile.ts` verifies each `requires` executable via:

```ts
await run('command', ['-v', bin], { shell: '/bin/sh' });
```

`bin` comes directly from the team repo's `mcp/mcp.yaml`. Because `command -v` runs under a shell, a crafted `requires` value is executed as shell code — **command injection** on any member's machine during `teamai pull` / `teamai mcp inject`.

```yaml
servers:
  - name: evil
    transport: stdio
    command: echo
    requires:
      - "npx; rm -rf ~"   # the part after `;` runs
```

Confirmed exploitable locally: a `requires` value of `echo; touch /tmp/PROOF` created the marker file. This is pre-existing (introduced in #252), independent of the MCP secret-writing change in #258.

## Change

Validate every `requires` name against `^[A-Za-z0-9][A-Za-z0-9._-]*$` before it reaches the shell. A genuine executable name has no shell metacharacters, so anything else is rejected with an `invalid name` skip reason instead of being run. Legitimate entries like `npx` are unaffected.

Kept the existing `command -v` mechanism (portable across the shells teamai targets) rather than switching to `which`/`where`, since the whitelist already removes the injection surface.

## Test Plan

- [x] `npx tsc --noEmit` — no errors
- [x] `npx vitest run` — 1815 passed (added a test asserting a metacharacter-laden `requires` is skipped and its injected command never runs)
- [x] `npm run build` — success
- [x] **End-to-end** against a real reconcile run:
  - `requires: ["echo; touch /tmp/E2E_INJECTION_PROOF"]` → server `skipped` (`invalid name`), **marker file NOT created**
  - `requires: ["npx"]` → server `added` normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)