### PR TITLE
fix(uninstall): stop command loop after uninstall_teamai and detect empty hooks residue

### DIFF
--- a/src/__tests__/uninstall.test.ts
+++ b/src/__tests__/uninstall.test.ts
@@ -879,6 +879,88 @@ describe('uninstall', () => {
     expect(mockReconcileHooks).not.toHaveBeenCalled();
   });
 
+  it('hooks 全为空数组时仍纳入清理范围（empty-array residue）', async () => {
+    const { homeDir, repoPath } = await setupFixture(tmpDir);
+    vi.stubEnv('HOME', homeDir);
+    vi.stubEnv('SHELL', '/bin/zsh');
+
+    // Simulate a prior partial uninstall that left hooks cleared to empty arrays.
+    await fse.writeJson(path.join(homeDir, '.claude', 'settings.json'), {
+      hooks: { SessionStart: [], Stop: [], PostToolUse: [] },
+    });
+
+    const teamConfig = makeTeamConfig();
+    const localConfig = makeLocalConfig(homeDir, repoPath);
+    mockAutoDetectInit.mockResolvedValue({ localConfig, teamConfig });
+
+    await uninstall({ force: true });
+
+    // reconcileHooks must be called — the file was recognised as having teamai residue.
+    expect(mockReconcileHooks).toHaveBeenCalledWith(
+      path.join(homeDir, '.claude', 'settings.json'),
+      'claude',
+      [],
+      expect.objectContaining({ removeAll: true }),
+    );
+  });
+
+  it('settings.json 无 hooks 字段时不纳入清理范围', async () => {
+    const { homeDir, repoPath } = await setupFixture(tmpDir);
+    vi.stubEnv('HOME', homeDir);
+    vi.stubEnv('SHELL', '/bin/zsh');
+
+    // settings.json exists but has no hooks key at all — not a teamai file.
+    await fse.writeJson(path.join(homeDir, '.claude', 'settings.json'), {
+      model: 'claude-opus-4',
+    });
+    // Also remove all other teamai resources so nothing triggers cleanup.
+    await fse.remove(path.join(homeDir, '.claude', 'skills', 'team-skill'));
+    await fse.remove(path.join(homeDir, '.claude', 'skills', 'teamai-share-learnings'));
+    await fse.remove(path.join(homeDir, '.claude', 'skills', 'team-wiki-codebase'));
+    await fse.remove(path.join(homeDir, '.claude', 'rules', 'team-rule.md'));
+    await fse.remove(path.join(homeDir, '.claude', 'rules', 'teamai-recall.md'));
+    await fse.remove(path.join(homeDir, '.claude', 'agents', 'teamai-recall.md'));
+    await fse.remove(path.join(homeDir, '.claude', 'CLAUDE.md'));
+
+    const teamConfig = makeTeamConfig();
+    const localConfig = makeLocalConfig(homeDir, repoPath);
+    mockAutoDetectInit.mockResolvedValue({ localConfig, teamConfig });
+
+    await uninstall({ force: true, agent: 'claude' });
+
+    // No hooks residue + no teamai resources → reconcileHooks not called.
+    expect(mockReconcileHooks).not.toHaveBeenCalled();
+  });
+
+  it('hooks 有非空数组（用户自有 hook）时仅由 hasTeamaiHooks 判断是否纳入', async () => {
+    const { homeDir, repoPath } = await setupFixture(tmpDir);
+    vi.stubEnv('HOME', homeDir);
+    vi.stubEnv('SHELL', '/bin/zsh');
+
+    // User has their own non-teamai hook — isEmptyHooksResidue must return false,
+    // but hasTeamaiHooks will still detect the teamai hook that setupFixture added.
+    await fse.writeJson(path.join(homeDir, '.claude', 'settings.json'), {
+      hooks: {
+        SessionStart: [{ matcher: '*', hooks: [{ type: 'command', command: 'teamai pull' }], description: '[teamai] Auto-pull' }],
+        PostToolUse: [{ matcher: '*', hooks: [{ type: 'command', command: 'echo user-hook' }] }],
+      },
+    });
+
+    const teamConfig = makeTeamConfig();
+    const localConfig = makeLocalConfig(homeDir, repoPath);
+    mockAutoDetectInit.mockResolvedValue({ localConfig, teamConfig });
+
+    await uninstall({ force: true });
+
+    // hasTeamaiHooks detects the teamai hook → reconcileHooks must be called.
+    expect(mockReconcileHooks).toHaveBeenCalledWith(
+      path.join(homeDir, '.claude', 'settings.json'),
+      'claude',
+      [],
+      expect.objectContaining({ removeAll: true }),
+    );
+  });
+
   it('--agent 大小写不敏感', async () => {
     const { homeDir, repoPath } = await setupFixture(tmpDir);
     vi.stubEnv('HOME', homeDir);

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -2020,6 +2020,11 @@ async function processCommands(
       const version = await executeCommand(config, command, context);
       await ackCommand(config, tag, command, 'success', version);
       log.debug(`${tag} command ${command.id} (${command.type ?? ''}) succeeded`);
+      // Uninstall succeeded — skip remaining commands; the hook process exits naturally.
+      if (command.type === 'uninstall_teamai') {
+        log.debug(`${tag} uninstall_teamai completed — remaining commands skipped`);
+        return;
+      }
     } catch (e) {
       const error = (e as Error).message;
       log.error(`${tag} command ${command.id} failed: ${error}`);

--- a/src/uninstall.ts
+++ b/src/uninstall.ts
@@ -163,6 +163,13 @@ async function collectTeamRuleNames(repoPath: string): Promise<Set<string>> {
   );
 }
 
+/** Detect hooks cleared to empty arrays — a residue of prior teamai installation. */
+function isEmptyHooksResidue(parsed: Record<string, unknown> | null): boolean {
+  if (parsed == null || !('hooks' in parsed) || typeof parsed.hooks !== 'object' || parsed.hooks == null) return false;
+  const entries = Object.values(parsed.hooks as Record<string, unknown>);
+  return entries.length > 0 && entries.every((v) => Array.isArray(v) && v.length === 0);
+}
+
 // ─── Discovery ─────────────────────────────────────────
 
 async function discoverToolResources(
@@ -181,7 +188,9 @@ async function discoverToolResources(
   // (a) Hooks — settings.json / hooks.json
   if (toolPath.settings) {
     const settingsPath = path.join(baseDir, toolPath.settings);
-    if (await pathExists(settingsPath) && await hasTeamaiHooks(settingsPath, tool, managedHooksPath)) {
+    if (await pathExists(settingsPath)
+      && (await hasTeamaiHooks(settingsPath, tool, managedHooksPath)
+        || isEmptyHooksResidue(await readJson<Record<string, unknown>>(settingsPath)))) {
       res.hookFiles.push({ path: settingsPath, tool });
     }
   } else {


### PR DESCRIPTION
## Summary

- **Bug 1**: processCommands now returns immediately after a successful uninstall_teamai ack, skipping remaining commands. Previously the loop continued after the child-process uninstall completed, allowing subsequent hook events to keep reporting running status.

- **Bug 2**: discoverToolResources adds a hasEmptyHooksResidue() fallback so that settings.json with emptied hook arrays (e.g. SessionStart:[], Stop:[]) is still included in the removal plan. Previously hasTeamaiHooks() returned false for empty arrays, isPlanEmpty became true, uninstall exited with nothing to remove while ~/.teamai/ remained on disk.

## Test plan

- [x] npx tsc --noEmit — type check passes
- [x] npx vitest run — 1885 tests pass (0 failures)
- [x] npm run build — build succeeds
- [x] E2E: simulate clawpro uninstall_teamai command, verify agent process exits and hooks/~/.teamai are cleaned up
- [x] E2E: manually empty settings.json hooks to SessionStart:[], run teamai uninstall --agent claude, verify cleanup proceeds