### PR TITLE
fix(hooks): skip hook injection when /bin/sh is absent

### DIFF
--- a/src/__tests__/hooks-shell-check.test.ts
+++ b/src/__tests__/hooks-shell-check.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import fse from 'fs-extra';
+
+// Mock logger before any imports that use it.
+vi.mock('../utils/logger.js', () => ({
+  log: { info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// Mock fs.existsSync to control /bin/sh detection.
+const originalExistsSync = (await import('node:fs')).existsSync;
+let shellExists = true;
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      existsSync: (p: string) => {
+        if (p === '/bin/sh') return shellExists;
+        return originalExistsSync(p);
+      },
+    },
+  };
+});
+
+import { hasShell, _resetShellCache } from '../builtin-hooks.js';
+import { injectHooksToAllTools } from '../hooks.js';
+import { log } from '../utils/logger.js';
+
+describe('hasShell()', () => {
+  beforeEach(() => {
+    _resetShellCache();
+  });
+
+  it('returns true when /bin/sh exists', () => {
+    shellExists = true;
+    expect(hasShell()).toBe(true);
+  });
+
+  it('returns false when /bin/sh does not exist', () => {
+    shellExists = false;
+    expect(hasShell()).toBe(false);
+  });
+
+  it('caches the result across calls', () => {
+    shellExists = true;
+    expect(hasShell()).toBe(true);
+    shellExists = false;
+    expect(hasShell()).toBe(true);
+  });
+
+  it('resets cache via _resetShellCache', () => {
+    shellExists = true;
+    expect(hasShell()).toBe(true);
+    _resetShellCache();
+    shellExists = false;
+    expect(hasShell()).toBe(false);
+  });
+});
+
+describe('injectHooksToAllTools — no-shell skip', () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    _resetShellCache();
+    tmp = await fse.mkdtemp(path.join(os.tmpdir(), 'hooks-shell-'));
+    vi.mocked(log.warn).mockClear();
+  });
+
+  afterEach(async () => {
+    await fse.remove(tmp);
+  });
+
+  it('skips codebuddy hook injection and warns when /bin/sh is absent', async () => {
+    shellExists = false;
+    const codebuddyDir = path.join(tmp, '.codebuddy');
+    await fse.ensureDir(codebuddyDir);
+    const settingsPath = '.codebuddy/settings.json';
+
+    await injectHooksToAllTools({ codebuddy: { settings: settingsPath } }, tmp);
+
+    expect(vi.mocked(log.warn)).toHaveBeenCalledWith(
+      expect.stringContaining('Skipping hook injection for CodeBuddy/WorkBuddy'),
+    );
+    const settingsExists = await fse.pathExists(path.join(tmp, settingsPath));
+    expect(settingsExists).toBe(false);
+  });
+
+  it('injects codebuddy hooks normally when /bin/sh is available', async () => {
+    shellExists = true;
+    const codebuddyDir = path.join(tmp, '.codebuddy');
+    await fse.ensureDir(codebuddyDir);
+    const settingsPath = '.codebuddy/settings.json';
+
+    await injectHooksToAllTools({ codebuddy: { settings: settingsPath } }, tmp);
+
+    const settingsExists = await fse.pathExists(path.join(tmp, settingsPath));
+    expect(settingsExists).toBe(true);
+  });
+});

--- a/src/builtin-hooks.ts
+++ b/src/builtin-hooks.ts
@@ -31,6 +31,36 @@ const TEAMAI_BIN_DIR = '.teamai/bin';
 const WRAPPER_NAME = 'teamai';
 
 /**
+ * Tools whose hook commands depend on /bin/sh being available.  CodeBuddy
+ * and WorkBuddy execute hooks via `spawn('/bin/sh', ['-c', command])`, so
+ * hook injection is skipped when /bin/sh is absent.
+ */
+export const SHELL_DEPENDENT_TOOLS = new Set(['workbuddy', 'codebuddy']);
+
+/**
+ * Check whether /bin/sh exists.  Remote containers (e.g. CloudStudio AI
+ * inference nodes) may lack it, causing CodeBuddy's `spawn /bin/sh` to
+ * fail with ENOENT on every hook invocation.  Exported so the injection
+ * entry points can skip hook installation and warn the user.
+ */
+let _hasShellCache: boolean | undefined;
+export function hasShell(): boolean {
+  if (_hasShellCache === undefined) {
+    try {
+      _hasShellCache = fs.existsSync('/bin/sh');
+    } catch {
+      _hasShellCache = false;
+    }
+  }
+  return _hasShellCache;
+}
+
+/** Reset the cached hasShell result. Test-only. */
+export function _resetShellCache(): void {
+  _hasShellCache = undefined;
+}
+
+/**
  * Compare two semver-like version strings numerically (segment by segment).
  * Returns negative if a < b, 0 if equal, positive if a > b.
  */
@@ -142,6 +172,17 @@ export function ensureTeamaiWrapper(): string | null {
   }
 }
 
+/**
+ * If /bin/sh is available, write the teamai wrapper and return true.
+ * Returns false when /bin/sh is absent — callers should skip
+ * shell-dependent tool injection and warn the user.
+ */
+export function ensureWrapperIfShellAvailable(): boolean {
+  if (!hasShell()) return false;
+  ensureTeamaiWrapper();
+  return true;
+}
+
 /** Generate the hook-dispatch command for a given event, tool, and optional matcher. */
 export function getDispatchCommand(event: string, tool: string, matcher?: string, binPath?: string): string {
   const bin = binPath ?? 'teamai';
@@ -196,7 +237,7 @@ const BUILTIN_HOOK_SPECS: BuiltinHookSpec[] = [
  * GUI tools (WorkBuddy, CodeBuddy) use the wrapper dispatch command so their
  * hook subprocesses can find `teamai` even without the user's full PATH.
  */
-const WRAPPER_TOOLS = new Set(['workbuddy', 'codebuddy']);
+const WRAPPER_TOOLS = SHELL_DEPENDENT_TOOLS;
 
 export function builtinHookDefs(tool: string): HookDef[] {
   const withTimeout = tool === 'cursor' || tool === 'workbuddy' || tool === 'codebuddy';

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -3,7 +3,7 @@ import { readJson, writeJson, expandHome, ensureDir, pathExists } from './utils/
 import { log } from './utils/logger.js';
 import { TEAMAI_HOOK_DESCRIPTION_PREFIX, TEAMAI_CUSTOM_HOOK_PREFIX, TEAMAI_AGENT_HOOK_PREFIX, getManagedHooksPath, resolveBaseDir } from './types.js';
 import type { HookDef, TeamaiConfig, LocalConfig } from './types.js';
-import { builtinHookDefs, applyBuiltinOverride, ensureTeamaiWrapper } from './builtin-hooks.js';
+import { builtinHookDefs, applyBuiltinOverride, ensureWrapperIfShellAvailable, SHELL_DEPENDENT_TOOLS } from './builtin-hooks.js';
 import type { BuiltinHookOverride } from './builtin-hooks.js';
 import { resolveTeamHooks } from './resources/hooks.js';
 
@@ -727,11 +727,19 @@ export async function hasTeamaiHooks(
 export async function injectHooksToAllTools(toolPaths: Record<string, { settings?: string }>, baseDir?: string, filterAgents?: string[]): Promise<void> {
   const resolvedBaseDir = baseDir ?? (process.env.HOME ?? '');
   const tools = Object.keys(toolPaths).filter(t => !filterAgents || filterAgents.includes(t));
-  if (tools.some(t => t === 'workbuddy' || t === 'codebuddy')) {
-    ensureTeamaiWrapper();
+  let shellAvailable = true;
+  if (tools.some(t => SHELL_DEPENDENT_TOOLS.has(t))) {
+    shellAvailable = ensureWrapperIfShellAvailable();
+    if (!shellAvailable) {
+      log.warn(
+        'Skipping hook injection for CodeBuddy/WorkBuddy: /bin/sh is not available in this environment. ' +
+        'Hooks require a shell to execute. Other tools (Claude Code, Cursor) are not affected.',
+      );
+    }
   }
   for (const [tool, paths] of Object.entries(toolPaths)) {
     if (filterAgents && !filterAgents.includes(tool)) continue;
+    if (!shellAvailable && SHELL_DEPENDENT_TOOLS.has(tool)) continue;
     if (paths.settings) {
       const toolRoot = path.join(resolvedBaseDir, paths.settings.split('/')[0]);
       if (!await pathExists(toolRoot)) continue;
@@ -774,13 +782,20 @@ export async function reconcileHooksToAllTools(
   manifestPath: string,
   opts: { removeAll?: boolean; builtinOverride?: BuiltinHookOverride; filterAgents?: string[] } = {},
 ): Promise<void> {
-  const wrapperTools = ['workbuddy', 'codebuddy'];
   const activeTools = Object.keys(toolPaths).filter(t => !opts.filterAgents || opts.filterAgents.includes(t));
-  if (activeTools.some(t => wrapperTools.includes(t))) {
-    ensureTeamaiWrapper();
+  let shellAvailable = true;
+  if (activeTools.some(t => SHELL_DEPENDENT_TOOLS.has(t))) {
+    shellAvailable = ensureWrapperIfShellAvailable();
+    if (!shellAvailable) {
+      log.warn(
+        'Skipping hook injection for CodeBuddy/WorkBuddy: /bin/sh is not available in this environment. ' +
+        'Hooks require a shell to execute. Other tools (Claude Code, Cursor) are not affected.',
+      );
+    }
   }
   for (const [tool, paths] of Object.entries(toolPaths)) {
     if (opts.filterAgents && !opts.filterAgents.includes(tool)) continue;
+    if (!shellAvailable && SHELL_DEPENDENT_TOOLS.has(tool)) continue;
     // Hermes uses config.yaml (YAML) + a script dir + allowlist instead of a
     // JSON settings file, so it bypasses the settings-based reconcile path.
     // Install when the .hermes home exists; removeAll clears the teamai hook.


### PR DESCRIPTION
## Summary
- In remote container environments (e.g. CloudStudio AI inference nodes), `/bin/sh` may not exist
- CodeBuddy executes hooks via `spawn('/bin/sh', ...)`, so every hook invocation fails with ENOENT (error 1001), blocking all user input
- Detect `/bin/sh` availability at install time and skip hook injection for shell-dependent tools (CodeBuddy/WorkBuddy) when absent, with a clear warning
- Other tools (Claude Code, Cursor) are unaffected

## Changes
- `src/builtin-hooks.ts`: Add `hasShell()` detection (cached), `SHELL_DEPENDENT_TOOLS` shared constant, `ensureWrapperIfShellAvailable()` helper, `_resetShellCache()` for tests
- `src/hooks.ts`: `injectHooksToAllTools` and `reconcileHooksToAllTools` skip shell-dependent tools when `/bin/sh` is absent and warn the user
- `src/__tests__/hooks-shell-check.test.ts`: 6 tests covering `hasShell()` caching and no-shell skip behavior

## Test plan
- [x] `npx tsc --noEmit` — type check passes
- [x] `npx vitest run` — 1891 tests pass (144 files), including golden tests
- [x] `npm run build` — build succeeds
- [ ] Deploy to a remote container without `/bin/sh`, run `teamai init` or `teamai pull`, verify warning is printed and CodeBuddy settings.json has no hook entries
- [ ] On normal environment (with `/bin/sh`), verify hooks are injected normally (no behavioral change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)