### PR TITLE
perf(hooks): tighten STDIN timeout, add try-catch, move pull to background

### DIFF
--- a/src/hook-dispatch-cli.ts
+++ b/src/hook-dispatch-cli.ts
@@ -31,7 +31,7 @@ import { log, setStderrOnly } from './utils/logger.js';
  * payload we already buffered (a healthy host EOFs within milliseconds, so this
  * never triggers in normal use).
  */
-const STDIN_READ_TIMEOUT_MS = 2_000;
+const STDIN_READ_TIMEOUT_MS = 1_000;
 
 /**
  * Read STDIN fully, but never block longer than STDIN_READ_TIMEOUT_MS waiting
@@ -152,41 +152,41 @@ export async function hookDispatchCli(
   matcher: string,
   bgOnly = false,
 ): Promise<void> {
-  // Reserve STDOUT for the dispatcher's hook payload; log lines go to STDERR.
   setStderrOnly(true);
+  try {
+    const raw = await readStdin();
+    const stdin = parseStdin(raw, event);
+    if (stdin === null) return;
 
-  const raw = await readStdin();
-  const stdin = parseStdin(raw, event);
-  if (stdin === null) return;
+    // Provider-config gate: HTTP-only teams must not receive git-provider-only
+    // hook prompts (contribute / mr-hint / votes). Prefer the project-scope
+    // config when the host tells us the working directory (#264), so
+    // filterHandlersForConfig can honour a project-level repo.kind.
+    const { loadLocalConfig, detectProjectConfig } = await import('./config.js');
+    const cwd = typeof stdin.cwd === 'string' ? stdin.cwd : undefined;
+    const localConfig = (cwd ? await detectProjectConfig(cwd) : null) ?? await loadLocalConfig();
+    const handlers = filterHandlersForConfig(buildHandlerRegistry(), localConfig);
+    const dispatcher = createDispatcher({ handlers });
 
-  // Provider-config gate: HTTP-only teams must not receive git-provider-only
-  // hook prompts (contribute / mr-hint / votes). Prefer the project-scope
-  // config when the host tells us the working directory (#264), so
-  // filterHandlersForConfig can honour a project-level repo.kind.
-  const { loadLocalConfig, detectProjectConfig } = await import('./config.js');
-  const cwd = typeof stdin.cwd === 'string' ? stdin.cwd : undefined;
-  const localConfig = (cwd ? await detectProjectConfig(cwd) : null) ?? await loadLocalConfig();
-  const handlers = filterHandlersForConfig(buildHandlerRegistry(), localConfig);
-  const dispatcher = createDispatcher({ handlers });
+    // Detached child: run the fire-and-forget handlers, then exit. No output is
+    // wired back to the host (the parent already returned).
+    if (bgOnly) {
+      await runDispatch(dispatcher, event, matcher, stdin, tool, 'background');
+      return;
+    }
 
-  // Detached child: run the fire-and-forget handlers, then exit. No output is
-  // wired back to the host (the parent already returned).
-  if (bgOnly) {
-    await runDispatch(dispatcher, event, matcher, stdin, tool, 'background');
-    return;
-  }
+    // Parent: kick off background handlers in a detached process first so they
+    // start working while we run the inline (foreground) pass.
+    if (dispatcher.hasBackground(event, matcher)) {
+      spawnBackground(event, tool, matcher, raw);
+    }
 
-  // Parent: kick off background handlers in a detached process first so they
-  // start working while we run the inline (foreground) pass.
-  if (dispatcher.hasBackground(event, matcher)) {
-    spawnBackground(event, tool, matcher, raw);
-  }
+    const output = await runDispatch(dispatcher, event, matcher, stdin, tool, 'foreground');
 
-  const output = await runDispatch(dispatcher, event, matcher, stdin, tool, 'foreground');
-
-  // Write output to STDOUT if any handler produced one, flushing before return
-  // so the caller's process.exit(0) cannot truncate it.
-  if (output) {
-    await new Promise<void>((resolve) => process.stdout.write(output, () => resolve()));
+    if (output) {
+      await new Promise<void>((resolve) => process.stdout.write(output, () => resolve()));
+    }
+  } catch (e) {
+    log.warn(`hook-dispatch: unexpected error: ${e instanceof Error ? e.message : String(e)}`);
   }
 }

--- a/src/hook-handlers.ts
+++ b/src/hook-handlers.ts
@@ -326,7 +326,10 @@ const localAgentHandler: HookHandler = {
 export function buildHandlerRegistry(): HandlerRegistration[] {
   return [
     // ─── SessionStart ─────────────────────────────────
-    { event: 'session-start', matcher: '*', handler: pullHandler, timeoutMs: FOREGROUND_HOOK_TIMEOUT_MS },
+    // pull does not produce output the host needs; run detached so git fetch
+    // on a slow network cannot delay session startup. Reuses LOCAL_AGENT_TIMEOUT_MS
+    // (15s) — ample for a background git pull that is not awaited by the host.
+    { event: 'session-start', matcher: '*', handler: pullHandler, timeoutMs: LOCAL_AGENT_TIMEOUT_MS, background: true },
     { event: 'session-start', matcher: '*', handler: dashboardReportHandler, timeoutMs: FOREGROUND_HOOK_TIMEOUT_MS },
     { event: 'session-start', matcher: '*', handler: mrHintHandler, timeoutMs: FOREGROUND_HOOK_TIMEOUT_MS, gitOnly: true },
     { event: 'session-start', matcher: '*', handler: localAgentHandler, timeoutMs: FOREGROUND_HOOK_TIMEOUT_MS },


### PR DESCRIPTION
## Summary
Three independent hook dispatch optimizations to improve reliability and responsiveness:

- **STDIN timeout 2s → 1s**: Healthy hosts EOF within milliseconds; the 2s timeout was overly generous for the missing-EOF edge case
- **Top-level try-catch in hookDispatchCli**: Prevents unexpected errors (dynamic import failures, config parse errors) from crashing the hook process — logs at warn level for diagnosability
- **pullHandler moved to background on session-start**: pull does not produce output the host needs to inject, so running it detached avoids blocking session startup on slow git fetches

## Changes
- src/hook-dispatch-cli.ts: Reduce STDIN_READ_TIMEOUT_MS from 2000 to 1000; wrap hookDispatchCli body in try-catch with log.warn
- src/hook-handlers.ts: Change pullHandler registration from foreground to background: true with LOCAL_AGENT_TIMEOUT_MS

## Test plan
- [x] npx tsc --noEmit — type check passes
- [x] npx vitest run — 1885 tests pass (143 files), including golden tests
- [x] npm run build — build succeeds
- [ ] Trigger session-start hook, verify pull runs in background (not blocking session prompt)
- [ ] Simulate hookDispatchCli error, verify warn-level log appears in stderr

Generated with Claude Code