### PR TITLE
fix(recall): stabilize relevance threshold and CJK domain inference

### DIFF
--- a/src/__tests__/recall-relevance-threshold.test.ts
+++ b/src/__tests__/recall-relevance-threshold.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import { isRelevantScore, computeIdfBaseline } from '../recall.js';
+import type { SearchIndex } from '../types.js';
+
+// ─── Helpers ──────────────────────────────────────────────
+
+function makeIndex(entryCount: number, withDf: boolean): SearchIndex {
+  const entries = Array.from({ length: entryCount }, (_, i) => ({
+    filename: `doc-${i}.md`,
+    title: `Doc ${i}`,
+    author: 'test',
+    date: '2026-01-01',
+    tags: [],
+    tokens: ['token'],
+    votes: 0,
+    type: 'learnings' as const,
+  }));
+  return {
+    builtAt: '2026-01-01T00:00:00Z',
+    elapsedMs: 0,
+    entries,
+    df: withDf ? { token: entryCount } : undefined,
+  };
+}
+
+// ─── computeIdfBaseline ───────────────────────────────────
+
+describe('computeIdfBaseline', () => {
+  it('returns 1 for a legacy index with no df field', () => {
+    const idx = makeIndex(25, false);
+    expect(computeIdfBaseline([idx])).toBe(1);
+  });
+
+  it('returns 1 when entries array is empty (no entries to compute baseline from)', () => {
+    const idx: SearchIndex = {
+      builtAt: '2026-01-01T00:00:00Z',
+      elapsedMs: 0,
+      entries: [],
+      df: {},
+    };
+    expect(computeIdfBaseline([idx])).toBe(1);
+  });
+
+  it('returns log((N+1)/2)+1 for N=25 with df present', () => {
+    const idx = makeIndex(25, true);
+    expect(computeIdfBaseline([idx])).toBeCloseTo(Math.log(13) + 1, 5);
+  });
+
+  it('uses the index with the most entries when multiple indexes are given', () => {
+    const small = makeIndex(5, true);
+    const large = makeIndex(25, true);
+    // should pick large (N=25), not small (N=5)
+    const expected = Math.log((25 + 1) / 2) + 1;
+    expect(computeIdfBaseline([small, large])).toBeCloseTo(expected, 5);
+    expect(computeIdfBaseline([large, small])).toBeCloseTo(expected, 5);
+  });
+
+  it('ignores legacy (no-df) indexes when picking maxEntries', () => {
+    // Legacy index is larger than the df-bearing one — its N must NOT be used.
+    // Without the P2-6 fix, the legacy index's entry count would inflate the
+    // baseline and silently raise the threshold against unrelated results.
+    const legacy = makeIndex(100, false); // large but no df
+    const modern = makeIndex(10, true);   // small but has df
+    const expected = Math.log((10 + 1) / 2) + 1;
+    expect(computeIdfBaseline([legacy, modern])).toBeCloseTo(expected, 5);
+  });
+});
+
+// ─── isRelevantScore ─────────────────────────────────────
+
+describe('isRelevantScore', () => {
+  describe('codebase hits (bounded [0,10] scale)', () => {
+    it('returns true when score is exactly at CODEBASE_RELEVANCE_THRESHOLD (4.0)', () => {
+      expect(isRelevantScore(4.0, true, 1)).toBe(true);
+    });
+
+    it('returns false when score is just below threshold (3.9)', () => {
+      expect(isRelevantScore(3.9, true, 1)).toBe(false);
+    });
+
+    it('is not affected by idfBaseline — a large baseline does not change the verdict', () => {
+      // even with a baseline of 100 the codebase branch still uses the fixed threshold
+      expect(isRelevantScore(4.0, true, 100)).toBe(true);
+      expect(isRelevantScore(3.9, true, 100)).toBe(false);
+    });
+  });
+
+  describe('learnings hits (TF-IDF unbounded, floor + ratio)', () => {
+    // The effective threshold is max(baseline * 1.35, 4.0).
+    //
+    // Cross-over baseline: 4.0 / 1.35 ≈ 2.963 (corresponds to N ≈ 6–7).
+    //   - baseline < 2.963 → floor (4.0) wins
+    //   - baseline > 2.963 → relative threshold (baseline * 1.35) wins
+
+    // --- Relative threshold governs (N=25, baseline > cross-over) ---
+    // baseline for N=25: log(26/2)+1 ≈ 3.5649; threshold = 3.5649 * 1.35 ≈ 4.813
+    // floor (4.0) is below the relative threshold, so relative wins.
+    const baseline25 = computeIdfBaseline([makeIndex(25, true)]);
+
+    it('N=25: relative threshold governs — score just above baseline*1.35 passes', () => {
+      // Verify relative threshold is above the floor at this corpus size.
+      expect(baseline25 * 1.35).toBeGreaterThan(4.0);
+      expect(isRelevantScore(4.82, false, baseline25)).toBe(true);
+    });
+
+    it('N=25: relative threshold governs — score just below baseline*1.35 fails', () => {
+      expect(isRelevantScore(4.80, false, baseline25)).toBe(false);
+    });
+
+    // --- Floor governs (idfBaseline = 1, cold-start / legacy fallback) ---
+    // threshold = max(1 * 1.35, 4.0) = 4.0
+    // Before the floor was added, threshold was 1.35 — a single tag match
+    // (~1.7) would have passed on a 1-entry corpus, causing false positives.
+
+    it('cold-start (baseline=1): floor governs — 4.0 passes', () => {
+      // floor: 4.0; relative: 1.35 → floor wins
+      expect(isRelevantScore(4.0, false, 1)).toBe(true);
+    });
+
+    it('cold-start (baseline=1): floor governs — 3.9 fails', () => {
+      expect(isRelevantScore(3.9, false, 1)).toBe(false);
+    });
+
+    it('cold-start (baseline=1): old passing score (1.35) now correctly fails', () => {
+      // Before the floor, isRelevantScore(1.35, false, 1) returned true.
+      // With the floor at 4.0, it must return false to prevent cold-start false positives.
+      expect(isRelevantScore(1.35, false, 1)).toBe(false);
+    });
+
+    // --- Cross-over boundary (baseline ≈ 2.963) ---
+    // At baseline exactly equal to 4.0/1.35, both sides tie at 4.0.
+    // Below this baseline the floor wins; above it the ratio wins.
+    it('below cross-over (baseline=2.0): floor governs — threshold is 4.0', () => {
+      // relative = 2.0 * 1.35 = 2.70 < 4.0 → floor wins
+      expect(isRelevantScore(3.99, false, 2.0)).toBe(false);
+      expect(isRelevantScore(4.0, false, 2.0)).toBe(true);
+    });
+
+    it('above cross-over (baseline=3.5): relative threshold governs', () => {
+      // relative = 3.5 * 1.35 ≈ 4.725 > 4.0 → relative wins
+      // Using computed threshold to avoid floating-point boundary issues.
+      const relThreshold = 3.5 * 1.35; // ≈ 4.725
+      expect(isRelevantScore(relThreshold - 0.001, false, 3.5)).toBe(false);
+      expect(isRelevantScore(relThreshold + 0.001, false, 3.5)).toBe(true);
+    });
+  });
+
+  describe('defensive: idfBaseline = 0', () => {
+    it('treats idfBaseline=0 as 1 — floor (4.0) governs', () => {
+      // baseline 0 is normalised to 1; threshold = max(1.35, 4.0) = 4.0
+      expect(isRelevantScore(3.99, false, 0)).toBe(false);
+      expect(isRelevantScore(4.0, false, 0)).toBe(true);
+    });
+  });
+});

--- a/src/__tests__/search-idf-domain-isolation.test.ts
+++ b/src/__tests__/search-idf-domain-isolation.test.ts
@@ -1,0 +1,595 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import os from 'node:os';
+import fse from 'fs-extra';
+import { buildIndex, loadIndex, search } from '../utils/search-index.js';
+
+// ---------------------------------------------------------------------------
+// IDF domain isolation regression tests — 0a-0c validation baseline
+//
+// This file exists to *prove* the current bug before the fix lands.
+// Some tests are intentionally expected to FAIL on unpatched code (those that
+// verify isolation). Others are characterisation / diagnostic tests that MUST
+// PASS on current code — they record the evidence of the bug, not an absence
+// of it.
+//
+// Legend per test:
+//   [PASS-NOW]  — expected to pass before any fix
+//   [FAIL-NOW]  — expected to fail on current code; should pass after 0a fix
+//   [PASS-NOW-0b] — previously characterised the 0b CJK query domain bug;
+//                   now rewritten to verify the 0b fix (should PASS after fix)
+// ---------------------------------------------------------------------------
+
+// N_TECH / N_OPS are used across multiple tests; kept as module-level consts
+// so the ratio (3:12) is declared once and easy to adjust.
+const N_TECH = 3;
+const N_OPS = 12;
+
+// ---------------------------------------------------------------------------
+// Shared token set: words that appear in BOTH technical AND ops fixture docs.
+// Must be plain ASCII so tokenize() handles them predictably.
+// ---------------------------------------------------------------------------
+const SHARED_TOKENS = ['timeout', 'retry', 'config'];
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Produces a minimal valid frontmatter + body markdown string.
+ * Tags are written as a YAML flow sequence: [tag1, tag2, ...]
+ */
+const learningDoc = (title: string, tags: string[], body: string): string =>
+  `---\ntitle: ${title}\nauthor: t\ndate: 2026-01-01\ntags: [${tags.join(', ')}]\n---\n\n${body}\n`;
+
+/**
+ * Writes `docs` (filename → content) into `dir`, builds an index, and returns
+ * the loaded SearchIndex. Throws if the index cannot be loaded.
+ */
+async function buildScopedIndex(
+  learningsDir: string,
+  indexPath: string,
+  docs: Record<string, string>,
+): Promise<NonNullable<Awaited<ReturnType<typeof loadIndex>>>> {
+  await fse.ensureDir(learningsDir);
+  for (const [filename, content] of Object.entries(docs)) {
+    await fse.writeFile(path.join(learningsDir, filename), content);
+  }
+  await buildIndex({ learningsDir, indexPath });
+  const index = await loadIndex(indexPath);
+  if (!index) throw new Error(`Failed to load index from ${indexPath}`);
+  return index;
+}
+
+// ---------------------------------------------------------------------------
+// Module-level tmp paths; initialised in beforeEach, cleaned in afterEach.
+// ---------------------------------------------------------------------------
+let tmpDir: string;
+let indexPath: string;
+
+beforeEach(async () => {
+  tmpDir = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-idf-domain-'));
+  indexPath = path.join(tmpDir, 'search-index.json');
+});
+
+afterEach(async () => {
+  await fse.remove(tmpDir);
+});
+
+// ---------------------------------------------------------------------------
+describe('IDF domain isolation (regression)', () => {
+  // -------------------------------------------------------------------------
+  // Test 1 [PASS-NOW]
+  //
+  // Characterisation test: prove that the current SearchIndex stores a *single
+  // global* df table that mixes all domains together. This test MUST pass both
+  // before and after the 0a fix (it just records the schema shape).
+  //
+  // After the 0a fix, df should become per-domain; update this test to assert
+  // the new shape (e.g. index.dfByDomain.technical, index.dfByDomain.ops).
+  // -------------------------------------------------------------------------
+  it('records global df/N as the current baseline [PASS-NOW]', async () => {
+    const learningsDir = path.join(tmpDir, 'learnings');
+
+    // 2 technical entries (tags from TECHNICAL_TAGS: api, typescript)
+    // 2 ops entries (tags from OPS_TAGS: k8s, deploy)
+    // All share the token "timeout" in their body.
+    const docs: Record<string, string> = {
+      'tech-1.md': learningDoc('Tech one', ['api', 'typescript'], 'timeout retry config details here'),
+      'tech-2.md': learningDoc('Tech two', ['api', 'debug'], 'timeout retry config more here'),
+      'ops-1.md': learningDoc('Ops one', ['k8s', 'deploy'], 'timeout retry config infra stuff'),
+      'ops-2.md': learningDoc('Ops two', ['monitor', 'deploy'], 'timeout retry config more ops'),
+    };
+
+    const index = await buildScopedIndex(learningsDir, indexPath, docs);
+
+    // The global df map must exist
+    expect(index.df).toBeDefined();
+    expect(index.entries.length).toBe(4);
+
+    // "timeout" appears in all 4 entries → df["timeout"] === 4
+    // This proves df is global (cross-domain), not isolated per domain.
+    // After 0a fix this assertion should change to check dfByDomain instead.
+    expect(index.df!['timeout']).toBe(4);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 2 — currently expected to FAIL (tracked with it.fails())
+  //
+  // What it tests: adding unrelated ops entries must NOT change the score of
+  // existing technical entries. This assertion captures the IDF domain isolation
+  // bug that the 0a fix is intended to solve.
+  //
+  // Why it currently fails:
+  //   IDF uses a single global N = entries.length. When 12 ops docs are added:
+  //   • N grows from 3 (N_TECH) → 15 (N_TECH + N_OPS)
+  //   • Shared tokens' df values also grow (ops docs contribute to the global
+  //     df table), but the token "title:timeout" is tech-exclusive (df unchanged)
+  //   • Because N grows while df("title:timeout") stays at N_TECH, IDF rises:
+  //       index A: idf = log((3+1)/(1+1))+1 ≈ 1.693  → score ≈ 14.0
+  //       index B: idf = log((15+1)/(1+1))+1 ≈ 3.079 → score ≈ 30.6
+  //   • The scores diverge even though the technical sub-corpus is identical.
+  //
+  // Why it.fails() rather than it.skip():
+  //   it.fails() makes "this assertion currently fails" an *assertable contract*:
+  //   CI stays green on unpatched code, AND when the 0a fix lands and the
+  //   assertion unexpectedly starts passing, it.fails() will itself report an
+  //   error — actively prompting the author to convert this back to a plain it().
+  //   it.skip() would silently pass forever and lose all regression value.
+  //
+  // TODO after 0a lands: convert this to a plain it() and verify it passes.
+  // -------------------------------------------------------------------------
+  // -------------------------------------------------------------------------
+  // Test 2a [PASS-NOW] — fixture sanity check
+  //
+  // Verifies that the two indexes used by the it.fails() regression test
+  // actually return the tracked entry ('tech-0.md') with a positive score.
+  // If the tokenizer or scoring changes in a way that causes the fixture to
+  // no longer return this entry, this test will fail with a clear message —
+  // instead of silently keeping the it.fails() green (which would be the case
+  // if the sanity assertions were left inside it.fails(), where any throw
+  // counts as "expected failure").
+  // -------------------------------------------------------------------------
+  it('fixture sanity: both indexes return the tracked technical entry', async () => {
+    const dirA = path.join(tmpDir, 'learnings-sanity-A');
+    const idxPathA = path.join(tmpDir, 'index-sanity-A.json');
+
+    const techDocs: Record<string, string> = {};
+    for (let i = 0; i < N_TECH; i++) {
+      techDocs[`tech-${i}.md`] = learningDoc(
+        `Timeout retry API ${i}`,
+        ['api', 'typescript', 'debug'],
+        `timeout retry config techonly details ${i}`,
+      );
+    }
+
+    const indexA = await buildScopedIndex(dirA, idxPathA, techDocs);
+
+    const dirB = path.join(tmpDir, 'learnings-sanity-B');
+    const idxPathB = path.join(tmpDir, 'index-sanity-B.json');
+
+    const techAndOpsDocs: Record<string, string> = { ...techDocs };
+    for (let i = 0; i < N_OPS; i++) {
+      techAndOpsDocs[`ops-${i}.md`] = learningDoc(
+        `Deploy monitor ops ${i}`,
+        ['k8s', 'deploy', 'monitor'],
+        `timeout retry config opsonly infrastructure ${i}`,
+      );
+    }
+
+    const indexB = await buildScopedIndex(dirB, idxPathB, techAndOpsDocs);
+
+    const query = 'timeout retry api';
+    const resultsA = search(query, indexA);
+    const resultsB = search(query, indexB);
+
+    const resA = resultsA.find((r) => r.entry.filename === 'tech-0.md');
+    const resB = resultsB.find((r) => r.entry.filename === 'tech-0.md');
+
+    expect(resA).toBeDefined();
+    expect(resA!.score).toBeGreaterThan(0);
+    expect(resB).toBeDefined();
+    expect(resB!.score).toBeGreaterThan(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 2b — currently expected to FAIL (tracked with it.fails())
+  //
+  // What it tests: adding unrelated ops entries must NOT change the score of
+  // existing technical entries. This assertion captures the IDF domain isolation
+  // bug that the 0a fix is intended to solve.
+  //
+  // Why it currently fails:
+  //   IDF uses a single global N = entries.length. When 12 ops docs are added:
+  //   • N grows from 3 (N_TECH) → 15 (N_TECH + N_OPS)
+  //   • Shared tokens' df values also grow (ops docs contribute to the global
+  //     df table), but the token "title:timeout" is tech-exclusive (df unchanged)
+  //   • Because N grows while df("title:timeout") stays at N_TECH, IDF rises:
+  //       index A: idf = log((3+1)/(1+1))+1 ≈ 1.693  → score ≈ 14.0
+  //       index B: idf = log((15+1)/(1+1))+1 ≈ 3.079 → score ≈ 30.6
+  //   • The scores diverge even though the technical sub-corpus is identical.
+  //
+  // Why it.fails() rather than it.skip():
+  //   it.fails() makes "this assertion currently fails" an *assertable contract*:
+  //   CI stays green on unpatched code, AND when the 0a fix lands and the
+  //   assertion unexpectedly starts passing, it.fails() will itself report an
+  //   error — actively prompting the author to convert this back to a plain it().
+  //   it.skip() would silently pass forever and lose all regression value.
+  //
+  // NOTE: Fixture sanity (both indexes returning tech-0.md with score > 0) is
+  // verified separately in the preceding 'fixture sanity' test. Only the key
+  // isolation assertion lives here; if the fixture breaks, the sanity test fails
+  // with a clear message rather than this it.fails() silently staying green.
+  //
+  // TODO after 0a lands: convert this to a plain it() and verify it passes.
+  // -------------------------------------------------------------------------
+  it.fails(
+    'technical entry scores are unaffected by unrelated ops entries (expected to fail until 0a lands)',
+    async () => {
+      // --- Index A: only N_TECH technical entries ---
+      const dirA = path.join(tmpDir, 'learnings-A');
+      const idxPathA = path.join(tmpDir, 'index-A.json');
+
+      const techDocs: Record<string, string> = {};
+      for (let i = 0; i < N_TECH; i++) {
+        // Each tech doc: title contains "timeout", body shares SHARED_TOKENS.
+        // Unique body token "techonly" ensures there is an exclusive technical token.
+        techDocs[`tech-${i}.md`] = learningDoc(
+          `Timeout retry API ${i}`,
+          ['api', 'typescript', 'debug'],
+          `timeout retry config techonly details ${i}`,
+        );
+      }
+
+      const indexA = await buildScopedIndex(dirA, idxPathA, techDocs);
+
+      // --- Index B: same N_TECH technical entries PLUS N_OPS ops entries ---
+      const dirB = path.join(tmpDir, 'learnings-B');
+      const idxPathB = path.join(tmpDir, 'index-B.json');
+
+      // Exact same tech docs
+      const techAndOpsDocs: Record<string, string> = { ...techDocs };
+      for (let i = 0; i < N_OPS; i++) {
+        // Ops docs also contain the SHARED_TOKENS to cause IDF drift.
+        // They have distinct titles and ops-domain tags.
+        techAndOpsDocs[`ops-${i}.md`] = learningDoc(
+          `Deploy monitor ops ${i}`,
+          ['k8s', 'deploy', 'monitor'],
+          `timeout retry config opsonly infrastructure ${i}`,
+        );
+      }
+
+      const indexB = await buildScopedIndex(dirB, idxPathB, techAndOpsDocs);
+
+      // Query: purely technical tokens → inferQueryDomain returns 'technical'
+      // DOMAIN_WEIGHT.technical.technical === 1.0 for both indexes
+      // → domain multiplier is identical, so any score difference is purely IDF.
+      const query = 'timeout retry api';
+
+      const resultsA = search(query, indexA);
+      const resultsB = search(query, indexB);
+
+      const targetFile = 'tech-0.md';
+      const resA = resultsA.find((r) => r.entry.filename === targetFile);
+      const resB = resultsB.find((r) => r.entry.filename === targetFile);
+
+      // THE KEY ASSERTION — currently FAILS because IDF is polluted by ops entries.
+      // After 0a fix, scoreA === scoreB (to floating-point precision).
+      // (resA/resB being undefined would throw a TypeError, which also counts as
+      // failure here; the fixture sanity test above catches that case explicitly.)
+      expect(resB!.score).toBeCloseTo(resA!.score, 5);
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // Test 3 [FAIL-NOW or PASS-NOW — as-observed]
+  //
+  // Weaker property: even if absolute scores change, the *relative ranking*
+  // of technical entries among themselves should be preserved when ops entries
+  // are injected.
+  //
+  // This test determines the *severity* of the bug. If ranking is preserved
+  // despite absolute score drift, the practical impact on users is lower.
+  //
+  // Ranking is controlled by token placement:
+  //   tech-rank-0.md — "timeout" appears in TITLE  (highest raw score)
+  //   tech-rank-1.md — "timeout" appears in TAG     (medium raw score)
+  //   tech-rank-2.md — "timeout" appears only in BODY (lowest raw score,
+  //                     but requires title/tag hit from another query token
+  //                     so we also put "api" in title)
+  //
+  // All three entries have the same domain (technical) and type (learnings),
+  // so the only differentiator among them is token placement.
+  // -------------------------------------------------------------------------
+  it(
+    'relative ranking among technical entries is preserved when ops entries are added [observe: PASS or FAIL]',
+    async () => {
+      // --- Index A: only the 3 rank-test tech entries ---
+      const dirA = path.join(tmpDir, 'learnings-rank-A');
+      const idxPathA = path.join(tmpDir, 'index-rank-A.json');
+
+      const rankDocs: Record<string, string> = {
+        // Title match: "timeout" in title → score += 3 * idf("title:timeout")
+        'tech-rank-0.md': learningDoc(
+          'Timeout api guide',
+          ['api', 'typescript'],
+          'retry config techrank details',
+        ),
+        // Tag match: "timeout" in tags → score += 2 * idf("tag:timeout")
+        'tech-rank-1.md': learningDoc(
+          'API retry guide',
+          ['api', 'timeout'],
+          'retry config techrank details',
+        ),
+        // Body-only: "timeout" only in body — also has "api" in title for
+        // hasTitleOrTagMatch gate to pass.
+        'tech-rank-2.md': learningDoc(
+          'API config guide',
+          ['api', 'typescript'],
+          'timeout retry config techrank body only',
+        ),
+      };
+
+      const indexA = await buildScopedIndex(dirA, idxPathA, rankDocs);
+
+      // --- Index B: same 3 tech entries + N_OPS ops entries ---
+      const dirB = path.join(tmpDir, 'learnings-rank-B');
+      const idxPathB = path.join(tmpDir, 'index-rank-B.json');
+
+      const rankAndOpsDocs: Record<string, string> = { ...rankDocs };
+      for (let i = 0; i < N_OPS; i++) {
+        rankAndOpsDocs[`ops-rank-${i}.md`] = learningDoc(
+          `Deploy monitor ops ${i}`,
+          ['k8s', 'deploy', 'monitor'],
+          `timeout retry config opsonly ${i}`,
+        );
+      }
+
+      const indexB = await buildScopedIndex(dirB, idxPathB, rankAndOpsDocs);
+
+      const query = 'timeout api';
+
+      const resultsA = search(query, indexA);
+      const resultsB = search(query, indexB);
+
+      // Extract only the rank-test entries from each result set, in score order
+      const rankFiles = ['tech-rank-0.md', 'tech-rank-1.md', 'tech-rank-2.md'];
+      const orderA = resultsA
+        .filter((r) => rankFiles.includes(r.entry.filename ?? ''))
+        .map((r) => r.entry.filename);
+      const orderB = resultsB
+        .filter((r) => rankFiles.includes(r.entry.filename ?? ''))
+        .map((r) => r.entry.filename);
+
+      // All three tech entries must appear in both result sets
+      expect(orderA).toHaveLength(3);
+      expect(orderB).toHaveLength(3);
+
+      // Relative order among technical entries must be identical.
+      // If this FAILS, IDF drift is changing intra-domain ranking (high severity).
+      // If it PASSES, IDF drift only affects absolute scores (lower severity).
+      expect(orderB).toEqual(orderA);
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // Test 4 [PASS-NOW]
+  //
+  // Diagnostic: measure and assert the *direction* of IDF drift.
+  // This test PASSES on current code because it only asserts that drift *exists*
+  // in the expected direction — it does not assert isolation.
+  //
+  // Run with --reporter=verbose or check console output for the exact numbers.
+  // -------------------------------------------------------------------------
+  it('documents IDF drift magnitude for shared tokens [PASS-NOW]', async () => {
+    // Fixture design rationale for measurable IDF drift:
+    //
+    // IDF = log((N+1) / (df+1)) + 1.
+    // For IDF of "shared_token" to *decrease* from index A to B we need:
+    //   (N_B+1)/(df_B+1) < (N_A+1)/(df_A+1)
+    // i.e. the token's coverage fraction must increase after adding ops docs.
+    //
+    // Strategy: "shared" token "timeout" appears in only 1 of the 3 tech docs
+    // (coverage = 1/3) but in ALL 12 ops docs (coverage = 12/12 = 1.0).
+    // The blended coverage in B = (1+12)/15 ≈ 0.87 > 1/3, so IDF drops.
+    //
+    //   Index A: df("timeout")=1, N=3  → idf = log(4/2)+1  ≈ 1.693
+    //   Index B: df("timeout")=13, N=15 → idf = log(16/14)+1 ≈ 1.134
+    //   Drop: ≈ -33%
+    //
+    // "techonly" is tech-exclusive (never in ops): df stays at N_TECH in both
+    // indexes while N grows from 3 to 15 → IDF *rises*.
+    //   Index A: df=1, N=3  → idf = log(4/2)+1  ≈ 1.693
+    //   Index B: df=1, N=15 → idf = log(16/2)+1 ≈ 3.079
+    //   Rise: ≈ +82%
+    const dirA = path.join(tmpDir, 'learnings-drift-A');
+    const idxPathA = path.join(tmpDir, 'index-drift-A.json');
+
+    const techDocs: Record<string, string> = {
+      // Only tech-drift-0.md has "timeout" in its body (coverage = 1/N_TECH)
+      'tech-drift-0.md': learningDoc(
+        'API retry guide',
+        ['api', 'typescript', 'debug'],
+        'timeout techonly details here',
+      ),
+      'tech-drift-1.md': learningDoc(
+        'API config guide',
+        ['api', 'typescript', 'debug'],
+        'retry config techonly details here',
+      ),
+      'tech-drift-2.md': learningDoc(
+        'API debug guide',
+        ['api', 'debug'],
+        'retry config techonly fix here',
+      ),
+    };
+
+    const indexA = await buildScopedIndex(dirA, idxPathA, techDocs);
+
+    const dirB = path.join(tmpDir, 'learnings-drift-B');
+    const idxPathB = path.join(tmpDir, 'index-drift-B.json');
+
+    // ALL N_OPS ops docs contain "timeout" — this raises df("timeout") sharply.
+    const techAndOpsDocs: Record<string, string> = { ...techDocs };
+    for (let i = 0; i < N_OPS; i++) {
+      techAndOpsDocs[`ops-drift-${i}.md`] = learningDoc(
+        `Deploy monitor ops ${i}`,
+        ['k8s', 'deploy', 'monitor'],
+        `timeout opsonly infrastructure ${i}`,
+      );
+    }
+
+    const indexB = await buildScopedIndex(dirB, idxPathB, techAndOpsDocs);
+
+    // Manual IDF computation — exact formula from search-index.ts :652
+    const computeIdf = (N: number, docFreq: number): number =>
+      Math.log((N + 1) / (docFreq + 1)) + 1;
+
+    const NA = indexA.entries.length; // 3
+    const NB = indexB.entries.length; // 15
+
+    // "timeout" body token: low tech coverage (1/3), high ops coverage (12/12)
+    const dfSharedA = indexA.df!['timeout'] ?? 0;  // expected: 1
+    const dfSharedB = indexB.df!['timeout'] ?? 0;  // expected: 13
+    const idfSharedA = computeIdf(NA, dfSharedA);
+    const idfSharedB = computeIdf(NB, dfSharedB);
+    const sharedDriftPct = ((idfSharedB - idfSharedA) / idfSharedA) * 100;
+
+    // "techonly" body token: only in tech docs; df stays at 3 while N triples
+    const dfExclA = indexA.df!['techonly'] ?? 0;   // expected: 3
+    const dfExclB = indexB.df!['techonly'] ?? 0;   // expected: 3
+    const idfExclA = computeIdf(NA, dfExclA);
+    const idfExclB = computeIdf(NB, dfExclB);
+    const exclDriftPct = ((idfExclB - idfExclA) / idfExclA) * 100;
+
+    console.log(`[idf-drift] N: ${NA} (baseline) -> ${NB} (polluted)`);
+    console.log(
+      `[idf-drift] shared "timeout": df ${dfSharedA}->${dfSharedB} | idf ${idfSharedA.toFixed(4)} -> ${idfSharedB.toFixed(4)} (${sharedDriftPct.toFixed(1)}%)`,
+    );
+    console.log(
+      `[idf-drift] exclusive "techonly": df ${dfExclA}->${dfExclB} | idf ${idfExclA.toFixed(4)} -> ${idfExclB.toFixed(4)} (${exclDriftPct.toFixed(1)}%)`,
+    );
+
+    // Shared token IDF must DROP: ops docs push df up faster than N
+    expect(idfSharedB).toBeLessThan(idfSharedA);
+
+    // Tech-exclusive token IDF must RISE: N grows but df is unchanged
+    expect(idfExclB).toBeGreaterThan(idfExclA);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 5 [PASS-NOW — verifies 0b CJK query domain fix]
+  //
+  // Previously (before the 0b fix), a pure CJK query produced no ASCII tokens,
+  // so inferQueryDomain() always returned 'neutral'. After adding CJK word
+  // entries to TECHNICAL_TAGS / OPS_TAGS / SUPPORT_TAGS, the tokenizer's
+  // 2-char bigram output (e.g. "超时", "重试", "集群", "节点") now matches the
+  // tag vocabularies, and Chinese queries resolve to a real domain.
+  //
+  // This test was previously "CJK query falls back to neutral domain [PASS-NOW]"
+  // which characterised the bug. It is now rewritten to verify the fix:
+  //
+  // Part A — technical CJK query:
+  //   query "接口超时重试" → tokens include "超时", "重试", "接口" (all in TECHNICAL_TAGS)
+  //   → inferQueryDomain = 'technical'
+  //   → DOMAIN_WEIGHT.technical: technical=1.0, ops=0.5
+  //   → technical entry score / ops entry score ≈ 1.0/0.5 = 2.0
+  //
+  // Part B — ops CJK query:
+  //   query "集群节点重启" → tokens include "集群", "节点", "重启" (all in OPS_TAGS)
+  //   → inferQueryDomain = 'ops'
+  //   → DOMAIN_WEIGHT.ops: ops=1.0, technical=0.7
+  //   → ops entry should outrank technical entry
+  // -------------------------------------------------------------------------
+  it('CJK query resolves to a real domain (0b)', async () => {
+    const learningsDir = path.join(tmpDir, 'learnings-cjk');
+
+    // Both entries share identical CJK title tokens so their raw IDF scores are
+    // equal. The only multiplier difference is the domain weight column.
+    // Part A uses technical-leaning Chinese (接口超时重试).
+    // Part B uses ops-leaning Chinese (集群节点重启).
+    const docs: Record<string, string> = {
+      'tech-cjk.md': learningDoc(
+        '接口超时重试配置 API technical',
+        ['api', 'typescript'],
+        '接口超时重试配置说明 timeout retry config',
+      ),
+      'ops-cjk.md': learningDoc(
+        '接口超时重试配置 k8s ops',
+        ['k8s', 'deploy'],
+        '接口超时重试配置说明 timeout retry config',
+      ),
+    };
+
+    const index = await buildScopedIndex(learningsDir, indexPath, docs);
+
+    // --- Part A: technical CJK query ---
+    // "接口超时重试" → bigrams include 接口/超时/重试, all in TECHNICAL_TAGS
+    // → inferQueryDomain = 'technical'
+    // → DOMAIN_WEIGHT.technical: technical=1.0, ops=0.5
+    const queryTech = '接口超时重试';
+    const resultsTech = search(queryTech, index);
+
+    const techResultA = resultsTech.find((r) => r.entry.filename === 'tech-cjk.md');
+    const opsResultA = resultsTech.find((r) => r.entry.filename === 'ops-cjk.md');
+
+    expect(techResultA).toBeDefined();
+    expect(opsResultA).toBeDefined();
+
+    const ratioA = techResultA!.score / opsResultA!.score;
+    console.log(
+      `[cjk-domain-0b] Part A (technical query): tech/ops ratio=${ratioA.toFixed(4)}`,
+      `expected ≈ ${(1.0 / 0.5).toFixed(4)}`,
+      `tech=${techResultA!.score.toFixed(4)}, ops=${opsResultA!.score.toFixed(4)}`,
+    );
+
+    // Technical entry must outrank ops entry under a technical query
+    expect(techResultA!.score).toBeGreaterThan(opsResultA!.score);
+    // Ratio should be close to 1.0/0.5 = 2.0 (technical:ops column weights)
+    expect(ratioA).toBeCloseTo(1.0 / 0.5, 1);
+
+    // --- Part B: ops CJK query ---
+    // Rebuild index with ops-leaning docs so that ops titles get matching tokens
+    const learningsDirB = path.join(tmpDir, 'learnings-cjk-ops');
+    const indexPathB = path.join(tmpDir, 'search-index-cjk-ops.json');
+
+    const docsB: Record<string, string> = {
+      'tech-cjk-ops.md': learningDoc(
+        '集群节点重启排查 API technical',
+        ['api', 'typescript'],
+        '集群节点重启排查说明 cluster node restart',
+      ),
+      'ops-cjk-ops.md': learningDoc(
+        '集群节点重启排查 k8s ops',
+        ['k8s', 'deploy'],
+        '集群节点重启排查说明 cluster node restart',
+      ),
+    };
+
+    const indexB = await buildScopedIndex(learningsDirB, indexPathB, docsB);
+
+    // "集群节点重启" → bigrams include 集群/节点/重启, all in OPS_TAGS
+    // → inferQueryDomain = 'ops'
+    // → DOMAIN_WEIGHT.ops: ops=1.0, technical=0.7
+    const queryOps = '集群节点重启';
+    const resultsOps = search(queryOps, indexB);
+
+    const techResultB = resultsOps.find((r) => r.entry.filename === 'tech-cjk-ops.md');
+    const opsResultB = resultsOps.find((r) => r.entry.filename === 'ops-cjk-ops.md');
+
+    expect(techResultB).toBeDefined();
+    expect(opsResultB).toBeDefined();
+
+    const ratioB = opsResultB!.score / techResultB!.score;
+    console.log(
+      `[cjk-domain-0b] Part B (ops query): ops/tech ratio=${ratioB.toFixed(4)}`,
+      `expected ≈ ${(1.0 / 0.7).toFixed(4)}`,
+      `ops=${opsResultB!.score.toFixed(4)}, tech=${techResultB!.score.toFixed(4)}`,
+    );
+
+    // Ops entry must outrank technical entry under an ops query
+    expect(opsResultB!.score).toBeGreaterThan(techResultB!.score);
+    // Ratio should be close to 1.0/0.7 ≈ 1.4286
+    expect(ratioB).toBeCloseTo(1.0 / 0.7, 1);
+  });
+});

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -11,11 +11,97 @@ import type { CodeKnowledgeResult, SourceAnchor } from './code-knowledge-recall.
 import { recordRecallQuality } from './recall-quality.js';
 import { deriveSessionId } from './utils/session-id.js';
 
-/** Minimum top-1 relevance score for recall to be considered worthwhile.
- *  Learnings meaningful hits score >=5; codebase hits are log-compressed to
- *  0-10 (recall.ts ~line 288). 4.0 balances not missing codebase hits vs
- *  filtering pure noise. Tunable — --check prints the actual score. */
-const RECALL_RELEVANCE_THRESHOLD = 4.0;
+/** Relevance threshold for codebase graph hits.
+ *  These are log-compressed to a bounded [0,10] range (see ~line 313),
+ *  so an absolute threshold is stable here — it does not drift with corpus size. */
+const CODEBASE_RELEVANCE_THRESHOLD = 4.0;
+
+/** Relevance threshold for learnings/docs hits, expressed as a fraction of the
+ *  theoretical single-token-match baseline rather than an absolute score.
+ *  Learnings scores are unbounded TF-IDF sums whose magnitude scales with
+ *  log(N) as the corpus grows (IDF numerator is the total entry count), so a
+ *  hardcoded absolute cutoff silently drifts. Normalizing by the baseline
+ *  keeps the decision stable across corpus sizes.
+ *
+ *  Calibrated against the current corpus (N=25): a single-token-match baseline
+ *  is log(26/2)+1 ≈ 3.56, giving an effective cutoff of ≈4.81 — slightly
+ *  stricter than the historical hardcoded 4.0.
+ *
+ *  IMPORTANT: this ratio is only "stricter" for N ≳ 20 (where baseline×1.35 >
+ *  4.0). For small corpora (N=1–5) the ratio gives a cutoff of 1.35–3.57, which
+ *  is significantly looser than 4.0. That is why LEARNINGS_ABSOLUTE_FLOOR exists:
+ *  isRelevantScore uses max(baseline*ratio, floor) so cold-start corpora are
+ *  held to the same strict bar as historical code, and the relative threshold
+ *  only takes effect once N is large enough (~20+) to push it above the floor. */
+const LEARNINGS_RELEVANCE_RATIO = 1.35;
+
+/** Absolute floor for learnings relevance, applied when the corpus is too small
+ *  for the relative threshold to be meaningful.
+ *
+ *  The ratio-based cutoff scales with log(N), so on a cold-start corpus (1-5
+ *  entries) it drops well below the historical absolute cutoff of 4.0 — a single
+ *  tag match would score ~1.7-3.6 and wrongly pass. Taking max(relative, floor)
+ *  keeps the stricter pre-existing behavior until the corpus is large enough
+ *  (N >= ~20) for the relative threshold to exceed the floor on its own. */
+const LEARNINGS_ABSOLUTE_FLOOR = 4.0;
+
+/**
+ * Decide whether a top-1 recall result clears the relevance bar.
+ *
+ * Codebase graph hits use a fixed threshold because their scores are already
+ * log-compressed into a bounded range. Learnings hits use
+ * `max(baseline * LEARNINGS_RELEVANCE_RATIO, LEARNINGS_ABSOLUTE_FLOOR)`:
+ * - On a large corpus (N ≳ 20), the relative threshold exceeds the floor and
+ *   provides a corpus-size-stable cutoff.
+ * - On a cold-start corpus (N = 1–5), the relative threshold drops well below
+ *   4.0, so the floor enforces the same strict bar as historical code and
+ *   prevents false positives from single-tag or single-title matches.
+ *
+ * @param score Top-1 merged result score.
+ * @param isCodebaseHit True when the top result came from the codebase graph.
+ * @param idfBaseline IDF of a single-occurrence token in the active index;
+ *                    pass 1 to fall back to absolute-score behavior.
+ * @returns True when the result is relevant enough to surface.
+ */
+export function isRelevantScore(
+  score: number,
+  isCodebaseHit: boolean,
+  idfBaseline: number,
+): boolean {
+  if (isCodebaseHit) return score >= CODEBASE_RELEVANCE_THRESHOLD;
+  const baseline = idfBaseline > 0 ? idfBaseline : 1;
+  return score >= Math.max(baseline * LEARNINGS_RELEVANCE_RATIO, LEARNINGS_ABSOLUTE_FLOOR);
+}
+
+/**
+ * IDF value of a token occurring in exactly one entry of the given index.
+ *
+ * Mirrors the formula in search-index.ts (`log((N+1)/(df+1)) + 1` with df=1)
+ * so learnings thresholds can be expressed relative to corpus size instead of
+ * as absolute scores. Returns 1 for legacy indexes lacking a df map, which
+ * makes `isRelevantScore` degrade to its previous absolute behavior.
+ *
+ * When multiple scopes are active, we take the entry count of whichever
+ * df-bearing index is largest. This is a deliberately conservative approximation
+ * (the resulting threshold is higher) — a more precise approach would carry each
+ * index's own baseline through to the per-result scoring, which is left as a
+ * known limitation (see P2-5).
+ *
+ * Legacy indexes (no df map) are excluded from the N computation because their
+ * presence would otherwise inflate maxEntries and raise the threshold against
+ * results that were actually scored against a small modern index.
+ *
+ * @returns IDF of a single-occurrence token (>= 1); 1 for legacy indexes without a df map.
+ */
+export function computeIdfBaseline(indexes: SearchIndex[]): number {
+  let maxEntries = 0;
+  for (const idx of indexes) {
+    if (!idx.df) continue;                    // legacy index: its N is not used for IDF anyway
+    if (idx.entries.length > maxEntries) maxEntries = idx.entries.length;
+  }
+  if (maxEntries === 0) return 1;
+  return Math.log((maxEntries + 1) / 2) + 1;
+}
 
 /** Resolve votes dir dynamically (respects HOME changes in tests). */
 function getVotesLocalDir(): string {
@@ -31,6 +117,8 @@ interface ScopedSearchResult extends SearchResult {
   sources?: SourceAnchor[];
   /** Forward-dependency neighbor files from graph (candidate change files). */
   relatedFiles?: string[];
+  /** True when this result came from the codebase knowledge graph (bounded score scale). */
+  fromCodebase?: boolean;
 }
 
 // ─── Recall data flow ────────────────────────────────────
@@ -225,9 +313,9 @@ export async function recall(
   query: string,
   options: GlobalOptions & { depth?: 'route' | 'context' | 'lookup'; check?: boolean },
 ): Promise<void> {
-  const emitCheckVerdict = (score: number, topResult?: ScopedSearchResult): void => {
+  const emitCheckVerdict = (score: number, isCodebaseHit = false, baseline = 1, topResult?: ScopedSearchResult): void => {
     const rounded = Math.round(score * 10) / 10;
-    const verdict = rounded >= RECALL_RELEVANCE_THRESHOLD ? 'RELEVANT' : 'NOT_RELEVANT';
+    const verdict = isRelevantScore(score, isCodebaseHit, baseline) ? 'RELEVANT' : 'NOT_RELEVANT';
     let line = `${verdict} score=${rounded.toFixed(1)}`;
     if (verdict === 'RELEVANT' && topResult) {
       line += ` title="${topResult.entry.title}"`;
@@ -328,6 +416,8 @@ export async function recall(
       .flatMap(({ index }) => index.entries.map((entry) => `${entry.type}:${entry.filename}`)),
   );
 
+  const idfBaseline = computeIdfBaseline(scopeIndexes.map((s) => s.index));
+
   for (const { index, scope, learningsBase } of scopeIndexes) {
     const results = search(query, index);
     for (const r of results) {
@@ -368,6 +458,7 @@ export async function recall(
         learningsBase: wikiRoot,
         sources: cr.sources,
         relatedFiles: cr.relatedFiles,
+        fromCodebase: true,
       });
     }
   } catch {
@@ -375,13 +466,20 @@ export async function recall(
   }
 
   // Re-sort merged results by score descending, then date descending
+  // TODO(cross-scale): learnings scores are unbounded TF-IDF sums that grow with
+  // log(N), while codebase scores are log-compressed into [0,10]. Sorting them
+  // directly compares different scales — as the corpus grows, learnings hits
+  // increasingly crowd out codebase hits regardless of true relevance. Fixing
+  // this properly means normalizing learnings scores against the IDF baseline
+  // before the merge (related to the per-domain IDF work).
   allResults.sort((a, b) => {
     if (b.score !== a.score) return b.score - a.score;
     return (b.entry.date || '').localeCompare(a.entry.date || '');
   });
 
   if (options.check) {
-    emitCheckVerdict(allResults.length > 0 ? allResults[0].score : 0, allResults[0]);
+    const top = allResults.length > 0 ? allResults[0] : undefined;
+    emitCheckVerdict(top?.score ?? 0, top?.fromCodebase ?? false, idfBaseline, top);
     return;
   }
 

--- a/src/utils/search-index.ts
+++ b/src/utils/search-index.ts
@@ -59,6 +59,16 @@ const TECHNICAL_TAGS = new Set([
   'http', 'grpc', 'proto', 'json', 'schema', 'migration', 'index',
   'test', 'unittest', 'e2e', 'mock', 'lint', 'typecheck',
   'docker', 'build', 'package', 'dependency', 'import', 'module',
+  // CJK terms: the tokenizer emits 2-char bigrams for Chinese text, so only
+  // 2-char entries can ever match — single chars are too ambiguous to include,
+  // and 3+ char words are unreachable by construction.
+  // Note: this table is also reused by inferDomain() to match frontmatter tags;
+  // a Chinese tag that appears in learnings frontmatter hits here the same way
+  // an English tag does — this is intentional and expected behaviour.
+  '接口', '代码', '函数', '类型', '重构', '报错', '异常', '调试', '修复', '补丁',
+  '性能', '延迟', '超时', '重试', '并发', '异步', '线程', '缓存',
+  '架构', '框架', '依赖', '模块', '编译', '构建', '测试', '单测', '断言',
+  '算法', '协议',
 ]);
 
 const OPS_TAGS = new Set([
@@ -69,12 +79,24 @@ const OPS_TAGS = new Set([
   'nginx', 'lb', 'ingress', 'service', 'network', 'firewall',
   'backup', 'restore', 'disaster', 'incident', 'oncall',
   'gpu', 'resource', 'quota', 'tke', 'tcr', 'cos',
+  // CJK terms: see TECHNICAL_TAGS comment above for rationale. Also reused by
+  // inferDomain() to match frontmatter tags — Chinese tag behaviour is the same
+  // as English tag behaviour, which is intentional.
+  '部署', '发布', '上线', '回滚', '扩容', '缩容', '重启', '集群', '节点',
+  '监控', '告警', '指标', '日志', '排查', '故障', '值班', '预案',
+  '容器', '镜像', '网关', '负载', '流量', '带宽', '磁盘', '内存', '显存',
+  '备份', '恢复', '容灾', '资源', '配额', '权限', '证书',
 ]);
 
 const SUPPORT_TAGS = new Set([
   'faq', 'support', 'user', 'customer', 'guide', 'tutorial',
   'onboard', 'onboarding', 'help', 'howto', 'usage', 'example',
   'feedback', 'issue', 'complaint', 'request', 'ticket',
+  // CJK terms: see TECHNICAL_TAGS comment above for rationale. Also reused by
+  // inferDomain() to match frontmatter tags — Chinese tag behaviour is the same
+  // as English tag behaviour, which is intentional.
+  '教程', '指南', '示例', '用法', '入门', '新手', '帮助',
+  '反馈', '咨询', '问题', '工单', '需求', '客户', '用户',
 ]);
 
 // Directory path sub-strings that signal a domain.
@@ -99,9 +121,12 @@ const DOMAIN_WEIGHT: Record<KnowledgeDomain, Record<KnowledgeDomain, number>> = 
 };
 
 /**
- * Infer the domain of a query from its tokens.
- * Uses the same tag sets used for document domain inference so the two sides
- * of the matching are symmetric.
+ * Infer the dominant domain of a search query from its tokens.
+ *
+ * Matches tokens against the same tag vocabularies used by `inferDomain`, which
+ * now include CJK word entries — the tokenizer emits 2-char words for Chinese
+ * text, so Chinese queries resolve to a real domain instead of always falling
+ * back to 'neutral'. Ties break technical > ops > support, mirroring inferDomain.
  */
 function inferQueryDomain(queryTokens: string[]): KnowledgeDomain {
   let techScore = 0;


### PR DESCRIPTION
## Summary

Two measured defects in recall's relevance gating, plus a regression baseline for a third that is deliberately deferred.

Both fixes came out of a real incident investigation where recall was of no help — the root causes turned out to be mechanical, not knowledge gaps.

## 1. `--check` compared a hardcoded absolute score against two incompatible scales

`RECALL_RELEVANCE_THRESHOLD = 4.0` was applied to whichever result sorted first, but `allResults` mixes:

| Source | Scale | Drifts with corpus size? |
|---|---|---|
| learnings (`search()`) | unbounded TF-IDF sum | **yes** — IDF numerator is total entry count |
| codebase graph (`recall.ts` ~L313) | `min(10, log2(s+1)*2)`, bounded `[0,10]` | no |

Measured drift: adding 12 unrelated-domain documents moved one entry from **14.0 → 30.6 (+119%)** without its own content changing.

Verdicts are now taken per source — codebase keeps the absolute threshold, learnings normalizes against `computeIdfBaseline()` (the IDF of a single-occurrence token).

### Cold-start regression this surfaced

The relative cutoff *alone* made small corpora **looser**, which is the opposite of what the initial framing assumed:

| N | relative cutoff | old 4.0 | newly passing |
|---|---|---|---|
| 1 | 1.35 | 4.0 | single title match (2.55), single tag (1.70) |
| 2 | 1.90 | 4.0 | 3.58 / 2.39 |
| 5 | 2.83 | 4.0 | single tag match (3.57) |
| ≥25 | 4.81+ | 4.0 | none (new is stricter) |

That lands squarely on new users and new projects. `LEARNINGS_ABSOLUTE_FLOOR` keeps the stricter pre-existing behavior until the corpus is large enough (**N ≥ 7**) for the ratio to exceed it on its own.

## 2. `inferQueryDomain` was unreachable for Chinese queries

The three tag vocabularies contained only ASCII entries, so any pure-Chinese query scored zero across all three and fell back to `'neutral'` — making the `technical` / `ops` / `support` rows of `DOMAIN_WEIGHT` **dead code for CJK users**.

Chinese entries added. Only **2-char words**, deliberately:

- the tokenizer emits bigrams, so single chars are too ambiguous (`超`, `时`, `重`)
- 3+ char words are **unreachable by construction** — `数据库` only ever yields `数据` / `据库`
- cross-domain terms excluded (`配置`, `失败`, `服务`, `文档`) — `文档` in particular would hijack `接口文档更新` and `故障复盘文档` into `support`

Verified after the change: `接口文档更新` → `technical`, `部署流程文档` → `ops`, `数据库连接池超时` → `technical`.

## 3. Deferred: cross-domain IDF pollution (regression baseline only)

The invariant *"adding entries of one domain must not change scores in another"* does not hold today. `df` and `N` are global (`search-index.ts` L549-554, L641), so any new domain reprices shared tokens.

Fixing it means partitioning IDF per domain → `SEARCH_INDEX_VERSION` 6→7 → full index rebuild for every user. **Deferred**, and the case is marked `it.fails()` so CI stays green while the contract is retained — if the assertion ever starts passing, `it.fails()` reports it and the case can be promoted to a plain `it()`.

Measured effect, which is *why* it was deprioritized:

```
[idf-drift] N: 3 -> 15
[idf-drift] shared    "timeout":  df 1->13 | idf 1.6931 -> 1.1335  (-33.1%)
[idf-drift] exclusive "techonly": df 3->3  | idf 1.0000 -> 2.3863 (+138.6%)
```

Absolute scores shift substantially, but **same-domain ordering is preserved** — IDF is a per-token multiplier that scales all candidates for a given query alike. The real damage was therefore concentrated in the absolute-threshold comparison, which is what §1 fixes.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Full suite **1913/1913 passing**, 146 files
- [x] New: `recall-relevance-threshold.test.ts` — floor vs. relative governance either side of the N≈7 cross-over, legacy/no-df fallback, `idfBaseline=0` defense, `computeIdfBaseline` excluding legacy indexes when picking max N
- [x] New: `search-idf-domain-isolation.test.ts` — global-df characterization, IDF drift measurement, CJK domain resolution (both directions: ratio 2.0 = 1.0/0.5 technical-query, 1.4286 = 1.0/0.7 ops-query), plus the deferred `it.fails()` invariant with fixture sanity split into its own `it()` so it cannot pass vacuously
- [x] `--check` stdout format byte-identical (`RELEVANT score=X.X\n`) — asserted by existing `recall-check.test.ts`
- [x] `SEARCH_INDEX_VERSION` and `DOMAIN_WEIGHT` values untouched; no index rebuild triggered

## Known limitations recorded, not fixed

- `allResults.sort` still compares the two scales directly — as the corpus grows, learnings hits increasingly crowd out codebase hits regardless of true relevance. Marked with a `TODO(cross-scale)` at the sort site; arguably worth more than the per-domain IDF work.
- `computeIdfBaseline` takes the max entry count across scopes — a conservative approximation. Precise handling means carrying each index's baseline alongside its results; noted in the docstring.
- `内存` / `资源` / `权限` / `证书` / `磁盘` are classified `ops`, so technically-framed memory questions get the ×0.7 cross-domain penalty. Known bias, left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)