### PR TITLE
feat(recall): add error-signature bypass and domain/type filters

### DIFF
--- a/src/__tests__/error-signature.test.ts
+++ b/src/__tests__/error-signature.test.ts
@@ -1,0 +1,381 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import os from 'node:os';
+import fse from 'fs-extra';
+import {
+  normalizeErrorSignature,
+  extractErrorSignatures,
+  matchErrorSignatures,
+} from '../utils/error-signature.js';
+import { buildIndex, loadIndex } from '../utils/search-index.js';
+
+// ---------------------------------------------------------------------------
+// error-signature: unit tests
+// ---------------------------------------------------------------------------
+
+describe('normalizeErrorSignature', () => {
+  // ── Defect 1 regression: pure decimal numbers must NOT become <HASH> ──────
+  it('pure decimal number becomes <n>, not <HASH>', () => {
+    const sig = normalizeErrorSignature('size 8388608');
+    expect(sig).toContain('<n>');
+    expect(sig).not.toContain('<hash>');
+  });
+
+  it('de0b3aa (hex string with letters) becomes <hash>', () => {
+    const sig = normalizeErrorSignature('de0b3aa');
+    expect(sig).toBe('<hash>');
+  });
+
+  it('abc1234 (hex string with letters) becomes <hash>', () => {
+    const sig = normalizeErrorSignature('abc1234');
+    expect(sig).toBe('<hash>');
+  });
+
+  // ── Defect 2 regression: quoted identifiers must NOT be normalised ────────
+  it('KeyError glm_moe_dsa and glm_moe_v2 produce different signatures', () => {
+    const sig1 = normalizeErrorSignature("KeyError: 'glm_moe_dsa'");
+    const sig2 = normalizeErrorSignature("KeyError: 'glm_moe_v2'");
+    expect(sig1).not.toBe(sig2);
+  });
+
+  // ── Core use-case: same failure reported with different concrete values ────
+  it('shape error with different dimensions and sizes collapse to same signature', () => {
+    const raw1 = "RuntimeError: shape '[2045, -1, 64]' is invalid for input of size 8388608";
+    const raw2 = "RuntimeError: shape '[2048, -1, 64]' is invalid for input of size 8368128";
+    const sig1 = normalizeErrorSignature(raw1);
+    const sig2 = normalizeErrorSignature(raw2);
+    expect(sig1).toBe(sig2);
+    // Confirm the signature is non-empty and lowercased
+    expect(sig1.length).toBeGreaterThan(0);
+    expect(sig1).toBe(sig1.toLowerCase());
+  });
+
+  it('ValueError with 64 and 256 block sizes collapse to same signature', () => {
+    const raw1 = 'ValueError: Weight output_partition_size = 64 is not divisible by weight quantization block_n = 128.';
+    const raw2 = 'ValueError: Weight output_partition_size = 256 is not divisible by weight quantization block_n = 128.';
+    const sig1 = normalizeErrorSignature(raw1);
+    const sig2 = normalizeErrorSignature(raw2);
+    expect(sig1).toBe(sig2);
+  });
+
+  it('RuntimeError: Gloo connectFullMesh failed and connectTimeout failed are different', () => {
+    const sig1 = normalizeErrorSignature('RuntimeError: Gloo connectFullMesh failed');
+    const sig2 = normalizeErrorSignature('RuntimeError: Gloo connectTimeout failed');
+    expect(sig1).not.toBe(sig2);
+  });
+
+  // ── Path normalisation ────────────────────────────────────────────────────
+  it('file path in error message is replaced with <PATH>', () => {
+    const raw = 'RuntimeError: Assertion error (csrc/apis/../jit_kernels/impls/../../jit/handle.hpp:126)';
+    const sig = normalizeErrorSignature(raw);
+    expect(sig).toContain('<path>');
+    // The number (126) should also be normalised
+    expect(sig).not.toMatch(/\b126\b/);
+    // A relative path's leading segment is absorbed too, so no 'csrc' residue
+    // is left dangling in front of the placeholder.
+    expect(sig).not.toContain('csrc');
+  });
+
+  it('URL is replaced with <URL> and leaves no scheme residue', () => {
+    const sig = normalizeErrorSignature('RuntimeError: fetch https://example.com/a/b/c failed');
+    expect(sig).toContain('<url>');
+    expect(sig).not.toContain('https:');
+    expect(sig).not.toContain('<path>');
+  });
+
+  it('treats short slash expressions symmetrically — neither a/b nor c/d/e is a path', () => {
+    // Both are below the 3-segment threshold, so neither may be rewritten.
+    // Asymmetric handling would make the same error yield different signatures
+    // depending on incidental prose.
+    const sig = normalizeErrorSignature('ValueError: ratio a/b and c/d/e differ');
+    expect(sig).toContain('a/b');
+    expect(sig).toContain('c/d/e');
+    expect(sig).not.toContain('<path>');
+  });
+
+  it('is idempotent — re-normalising an already normalised signature is stable', () => {
+    const raw =
+      'RuntimeError: at /a/b/c/d see https://x.io/p/q hash de0b3aa ver 12.9.1 num 8388608';
+    const once = normalizeErrorSignature(raw);
+    expect(normalizeErrorSignature(once)).toBe(once);
+  });
+
+  // ── Version numbers ───────────────────────────────────────────────────────
+  it('CUDA version string becomes <VER>', () => {
+    const sig = normalizeErrorSignature('CUDA 12.9.1');
+    expect(sig).toContain('<ver>');
+    // Should not produce three separate <N> tokens for "12", "9", "1"
+    expect(sig).not.toMatch(/<n>\.<n>\.<n>/);
+  });
+
+  // ── Edge cases ────────────────────────────────────────────────────────────
+  it('empty string returns empty string', () => {
+    expect(normalizeErrorSignature('')).toBe('');
+  });
+
+  it('whitespace-only string returns empty string', () => {
+    expect(normalizeErrorSignature('   \t\n  ')).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('extractErrorSignatures', () => {
+  it('extracts error signatures from a markdown body with multiple errors', () => {
+    // Use plain error lines, not heading lines, to avoid ambiguity
+    const body = [
+      'We saw this when running inference:',
+      "RuntimeError: shape '[2045, -1, 64]' is invalid for input of size 8388608",
+      '',
+      'And also:',
+      'ValueError: Weight output_partition_size = 64 is not divisible by weight quantization block_n = 128.',
+    ].join('\n');
+    const sigs = extractErrorSignatures(body);
+    expect(sigs.length).toBe(2);
+    // Both should be normalised (lowercased)
+    expect(sigs.every((s) => s === s.toLowerCase())).toBe(true);
+  });
+
+  it('deduplicates identical signatures appearing multiple times', () => {
+    const body = `
+RuntimeError: Gloo connectFullMesh failed
+Some text in between.
+RuntimeError: Gloo connectFullMesh failed
+`;
+    const sigs = extractErrorSignatures(body);
+    expect(sigs.length).toBe(1);
+  });
+
+  it('respects EXTRACT_LIMIT (8) and returns at most 8 distinct signatures', () => {
+    // Construct 12 different errors
+    const errorLines = Array.from({ length: 12 }, (_, i) =>
+      `RuntimeError: unique error message number ${i + 1} occurred in the system`,
+    ).join('\n');
+
+    const sigs = extractErrorSignatures(errorLines);
+    expect(sigs.length).toBeLessThanOrEqual(8);
+    expect(sigs.length).toBeGreaterThan(0);
+  });
+
+  it('returns empty array for plain text with no error lines', () => {
+    const body = 'This is a normal document with no exceptions or errors of the RuntimeError variety.';
+    const sigs = extractErrorSignatures(body);
+    // "no error lines" means no colon-delimited exception class
+    // The word "errors" alone won't match because we need "Error:" or "Exception:" pattern
+    expect(sigs).toEqual([]);
+  });
+
+  it('returns empty array for empty body', () => {
+    expect(extractErrorSignatures('')).toEqual([]);
+  });
+
+  it('returns signatures in first-seen order', () => {
+    const body = `
+RuntimeError: first error occurred
+ValueError: second error happened
+`;
+    const sigs = extractErrorSignatures(body);
+    expect(sigs.length).toBe(2);
+    // First signature should correspond to RuntimeError
+    expect(sigs[0]).toContain('runtimeerror');
+    expect(sigs[1]).toContain('valueerror');
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('matchErrorSignatures', () => {
+  // Build the sigIndex using normalizeErrorSignature so keys always match
+  // exactly what the lookup would produce at query time.
+  const glooSig = normalizeErrorSignature('RuntimeError: Gloo connectFullMesh failed');
+  const partitionSig = normalizeErrorSignature(
+    'ValueError: Weight output_partition_size = 64 is not divisible by weight quantization block_n = 128.',
+  );
+
+  const sigIndex: Record<string, string[]> = {
+    [glooSig]: ['gloo-fix.md'],
+    [partitionSig]: ['partition-fix.md'],
+  };
+
+  it('returns matching filenames when query contains a known error', () => {
+    const query = 'RuntimeError: Gloo connectFullMesh failed';
+    const matches = matchErrorSignatures(query, sigIndex);
+    expect(matches).toContain('gloo-fix.md');
+  });
+
+  it('returns matching filenames when query contains error with different numbers (same signature)', () => {
+    // Different numbers but same structure → same normalised signature
+    const query = 'ValueError: Weight output_partition_size = 256 is not divisible by weight quantization block_n = 128.';
+    const matches = matchErrorSignatures(query, sigIndex);
+    expect(matches).toContain('partition-fix.md');
+  });
+
+  it('returns empty array when query error is not in index', () => {
+    const query = 'RuntimeError: completely unknown error message nobody has seen';
+    const matches = matchErrorSignatures(query, sigIndex);
+    expect(matches).toEqual([]);
+  });
+
+  it('returns empty array when query has no error-like content', () => {
+    const query = 'how do I configure the learning rate for distributed training?';
+    const matches = matchErrorSignatures(query, sigIndex);
+    expect(matches).toEqual([]);
+  });
+
+  it('deduplicates results when multiple signatures map to the same file', () => {
+    const sig1 = normalizeErrorSignature('RuntimeError: first error happened');
+    const sig2 = normalizeErrorSignature('ValueError: second error happened');
+    const multiIndex: Record<string, string[]> = {
+      [sig1]: ['shared.md'],
+      [sig2]: ['shared.md'],
+    };
+    const query = 'RuntimeError: first error happened\nValueError: second error happened';
+    const matches = matchErrorSignatures(query, multiIndex);
+    const uniqueMatches = [...new Set(matches)];
+    expect(matches.length).toBe(uniqueMatches.length);
+    expect(matches).toContain('shared.md');
+  });
+
+  it('returns empty array when sigIndex is empty', () => {
+    const query = 'RuntimeError: some error message here';
+    const matches = matchErrorSignatures(query, {});
+    expect(matches).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildIndex level: assert errorSignatures populated and df isolation
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+let indexPath: string;
+
+beforeEach(async () => {
+  tmpDir = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-sig-test-'));
+  indexPath = path.join(tmpDir, 'search-index.json');
+});
+
+afterEach(async () => {
+  await fse.remove(tmpDir);
+});
+
+describe('buildIndex error signature integration', () => {
+  it('errorSignatures field is populated when learnings contain error lines', async () => {
+    const learningsDir = path.join(tmpDir, 'learnings');
+    await fse.ensureDir(learningsDir);
+
+    await fse.writeFile(
+      path.join(learningsDir, 'gloo-fix.md'),
+      '---\ntitle: "Gloo training fix"\ntags: [troubleshooting]\n---\n' +
+      'We saw: RuntimeError: Gloo connectFullMesh failed during distributed training.\n',
+    );
+
+    await buildIndex({ learningsDir, indexPath });
+    const index = await loadIndex(indexPath);
+
+    expect(index).not.toBeNull();
+    expect(index!.errorSignatures).toBeDefined();
+    expect(Object.keys(index!.errorSignatures!).length).toBeGreaterThan(0);
+
+    // At least one signature should map to gloo-fix.md
+    const allFiles = Object.values(index!.errorSignatures!).flat();
+    expect(allFiles).toContain('gloo-fix.md');
+  });
+
+  it('error signature strings do NOT appear in entry.tokens', async () => {
+    const learningsDir = path.join(tmpDir, 'learnings');
+    await fse.ensureDir(learningsDir);
+
+    await fse.writeFile(
+      path.join(learningsDir, 'error-doc.md'),
+      '---\ntitle: "Error doc"\ntags: [troubleshooting]\n---\n' +
+      'RuntimeError: Gloo connectFullMesh failed when training.\n',
+    );
+
+    await buildIndex({ learningsDir, indexPath });
+    const index = await loadIndex(indexPath);
+
+    expect(index).not.toBeNull();
+    const entry = index!.entries.find((e) => e.filename === 'error-doc.md');
+    expect(entry).toBeDefined();
+
+    // The normalised signature must not appear as a token.
+    // Signatures look like "runtimeerror: gloo connectfullmesh failed" (lowercased full line),
+    // which the tokenizer would split differently. But we want to assert that the
+    // raw signature string was never inserted into tokens.
+    const tokenSet = new Set(entry!.tokens);
+    const sigs = Object.keys(index!.errorSignatures ?? {});
+    for (const sig of sigs) {
+      expect(tokenSet.has(sig)).toBe(false);
+    }
+  });
+
+  it('df is not affected by error signatures — a plain word has the same df with or without error content', async () => {
+    const learningsDir1 = path.join(tmpDir, 'learnings1');
+    const learningsDir2 = path.join(tmpDir, 'learnings2');
+    const indexPath1 = path.join(tmpDir, 'index1.json');
+    const indexPath2 = path.join(tmpDir, 'index2.json');
+    await fse.ensureDir(learningsDir1);
+    await fse.ensureDir(learningsDir2);
+
+    // Both documents share the same prose; doc2 additionally carries error lines.
+    //
+    // Design note (why NOT whole-map df equality):
+    //   Asserting df['timeout']==1 in both maps does NOT detect the PR-278
+    //   failure mode, since 'timeout' is not a signature token — it stays 1 even
+    //   if every signature leaks into tokens.
+    //   Whole-map equality does not work either: an error line's *ordinary*
+    //   words ('divisible', 'runtimeerror', '2045', ...) legitimately enter
+    //   tokens and df, because the raw body text is tokenized for BM25 as it
+    //   always was. That is by design, not leakage.
+    //   The real invariant is therefore: no *normalised placeholder* ever
+    //   reaches tokens or df. Placeholders exist only inside errorSignatures.
+    const sharedProse =
+      '---\ntitle: "timeout guide"\ntags: [api]\n---\n' +
+      'Handle timeout carefully.\n';
+
+    await fse.writeFile(path.join(learningsDir1, 'doc.md'), sharedProse);
+
+    await fse.writeFile(
+      path.join(learningsDir2, 'doc.md'),
+      sharedProse +
+      'RuntimeError: Gloo connectFullMesh failed.\n' +
+      'ValueError: Weight output_partition_size = 64 is not divisible by block_n = 128.\n' +
+      "RuntimeError: shape '[2045, -1, 64]' is invalid for input of size 8388608.\n" +
+      'RuntimeError: Assertion error (csrc/apis/../jit/handle.hpp:126):\n',
+    );
+
+    await buildIndex({ learningsDir: learningsDir1, indexPath: indexPath1 });
+    await buildIndex({ learningsDir: learningsDir2, indexPath: indexPath2 });
+
+    const index1 = await loadIndex(indexPath1);
+    const index2 = await loadIndex(indexPath2);
+
+    expect(index1).not.toBeNull();
+    expect(index2).not.toBeNull();
+
+    const PLACEHOLDERS = ['<n>', '<path>', '<hash>', '<hex>', '<ver>', '<url>'];
+
+    // No placeholder may appear as (or inside) a df key.
+    for (const key of Object.keys(index2!.df ?? {})) {
+      for (const ph of PLACEHOLDERS) {
+        expect(key).not.toContain(ph);
+      }
+    }
+
+    // No placeholder may appear in entry.tokens.
+    const entry2 = index2!.entries.find((e) => e.filename === 'doc.md');
+    expect(entry2).toBeDefined();
+    expect(entry2!.tokens.some((t) => PLACEHOLDERS.some((ph) => t.includes(ph)))).toBe(false);
+
+    // The df of a word untouched by the error lines stays put, confirming the
+    // error content did not perturb pre-existing entries' weighting.
+    expect(index2!.df?.['timeout']).toBe(index1!.df?.['timeout']);
+
+    // Signatures — which DO contain placeholders — are present only in index2.
+    expect(Object.keys(index1!.errorSignatures ?? {}).length).toBe(0);
+    const sigs2 = Object.keys(index2!.errorSignatures ?? {});
+    expect(sigs2.length).toBeGreaterThan(0);
+    expect(sigs2.some((s) => PLACEHOLDERS.some((ph) => s.includes(ph)))).toBe(true);
+  });
+});

--- a/src/__tests__/recall-check.test.ts
+++ b/src/__tests__/recall-check.test.ts
@@ -92,6 +92,10 @@ describe('recall --check precheck mode', () => {
 
     expect(captured).toMatch(/^RELEVANT score=\d+\.\d+\n$/);
     expect(captured).not.toContain(CHECK_LEARNING_TITLE);
+    // With a single-entry index the learnings IDF baseline is 1 (log(1)+1=1),
+    // so the effective threshold is 1.35. A high-signal query against a closely
+    // matching title/tags should score well above that. The >= 4.0 guard
+    // confirms the fixture actually exercises a strong hit, not a borderline one.
     expect(Number(captured.match(/score=([\d.]+)/)![1])).toBeGreaterThanOrEqual(4.0);
   });
 

--- a/src/__tests__/recall-filters.test.ts
+++ b/src/__tests__/recall-filters.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { KnowledgeDomain, KnowledgeType } from '../types.js';
+import { parseFilterValues, matchesFilters, compareResults } from '../recall.js';
+
+// ---------------------------------------------------------------------------
+// recall-filters.test.ts — unit tests for parseFilterValues and matchesFilters
+//
+// These are pure-function tests only. The recall() function itself depends on
+// file-system and network resources (~/.teamai/, repo config) that make
+// end-to-end isolation impractical without large mocks. The two exported
+// helpers cover all filter logic, so testing them directly is both sufficient
+// and reliable.
+// ---------------------------------------------------------------------------
+
+const VALID_DOMAINS = new Set<KnowledgeDomain>(['technical', 'ops', 'support', 'neutral']);
+const VALID_TYPES = new Set<KnowledgeType>(['learnings', 'docs', 'rules', 'skills']);
+
+describe('parseFilterValues', () => {
+  it('returns undefined for undefined input', () => {
+    expect(parseFilterValues(undefined, VALID_DOMAINS, '--domain')).toBeUndefined();
+  });
+
+  it('returns undefined for empty string', () => {
+    expect(parseFilterValues('', VALID_DOMAINS, '--domain')).toBeUndefined();
+  });
+
+  it('returns undefined for whitespace-only string', () => {
+    expect(parseFilterValues('  ', VALID_DOMAINS, '--domain')).toBeUndefined();
+  });
+
+  it('parses a single valid value', () => {
+    const result = parseFilterValues('technical', VALID_DOMAINS, '--domain');
+    expect(result).not.toBeUndefined();
+    expect(result).toEqual(new Set(['technical']));
+  });
+
+  it('parses comma-separated valid values', () => {
+    const result = parseFilterValues('technical,ops', VALID_DOMAINS, '--domain');
+    expect(result).not.toBeUndefined();
+    expect(result).toEqual(new Set(['technical', 'ops']));
+  });
+
+  it('normalises mixed case and surrounding spaces', () => {
+    const result = parseFilterValues('Technical, OPS ', VALID_DOMAINS, '--domain');
+    expect(result).not.toBeUndefined();
+    expect(result).toEqual(new Set(['technical', 'ops']));
+  });
+
+  it('returns undefined and warns when all values are invalid', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = parseFilterValues('foo', VALID_DOMAINS, '--domain');
+    expect(result).toBeUndefined();
+    warnSpy.mockRestore();
+  });
+
+  it('drops invalid values and keeps valid ones (partial invalid)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = parseFilterValues('technical,foo', VALID_DOMAINS, '--domain');
+    expect(result).not.toBeUndefined();
+    expect(result).toEqual(new Set(['technical']));
+    warnSpy.mockRestore();
+  });
+
+  it('deduplicates repeated values', () => {
+    const result = parseFilterValues('technical,technical', VALID_DOMAINS, '--domain');
+    expect(result).not.toBeUndefined();
+    expect(result!.size).toBe(1);
+    expect(result).toEqual(new Set(['technical']));
+  });
+
+  it('works with KnowledgeType values', () => {
+    const result = parseFilterValues('learnings,docs', VALID_TYPES, '--type');
+    expect(result).not.toBeUndefined();
+    expect(result).toEqual(new Set(['learnings', 'docs']));
+  });
+});
+
+describe('matchesFilters', () => {
+  const makeEntry = (domain: KnowledgeDomain | undefined, type: KnowledgeType) => ({ domain, type });
+
+  it('returns true when both filters are undefined (no filter applied)', () => {
+    const entry = makeEntry('technical', 'learnings');
+    expect(matchesFilters(entry, undefined, undefined)).toBe(true);
+  });
+
+  it('passes when entry domain matches domainFilter (only domainFilter active)', () => {
+    const entry = makeEntry('ops', 'learnings');
+    const domainFilter = new Set<KnowledgeDomain>(['ops']);
+    expect(matchesFilters(entry, domainFilter, undefined)).toBe(true);
+  });
+
+  it('fails when entry domain does not match domainFilter', () => {
+    const entry = makeEntry('technical', 'learnings');
+    const domainFilter = new Set<KnowledgeDomain>(['ops']);
+    expect(matchesFilters(entry, domainFilter, undefined)).toBe(false);
+  });
+
+  it('treats missing domain as neutral when domainFilter active', () => {
+    const entry = makeEntry(undefined, 'learnings');
+    const domainFilter = new Set<KnowledgeDomain>(['neutral']);
+    expect(matchesFilters(entry, domainFilter, undefined)).toBe(true);
+  });
+
+  it('fails when missing domain treated as neutral but filter excludes neutral', () => {
+    const entry = makeEntry(undefined, 'learnings');
+    const domainFilter = new Set<KnowledgeDomain>(['technical']);
+    expect(matchesFilters(entry, domainFilter, undefined)).toBe(false);
+  });
+
+  it('passes when entry type matches typeFilter (only typeFilter active)', () => {
+    const entry = makeEntry('technical', 'docs');
+    const typeFilter = new Set<KnowledgeType>(['docs']);
+    expect(matchesFilters(entry, undefined, typeFilter)).toBe(true);
+  });
+
+  it('fails when entry type does not match typeFilter', () => {
+    const entry = makeEntry('technical', 'learnings');
+    const typeFilter = new Set<KnowledgeType>(['docs']);
+    expect(matchesFilters(entry, undefined, typeFilter)).toBe(false);
+  });
+
+  it('passes when both filters active and entry matches both', () => {
+    const entry = makeEntry('ops', 'rules');
+    const domainFilter = new Set<KnowledgeDomain>(['ops']);
+    const typeFilter = new Set<KnowledgeType>(['rules']);
+    expect(matchesFilters(entry, domainFilter, typeFilter)).toBe(true);
+  });
+
+  it('fails when both filters active but domain does not match', () => {
+    const entry = makeEntry('technical', 'rules');
+    const domainFilter = new Set<KnowledgeDomain>(['ops']);
+    const typeFilter = new Set<KnowledgeType>(['rules']);
+    expect(matchesFilters(entry, domainFilter, typeFilter)).toBe(false);
+  });
+
+  it('fails when both filters active but type does not match', () => {
+    const entry = makeEntry('ops', 'learnings');
+    const domainFilter = new Set<KnowledgeDomain>(['ops']);
+    const typeFilter = new Set<KnowledgeType>(['rules']);
+    expect(matchesFilters(entry, domainFilter, typeFilter)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// compareResults — sorting partition tests (P1-1)
+// ---------------------------------------------------------------------------
+
+// Minimal SearchIndexEntry for constructing test results.
+type RecallResult = Parameters<typeof compareResults>[0];
+
+function makeResult(score: number, fromSignature?: boolean, date = ''): RecallResult {
+  return {
+    entry: {
+      filename: 'x.md',
+      title: 'x',
+      author: '',
+      date,
+      tags: [],
+      tokens: [],
+      votes: 0,
+      type: 'learnings' as const,
+    },
+    score,
+    fromSignature,
+  };
+}
+
+describe('compareResults', () => {
+  it('signature hit precedes a scored hit whose score exceeds SIGNATURE_MATCH_SCORE (20)', () => {
+    // Simulate a TF-IDF hit that exceeds the fixed display value (e.g. N=83 corpus).
+    const sigHit = makeResult(20, true);
+    const scoredHit = makeResult(29.5, false);
+    // sigHit should come before scoredHit → comparator must return negative
+    expect(compareResults(sigHit, scoredHit)).toBeLessThan(0);
+    // And sorting an array should place sigHit first.
+    const sorted = [scoredHit, sigHit].sort(compareResults);
+    expect(sorted[0].fromSignature).toBe(true);
+    expect(sorted[0].score).toBe(20);
+  });
+
+  it('within non-signature partition, higher score sorts first', () => {
+    const high = makeResult(15, false);
+    const low = makeResult(5, false);
+    expect(compareResults(high, low)).toBeLessThan(0);
+  });
+
+  it('within signature partition, higher score sorts first', () => {
+    const a = makeResult(20, true);
+    const b = makeResult(20, true);
+    // Equal scores — tie-break by date
+    const older = { ...a, entry: { ...a.entry, date: '2024-01-01' } };
+    const newer = { ...a, entry: { ...a.entry, date: '2025-01-01' } };
+    expect(compareResults(newer, older)).toBeLessThan(0);
+  });
+
+  it('two non-signature results with equal score break tie by date descending', () => {
+    const older = makeResult(10, false, '2024-01-01');
+    const newer = makeResult(10, false, '2025-01-01');
+    expect(compareResults(newer, older)).toBeLessThan(0);
+  });
+});

--- a/src/__tests__/recall-relevance-threshold.test.ts
+++ b/src/__tests__/recall-relevance-threshold.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import { isRelevantScore, computeIdfBaseline } from '../recall.js';
+import type { SearchIndex } from '../types.js';
+
+// ─── Helpers ──────────────────────────────────────────────
+
+function makeIndex(entryCount: number, withDf: boolean): SearchIndex {
+  const entries = Array.from({ length: entryCount }, (_, i) => ({
+    filename: `doc-${i}.md`,
+    title: `Doc ${i}`,
+    author: 'test',
+    date: '2026-01-01',
+    tags: [],
+    tokens: ['token'],
+    votes: 0,
+    type: 'learnings' as const,
+  }));
+  return {
+    builtAt: '2026-01-01T00:00:00Z',
+    elapsedMs: 0,
+    entries,
+    df: withDf ? { token: entryCount } : undefined,
+  };
+}
+
+// ─── computeIdfBaseline ───────────────────────────────────
+
+describe('computeIdfBaseline', () => {
+  it('returns 1 for a legacy index with no df field', () => {
+    const idx = makeIndex(25, false);
+    expect(computeIdfBaseline([idx])).toBe(1);
+  });
+
+  it('returns 1 when entries array is empty (no entries to compute baseline from)', () => {
+    const idx: SearchIndex = {
+      builtAt: '2026-01-01T00:00:00Z',
+      elapsedMs: 0,
+      entries: [],
+      df: {},
+    };
+    expect(computeIdfBaseline([idx])).toBe(1);
+  });
+
+  it('returns log((N+1)/2)+1 for N=25 with df present', () => {
+    const idx = makeIndex(25, true);
+    expect(computeIdfBaseline([idx])).toBeCloseTo(Math.log(13) + 1, 5);
+  });
+
+  it('uses the index with the most entries when multiple indexes are given', () => {
+    const small = makeIndex(5, true);
+    const large = makeIndex(25, true);
+    // should pick large (N=25), not small (N=5)
+    const expected = Math.log((25 + 1) / 2) + 1;
+    expect(computeIdfBaseline([small, large])).toBeCloseTo(expected, 5);
+    expect(computeIdfBaseline([large, small])).toBeCloseTo(expected, 5);
+  });
+
+  it('ignores legacy (no-df) indexes when picking maxEntries', () => {
+    // Legacy index is larger than the df-bearing one — its N must NOT be used.
+    // Without the P2-6 fix, the legacy index's entry count would inflate the
+    // baseline and silently raise the threshold against unrelated results.
+    const legacy = makeIndex(100, false); // large but no df
+    const modern = makeIndex(10, true);   // small but has df
+    const expected = Math.log((10 + 1) / 2) + 1;
+    expect(computeIdfBaseline([legacy, modern])).toBeCloseTo(expected, 5);
+  });
+});
+
+// ─── isRelevantScore ─────────────────────────────────────
+
+describe('isRelevantScore', () => {
+  describe('codebase hits (bounded [0,10] scale)', () => {
+    it('returns true when score is exactly at CODEBASE_RELEVANCE_THRESHOLD (4.0)', () => {
+      expect(isRelevantScore(4.0, true, 1)).toBe(true);
+    });
+
+    it('returns false when score is just below threshold (3.9)', () => {
+      expect(isRelevantScore(3.9, true, 1)).toBe(false);
+    });
+
+    it('is not affected by idfBaseline — a large baseline does not change the verdict', () => {
+      // even with a baseline of 100 the codebase branch still uses the fixed threshold
+      expect(isRelevantScore(4.0, true, 100)).toBe(true);
+      expect(isRelevantScore(3.9, true, 100)).toBe(false);
+    });
+  });
+
+  describe('learnings hits (TF-IDF unbounded, floor + ratio)', () => {
+    // The effective threshold is max(baseline * 1.35, 4.0).
+    //
+    // Cross-over baseline: 4.0 / 1.35 ≈ 2.963 (corresponds to N ≈ 6–7).
+    //   - baseline < 2.963 → floor (4.0) wins
+    //   - baseline > 2.963 → relative threshold (baseline * 1.35) wins
+
+    // --- Relative threshold governs (N=25, baseline > cross-over) ---
+    // baseline for N=25: log(26/2)+1 ≈ 3.5649; threshold = 3.5649 * 1.35 ≈ 4.813
+    // floor (4.0) is below the relative threshold, so relative wins.
+    const baseline25 = computeIdfBaseline([makeIndex(25, true)]);
+
+    it('N=25: relative threshold governs — score just above baseline*1.35 passes', () => {
+      // Verify relative threshold is above the floor at this corpus size.
+      expect(baseline25 * 1.35).toBeGreaterThan(4.0);
+      expect(isRelevantScore(4.82, false, baseline25)).toBe(true);
+    });
+
+    it('N=25: relative threshold governs — score just below baseline*1.35 fails', () => {
+      expect(isRelevantScore(4.80, false, baseline25)).toBe(false);
+    });
+
+    // --- Floor governs (idfBaseline = 1, cold-start / legacy fallback) ---
+    // threshold = max(1 * 1.35, 4.0) = 4.0
+    // Before the floor was added, threshold was 1.35 — a single tag match
+    // (~1.7) would have passed on a 1-entry corpus, causing false positives.
+
+    it('cold-start (baseline=1): floor governs — 4.0 passes', () => {
+      // floor: 4.0; relative: 1.35 → floor wins
+      expect(isRelevantScore(4.0, false, 1)).toBe(true);
+    });
+
+    it('cold-start (baseline=1): floor governs — 3.9 fails', () => {
+      expect(isRelevantScore(3.9, false, 1)).toBe(false);
+    });
+
+    it('cold-start (baseline=1): old passing score (1.35) now correctly fails', () => {
+      // Before the floor, isRelevantScore(1.35, false, 1) returned true.
+      // With the floor at 4.0, it must return false to prevent cold-start false positives.
+      expect(isRelevantScore(1.35, false, 1)).toBe(false);
+    });
+
+    // --- Cross-over boundary (baseline ≈ 2.963) ---
+    // At baseline exactly equal to 4.0/1.35, both sides tie at 4.0.
+    // Below this baseline the floor wins; above it the ratio wins.
+    it('below cross-over (baseline=2.0): floor governs — threshold is 4.0', () => {
+      // relative = 2.0 * 1.35 = 2.70 < 4.0 → floor wins
+      expect(isRelevantScore(3.99, false, 2.0)).toBe(false);
+      expect(isRelevantScore(4.0, false, 2.0)).toBe(true);
+    });
+
+    it('above cross-over (baseline=3.5): relative threshold governs', () => {
+      // relative = 3.5 * 1.35 ≈ 4.725 > 4.0 → relative wins
+      // Using computed threshold to avoid floating-point boundary issues.
+      const relThreshold = 3.5 * 1.35; // ≈ 4.725
+      expect(isRelevantScore(relThreshold - 0.001, false, 3.5)).toBe(false);
+      expect(isRelevantScore(relThreshold + 0.001, false, 3.5)).toBe(true);
+    });
+  });
+
+  describe('defensive: idfBaseline = 0', () => {
+    it('treats idfBaseline=0 as 1 — floor (4.0) governs', () => {
+      // baseline 0 is normalised to 1; threshold = max(1.35, 4.0) = 4.0
+      expect(isRelevantScore(3.99, false, 0)).toBe(false);
+      expect(isRelevantScore(4.0, false, 0)).toBe(true);
+    });
+  });
+});

--- a/src/__tests__/search-domain-weighting.test.ts
+++ b/src/__tests__/search-domain-weighting.test.ts
@@ -197,7 +197,7 @@ describe('domain-weighted search scoring', () => {
     const index = await loadIndex(indexPath);
 
     expect(index).not.toBeNull();
-    expect(index!.version).toBe(6);
+    expect(index!.version).toBe(7);
 
     for (const entry of index!.entries) {
       expect(entry.domain).toBeDefined();

--- a/src/__tests__/search-idf-domain-isolation.test.ts
+++ b/src/__tests__/search-idf-domain-isolation.test.ts
@@ -1,0 +1,595 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import os from 'node:os';
+import fse from 'fs-extra';
+import { buildIndex, loadIndex, search } from '../utils/search-index.js';
+
+// ---------------------------------------------------------------------------
+// IDF domain isolation regression tests — 0a-0c validation baseline
+//
+// This file exists to *prove* the current bug before the fix lands.
+// Some tests are intentionally expected to FAIL on unpatched code (those that
+// verify isolation). Others are characterisation / diagnostic tests that MUST
+// PASS on current code — they record the evidence of the bug, not an absence
+// of it.
+//
+// Legend per test:
+//   [PASS-NOW]  — expected to pass before any fix
+//   [FAIL-NOW]  — expected to fail on current code; should pass after 0a fix
+//   [PASS-NOW-0b] — previously characterised the 0b CJK query domain bug;
+//                   now rewritten to verify the 0b fix (should PASS after fix)
+// ---------------------------------------------------------------------------
+
+// N_TECH / N_OPS are used across multiple tests; kept as module-level consts
+// so the ratio (3:12) is declared once and easy to adjust.
+const N_TECH = 3;
+const N_OPS = 12;
+
+// ---------------------------------------------------------------------------
+// Shared token set: words that appear in BOTH technical AND ops fixture docs.
+// Must be plain ASCII so tokenize() handles them predictably.
+// ---------------------------------------------------------------------------
+const SHARED_TOKENS = ['timeout', 'retry', 'config'];
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Produces a minimal valid frontmatter + body markdown string.
+ * Tags are written as a YAML flow sequence: [tag1, tag2, ...]
+ */
+const learningDoc = (title: string, tags: string[], body: string): string =>
+  `---\ntitle: ${title}\nauthor: t\ndate: 2026-01-01\ntags: [${tags.join(', ')}]\n---\n\n${body}\n`;
+
+/**
+ * Writes `docs` (filename → content) into `dir`, builds an index, and returns
+ * the loaded SearchIndex. Throws if the index cannot be loaded.
+ */
+async function buildScopedIndex(
+  learningsDir: string,
+  indexPath: string,
+  docs: Record<string, string>,
+): Promise<NonNullable<Awaited<ReturnType<typeof loadIndex>>>> {
+  await fse.ensureDir(learningsDir);
+  for (const [filename, content] of Object.entries(docs)) {
+    await fse.writeFile(path.join(learningsDir, filename), content);
+  }
+  await buildIndex({ learningsDir, indexPath });
+  const index = await loadIndex(indexPath);
+  if (!index) throw new Error(`Failed to load index from ${indexPath}`);
+  return index;
+}
+
+// ---------------------------------------------------------------------------
+// Module-level tmp paths; initialised in beforeEach, cleaned in afterEach.
+// ---------------------------------------------------------------------------
+let tmpDir: string;
+let indexPath: string;
+
+beforeEach(async () => {
+  tmpDir = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-idf-domain-'));
+  indexPath = path.join(tmpDir, 'search-index.json');
+});
+
+afterEach(async () => {
+  await fse.remove(tmpDir);
+});
+
+// ---------------------------------------------------------------------------
+describe('IDF domain isolation (regression)', () => {
+  // -------------------------------------------------------------------------
+  // Test 1 [PASS-NOW]
+  //
+  // Characterisation test: prove that the current SearchIndex stores a *single
+  // global* df table that mixes all domains together. This test MUST pass both
+  // before and after the 0a fix (it just records the schema shape).
+  //
+  // After the 0a fix, df should become per-domain; update this test to assert
+  // the new shape (e.g. index.dfByDomain.technical, index.dfByDomain.ops).
+  // -------------------------------------------------------------------------
+  it('records global df/N as the current baseline [PASS-NOW]', async () => {
+    const learningsDir = path.join(tmpDir, 'learnings');
+
+    // 2 technical entries (tags from TECHNICAL_TAGS: api, typescript)
+    // 2 ops entries (tags from OPS_TAGS: k8s, deploy)
+    // All share the token "timeout" in their body.
+    const docs: Record<string, string> = {
+      'tech-1.md': learningDoc('Tech one', ['api', 'typescript'], 'timeout retry config details here'),
+      'tech-2.md': learningDoc('Tech two', ['api', 'debug'], 'timeout retry config more here'),
+      'ops-1.md': learningDoc('Ops one', ['k8s', 'deploy'], 'timeout retry config infra stuff'),
+      'ops-2.md': learningDoc('Ops two', ['monitor', 'deploy'], 'timeout retry config more ops'),
+    };
+
+    const index = await buildScopedIndex(learningsDir, indexPath, docs);
+
+    // The global df map must exist
+    expect(index.df).toBeDefined();
+    expect(index.entries.length).toBe(4);
+
+    // "timeout" appears in all 4 entries → df["timeout"] === 4
+    // This proves df is global (cross-domain), not isolated per domain.
+    // After 0a fix this assertion should change to check dfByDomain instead.
+    expect(index.df!['timeout']).toBe(4);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 2 — currently expected to FAIL (tracked with it.fails())
+  //
+  // What it tests: adding unrelated ops entries must NOT change the score of
+  // existing technical entries. This assertion captures the IDF domain isolation
+  // bug that the 0a fix is intended to solve.
+  //
+  // Why it currently fails:
+  //   IDF uses a single global N = entries.length. When 12 ops docs are added:
+  //   • N grows from 3 (N_TECH) → 15 (N_TECH + N_OPS)
+  //   • Shared tokens' df values also grow (ops docs contribute to the global
+  //     df table), but the token "title:timeout" is tech-exclusive (df unchanged)
+  //   • Because N grows while df("title:timeout") stays at N_TECH, IDF rises:
+  //       index A: idf = log((3+1)/(1+1))+1 ≈ 1.693  → score ≈ 14.0
+  //       index B: idf = log((15+1)/(1+1))+1 ≈ 3.079 → score ≈ 30.6
+  //   • The scores diverge even though the technical sub-corpus is identical.
+  //
+  // Why it.fails() rather than it.skip():
+  //   it.fails() makes "this assertion currently fails" an *assertable contract*:
+  //   CI stays green on unpatched code, AND when the 0a fix lands and the
+  //   assertion unexpectedly starts passing, it.fails() will itself report an
+  //   error — actively prompting the author to convert this back to a plain it().
+  //   it.skip() would silently pass forever and lose all regression value.
+  //
+  // TODO after 0a lands: convert this to a plain it() and verify it passes.
+  // -------------------------------------------------------------------------
+  // -------------------------------------------------------------------------
+  // Test 2a [PASS-NOW] — fixture sanity check
+  //
+  // Verifies that the two indexes used by the it.fails() regression test
+  // actually return the tracked entry ('tech-0.md') with a positive score.
+  // If the tokenizer or scoring changes in a way that causes the fixture to
+  // no longer return this entry, this test will fail with a clear message —
+  // instead of silently keeping the it.fails() green (which would be the case
+  // if the sanity assertions were left inside it.fails(), where any throw
+  // counts as "expected failure").
+  // -------------------------------------------------------------------------
+  it('fixture sanity: both indexes return the tracked technical entry', async () => {
+    const dirA = path.join(tmpDir, 'learnings-sanity-A');
+    const idxPathA = path.join(tmpDir, 'index-sanity-A.json');
+
+    const techDocs: Record<string, string> = {};
+    for (let i = 0; i < N_TECH; i++) {
+      techDocs[`tech-${i}.md`] = learningDoc(
+        `Timeout retry API ${i}`,
+        ['api', 'typescript', 'debug'],
+        `timeout retry config techonly details ${i}`,
+      );
+    }
+
+    const indexA = await buildScopedIndex(dirA, idxPathA, techDocs);
+
+    const dirB = path.join(tmpDir, 'learnings-sanity-B');
+    const idxPathB = path.join(tmpDir, 'index-sanity-B.json');
+
+    const techAndOpsDocs: Record<string, string> = { ...techDocs };
+    for (let i = 0; i < N_OPS; i++) {
+      techAndOpsDocs[`ops-${i}.md`] = learningDoc(
+        `Deploy monitor ops ${i}`,
+        ['k8s', 'deploy', 'monitor'],
+        `timeout retry config opsonly infrastructure ${i}`,
+      );
+    }
+
+    const indexB = await buildScopedIndex(dirB, idxPathB, techAndOpsDocs);
+
+    const query = 'timeout retry api';
+    const resultsA = search(query, indexA);
+    const resultsB = search(query, indexB);
+
+    const resA = resultsA.find((r) => r.entry.filename === 'tech-0.md');
+    const resB = resultsB.find((r) => r.entry.filename === 'tech-0.md');
+
+    expect(resA).toBeDefined();
+    expect(resA!.score).toBeGreaterThan(0);
+    expect(resB).toBeDefined();
+    expect(resB!.score).toBeGreaterThan(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 2b — currently expected to FAIL (tracked with it.fails())
+  //
+  // What it tests: adding unrelated ops entries must NOT change the score of
+  // existing technical entries. This assertion captures the IDF domain isolation
+  // bug that the 0a fix is intended to solve.
+  //
+  // Why it currently fails:
+  //   IDF uses a single global N = entries.length. When 12 ops docs are added:
+  //   • N grows from 3 (N_TECH) → 15 (N_TECH + N_OPS)
+  //   • Shared tokens' df values also grow (ops docs contribute to the global
+  //     df table), but the token "title:timeout" is tech-exclusive (df unchanged)
+  //   • Because N grows while df("title:timeout") stays at N_TECH, IDF rises:
+  //       index A: idf = log((3+1)/(1+1))+1 ≈ 1.693  → score ≈ 14.0
+  //       index B: idf = log((15+1)/(1+1))+1 ≈ 3.079 → score ≈ 30.6
+  //   • The scores diverge even though the technical sub-corpus is identical.
+  //
+  // Why it.fails() rather than it.skip():
+  //   it.fails() makes "this assertion currently fails" an *assertable contract*:
+  //   CI stays green on unpatched code, AND when the 0a fix lands and the
+  //   assertion unexpectedly starts passing, it.fails() will itself report an
+  //   error — actively prompting the author to convert this back to a plain it().
+  //   it.skip() would silently pass forever and lose all regression value.
+  //
+  // NOTE: Fixture sanity (both indexes returning tech-0.md with score > 0) is
+  // verified separately in the preceding 'fixture sanity' test. Only the key
+  // isolation assertion lives here; if the fixture breaks, the sanity test fails
+  // with a clear message rather than this it.fails() silently staying green.
+  //
+  // TODO after 0a lands: convert this to a plain it() and verify it passes.
+  // -------------------------------------------------------------------------
+  it.fails(
+    'technical entry scores are unaffected by unrelated ops entries (expected to fail until 0a lands)',
+    async () => {
+      // --- Index A: only N_TECH technical entries ---
+      const dirA = path.join(tmpDir, 'learnings-A');
+      const idxPathA = path.join(tmpDir, 'index-A.json');
+
+      const techDocs: Record<string, string> = {};
+      for (let i = 0; i < N_TECH; i++) {
+        // Each tech doc: title contains "timeout", body shares SHARED_TOKENS.
+        // Unique body token "techonly" ensures there is an exclusive technical token.
+        techDocs[`tech-${i}.md`] = learningDoc(
+          `Timeout retry API ${i}`,
+          ['api', 'typescript', 'debug'],
+          `timeout retry config techonly details ${i}`,
+        );
+      }
+
+      const indexA = await buildScopedIndex(dirA, idxPathA, techDocs);
+
+      // --- Index B: same N_TECH technical entries PLUS N_OPS ops entries ---
+      const dirB = path.join(tmpDir, 'learnings-B');
+      const idxPathB = path.join(tmpDir, 'index-B.json');
+
+      // Exact same tech docs
+      const techAndOpsDocs: Record<string, string> = { ...techDocs };
+      for (let i = 0; i < N_OPS; i++) {
+        // Ops docs also contain the SHARED_TOKENS to cause IDF drift.
+        // They have distinct titles and ops-domain tags.
+        techAndOpsDocs[`ops-${i}.md`] = learningDoc(
+          `Deploy monitor ops ${i}`,
+          ['k8s', 'deploy', 'monitor'],
+          `timeout retry config opsonly infrastructure ${i}`,
+        );
+      }
+
+      const indexB = await buildScopedIndex(dirB, idxPathB, techAndOpsDocs);
+
+      // Query: purely technical tokens → inferQueryDomain returns 'technical'
+      // DOMAIN_WEIGHT.technical.technical === 1.0 for both indexes
+      // → domain multiplier is identical, so any score difference is purely IDF.
+      const query = 'timeout retry api';
+
+      const resultsA = search(query, indexA);
+      const resultsB = search(query, indexB);
+
+      const targetFile = 'tech-0.md';
+      const resA = resultsA.find((r) => r.entry.filename === targetFile);
+      const resB = resultsB.find((r) => r.entry.filename === targetFile);
+
+      // THE KEY ASSERTION — currently FAILS because IDF is polluted by ops entries.
+      // After 0a fix, scoreA === scoreB (to floating-point precision).
+      // (resA/resB being undefined would throw a TypeError, which also counts as
+      // failure here; the fixture sanity test above catches that case explicitly.)
+      expect(resB!.score).toBeCloseTo(resA!.score, 5);
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // Test 3 [FAIL-NOW or PASS-NOW — as-observed]
+  //
+  // Weaker property: even if absolute scores change, the *relative ranking*
+  // of technical entries among themselves should be preserved when ops entries
+  // are injected.
+  //
+  // This test determines the *severity* of the bug. If ranking is preserved
+  // despite absolute score drift, the practical impact on users is lower.
+  //
+  // Ranking is controlled by token placement:
+  //   tech-rank-0.md — "timeout" appears in TITLE  (highest raw score)
+  //   tech-rank-1.md — "timeout" appears in TAG     (medium raw score)
+  //   tech-rank-2.md — "timeout" appears only in BODY (lowest raw score,
+  //                     but requires title/tag hit from another query token
+  //                     so we also put "api" in title)
+  //
+  // All three entries have the same domain (technical) and type (learnings),
+  // so the only differentiator among them is token placement.
+  // -------------------------------------------------------------------------
+  it(
+    'relative ranking among technical entries is preserved when ops entries are added [observe: PASS or FAIL]',
+    async () => {
+      // --- Index A: only the 3 rank-test tech entries ---
+      const dirA = path.join(tmpDir, 'learnings-rank-A');
+      const idxPathA = path.join(tmpDir, 'index-rank-A.json');
+
+      const rankDocs: Record<string, string> = {
+        // Title match: "timeout" in title → score += 3 * idf("title:timeout")
+        'tech-rank-0.md': learningDoc(
+          'Timeout api guide',
+          ['api', 'typescript'],
+          'retry config techrank details',
+        ),
+        // Tag match: "timeout" in tags → score += 2 * idf("tag:timeout")
+        'tech-rank-1.md': learningDoc(
+          'API retry guide',
+          ['api', 'timeout'],
+          'retry config techrank details',
+        ),
+        // Body-only: "timeout" only in body — also has "api" in title for
+        // hasTitleOrTagMatch gate to pass.
+        'tech-rank-2.md': learningDoc(
+          'API config guide',
+          ['api', 'typescript'],
+          'timeout retry config techrank body only',
+        ),
+      };
+
+      const indexA = await buildScopedIndex(dirA, idxPathA, rankDocs);
+
+      // --- Index B: same 3 tech entries + N_OPS ops entries ---
+      const dirB = path.join(tmpDir, 'learnings-rank-B');
+      const idxPathB = path.join(tmpDir, 'index-rank-B.json');
+
+      const rankAndOpsDocs: Record<string, string> = { ...rankDocs };
+      for (let i = 0; i < N_OPS; i++) {
+        rankAndOpsDocs[`ops-rank-${i}.md`] = learningDoc(
+          `Deploy monitor ops ${i}`,
+          ['k8s', 'deploy', 'monitor'],
+          `timeout retry config opsonly ${i}`,
+        );
+      }
+
+      const indexB = await buildScopedIndex(dirB, idxPathB, rankAndOpsDocs);
+
+      const query = 'timeout api';
+
+      const resultsA = search(query, indexA);
+      const resultsB = search(query, indexB);
+
+      // Extract only the rank-test entries from each result set, in score order
+      const rankFiles = ['tech-rank-0.md', 'tech-rank-1.md', 'tech-rank-2.md'];
+      const orderA = resultsA
+        .filter((r) => rankFiles.includes(r.entry.filename ?? ''))
+        .map((r) => r.entry.filename);
+      const orderB = resultsB
+        .filter((r) => rankFiles.includes(r.entry.filename ?? ''))
+        .map((r) => r.entry.filename);
+
+      // All three tech entries must appear in both result sets
+      expect(orderA).toHaveLength(3);
+      expect(orderB).toHaveLength(3);
+
+      // Relative order among technical entries must be identical.
+      // If this FAILS, IDF drift is changing intra-domain ranking (high severity).
+      // If it PASSES, IDF drift only affects absolute scores (lower severity).
+      expect(orderB).toEqual(orderA);
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // Test 4 [PASS-NOW]
+  //
+  // Diagnostic: measure and assert the *direction* of IDF drift.
+  // This test PASSES on current code because it only asserts that drift *exists*
+  // in the expected direction — it does not assert isolation.
+  //
+  // Run with --reporter=verbose or check console output for the exact numbers.
+  // -------------------------------------------------------------------------
+  it('documents IDF drift magnitude for shared tokens [PASS-NOW]', async () => {
+    // Fixture design rationale for measurable IDF drift:
+    //
+    // IDF = log((N+1) / (df+1)) + 1.
+    // For IDF of "shared_token" to *decrease* from index A to B we need:
+    //   (N_B+1)/(df_B+1) < (N_A+1)/(df_A+1)
+    // i.e. the token's coverage fraction must increase after adding ops docs.
+    //
+    // Strategy: "shared" token "timeout" appears in only 1 of the 3 tech docs
+    // (coverage = 1/3) but in ALL 12 ops docs (coverage = 12/12 = 1.0).
+    // The blended coverage in B = (1+12)/15 ≈ 0.87 > 1/3, so IDF drops.
+    //
+    //   Index A: df("timeout")=1, N=3  → idf = log(4/2)+1  ≈ 1.693
+    //   Index B: df("timeout")=13, N=15 → idf = log(16/14)+1 ≈ 1.134
+    //   Drop: ≈ -33%
+    //
+    // "techonly" is tech-exclusive (never in ops): df stays at N_TECH in both
+    // indexes while N grows from 3 to 15 → IDF *rises*.
+    //   Index A: df=1, N=3  → idf = log(4/2)+1  ≈ 1.693
+    //   Index B: df=1, N=15 → idf = log(16/2)+1 ≈ 3.079
+    //   Rise: ≈ +82%
+    const dirA = path.join(tmpDir, 'learnings-drift-A');
+    const idxPathA = path.join(tmpDir, 'index-drift-A.json');
+
+    const techDocs: Record<string, string> = {
+      // Only tech-drift-0.md has "timeout" in its body (coverage = 1/N_TECH)
+      'tech-drift-0.md': learningDoc(
+        'API retry guide',
+        ['api', 'typescript', 'debug'],
+        'timeout techonly details here',
+      ),
+      'tech-drift-1.md': learningDoc(
+        'API config guide',
+        ['api', 'typescript', 'debug'],
+        'retry config techonly details here',
+      ),
+      'tech-drift-2.md': learningDoc(
+        'API debug guide',
+        ['api', 'debug'],
+        'retry config techonly fix here',
+      ),
+    };
+
+    const indexA = await buildScopedIndex(dirA, idxPathA, techDocs);
+
+    const dirB = path.join(tmpDir, 'learnings-drift-B');
+    const idxPathB = path.join(tmpDir, 'index-drift-B.json');
+
+    // ALL N_OPS ops docs contain "timeout" — this raises df("timeout") sharply.
+    const techAndOpsDocs: Record<string, string> = { ...techDocs };
+    for (let i = 0; i < N_OPS; i++) {
+      techAndOpsDocs[`ops-drift-${i}.md`] = learningDoc(
+        `Deploy monitor ops ${i}`,
+        ['k8s', 'deploy', 'monitor'],
+        `timeout opsonly infrastructure ${i}`,
+      );
+    }
+
+    const indexB = await buildScopedIndex(dirB, idxPathB, techAndOpsDocs);
+
+    // Manual IDF computation — exact formula from search-index.ts :652
+    const computeIdf = (N: number, docFreq: number): number =>
+      Math.log((N + 1) / (docFreq + 1)) + 1;
+
+    const NA = indexA.entries.length; // 3
+    const NB = indexB.entries.length; // 15
+
+    // "timeout" body token: low tech coverage (1/3), high ops coverage (12/12)
+    const dfSharedA = indexA.df!['timeout'] ?? 0;  // expected: 1
+    const dfSharedB = indexB.df!['timeout'] ?? 0;  // expected: 13
+    const idfSharedA = computeIdf(NA, dfSharedA);
+    const idfSharedB = computeIdf(NB, dfSharedB);
+    const sharedDriftPct = ((idfSharedB - idfSharedA) / idfSharedA) * 100;
+
+    // "techonly" body token: only in tech docs; df stays at 3 while N triples
+    const dfExclA = indexA.df!['techonly'] ?? 0;   // expected: 3
+    const dfExclB = indexB.df!['techonly'] ?? 0;   // expected: 3
+    const idfExclA = computeIdf(NA, dfExclA);
+    const idfExclB = computeIdf(NB, dfExclB);
+    const exclDriftPct = ((idfExclB - idfExclA) / idfExclA) * 100;
+
+    console.log(`[idf-drift] N: ${NA} (baseline) -> ${NB} (polluted)`);
+    console.log(
+      `[idf-drift] shared "timeout": df ${dfSharedA}->${dfSharedB} | idf ${idfSharedA.toFixed(4)} -> ${idfSharedB.toFixed(4)} (${sharedDriftPct.toFixed(1)}%)`,
+    );
+    console.log(
+      `[idf-drift] exclusive "techonly": df ${dfExclA}->${dfExclB} | idf ${idfExclA.toFixed(4)} -> ${idfExclB.toFixed(4)} (${exclDriftPct.toFixed(1)}%)`,
+    );
+
+    // Shared token IDF must DROP: ops docs push df up faster than N
+    expect(idfSharedB).toBeLessThan(idfSharedA);
+
+    // Tech-exclusive token IDF must RISE: N grows but df is unchanged
+    expect(idfExclB).toBeGreaterThan(idfExclA);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 5 [PASS-NOW — verifies 0b CJK query domain fix]
+  //
+  // Previously (before the 0b fix), a pure CJK query produced no ASCII tokens,
+  // so inferQueryDomain() always returned 'neutral'. After adding CJK word
+  // entries to TECHNICAL_TAGS / OPS_TAGS / SUPPORT_TAGS, the tokenizer's
+  // 2-char bigram output (e.g. "超时", "重试", "集群", "节点") now matches the
+  // tag vocabularies, and Chinese queries resolve to a real domain.
+  //
+  // This test was previously "CJK query falls back to neutral domain [PASS-NOW]"
+  // which characterised the bug. It is now rewritten to verify the fix:
+  //
+  // Part A — technical CJK query:
+  //   query "接口超时重试" → tokens include "超时", "重试", "接口" (all in TECHNICAL_TAGS)
+  //   → inferQueryDomain = 'technical'
+  //   → DOMAIN_WEIGHT.technical: technical=1.0, ops=0.5
+  //   → technical entry score / ops entry score ≈ 1.0/0.5 = 2.0
+  //
+  // Part B — ops CJK query:
+  //   query "集群节点重启" → tokens include "集群", "节点", "重启" (all in OPS_TAGS)
+  //   → inferQueryDomain = 'ops'
+  //   → DOMAIN_WEIGHT.ops: ops=1.0, technical=0.7
+  //   → ops entry should outrank technical entry
+  // -------------------------------------------------------------------------
+  it('CJK query resolves to a real domain (0b)', async () => {
+    const learningsDir = path.join(tmpDir, 'learnings-cjk');
+
+    // Both entries share identical CJK title tokens so their raw IDF scores are
+    // equal. The only multiplier difference is the domain weight column.
+    // Part A uses technical-leaning Chinese (接口超时重试).
+    // Part B uses ops-leaning Chinese (集群节点重启).
+    const docs: Record<string, string> = {
+      'tech-cjk.md': learningDoc(
+        '接口超时重试配置 API technical',
+        ['api', 'typescript'],
+        '接口超时重试配置说明 timeout retry config',
+      ),
+      'ops-cjk.md': learningDoc(
+        '接口超时重试配置 k8s ops',
+        ['k8s', 'deploy'],
+        '接口超时重试配置说明 timeout retry config',
+      ),
+    };
+
+    const index = await buildScopedIndex(learningsDir, indexPath, docs);
+
+    // --- Part A: technical CJK query ---
+    // "接口超时重试" → bigrams include 接口/超时/重试, all in TECHNICAL_TAGS
+    // → inferQueryDomain = 'technical'
+    // → DOMAIN_WEIGHT.technical: technical=1.0, ops=0.5
+    const queryTech = '接口超时重试';
+    const resultsTech = search(queryTech, index);
+
+    const techResultA = resultsTech.find((r) => r.entry.filename === 'tech-cjk.md');
+    const opsResultA = resultsTech.find((r) => r.entry.filename === 'ops-cjk.md');
+
+    expect(techResultA).toBeDefined();
+    expect(opsResultA).toBeDefined();
+
+    const ratioA = techResultA!.score / opsResultA!.score;
+    console.log(
+      `[cjk-domain-0b] Part A (technical query): tech/ops ratio=${ratioA.toFixed(4)}`,
+      `expected ≈ ${(1.0 / 0.5).toFixed(4)}`,
+      `tech=${techResultA!.score.toFixed(4)}, ops=${opsResultA!.score.toFixed(4)}`,
+    );
+
+    // Technical entry must outrank ops entry under a technical query
+    expect(techResultA!.score).toBeGreaterThan(opsResultA!.score);
+    // Ratio should be close to 1.0/0.5 = 2.0 (technical:ops column weights)
+    expect(ratioA).toBeCloseTo(1.0 / 0.5, 1);
+
+    // --- Part B: ops CJK query ---
+    // Rebuild index with ops-leaning docs so that ops titles get matching tokens
+    const learningsDirB = path.join(tmpDir, 'learnings-cjk-ops');
+    const indexPathB = path.join(tmpDir, 'search-index-cjk-ops.json');
+
+    const docsB: Record<string, string> = {
+      'tech-cjk-ops.md': learningDoc(
+        '集群节点重启排查 API technical',
+        ['api', 'typescript'],
+        '集群节点重启排查说明 cluster node restart',
+      ),
+      'ops-cjk-ops.md': learningDoc(
+        '集群节点重启排查 k8s ops',
+        ['k8s', 'deploy'],
+        '集群节点重启排查说明 cluster node restart',
+      ),
+    };
+
+    const indexB = await buildScopedIndex(learningsDirB, indexPathB, docsB);
+
+    // "集群节点重启" → bigrams include 集群/节点/重启, all in OPS_TAGS
+    // → inferQueryDomain = 'ops'
+    // → DOMAIN_WEIGHT.ops: ops=1.0, technical=0.7
+    const queryOps = '集群节点重启';
+    const resultsOps = search(queryOps, indexB);
+
+    const techResultB = resultsOps.find((r) => r.entry.filename === 'tech-cjk-ops.md');
+    const opsResultB = resultsOps.find((r) => r.entry.filename === 'ops-cjk-ops.md');
+
+    expect(techResultB).toBeDefined();
+    expect(opsResultB).toBeDefined();
+
+    const ratioB = opsResultB!.score / techResultB!.score;
+    console.log(
+      `[cjk-domain-0b] Part B (ops query): ops/tech ratio=${ratioB.toFixed(4)}`,
+      `expected ≈ ${(1.0 / 0.7).toFixed(4)}`,
+      `ops=${opsResultB!.score.toFixed(4)}, tech=${techResultB!.score.toFixed(4)}`,
+    );
+
+    // Ops entry must outrank technical entry under an ops query
+    expect(opsResultB!.score).toBeGreaterThan(techResultB!.score);
+    // Ratio should be close to 1.0/0.7 ≈ 1.4286
+    expect(ratioB).toBeCloseTo(1.0 / 0.7, 1);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -725,11 +725,13 @@ const recallCmd = program
   .description('Search team learnings knowledge base')
   .option('--depth <level>', 'Recall depth: route (entry-points only) | context (module-level, default) | lookup (full graph traversal)', 'context')
   .option('--check', 'Relevance precheck only: print RELEVANT/NOT_RELEVANT + top score; no file reads, no upvote')
+  .option('--domain <list>', 'Filter by knowledge domain, comma-separated: technical | ops | support | neutral')
+  .option('--type <list>', 'Filter by knowledge type, comma-separated: learnings | docs | rules | skills')
   .action(async (queryParts, cmdOpts) => {
     const globalOpts = program.opts() as GlobalOptions;
     const query = (queryParts as string[]).join(' ');
     const { recall } = await import('./recall.js');
-    await recall(query, { ...globalOpts, depth: cmdOpts.depth, check: cmdOpts.check });
+    await recall(query, { ...globalOpts, depth: cmdOpts.depth, check: cmdOpts.check, domain: cmdOpts.domain, type: cmdOpts.type });
   });
 
 recallCmd

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -11,11 +11,97 @@ import type { CodeKnowledgeResult } from './code-knowledge-recall.js';
 import { recordRecallQuality } from './recall-quality.js';
 import { deriveSessionId } from './utils/session-id.js';
 
-/** Minimum top-1 relevance score for recall to be considered worthwhile.
- *  Learnings meaningful hits score >=5; codebase hits are log-compressed to
- *  0-10 (recall.ts ~line 288). 4.0 balances not missing codebase hits vs
- *  filtering pure noise. Tunable — --check prints the actual score. */
-const RECALL_RELEVANCE_THRESHOLD = 4.0;
+/** Relevance threshold for codebase graph hits.
+ *  These are log-compressed to a bounded [0,10] range (see ~line 313),
+ *  so an absolute threshold is stable here — it does not drift with corpus size. */
+const CODEBASE_RELEVANCE_THRESHOLD = 4.0;
+
+/** Relevance threshold for learnings/docs hits, expressed as a fraction of the
+ *  theoretical single-token-match baseline rather than an absolute score.
+ *  Learnings scores are unbounded TF-IDF sums whose magnitude scales with
+ *  log(N) as the corpus grows (IDF numerator is the total entry count), so a
+ *  hardcoded absolute cutoff silently drifts. Normalizing by the baseline
+ *  keeps the decision stable across corpus sizes.
+ *
+ *  Calibrated against the current corpus (N=25): a single-token-match baseline
+ *  is log(26/2)+1 ≈ 3.56, giving an effective cutoff of ≈4.81 — slightly
+ *  stricter than the historical hardcoded 4.0.
+ *
+ *  IMPORTANT: this ratio is only "stricter" for N ≳ 20 (where baseline×1.35 >
+ *  4.0). For small corpora (N=1–5) the ratio gives a cutoff of 1.35–3.57, which
+ *  is significantly looser than 4.0. That is why LEARNINGS_ABSOLUTE_FLOOR exists:
+ *  isRelevantScore uses max(baseline*ratio, floor) so cold-start corpora are
+ *  held to the same strict bar as historical code, and the relative threshold
+ *  only takes effect once N is large enough (~20+) to push it above the floor. */
+const LEARNINGS_RELEVANCE_RATIO = 1.35;
+
+/** Absolute floor for learnings relevance, applied when the corpus is too small
+ *  for the relative threshold to be meaningful.
+ *
+ *  The ratio-based cutoff scales with log(N), so on a cold-start corpus (1-5
+ *  entries) it drops well below the historical absolute cutoff of 4.0 — a single
+ *  tag match would score ~1.7-3.6 and wrongly pass. Taking max(relative, floor)
+ *  keeps the stricter pre-existing behavior until the corpus is large enough
+ *  (N >= ~20) for the relative threshold to exceed the floor on its own. */
+const LEARNINGS_ABSOLUTE_FLOOR = 4.0;
+
+/**
+ * Decide whether a top-1 recall result clears the relevance bar.
+ *
+ * Codebase graph hits use a fixed threshold because their scores are already
+ * log-compressed into a bounded range. Learnings hits use
+ * `max(baseline * LEARNINGS_RELEVANCE_RATIO, LEARNINGS_ABSOLUTE_FLOOR)`:
+ * - On a large corpus (N ≳ 20), the relative threshold exceeds the floor and
+ *   provides a corpus-size-stable cutoff.
+ * - On a cold-start corpus (N = 1–5), the relative threshold drops well below
+ *   4.0, so the floor enforces the same strict bar as historical code and
+ *   prevents false positives from single-tag or single-title matches.
+ *
+ * @param score Top-1 merged result score.
+ * @param isCodebaseHit True when the top result came from the codebase graph.
+ * @param idfBaseline IDF of a single-occurrence token in the active index;
+ *                    pass 1 to fall back to absolute-score behavior.
+ * @returns True when the result is relevant enough to surface.
+ */
+export function isRelevantScore(
+  score: number,
+  isCodebaseHit: boolean,
+  idfBaseline: number,
+): boolean {
+  if (isCodebaseHit) return score >= CODEBASE_RELEVANCE_THRESHOLD;
+  const baseline = idfBaseline > 0 ? idfBaseline : 1;
+  return score >= Math.max(baseline * LEARNINGS_RELEVANCE_RATIO, LEARNINGS_ABSOLUTE_FLOOR);
+}
+
+/**
+ * IDF value of a token occurring in exactly one entry of the given index.
+ *
+ * Mirrors the formula in search-index.ts (`log((N+1)/(df+1)) + 1` with df=1)
+ * so learnings thresholds can be expressed relative to corpus size instead of
+ * as absolute scores. Returns 1 for legacy indexes lacking a df map, which
+ * makes `isRelevantScore` degrade to its previous absolute behavior.
+ *
+ * When multiple scopes are active, we take the entry count of whichever
+ * df-bearing index is largest. This is a deliberately conservative approximation
+ * (the resulting threshold is higher) — a more precise approach would carry each
+ * index's own baseline through to the per-result scoring, which is left as a
+ * known limitation (see P2-5).
+ *
+ * Legacy indexes (no df map) are excluded from the N computation because their
+ * presence would otherwise inflate maxEntries and raise the threshold against
+ * results that were actually scored against a small modern index.
+ *
+ * @returns IDF of a single-occurrence token (>= 1); 1 for legacy indexes without a df map.
+ */
+export function computeIdfBaseline(indexes: SearchIndex[]): number {
+  let maxEntries = 0;
+  for (const idx of indexes) {
+    if (!idx.df) continue;                    // legacy index: its N is not used for IDF anyway
+    if (idx.entries.length > maxEntries) maxEntries = idx.entries.length;
+  }
+  if (maxEntries === 0) return 1;
+  return Math.log((maxEntries + 1) / 2) + 1;
+}
 
 /** Resolve votes dir dynamically (respects HOME changes in tests). */
 function getVotesLocalDir(): string {
@@ -29,6 +115,8 @@ interface ScopedSearchResult extends SearchResult {
   learningsBase?: string;
   /** Source file anchors from codebase wiki frontmatter (codebase results only). */
   sources?: string[];
+  /** True when this result came from the codebase knowledge graph (bounded score scale). */
+  fromCodebase?: boolean;
 }
 
 // ─── Recall data flow ────────────────────────────────────
@@ -203,9 +291,18 @@ export async function recall(
   query: string,
   options: GlobalOptions & { depth?: 'route' | 'context' | 'lookup'; check?: boolean },
 ): Promise<void> {
-  const emitCheckVerdict = (score: number): void => {
+  /**
+   * Emit a --check verdict line to stdout.
+   *
+   * @param score     Top-1 result score (pass 0 for early-exit paths).
+   * @param isCodebaseHit  True when the result came from the codebase graph.
+   * @param baseline  IDF of a single-occurrence token; defaults to 1 so that
+   *                  early-exit paths (score always 0) always emit NOT_RELEVANT
+   *                  without needing the caller to supply a corpus-derived value.
+   */
+  const emitCheckVerdict = (score: number, isCodebaseHit = false, baseline = 1): void => {
     const rounded = Math.round(score * 10) / 10;
-    const verdict = rounded >= RECALL_RELEVANCE_THRESHOLD ? 'RELEVANT' : 'NOT_RELEVANT';
+    const verdict = isRelevantScore(score, isCodebaseHit, baseline) ? 'RELEVANT' : 'NOT_RELEVANT';
     process.stdout.write(`${verdict} score=${rounded.toFixed(1)}\n`);
   };
 
@@ -279,6 +376,8 @@ export async function recall(
   const allResults: ScopedSearchResult[] = [];
   const seenFilenames = new Set<string>();
 
+  const idfBaseline = computeIdfBaseline(scopeIndexes.map((s) => s.index));
+
   for (const { index, scope, learningsBase } of scopeIndexes) {
     const results = search(query, index);
     for (const r of results) {
@@ -314,6 +413,7 @@ export async function recall(
         scope: 'project',
         learningsBase: wikiRoot,
         sources: cr.sources,
+        fromCodebase: true,
       });
     }
   } catch {
@@ -321,13 +421,20 @@ export async function recall(
   }
 
   // Re-sort merged results by score descending, then date descending
+  // TODO(cross-scale): learnings scores are unbounded TF-IDF sums that grow with
+  // log(N), while codebase scores are log-compressed into [0,10]. Sorting them
+  // directly compares different scales — as the corpus grows, learnings hits
+  // increasingly crowd out codebase hits regardless of true relevance. Fixing
+  // this properly means normalizing learnings scores against the IDF baseline
+  // before the merge (related to the per-domain IDF work).
   allResults.sort((a, b) => {
     if (b.score !== a.score) return b.score - a.score;
     return (b.entry.date || '').localeCompare(a.entry.date || '');
   });
 
   if (options.check) {
-    emitCheckVerdict(allResults.length > 0 ? allResults[0].score : 0);
+    const top = allResults.length > 0 ? allResults[0] : undefined;
+    emitCheckVerdict(top?.score ?? 0, top?.fromCodebase ?? false, idfBaseline);
     return;
   }
 

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -4,17 +4,27 @@ import { loadIndex, buildIndex, search, isLegacyIndex } from './utils/search-ind
 import type { SearchResult } from './utils/search-index.js';
 import { readFileSafe, ensureDir, pathExists } from './utils/fs.js';
 import { log } from './utils/logger.js';
-import type { GlobalOptions, SearchIndex, LocalConfig } from './types.js';
+import type { GlobalOptions, SearchIndex, LocalConfig, KnowledgeDomain, KnowledgeType } from './types.js';
 import { getTeamaiHome } from './types.js';
 import { queryCodeKnowledge } from './code-knowledge-recall.js';
 import type { CodeKnowledgeResult } from './code-knowledge-recall.js';
 import { recordRecallQuality } from './recall-quality.js';
 import { deriveSessionId } from './utils/session-id.js';
+import { matchErrorSignatures } from './utils/error-signature.js';
 
 /** Relevance threshold for codebase graph hits.
  *  These are log-compressed to a bounded [0,10] range (see ~line 313),
  *  so an absolute threshold is stable here — it does not drift with corpus size. */
 const CODEBASE_RELEVANCE_THRESHOLD = 4.0;
+
+/** Display score assigned to exact error-signature matches.
+ *
+ *  This value does NOT establish ranking — learnings scores are unbounded TF-IDF
+ *  sums that exceed any fixed constant once the corpus grows (a single token
+ *  matching title+tag+body already scores ~21 at N=25). Precedence is enforced
+ *  by sorting on `fromSignature` first; this constant only gives the hit a
+ *  stable, recognizable number in `--check` output and formatted results. */
+const SIGNATURE_MATCH_SCORE = 20;
 
 /** Relevance threshold for learnings/docs hits, expressed as a fraction of the
  *  theoretical single-token-match baseline rather than an absolute score.
@@ -44,6 +54,12 @@ const LEARNINGS_RELEVANCE_RATIO = 1.35;
  *  keeps the stricter pre-existing behavior until the corpus is large enough
  *  (N >= ~20) for the relative threshold to exceed the floor on its own. */
 const LEARNINGS_ABSOLUTE_FLOOR = 4.0;
+
+/** Valid --domain filter values. Module-level constant so it is not rebuilt on each recall() call. */
+const VALID_DOMAINS = new Set<KnowledgeDomain>(['technical', 'ops', 'support', 'neutral']);
+
+/** Valid --type filter values. Module-level constant so it is not rebuilt on each recall() call. */
+const VALID_TYPES = new Set<KnowledgeType>(['learnings', 'docs', 'rules', 'skills']);
 
 /**
  * Decide whether a top-1 recall result clears the relevance bar.
@@ -103,6 +119,62 @@ export function computeIdfBaseline(indexes: SearchIndex[]): number {
   return Math.log((maxEntries + 1) / 2) + 1;
 }
 
+/**
+ * Parse a comma-separated CLI filter value against an allowed vocabulary.
+ *
+ * Unknown entries are dropped with a warning rather than aborting the command —
+ * a typo in one value should not discard the whole query. Returns undefined when
+ * nothing valid remains, which callers treat as "no filter".
+ *
+ * @param raw Raw option string, e.g. 'technical,ops'.
+ * @param allowed Permitted values.
+ * @param flagName Flag name used in the warning message, e.g. '--domain'.
+ * @returns Set of valid values, or undefined when the filter should not apply.
+ */
+export function parseFilterValues<T extends string>(
+  raw: string | undefined,
+  allowed: ReadonlySet<T>,
+  flagName: string,
+): Set<T> | undefined {
+  if (!raw) return undefined;
+  const parts = raw.split(',').map((s) => s.trim().toLowerCase()).filter(Boolean);
+  if (parts.length === 0) return undefined;
+  const valid = new Set<T>();
+  const invalid: string[] = [];
+  for (const p of parts) {
+    if (allowed.has(p as T)) valid.add(p as T);
+    else invalid.push(p);
+  }
+  if (invalid.length > 0) {
+    log.warn(
+      `Ignoring invalid ${flagName} value(s): ${invalid.join(', ')}. Valid: ${[...allowed].join(', ')}`,
+    );
+  }
+  return valid.size > 0 ? valid : undefined;
+}
+
+/**
+ * Test whether a search result entry matches the given domain/type filters.
+ *
+ * Both filters are optional; when absent that dimension is unconstrained.
+ * A missing `entry.domain` is treated as `'neutral'` to match the indexing
+ * convention in search-index.ts (entry.domain ?? 'neutral').
+ *
+ * @param entry The search index entry to test.
+ * @param domainFilter Set of allowed domains, or undefined for no restriction.
+ * @param typeFilter Set of allowed types, or undefined for no restriction.
+ * @returns True when the entry satisfies all active filters.
+ */
+export function matchesFilters(
+  entry: { domain?: KnowledgeDomain; type: KnowledgeType },
+  domainFilter: Set<KnowledgeDomain> | undefined,
+  typeFilter: Set<KnowledgeType> | undefined,
+): boolean {
+  if (domainFilter && !domainFilter.has(entry.domain ?? 'neutral')) return false;
+  if (typeFilter && !typeFilter.has(entry.type)) return false;
+  return true;
+}
+
 /** Resolve votes dir dynamically (respects HOME changes in tests). */
 function getVotesLocalDir(): string {
   return `${process.env.HOME ?? ''}/.teamai/votes`;
@@ -117,6 +189,8 @@ interface ScopedSearchResult extends SearchResult {
   sources?: string[];
   /** True when this result came from the codebase knowledge graph (bounded score scale). */
   fromCodebase?: boolean;
+  /** True when this result came from an exact error-signature match. */
+  fromSignature?: boolean;
 }
 
 // ─── Recall data flow ────────────────────────────────────
@@ -162,7 +236,10 @@ export function formatResults(results: ScopedSearchResult[]): string {
     // bucket each hit came from. Falls back to no tag for legacy entries that
     // pre-date the schema bump (these are auto-rebuilt on the next pull).
     const typeTag = entry.type ? `[${entry.type}] ` : '';
-    lines.push(`[${i + 1}/${results.length}] ${typeTag}${entry.title}${voteStr}${scopeStr}`);
+    // Exact error-signature matches get an additional tag so the AI knows this
+    // is a precise structural match, not a scored keyword hit.
+    const sigTag = results[i].fromSignature ? '[exact-error-match] ' : '';
+    lines.push(`[${i + 1}/${results.length}] ${sigTag}${typeTag}${entry.title}${voteStr}${scopeStr}`);
     lines.push(`Author: ${entry.author || 'unknown'} | Date: ${entry.date || 'unknown'} | Score: ${score.toFixed(1)}`);
     if (entry.tags.length > 0) {
       lines.push(`Tags: ${entry.tags.join(', ')}`);
@@ -186,6 +263,34 @@ export function formatResults(results: ScopedSearchResult[]): string {
   lines.push('');
   lines.push('以上内容来自团队知识库，仅供参考。如需详细信息，请用 Read 工具读取对应文件。');
   return lines.join('\n');
+}
+
+/**
+ * Comparator for merged recall results.
+ *
+ * Sorting strategy:
+ *  1. Exact error-signature matches always precede scored hits. Their score is a
+ *     fixed display value, not a comparable magnitude — learnings scores are
+ *     unbounded TF-IDF sums that exceed SIGNATURE_MATCH_SCORE as the corpus grows
+ *     (a single token matching title+tag+body already scores ~21 at N=25).
+ *  2. Within each partition, sort by score descending.
+ *  3. Ties broken by date descending.
+ *
+ * Exported so tests can validate the partitioning behaviour in isolation,
+ * without needing to spin up an index.
+ *
+ * TODO(cross-scale): learnings scores are unbounded TF-IDF sums that grow with
+ * log(N), while codebase scores are log-compressed into [0,10]. Sorting them
+ * directly compares different scales — as the corpus grows, learnings hits
+ * increasingly crowd out codebase hits regardless of true relevance. Fixing
+ * this properly means normalizing learnings scores against the IDF baseline
+ * before the merge (related to the per-domain IDF work).
+ */
+export function compareResults(a: ScopedSearchResult, b: ScopedSearchResult): number {
+  const sigDelta = Number(b.fromSignature ?? false) - Number(a.fromSignature ?? false);
+  if (sigDelta !== 0) return sigDelta;
+  if (b.score !== a.score) return b.score - a.score;
+  return (b.entry.date || '').localeCompare(a.entry.date || '');
 }
 
 /**
@@ -289,7 +394,12 @@ async function loadOrBuildScopeIndex(
  */
 export async function recall(
   query: string,
-  options: GlobalOptions & { depth?: 'route' | 'context' | 'lookup'; check?: boolean },
+  options: GlobalOptions & {
+    depth?: 'route' | 'context' | 'lookup';
+    check?: boolean;
+    domain?: string;
+    type?: string;
+  },
 ): Promise<void> {
   /**
    * Emit a --check verdict line to stdout.
@@ -373,15 +483,41 @@ export async function recall(
   }
 
   // Merge: search each scope index, tag results with scope, then combine & sort
-  const allResults: ScopedSearchResult[] = [];
+  let allResults: ScopedSearchResult[] = [];
   const seenFilenames = new Set<string>();
 
   const idfBaseline = computeIdfBaseline(scopeIndexes.map((s) => s.index));
 
+  // ── Exact error-signature bypass ─────────────────────────
+  // Check the errorSignatures map before running BM25 scoring. A signature hit
+  // means the query contains a pasted error that exactly matches a known failure.
+  // These hits are assigned SIGNATURE_MATCH_SCORE (a fixed display value) and
+  // always sorted before scored hits by compareResults (partitioned by fromSignature).
+  // Signature hits still go through --domain/--type filters so they respect user constraints.
+  for (const { index, scope, learningsBase } of scopeIndexes) {
+    const matchedFilenames = matchErrorSignatures(query, index.errorSignatures ?? {});
+    if (matchedFilenames.length === 0) continue;
+    // Build a filename → entry map once per index to avoid O(n²) find() in loop.
+    const entryByFilename = new Map(index.entries.map((e) => [e.filename, e]));
+    for (const filename of matchedFilenames) {
+      if (seenFilenames.has(filename)) continue;
+      const entry = entryByFilename.get(filename);
+      if (!entry) continue;
+      seenFilenames.add(filename);
+      allResults.push({
+        entry,
+        score: SIGNATURE_MATCH_SCORE,
+        scope,
+        learningsBase,
+        fromSignature: true,
+      });
+    }
+  }
+
   for (const { index, scope, learningsBase } of scopeIndexes) {
     const results = search(query, index);
     for (const r of results) {
-      // Deduplicate by filename across scopes
+      // Deduplicate by filename across scopes; signature hits already inserted above take priority.
       if (!seenFilenames.has(r.entry.filename)) {
         seenFilenames.add(r.entry.filename);
         allResults.push({ ...r, scope, learningsBase });
@@ -420,21 +556,28 @@ export async function recall(
     log.warn('recall: code graph retrieval unavailable, run teamai codebase --lint to diagnose');
   }
 
-  // Re-sort merged results by score descending, then date descending
-  // TODO(cross-scale): learnings scores are unbounded TF-IDF sums that grow with
-  // log(N), while codebase scores are log-compressed into [0,10]. Sorting them
-  // directly compares different scales — as the corpus grows, learnings hits
-  // increasingly crowd out codebase hits regardless of true relevance. Fixing
-  // this properly means normalizing learnings scores against the IDF baseline
-  // before the merge (related to the per-domain IDF work).
-  allResults.sort((a, b) => {
-    if (b.score !== a.score) return b.score - a.score;
-    return (b.entry.date || '').localeCompare(a.entry.date || '');
-  });
+  // Apply --domain / --type filters before sorting so --check reflects filtered results
+  const domainFilter = parseFilterValues(options.domain, VALID_DOMAINS, '--domain');
+  const typeFilter = parseFilterValues(options.type, VALID_TYPES, '--type');
+  if (domainFilter || typeFilter) {
+    const before = allResults.length;
+    allResults = allResults.filter((r) => matchesFilters(r.entry, domainFilter, typeFilter));
+    if (options.verbose) {
+      log.info(`recall: filters removed ${before - allResults.length} of ${before} result(s) (domain=${options.domain ?? 'none'}, type=${options.type ?? 'none'})`);
+    }
+  }
+
+  // Re-sort merged results. Signature matches partition first, then score descending,
+  // then date descending. See compareResults for the full rationale.
+  allResults.sort(compareResults);
 
   if (options.check) {
     const top = allResults.length > 0 ? allResults[0] : undefined;
-    emitCheckVerdict(top?.score ?? 0, top?.fromCodebase ?? false, idfBaseline);
+    // Signature hits use the codebase branch (absolute threshold CODEBASE_RELEVANCE_THRESHOLD = 4.0)
+    // because SIGNATURE_MATCH_SCORE (20) is a fixed constant that does not drift with corpus size,
+    // so comparing it against a corpus-relative learnings threshold would be meaningless.
+    const isAbsoluteScaleHit = (top?.fromCodebase ?? false) || (top?.fromSignature ?? false);
+    emitCheckVerdict(top?.score ?? 0, isAbsoluteScaleHit, idfBaseline);
     return;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -889,7 +889,7 @@ export interface SearchIndexEntry {
 }
 
 /** Schema version of the on-disk search-index.json (bump on breaking change). */
-export const SEARCH_INDEX_VERSION = 6;
+export const SEARCH_INDEX_VERSION = 7;
 
 /** Shape of the search-index.json file. */
 export interface SearchIndex {
@@ -905,6 +905,10 @@ export interface SearchIndex {
    *  Used for IDF weighting in search(). Optional for backward compatibility
    *  with indexes built before this field was introduced. */
   df?: Record<string, number>;
+  /** Error signature → filenames. Exact-match bypass; never feeds df/IDF.
+   *  Populated at index build time from error strings found in document bodies.
+   *  Optional so old indexes missing this field degrade gracefully to "no bypass". */
+  errorSignatures?: Record<string, string[]>;
 }
 
 /** Per-user vote file (votes/<user>.yaml). */

--- a/src/utils/error-signature.ts
+++ b/src/utils/error-signature.ts
@@ -1,0 +1,168 @@
+/**
+ * Error signature extraction and matching utilities.
+ *
+ * Provides a precise-match bypass for recall: error strings are normalised into
+ * stable signatures so that the same failure reported with different concrete
+ * values (addresses, sizes, line numbers) collapses to one signature.
+ *
+ * This index is intentionally kept completely separate from the BM25 token
+ * corpus so it never feeds df/IDF calculations.
+ */
+
+/**
+ * Maximum number of distinct signatures kept per document.
+ * Prevents a log-dump document from flooding the index with low-quality entries.
+ */
+const EXTRACT_LIMIT = 8;
+
+/** Maximum character length of a normalised signature before truncation. */
+const MAX_SIGNATURE_LENGTH = 200;
+
+/**
+ * Regex that recognises conventional exception/warning lines.
+ *
+ * Matches `SomethingError: message`, `RuntimeException: message`, etc.
+ * Requires the class name to start with an uppercase letter so mid-prose
+ * occurrences like `parseError` are not captured. The message part is
+ * captured (5–200 chars) to avoid empty or pathologically long lines.
+ * Note: MAX_SIGNATURE_LENGTH truncation is applied after normalisation,
+ * so the effective upper limit may differ from the 200 in this regex.
+ * Warning is included because it often appears in stack traces that share
+ * root cause with an Error line.
+ */
+const ERROR_LINE_RE = /\b([A-Z]\w*(?:Error|Exception|Warning))\s*:\s*(.{5,200})/g;
+
+/**
+ * Normalise an error string into a stable signature.
+ *
+ * Replaces volatile parts — hex literals, hashes, paths, versions, numbers —
+ * with placeholders so that the same failure reported with different concrete
+ * values collapses to one signature. Quoted identifiers are deliberately kept:
+ * `KeyError: 'glm_moe_dsa'` and `KeyError: 'glm_moe_v2'` are distinct root
+ * causes and must not merge.
+ *
+ * Normalisation order (matters):
+ *  1. Hex literals (0x…)          → <HEX>
+ *  2. Hex hashes (7–40 hex chars containing at least one letter) → <HASH>
+ *  3a. URLs (http/https scheme)                                   → <URL>
+ *  3b. Paths (≥ 3 slash-separated segments, boundary-anchored)   → <PATH>
+ *  4. Version strings (N.N.N…)                                   → <VER>
+ *  5. Numbers (integers and simple decimals)                     → <N>
+ *  6. Collapse whitespace, lowercase
+ *
+ * @param raw Raw error line.
+ * @returns Lowercased signature, or empty string when raw has no usable content.
+ */
+export function normalizeErrorSignature(raw: string): string {
+  if (!raw || !raw.trim()) return '';
+
+  let s = raw;
+
+  // 1. Hex literals: 0x[0-9a-fA-F]+
+  s = s.replace(/0x[0-9a-fA-F]+/g, '<HEX>');
+
+  // 2. Commit hashes / long hex strings: must be 7–40 hex chars AND contain
+  //    at least one letter (a–f). Two-step to keep the regex readable:
+  //    first find candidate tokens, then discard pure-decimal strings.
+  s = s.replace(/\b[0-9a-fA-F]{7,40}\b/g, (candidate) => {
+    // Require at least one letter — pure decimal numbers go to rule 5 (<N>).
+    return /[a-fA-F]/.test(candidate) ? '<HASH>' : candidate;
+  });
+
+  // 3a. URLs: replace entire URL before path rule so scheme residue is not left behind.
+  s = s.replace(/https?:\/\/\S+/g, '<URL>');
+
+  // 3b. Paths: three or more slash-separated segments, anchored to a word
+  //     boundary / whitespace / punctuation so we don't slice a token in half
+  //     (e.g. "a/b" in "ratio a/b" is NOT a path). An optional leading segment
+  //     lets relative paths match too — `csrc/apis/../jit/handle.hpp` is a path
+  //     even though it does not begin with a slash.
+  //     Uses capture-and-preserve for the leading boundary character rather
+  //     than lookbehind, so it works on all Node LTS versions.
+  s = s.replace(
+    /(^|[\s(['"=,:])([\w.\-+]*(?:\/[\w.\-+]+){3,})/g,
+    (_, pre: string) => pre + '<PATH>',
+  );
+
+  // 4. Version strings: must come before plain number rule to avoid
+  //    "12.9.1" becoming "<N>.<N>.<N>".
+  s = s.replace(/\b\d+\.\d+\.\d+\S*/g, '<VER>');
+
+  // 5. Numbers (integers and simple decimals).
+  s = s.replace(/\b\d+(?:\.\d+)?\b/g, '<N>');
+
+  // 6. Normalise whitespace and lowercase.
+  s = s.replace(/\s+/g, ' ').trim().toLowerCase();
+
+  return s.slice(0, MAX_SIGNATURE_LENGTH);
+}
+
+/**
+ * Extract candidate error lines from markdown body text.
+ *
+ * Recognises conventional `SomeError: message` forms for common exception
+ * suffixes. Only the first EXTRACT_LIMIT distinct signatures are kept per
+ * document, so a log dump cannot flood the index.
+ *
+ * @param body Document body (markdown).
+ * @returns Distinct normalised signatures, in first-seen order.
+ */
+export function extractErrorSignatures(body: string): string[] {
+  if (!body) return [];
+
+  const seen = new Set<string>();
+  const results: string[] = [];
+
+  // Reset lastIndex before iterating (global regex is stateful).
+  ERROR_LINE_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = ERROR_LINE_RE.exec(body)) !== null) {
+    // Re-construct the full matched text so the normaliser handles the whole line.
+    const fullMatch = match[0];
+    const sig = normalizeErrorSignature(fullMatch);
+    if (sig && !seen.has(sig)) {
+      seen.add(sig);
+      results.push(sig);
+      if (results.length >= EXTRACT_LIMIT) break;
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Look up documents whose recorded signatures match those found in a query.
+ *
+ * Returns entries in index order; an empty result means no exact match and the
+ * caller should fall back to scoring-based search.
+ *
+ * @param query Raw user query, possibly containing a pasted error.
+ * @param sigIndex Signature → filenames map from the search index.
+ * @returns Matching filenames, deduplicated.
+ */
+export function matchErrorSignatures(
+  query: string,
+  sigIndex: Record<string, string[]>,
+): string[] {
+  if (!query || Object.keys(sigIndex).length === 0) return [];
+
+  const querySigs = extractErrorSignatures(query);
+  if (querySigs.length === 0) return [];
+
+  const seen = new Set<string>();
+  const results: string[] = [];
+
+  for (const sig of querySigs) {
+    const files = sigIndex[sig];
+    if (!files) continue;
+    for (const f of files) {
+      if (!seen.has(f)) {
+        seen.add(f);
+        results.push(f);
+      }
+    }
+  }
+
+  return results;
+}

--- a/src/utils/search-index.ts
+++ b/src/utils/search-index.ts
@@ -59,6 +59,16 @@ const TECHNICAL_TAGS = new Set([
   'http', 'grpc', 'proto', 'json', 'schema', 'migration', 'index',
   'test', 'unittest', 'e2e', 'mock', 'lint', 'typecheck',
   'docker', 'build', 'package', 'dependency', 'import', 'module',
+  // CJK terms: the tokenizer emits 2-char bigrams for Chinese text, so only
+  // 2-char entries can ever match — single chars are too ambiguous to include,
+  // and 3+ char words are unreachable by construction.
+  // Note: this table is also reused by inferDomain() to match frontmatter tags;
+  // a Chinese tag that appears in learnings frontmatter hits here the same way
+  // an English tag does — this is intentional and expected behaviour.
+  '接口', '代码', '函数', '类型', '重构', '报错', '异常', '调试', '修复', '补丁',
+  '性能', '延迟', '超时', '重试', '并发', '异步', '线程', '缓存',
+  '架构', '框架', '依赖', '模块', '编译', '构建', '测试', '单测', '断言',
+  '算法', '协议',
 ]);
 
 const OPS_TAGS = new Set([
@@ -69,12 +79,24 @@ const OPS_TAGS = new Set([
   'nginx', 'lb', 'ingress', 'service', 'network', 'firewall',
   'backup', 'restore', 'disaster', 'incident', 'oncall',
   'gpu', 'resource', 'quota', 'tke', 'tcr', 'cos',
+  // CJK terms: see TECHNICAL_TAGS comment above for rationale. Also reused by
+  // inferDomain() to match frontmatter tags — Chinese tag behaviour is the same
+  // as English tag behaviour, which is intentional.
+  '部署', '发布', '上线', '回滚', '扩容', '缩容', '重启', '集群', '节点',
+  '监控', '告警', '指标', '日志', '排查', '故障', '值班', '预案',
+  '容器', '镜像', '网关', '负载', '流量', '带宽', '磁盘', '内存', '显存',
+  '备份', '恢复', '容灾', '资源', '配额', '权限', '证书',
 ]);
 
 const SUPPORT_TAGS = new Set([
   'faq', 'support', 'user', 'customer', 'guide', 'tutorial',
   'onboard', 'onboarding', 'help', 'howto', 'usage', 'example',
   'feedback', 'issue', 'complaint', 'request', 'ticket',
+  // CJK terms: see TECHNICAL_TAGS comment above for rationale. Also reused by
+  // inferDomain() to match frontmatter tags — Chinese tag behaviour is the same
+  // as English tag behaviour, which is intentional.
+  '教程', '指南', '示例', '用法', '入门', '新手', '帮助',
+  '反馈', '咨询', '问题', '工单', '需求', '客户', '用户',
 ]);
 
 // Directory path sub-strings that signal a domain.
@@ -99,9 +121,12 @@ const DOMAIN_WEIGHT: Record<KnowledgeDomain, Record<KnowledgeDomain, number>> = 
 };
 
 /**
- * Infer the domain of a query from its tokens.
- * Uses the same tag sets used for document domain inference so the two sides
- * of the matching are symmetric.
+ * Infer the dominant domain of a search query from its tokens.
+ *
+ * Matches tokens against the same tag vocabularies used by `inferDomain`, which
+ * now include CJK word entries — the tokenizer emits 2-char words for Chinese
+ * text, so Chinese queries resolve to a real domain instead of always falling
+ * back to 'neutral'. Ties break technical > ops > support, mirroring inferDomain.
  */
 function inferQueryDomain(queryTokens: string[]): KnowledgeDomain {
   let techScore = 0;

--- a/src/utils/search-index.ts
+++ b/src/utils/search-index.ts
@@ -3,6 +3,7 @@ import matter from 'gray-matter';
 import { readFileSafe, readJson, writeJson, listFiles, listFilesRecursive, listDirs, pathExists } from './fs.js';
 import { tokenize, MAX_TOKENIZE_CHARS } from './tokenizer.js';
 import { log } from './logger.js';
+import { extractErrorSignatures } from './error-signature.js';
 import {
   SEARCH_INDEX_VERSION,
   type KnowledgeDomain,
@@ -355,13 +356,16 @@ async function aggregateVotes(votesDir: string): Promise<VoteAggregation> {
  * Read a markdown file, truncate oversized content, and convert it to a
  * SearchIndexEntry of the given category. Used by all four collectors.
  * Returns null when the file is empty/unreadable.
+ *
+ * Also returns the body excerpt so callers can extract error signatures from
+ * the raw body without re-reading the file.
  */
 async function entryFromMdFile(
   absPath: string,
   filenameForId: string,
   type: KnowledgeType,
   voteCounts: Map<string, number>,
-): Promise<SearchIndexEntry | null> {
+): Promise<{ entry: SearchIndexEntry; bodyExcerpt: string } | null> {
   // 若当前文件是全量 codebase.md，且同目录存在 codebase-index.md，则跳过以避免重复命中。
   const basename = path.basename(absPath);
   if (basename === CODEBASE_FULL_FILENAME) {
@@ -417,16 +421,19 @@ async function entryFromMdFile(
   const docId = filenameForId.replace(/\.md$/i, '');
 
   return {
-    filename: filenameForId,
-    title,
-    author: meta.author ?? '',
-    date: meta.date ?? '',
-    tags,
-    tokens: [...new Set(tokens)],
-    votes: voteCounts.get(docId) ?? 0,
-    type,
-    domain,
-    path: absPath,
+    entry: {
+      filename: filenameForId,
+      title,
+      author: meta.author ?? '',
+      date: meta.date ?? '',
+      tags,
+      tokens: [...new Set(tokens)],
+      votes: voteCounts.get(docId) ?? 0,
+      type,
+      domain,
+      path: absPath,
+    },
+    bodyExcerpt,
   };
 }
 
@@ -435,10 +442,10 @@ async function collectFlatMdEntries(
   dir: string,
   type: KnowledgeType,
   voteCounts: Map<string, number>,
-): Promise<SearchIndexEntry[]> {
+): Promise<Array<{ entry: SearchIndexEntry; bodyExcerpt: string }>> {
   if (!await pathExists(dir)) return [];
   const files = await listFiles(dir);
-  const out: SearchIndexEntry[] = [];
+  const out: Array<{ entry: SearchIndexEntry; bodyExcerpt: string }> = [];
   for (const filename of files) {
     if (!filename.endsWith('.md')) continue;
     const e = await entryFromMdFile(path.join(dir, filename), filename, type, voteCounts);
@@ -455,10 +462,10 @@ async function collectRecursiveMdEntries(
   dir: string,
   type: KnowledgeType,
   voteCounts: Map<string, number>,
-): Promise<SearchIndexEntry[]> {
+): Promise<Array<{ entry: SearchIndexEntry; bodyExcerpt: string }>> {
   if (!await pathExists(dir)) return [];
   const files = await listFilesRecursive(dir);
-  const out: SearchIndexEntry[] = [];
+  const out: Array<{ entry: SearchIndexEntry; bodyExcerpt: string }> = [];
   for (const rel of files) {
     if (!rel.endsWith('.md')) continue;
     // Use the relative path as the filename so the entry id is unique
@@ -479,9 +486,9 @@ async function collectRecursiveMdEntries(
 async function collectSkillEntries(
   dir: string,
   voteCounts: Map<string, number>,
-): Promise<SearchIndexEntry[]> {
+): Promise<Array<{ entry: SearchIndexEntry; bodyExcerpt: string }>> {
   if (!await pathExists(dir)) return [];
-  const out: SearchIndexEntry[] = [];
+  const out: Array<{ entry: SearchIndexEntry; bodyExcerpt: string }> = [];
 
   async function walk(current: string): Promise<void> {
     const subdirs = await listDirs(current);
@@ -541,23 +548,28 @@ export async function buildIndex(
     : { scores: new Map<string, number>(), confidenceMap: new Map<string, number>() };
   const voteCounts = voteAgg.scores;
 
-  const entries: SearchIndexEntry[] = [];
+  // Collect raw results (entry + bodyExcerpt) from all sources.
+  // bodyExcerpt is kept alongside the entry only during index build so we can
+  // extract error signatures below without re-reading any files.
+  const rawResults: Array<{ entry: SearchIndexEntry; bodyExcerpt: string }> = [];
 
   if (opts.learningsDir) {
-    entries.push(...await collectFlatMdEntries(opts.learningsDir, 'learnings', voteCounts));
+    rawResults.push(...await collectFlatMdEntries(opts.learningsDir, 'learnings', voteCounts));
   }
   if (opts.docsDir) {
-    entries.push(...await collectRecursiveMdEntries(opts.docsDir, 'docs', voteCounts));
+    rawResults.push(...await collectRecursiveMdEntries(opts.docsDir, 'docs', voteCounts));
   }
   if (opts.rulesDir) {
-    entries.push(...await collectRecursiveMdEntries(opts.rulesDir, 'rules', voteCounts));
+    rawResults.push(...await collectRecursiveMdEntries(opts.rulesDir, 'rules', voteCounts));
   }
   if (opts.skillsDir) {
-    entries.push(...await collectSkillEntries(opts.skillsDir, voteCounts));
+    rawResults.push(...await collectSkillEntries(opts.skillsDir, voteCounts));
   }
   if (opts.codebaseDir) {
-    entries.push(...await collectRecursiveMdEntries(opts.codebaseDir, 'docs', voteCounts));
+    rawResults.push(...await collectRecursiveMdEntries(opts.codebaseDir, 'docs', voteCounts));
   }
+
+  const entries: SearchIndexEntry[] = rawResults.map((r) => r.entry);
 
   // Annotate entries with confidence/hotness for hot/cold scoring.
   if (voteAgg.confidenceMap.size > 0) {
@@ -571,10 +583,29 @@ export async function buildIndex(
 
   // Build document-frequency map for IDF weighting.
   // Count how many *entries* contain each token (not raw term frequency).
+  // IMPORTANT: error signatures are kept in a separate errorSignatures map and
+  // must NEVER be added to entry.tokens or counted here, to avoid polluting
+  // df/IDF calculations (which would cause IDF dilution across the corpus).
   const df: Record<string, number> = {};
   for (const entry of entries) {
     for (const token of new Set(entry.tokens)) {
       df[token] = (df[token] ?? 0) + 1;
+    }
+  }
+
+  // Build error-signature index: signature → filenames.
+  // This is a completely separate map that never touches entry.tokens or df,
+  // ensuring zero impact on BM25 IDF calculations.
+  const errorSignatures: Record<string, string[]> = {};
+  for (const { entry, bodyExcerpt } of rawResults) {
+    const sigs = extractErrorSignatures(bodyExcerpt);
+    for (const sig of sigs) {
+      if (!errorSignatures[sig]) {
+        errorSignatures[sig] = [];
+      }
+      if (!errorSignatures[sig].includes(entry.filename)) {
+        errorSignatures[sig].push(entry.filename);
+      }
     }
   }
 
@@ -594,6 +625,7 @@ export async function buildIndex(
     elapsedMs: elapsed,
     entries,
     df,
+    errorSignatures: Object.keys(errorSignatures).length > 0 ? errorSignatures : undefined,
   };
 
   await writeJson(targetPath, index);
@@ -612,6 +644,12 @@ export async function buildIndex(
  */
 export function isLegacyIndex(index: SearchIndex | null): boolean {
   if (!index) return false;
+  // Version number is the sole migration trigger. `errorSignatures` is intentionally
+  // absent (undefined) when no signatures were extracted — a zero-signature v7 index
+  // is still current. Do NOT use the presence/absence of errorSignatures as a detector:
+  // that would make a current empty-signature index indistinguishable from a stale one.
+  // When adding a new schema field in a future version, bump SEARCH_INDEX_VERSION;
+  // do not rely on field presence.
   if (typeof index.version !== 'number' || index.version < SEARCH_INDEX_VERSION) return true;
   // Any entry missing type or domain → legacy; domain was added in v3.
   return index.entries.some((e) => !e.type || e.domain === undefined) || !index.df;


### PR DESCRIPTION
> **Stacked on #278.** This branch is cut from `feature/recall-idf-domain-isolation`, so the diff shown here **includes #278's two commits**. Review #278 first; only the second commit (`0ed1e81`) belongs to this PR. GitHub can't target a base branch that doesn't exist upstream, hence `main`. Once #278 merges, this diff reduces to just its own commit.

## Motivation came from the data, not from a hunch

I profiled the real team knowledge base (`HyperAI/teamai`, 83 learnings) before writing anything:

| tag | docs | share |
|---|---|---|
| `troubleshooting` | 42 | **51%** |
| `sglang` | 36 | 43% |
| `k8s` | 23 | 28% |
| `deployment` | 19 | 23% |

That library is a **failure-case archive**. And the natural lookup key for a failure case is the error text — which is exactly where BM25-over-CJK-bigrams is weakest: the signal lives in the *structure* of the message, while the numbers differ on every occurrence.

This profiling also **killed a third change I had planned** (per-domain subscription filtering for learnings). With 83 docs overwhelmingly tagged ops/k8s/deployment across a single product line, there is no meaningful subset to isolate — every member works on the same thing. Dropped rather than built on a false premise.

## 1. Error-signature bypass

Error lines are normalized — hex, hashes, URLs, paths, versions, numbers → placeholders — and stored as a `signature → filenames` map consulted **before** scoring. An exact hit is strong evidence by definition, so it carries no score.

**Verified on real data.** The crash I was investigating when this idea surfaced:

```
RuntimeError: shape '[2045, -1, 64]' is invalid for input of size 8388608
```

collapses to the same signature as upstream sglang [issue #30037](https://github.com/sgl-project/sglang/issues/30037)'s `'[2048, -1, 64]' ... 8368128`:

```
runtimeerror: shape '[<n>, -<n>, <n>]' is invalid for input of size <n>
```

Extraction over the 83 real documents yields 13 signatures, including the team's own:

```
 1. runtimeerror: assertion error (<path>:<n>):
 2. valueerror: weight output_partition_size = <n> is not divisible by weight quantization block_n = <n>
 3. keyerror: 'glm_moe_dsa'
 5. nameerror: name 'deep_gemm' is not defined
 7. outofmemoryerror: cuda out of memory. tried to allocate <n> mib.
12. indexerror: start out of range (expected [-<n>,<n>], got <n>)
```

Signature #2 is the *same class of bug* as the one I was chasing — tensor partitioning that doesn't divide evenly. Had this existed, my first query would have surfaced it instead of a source-reading detour.

### Three normalization decisions that testing forced

- **Hash detection requires at least one letter.** The obvious `[0-9a-f]{7,40}` reads `8388608` as a hash, and the two shape errors then never merge. Pure decimals must fall through to `<N>`.
- **Quoted identifiers stay verbatim.** An early draft replaced `'...'` wholesale, collapsing `KeyError: 'glm_moe_dsa'` and `'glm_moe_v2'` — distinct root causes. Numbers inside quotes are still normalized, so shape-error merging is unaffected.
- **Paths need ≥3 segments and absorb a relative leading segment.** A 2-segment rule mangled URLs into `https:/<path>` and split prose asymmetrically (`a/b` survived while `c/d/e` was eaten mid-token). Two docs describing one error would then yield different signatures.

### Isolation from IDF — the hard constraint

Signatures live in their own top-level map and **never** enter `entry.tokens` or the `df` table. This matters because #278 exists to fix IDF drift; a bypass that fed the corpus would reintroduce it.

A test asserts no placeholder reaches `df` or `tokens`. Note what it does *not* assert: whole-map `df` equality. An error line's *ordinary* words (`divisible`, `runtimeerror`, `2045`) legitimately enter `df`, because raw body text is tokenized for BM25 as it always was. The invariant is placeholder absence, not df identity — an earlier draft asserted `df['timeout'] === 1`, which cannot observe the regression it claimed to guard (`timeout` isn't a signature token, so it stays 1 even under total leakage).

### Precedence by sorting, not by score

`SIGNATURE_MATCH_SCORE = 20` was initially meant to outrank scored hits "by construction." **It cannot.** Learnings scores are unbounded TF-IDF sums:

| N | single token hitting title+tag+body | +votes |
|---|---|---|
| 25 | 21.4 | 26.4 |
| **83** (this corpus) | **~29.5** | — |
| 1000 | 43.3 | 48.3 |

Already beaten at N=25 — so on the team's own library, exact error matches would have ranked *below* ordinary keyword hits, silently inverting the feature's premise as the corpus grew. Precedence is now enforced by sorting on the signature flag first; the constant remains for display only.

## 2. `recall --domain` / `--type`

Comma-separated filters over knowledge domain and type, giving callers an escape hatch to narrow retrieval:

```bash
teamai recall "重试逻辑" --domain technical
teamai recall "部署失败" --domain ops
teamai recall "xxx" --type learnings,docs
```

Applied **before** sorting and before the `--check` verdict, so `--check --domain ops` reflects the narrowed set. Signature hits are subject to these filters too — no back door.

Wholly invalid values warn and disable the filter rather than aborting: one typo should not silently return nothing. Validation follows the existing hand-rolled `Set` + `log.warn` convention (as `--depth` does), not commander's `.choices()`.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Full suite **1966/1966**, 148 files
- [x] `error-signature.test.ts` — both normalization regressions (`8388608` → `<N>`; `'glm_moe_dsa'` ≠ `'glm_moe_v2'`), the core merge case, URL/path symmetry, idempotency, `EXTRACT_LIMIT`, and the df/tokens isolation assertions
- [x] `recall-filters.test.ts` — `parseFilterValues` edge cases (empty, casing, partial-invalid, all-invalid, duplicates) and `matchesFilters` (missing domain → `neutral`)
- [x] Sort-partition test: a BM25 hit scoring **above** 20 still ranks below a signature hit
- [x] End-to-end against the real 83-doc library: 13 signatures extracted, zero placeholder leakage into `df`
- [x] `--check` stdout format byte-identical

Index version 6→7 so existing indexes rebuild and pick up signatures.

## Known limitations

- **Only 11 of 83 docs contain a parseable `XxxError:` line** — most troubleshooting write-ups describe failures in Chinese prose ("707 错误", "创建卡 Creating"). Extraction stays deliberately conservative; loosening it would mint noisy signatures and dilute the exactness that makes the bypass worth having. Of those 11, 9 have their error within the 2000-char body excerpt, so truncation costs 2 docs — not worth changing the excerpt logic for.
- Signature extraction reads the truncated `bodyExcerpt`, so errors past 2000 chars are missed (measured cost above).
- The `TODO(cross-scale)` from #278 still stands: learnings and codebase scores remain directly compared in the sort. The signature channel now sidesteps it, but the underlying mismatch is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)