### PR TITLE
docs(scope): align scope docs with runtime behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Author: member-b | Score: 12.0 | Tags: deploy, config
 - **Shared search index** (`search-index.json`): four categories — learnings (session experience), docs (team docs), rules (coding rules), and skills (each `SKILL.md`) — sourced from the corresponding team-repo directories, (re)built on `teamai pull` / `teamai contribute`.
 - **Codebase knowledge graph** (`teamwiki/`): produced by `teamai import`, queried live at search time.
 
-Ranking uses BM25 + graph-boost, merges dual-scope (user + project) results tagged with origin, and implicitly upvotes matched docs so good content floats up over time.
+Ranking uses BM25 + graph-boost within the active scope. Search-index results are tagged with their origin, and matched indexed documents are implicitly upvoted so good content floats up over time. When the current working directory contains a project-scope config, recall searches only that project scope; otherwise it searches the user scope.
 
 ### Codebase Knowledge Graph
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -153,7 +153,7 @@ Author: member-b | Score: 12.0 | Tags: deploy, config
 - **共享检索索引**（`search-index.json`）：learnings（session 经验）、docs（团队文档）、rules（编码规则）、skills（各 `SKILL.md`）四类，源自团队仓库对应目录，在 `teamai pull` / `teamai contribute` 时构建重建。
 - **代码知识图谱**（`teamwiki/`）：由 `teamai import` 生成，检索时实时查询。
 
-排序采用 BM25 + 图谱增强，合并用户 / 项目双 scope 结果并标注来源；搜索会隐式为命中文档投票，优质内容自然上浮。
+排序在当前生效的 scope 内采用 BM25 + 图谱增强。检索索引结果会标注来源，搜索会隐式为命中的索引文档投票，让优质内容自然上浮。当当前工作目录包含 project scope 配置时，recall 只检索该 project scope；否则检索 user scope。
 
 ### 代码知识图谱
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -160,7 +160,7 @@ Resulting directory structure:
 |------|-------------------|---------------|
 | **Install location** | Under the project directory | Under `~/` |
 | **Best for** | Project-specific skills and rules | General team conventions, cross-project skills |
-| **Can coexist** | ✅ Yes, both scopes can be active at once | ✅ Yes, both scopes can be active at once |
+| **Can coexist** | ✅ Yes; selected when the current directory has its config | ✅ Yes; selected otherwise |
 
 > **Local install location** is decided only by `teamai init`'s `--scope` (default `project`). A `scope` field in remote `teamai.yaml`, if present, is ignored.
 
@@ -230,7 +230,7 @@ teamai pull              # Manual pull
 teamai pull --dry-run    # Dry run, no actual changes
 ```
 
-> If you have both a user scope and a project scope, `pull` will pull resources for both scopes in sequence, without conflicts.
+> User and project scopes can both be installed, but `pull` processes only the active scope. When the current working directory contains a project-scope `.teamai/config.yaml`, it pulls the project scope and skips the user scope; otherwise it pulls the user scope.
 
 With role-based skills enabled, `pull`'s skill sync source becomes the contents of `skills/<namespace>/`, expanded according to `primaryRole + additionalRoles` and flattened into each local AI tool's skills directory. `rules/`, `docs/`, and `learnings/` keep their original global sync behavior.
 
@@ -477,7 +477,7 @@ teamai recall "GPU out of memory"
 ```
 
 - Supports mixed-language search
-- Automatically merges the knowledge bases of both user + project scope, labeling results `[user]`/`[project]` by source
+- Searches only the active scope and labels search-index results `[user]` or `[project]`; a project-scope config in the current working directory takes precedence over the user scope
 - Consulted knowledge is automatically upvoted, surfacing high-quality docs to the top
 - A lightweight relevance precheck is available via `teamai recall --check "<keywords>"`, which prints `RELEVANT score=<n>` or `NOT_RELEVANT score=<n>` without reading files or upvoting — the recall subagent uses it to skip retrieval on unrelated tasks
 
@@ -1028,7 +1028,7 @@ teamai pull
 
 **Q: Can user scope and project scope coexist?**
 
-Yes. `pull` pulls both scopes in sequence, and `recall` merges search results across both scopes' knowledge bases. They don't conflict with each other.
+Yes, both configurations can be installed on the same machine. They are isolated at runtime: when the current working directory contains a project-scope `.teamai/config.yaml`, `pull` and `recall` use only that project scope; otherwise they use the user scope.
 
 **Q: `teamai init` says it's already initialized?**
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -158,7 +158,7 @@ teamai init <group>/TeamAi-<team> --scope user
 |------|-------------------|---------------|
 | **资源安装位置** | 项目目录下 | `~/` 下 |
 | **适用场景** | 项目特定的技能和规则 | 通用团队规范、跨项目技能 |
-| **能否共存** | ✅ 可以同时拥有两个 scope | ✅ 可以同时拥有两个 scope |
+| **能否共存** | ✅ 可以；当前目录包含对应配置时生效 | ✅ 可以；其他情况下生效 |
 
 > **本机安装位置**仅由 `teamai init` 的 `--scope`（默认 `project`）决定。远端 `teamai.yaml` 中若仍有 `scope` 字段会被忽略。
 
@@ -228,7 +228,7 @@ teamai pull              # 手动拉取
 teamai pull --dry-run    # 试运行，不实际修改
 ```
 
-> 如果你同时有 user 和 project scope，`pull` 会依次拉取两个 scope 的资源，互不冲突。
+> user 和 project scope 可以同时安装，但 `pull` 只处理当前生效的 scope。当前工作目录包含 project scope 的 `.teamai/config.yaml` 时，会拉取 project scope 并跳过 user scope；否则拉取 user scope。
 
 启用角色化 skills 后，`pull` 的 skills 同步来源会变成 `skills/<namespace>/` 中的内容，按 `primaryRole + additionalRoles` 展开对应的 namespace，拍平安装到本地各 AI 工具 skills 目录。`rules/`、`docs/`、`learnings/` 仍然保持原有全局同步逻辑。
 
@@ -475,7 +475,7 @@ teamai recall "GPU 内存不足"
 ```
 
 - 支持中英文混合搜索
-- 自动合并 user + project 双 scope 的知识库，结果标注 `[user]`/`[project]` 来源
+- 只检索当前生效的 scope，并将检索索引结果标注为 `[user]` 或 `[project]`；当前工作目录包含 project scope 配置时优先使用 project scope
 - 被查阅的知识自动 upvote，好文档浮到顶部
 - 提供轻量相关性预检 `teamai recall --check "<关键词>"`，仅输出 `RELEVANT score=<n>` 或 `NOT_RELEVANT score=<n>`，不读取文件、不 upvote —— recall subagent 用它在任务与团队知识无关时跳过检索
 
@@ -1023,7 +1023,7 @@ teamai pull
 
 **Q: User scope 和 Project scope 可以共存吗？**
 
-可以。`pull` 会依次拉取两个 scope，`recall` 会合并搜索两个 scope 的知识库。两者互不冲突。
+可以在同一台机器上同时安装两个 scope 的配置，但运行时彼此隔离：当前工作目录包含 project scope 的 `.teamai/config.yaml` 时，`pull` 和 `recall` 只使用该 project scope；否则使用 user scope。
 
 **Q: `teamai init` 提示已初始化？**
 


### PR DESCRIPTION
## Summary

Align the English and Chinese scope documentation with the runtime behavior introduced by #73. When the current working directory contains a project-scope config, `pull` and `recall` use that scope only; otherwise they use the user scope.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing behavior to change)
- [x] Documentation only
- [ ] Refactor / internal cleanup

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` passes (144 files, 1891 tests)
- [x] `git diff --check` passes
- [ ] Added/updated tests for the change (not applicable; documentation only)

## Related Issues

Refs #73 and #77.

## Notes for Reviewers

This PR changes documentation only. The existing project-scope isolation behavior remains unchanged.
