### PR TITLE
feat(scope): add opt-in user resource inheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Author: member-b | Score: 12.0 | Tags: deploy, config
 - **Shared search index** (`search-index.json`): four categories — learnings (session experience), docs (team docs), rules (coding rules), and skills (each `SKILL.md`) — sourced from the corresponding team-repo directories, (re)built on `teamai pull` / `teamai contribute`.
 - **Codebase knowledge graph** (`teamwiki/`): produced by `teamai import`, queried live at search time.
 
-Ranking uses BM25 + graph-boost, merges dual-scope (user + project) results tagged with origin, and implicitly upvotes matched docs so good content floats up over time.
+Ranking uses BM25 + graph-boost within the active scope. Search-index results are tagged with their origin, and matched indexed documents are implicitly upvoted so good content floats up over time. When the current working directory contains a project-scope config, recall searches only that project scope; otherwise it searches the user scope.
 
 ### Codebase Knowledge Graph
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ teamai init https://github.com/yourorg/yourrepo
 
 # User-scope init (resources installed under ~/)
 teamai init https://github.com/yourorg/yourrepo --scope user
+
+# Optional layered setup: keep a project repo active while inheriting safe
+# resources and searchable knowledge from an initialized user-scope repo
+cd /path/to/my-project
+teamai init https://github.com/yourorg/project-repo --inherit-user-scope
 ```
 
 Once initialized, every AI session automatically pulls the latest skills / rules and other Harness updates published by admins — no manual sync needed.
@@ -153,7 +158,7 @@ Author: member-b | Score: 12.0 | Tags: deploy, config
 - **Shared search index** (`search-index.json`): four categories — learnings (session experience), docs (team docs), rules (coding rules), and skills (each `SKILL.md`) — sourced from the corresponding team-repo directories, (re)built on `teamai pull` / `teamai contribute`.
 - **Codebase knowledge graph** (`teamwiki/`): produced by `teamai import`, queried live at search time.
 
-Ranking uses BM25 + graph-boost within the active scope. Search-index results are tagged with their origin, and matched indexed documents are implicitly upvoted so good content floats up over time. When the current working directory contains a project-scope config, recall searches only that project scope; otherwise it searches the user scope.
+Ranking uses BM25 + graph-boost. When the current working directory contains a project-scope config, Recall searches that project; if the project enables `--inherit-user-scope`, it then searches user knowledge, tags each result with its origin, and lets an identical project entry override the user entry. Without a project config in the current directory, Recall searches the user scope. Active-scope hits are implicitly upvoted; inherited user hits remain read-only while the project is active.
 
 ### Codebase Knowledge Graph
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -43,6 +43,11 @@ teamai init https://github.com/yourorg/yourrepo
 
 # 用户级初始化（资源安装到 ~/ 下）
 teamai init https://github.com/yourorg/yourrepo --scope user
+
+# 可选的分层模式：项目仓库保持为当前 scope，同时继承已初始化的
+# user scope 中的安全资源和可检索知识
+cd /path/to/my-project
+teamai init https://github.com/yourorg/project-repo --inherit-user-scope
 ```
 
 初始化完成后，每次开启 AI 会话时都会自动拉取管理员发布的 skills / rules 等 Harness 更新，无需手动同步。
@@ -153,7 +158,7 @@ Author: member-b | Score: 12.0 | Tags: deploy, config
 - **共享检索索引**（`search-index.json`）：learnings（session 经验）、docs（团队文档）、rules（编码规则）、skills（各 `SKILL.md`）四类，源自团队仓库对应目录，在 `teamai pull` / `teamai contribute` 时构建重建。
 - **代码知识图谱**（`teamwiki/`）：由 `teamai import` 生成，检索时实时查询。
 
-排序在当前生效的 scope 内采用 BM25 + 图谱增强。检索索引结果会标注来源，搜索会隐式为命中的索引文档投票，让优质内容自然上浮。当当前工作目录包含 project scope 配置时，recall 只检索该 project scope；否则检索 user scope。
+排序采用 BM25 + 图谱增强。当前工作目录包含 project scope 配置时，Recall 先检索该项目；如果项目启用了 `--inherit-user-scope`，再检索 user 知识并标注结果来源，相同条目由 project 版本覆盖 user 版本。当前目录没有 project 配置时，Recall 检索 user scope。当前 scope 的命中会隐式投票，项目运行期间继承的 user 命中保持只读。
 
 ### 代码知识图谱
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -153,7 +153,7 @@ Author: member-b | Score: 12.0 | Tags: deploy, config
 - **共享检索索引**（`search-index.json`）：learnings（session 经验）、docs（团队文档）、rules（编码规则）、skills（各 `SKILL.md`）四类，源自团队仓库对应目录，在 `teamai pull` / `teamai contribute` 时构建重建。
 - **代码知识图谱**（`teamwiki/`）：由 `teamai import` 生成，检索时实时查询。
 
-排序采用 BM25 + 图谱增强，合并用户 / 项目双 scope 结果并标注来源；搜索会隐式为命中文档投票，优质内容自然上浮。
+排序在当前生效的 scope 内采用 BM25 + 图谱增强。检索索引结果会标注来源，搜索会隐式为命中的索引文档投票，让优质内容自然上浮。当当前工作目录包含 project scope 配置时，recall 只检索该 project scope；否则检索 user scope。
 
 ### 代码知识图谱
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -13,9 +13,10 @@
 - [Core Concepts](#core-concepts)
 - [Installation](#installation)
 - [Admin Initialization](#admin-initialization)
-  - [User Scope](#user-scope)
   - [Project Scope](#project-scope)
+  - [User Scope](#user-scope)
   - [How to Choose a Scope?](#how-to-choose-a-scope)
+  - [Layer an organization repo under a project repo](#layer-an-organization-repo-under-a-project-repo)
 - [Member Onboarding](#member-onboarding)
 - [Day-to-Day Use](#day-to-day-use)
 - [Sharing Team Resources](#sharing-team-resources)
@@ -33,7 +34,7 @@
 | Concept | Description |
 |------|------|
 | **Team Repo** | A Git repository that centrally stores a team's shared Skills / Rules / Docs / Env resources |
-| **Scope** | Where resources are installed: `user` (home directory, default) or `project` (project directory) |
+| **Scope** | Where resources are installed: `project` (current project, default) or `user` (home directory) |
 | **Skills** | Custom skills the AI can invoke (a directory containing a `SKILL.md`) |
 | **Rules** | Markdown-formatted team conventions, automatically merged into AI tool configs |
 | **Docs** | Shared team documentation for the AI to reference |
@@ -114,6 +115,8 @@ teamai init <group>/TeamAi-<team> --scope project --role hai_dev --force
 |------|------|
 | `[repo]` / `--repo <url>` | Team repo URL (positional preferred; `--repo` is a permanent alias) |
 | `--scope <project\|user>` | Install scope, defaults to `project` (`<cwd>/.teamai`). Use `user` for `~/` |
+| `--inherit-user-scope` | Project scope only: also sync safe user resources and search user knowledge |
+| `--no-inherit-user-scope` | Disable previously configured user-scope inheritance for this project |
 | `--role <id>` | Directly specify the primary role, skipping the interactive role prompt |
 | `--force` | Overwrite existing config, skipping confirmation prompts |
 
@@ -126,6 +129,7 @@ repo:
 username: alice
 scope: project
 projectRoot: /path/to/my-project
+inheritUserScope: true            # optional; project scope only
 primaryRole: hai
 additionalRoles:
   - pm
@@ -160,9 +164,24 @@ Resulting directory structure:
 |------|-------------------|---------------|
 | **Install location** | Under the project directory | Under `~/` |
 | **Best for** | Project-specific skills and rules | General team conventions, cross-project skills |
-| **Can coexist** | ✅ Yes; selected when the current directory has its config | ✅ Yes; selected otherwise |
+| **Can coexist** | ✅ Yes; project stays active and can opt into safe user resources | ✅ Yes; remains a separate home-level install |
 
 > **Local install location** is decided only by `teamai init`'s `--scope` (default `project`). A `scope` field in remote `teamai.yaml`, if present, is ignored.
+
+### Layer an organization repo under a project repo
+
+Use two Team Repos when some knowledge is organization-wide and other resources are project-specific. The CLI is installed only once, but each scope has its own local config and repository clone:
+
+```bash
+# Once per developer: organization-wide skills, rules, docs, agents, and learnings
+teamai init https://github.com/yourorg/engineering-practices --scope user
+
+# In a Java project: project resources stay active and recall prefers them
+cd /path/to/java-service
+teamai init https://github.com/yourorg/java-service-teamai --inherit-user-scope
+```
+
+With inheritance enabled, `teamai pull` refreshes user `skills`, `rules`, `docs`, `agents`, shared instructions/culture, and the user search index in their home-level locations, then refreshes the project scope in the project directory. User `env`, hooks, MCP definitions, cross-team sources, usage reporting, and remote repository writes are not inherited. The two configs and repositories remain separate; this feature composes their safe read paths rather than merging Git repositories or files. Installed resources with the same name remain in separate user/project paths, so the AI tool decides runtime precedence; Recall separately guarantees that a project entry shadows the same user resource type and filename.
 
 ---
 
@@ -230,7 +249,7 @@ teamai pull              # Manual pull
 teamai pull --dry-run    # Dry run, no actual changes
 ```
 
-> User and project scopes can both be installed, but `pull` processes only the active scope. When the current working directory contains a project-scope `.teamai/config.yaml`, it pulls the project scope and skips the user scope; otherwise it pulls the user scope.
+> Project scope is isolated by default. When the current working directory contains a project-scope `.teamai/config.yaml`, `pull` processes that project and skips user scope unless the local config has `inheritUserScope: true`; in that case it first refreshes the safe user-resource channel. Without a project config in the current directory, `pull` processes user scope. User `env`, hooks, MCP definitions, sources, reporting, and writes remain isolated in project mode.
 
 With role-based skills enabled, `pull`'s skill sync source becomes the contents of `skills/<namespace>/`, expanded according to `primaryRole + additionalRoles` and flattened into each local AI tool's skills directory. `rules/`, `docs/`, and `learnings/` keep their original global sync behavior.
 
@@ -477,8 +496,9 @@ teamai recall "GPU out of memory"
 ```
 
 - Supports mixed-language search
-- Searches only the active scope and labels search-index results `[user]` or `[project]`; a project-scope config in the current working directory takes precedence over the user scope
-- Consulted knowledge is automatically upvoted, surfacing high-quality docs to the top
+- Searches the project scope when the current working directory contains its config; with `inheritUserScope: true`, searches project first and user second, labeling results `[project]`/`[user]`. Otherwise searches user scope
+- For the same resource type and filename, the project entry wins; different resource types with the same filename remain separate
+- Consulted active-scope knowledge is automatically upvoted. Inherited user hits remain read-only while the project is active
 - A lightweight relevance precheck is available via `teamai recall --check "<keywords>"`, which prints `RELEVANT score=<n>` or `NOT_RELEVANT score=<n>` without reading files or upvoting — the recall subagent uses it to skip retrieval on unrelated tasks
 
 ### Enabling / Disabling Recall
@@ -977,6 +997,7 @@ username: your-name
 updatePolicy: auto
 scope: project                 # project (default from init) or user
 projectRoot: /path/to/project  # project scope only
+inheritUserScope: true         # optional; project scope only, defaults to false
 ```
 
 ---
@@ -1028,7 +1049,7 @@ teamai pull
 
 **Q: Can user scope and project scope coexist?**
 
-Yes, both configurations can be installed on the same machine. They are isolated at runtime: when the current working directory contains a project-scope `.teamai/config.yaml`, `pull` and `recall` use only that project scope; otherwise they use the user scope.
+Yes, but project scope remains isolated by default. When the current working directory contains a project-scope config, it is active and user scope is skipped. Initialize user scope first, then initialize the project with `--inherit-user-scope` (or set `inheritUserScope: true` in the project's local config) to compose safe resources and Recall results. Executable and control-plane configuration remains project-only.
 
 **Q: `teamai init` says it's already initialized?**
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -160,7 +160,7 @@ Resulting directory structure:
 |------|-------------------|---------------|
 | **Install location** | Under the project directory | Under `~/` |
 | **Best for** | Project-specific skills and rules | General team conventions, cross-project skills |
-| **Can coexist** | ✅ Yes, both scopes can be active at once | ✅ Yes, both scopes can be active at once |
+| **Can coexist** | ✅ Yes; selected when the current directory has its config | ✅ Yes; selected otherwise |
 
 > **Local install location** is decided only by `teamai init`'s `--scope` (default `project`). A `scope` field in remote `teamai.yaml`, if present, is ignored.
 
@@ -230,7 +230,7 @@ teamai pull              # Manual pull
 teamai pull --dry-run    # Dry run, no actual changes
 ```
 
-> If you have both a user scope and a project scope, `pull` will pull resources for both scopes in sequence, without conflicts.
+> User and project scopes can both be installed, but `pull` processes only the active scope. When the current working directory contains a project-scope `.teamai/config.yaml`, it pulls the project scope and skips the user scope; otherwise it pulls the user scope.
 
 With role-based skills enabled, `pull`'s skill sync source becomes the contents of `skills/<namespace>/`, expanded according to `primaryRole + additionalRoles` and flattened into each local AI tool's skills directory. `rules/`, `docs/`, and `learnings/` keep their original global sync behavior.
 
@@ -477,7 +477,7 @@ teamai recall "GPU out of memory"
 ```
 
 - Supports mixed-language search
-- Automatically merges the knowledge bases of both user + project scope, labeling results `[user]`/`[project]` by source
+- Searches only the active scope and labels search-index results `[user]` or `[project]`; a project-scope config in the current working directory takes precedence over the user scope
 - Consulted knowledge is automatically upvoted, surfacing high-quality docs to the top
 - A lightweight relevance precheck is available via `teamai recall --check "<keywords>"`, which prints `RELEVANT score=<n>` or `NOT_RELEVANT score=<n>` without reading files or upvoting — the recall subagent uses it to skip retrieval on unrelated tasks
 
@@ -1028,7 +1028,7 @@ teamai pull
 
 **Q: Can user scope and project scope coexist?**
 
-Yes. `pull` pulls both scopes in sequence, and `recall` merges search results across both scopes' knowledge bases. They don't conflict with each other.
+Yes, both configurations can be installed on the same machine. They are isolated at runtime: when the current working directory contains a project-scope `.teamai/config.yaml`, `pull` and `recall` use only that project scope; otherwise they use the user scope.
 
 **Q: `teamai init` says it's already initialized?**
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -158,7 +158,7 @@ teamai init <group>/TeamAi-<team> --scope user
 |------|-------------------|---------------|
 | **资源安装位置** | 项目目录下 | `~/` 下 |
 | **适用场景** | 项目特定的技能和规则 | 通用团队规范、跨项目技能 |
-| **能否共存** | ✅ 可以同时拥有两个 scope | ✅ 可以同时拥有两个 scope |
+| **能否共存** | ✅ 可以；当前目录包含对应配置时生效 | ✅ 可以；其他情况下生效 |
 
 > **本机安装位置**仅由 `teamai init` 的 `--scope`（默认 `project`）决定。远端 `teamai.yaml` 中若仍有 `scope` 字段会被忽略。
 
@@ -228,7 +228,7 @@ teamai pull              # 手动拉取
 teamai pull --dry-run    # 试运行，不实际修改
 ```
 
-> 如果你同时有 user 和 project scope，`pull` 会依次拉取两个 scope 的资源，互不冲突。
+> user 和 project scope 可以同时安装，但 `pull` 只处理当前生效的 scope。当前工作目录包含 project scope 的 `.teamai/config.yaml` 时，会拉取 project scope 并跳过 user scope；否则拉取 user scope。
 
 启用角色化 skills 后，`pull` 的 skills 同步来源会变成 `skills/<namespace>/` 中的内容，按 `primaryRole + additionalRoles` 展开对应的 namespace，拍平安装到本地各 AI 工具 skills 目录。`rules/`、`docs/`、`learnings/` 仍然保持原有全局同步逻辑。
 
@@ -475,7 +475,7 @@ teamai recall "GPU 内存不足"
 ```
 
 - 支持中英文混合搜索
-- 自动合并 user + project 双 scope 的知识库，结果标注 `[user]`/`[project]` 来源
+- 只检索当前生效的 scope，并将检索索引结果标注为 `[user]` 或 `[project]`；当前工作目录包含 project scope 配置时优先使用 project scope
 - 被查阅的知识自动 upvote，好文档浮到顶部
 - 提供轻量相关性预检 `teamai recall --check "<关键词>"`，仅输出 `RELEVANT score=<n>` 或 `NOT_RELEVANT score=<n>`，不读取文件、不 upvote —— recall subagent 用它在任务与团队知识无关时跳过检索
 
@@ -1023,7 +1023,7 @@ teamai pull
 
 **Q: User scope 和 Project scope 可以共存吗？**
 
-可以。`pull` 会依次拉取两个 scope，`recall` 会合并搜索两个 scope 的知识库。两者互不冲突。
+可以在同一台机器上同时安装两个 scope 的配置，但运行时彼此隔离：当前工作目录包含 project scope 的 `.teamai/config.yaml` 时，`pull` 和 `recall` 只使用该 project scope；否则使用 user scope。
 
 **Q: `teamai init` 提示已初始化？**
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -13,9 +13,10 @@
 - [核心概念](#核心概念)
 - [安装](#安装)
 - [管理员初始化](#管理员初始化)
-  - [用户级（User Scope）](#用户级user-scope)
   - [项目级（Project Scope）](#项目级project-scope)
+  - [用户级（User Scope）](#用户级user-scope)
   - [如何选择 Scope？](#如何选择-scope)
+  - [在项目仓库下叠加组织级仓库](#在项目仓库下叠加组织级仓库)
 - [成员接入](#成员接入)
 - [日常使用](#日常使用)
 - [共享团队资源](#共享团队资源)
@@ -32,7 +33,7 @@
 | 概念 | 说明 |
 |------|------|
 | **Team Repo** | 一个 Git 仓库，集中存放团队共享的 Skills / Rules / Docs / Env 资源 |
-| **Scope** | 资源安装位置：`user`（用户主目录，默认）或 `project`（项目目录）|
+| **Scope** | 资源安装位置：`project`（当前项目，默认）或 `user`（用户主目录）|
 | **Skills** | AI 可调用的自定义技能（目录形式，含 `SKILL.md`） |
 | **Rules** | Markdown 格式的团队规范，自动合并到 AI 工具配置中 |
 | **Docs** | 团队共享文档，供 AI 参考 |
@@ -112,6 +113,8 @@ teamai init <group>/TeamAi-<team> --scope project --role hai_dev --force
 |------|------|
 | `[repo]` / `--repo <url>` | 团队仓库地址（推荐位置参数；`--repo` 为永久别名） |
 | `--scope <project\|user>` | 安装作用域，默认 `project`（`<cwd>/.teamai`）。需要装到 `~/` 时用 `user` |
+| `--inherit-user-scope` | 仅 project scope：同时同步安全的 user 资源并检索 user 知识 |
+| `--no-inherit-user-scope` | 关闭当前项目先前配置的 user scope 继承 |
 | `--role <id>` | 直接指定 primaryRole，跳过角色交互选择 |
 | `--force` | 覆盖已有配置，跳过确认提示 |
 
@@ -124,6 +127,7 @@ repo:
 username: alice
 scope: project
 projectRoot: /path/to/my-project
+inheritUserScope: true            # 可选，仅 project scope
 primaryRole: hai
 additionalRoles:
   - pm
@@ -158,9 +162,24 @@ teamai init <group>/TeamAi-<team> --scope user
 |------|-------------------|---------------|
 | **资源安装位置** | 项目目录下 | `~/` 下 |
 | **适用场景** | 项目特定的技能和规则 | 通用团队规范、跨项目技能 |
-| **能否共存** | ✅ 可以；当前目录包含对应配置时生效 | ✅ 可以；其他情况下生效 |
+| **能否共存** | ✅ 可以；project 保持当前 scope，并可选择继承安全的 user 资源 | ✅ 可以；仍是独立的用户主目录级安装 |
 
 > **本机安装位置**仅由 `teamai init` 的 `--scope`（默认 `project`）决定。远端 `teamai.yaml` 中若仍有 `scope` 字段会被忽略。
+
+### 在项目仓库下叠加组织级仓库
+
+当一部分经验全组织通用、另一部分只属于具体项目时，可以使用两个 Team Repo。CLI 只安装一次，但两个 scope 各有独立的本地配置和仓库克隆：
+
+```bash
+# 每位开发者执行一次：组织通用 skills、rules、docs、agents 和 learnings
+teamai init https://github.com/yourorg/engineering-practices --scope user
+
+# 在 Java 项目中：项目资源保持当前 scope，recall 时优先
+cd /path/to/java-service
+teamai init https://github.com/yourorg/java-service-teamai --inherit-user-scope
+```
+
+启用继承后，`teamai pull` 会先把 user 的 `skills`、`rules`、`docs`、`agents`、共享指令/文化和检索索引刷新到用户主目录级位置，再刷新项目目录中的 project scope。user 的 `env`、hooks、MCP 定义、跨团队 sources、usage reporting 和远端仓库写入不会被继承。两个配置和两个 Git 仓库仍然分离；该功能组合的是安全读取路径，不会合并 Git 仓库或文件。同名的已安装资源仍分别位于 user/project 路径，由具体 AI 工具决定运行时优先级；Recall 则明确保证相同资源类型和文件名的 project 条目覆盖 user 条目。
 
 ---
 
@@ -228,7 +247,7 @@ teamai pull              # 手动拉取
 teamai pull --dry-run    # 试运行，不实际修改
 ```
 
-> user 和 project scope 可以同时安装，但 `pull` 只处理当前生效的 scope。当前工作目录包含 project scope 的 `.teamai/config.yaml` 时，会拉取 project scope 并跳过 user scope；否则拉取 user scope。
+> Project scope 默认与 user scope 隔离。当前工作目录包含 project scope 的 `.teamai/config.yaml` 时，`pull` 会处理该项目并跳过 user scope；仅当本地配置包含 `inheritUserScope: true` 时，才会先刷新安全的 user 资源通道。当前目录没有 project 配置时，`pull` 处理 user scope。project 模式下，user 的 `env`、hooks、MCP 定义、sources、reporting 和写入行为仍保持隔离。
 
 启用角色化 skills 后，`pull` 的 skills 同步来源会变成 `skills/<namespace>/` 中的内容，按 `primaryRole + additionalRoles` 展开对应的 namespace，拍平安装到本地各 AI 工具 skills 目录。`rules/`、`docs/`、`learnings/` 仍然保持原有全局同步逻辑。
 
@@ -475,8 +494,9 @@ teamai recall "GPU 内存不足"
 ```
 
 - 支持中英文混合搜索
-- 只检索当前生效的 scope，并将检索索引结果标注为 `[user]` 或 `[project]`；当前工作目录包含 project scope 配置时优先使用 project scope
-- 被查阅的知识自动 upvote，好文档浮到顶部
+- 当前工作目录包含 project scope 配置时搜索该项目；配置 `inheritUserScope: true` 后先搜索 project、再搜索 user，并标注 `[project]`/`[user]` 来源；否则搜索 user scope
+- 资源类型和文件名都相同时由 project 条目优先；不同资源类型即使文件名相同也分别保留
+- 当前 scope 中被查阅的知识自动 upvote；项目运行期间继承的 user 命中保持只读
 - 提供轻量相关性预检 `teamai recall --check "<关键词>"`，仅输出 `RELEVANT score=<n>` 或 `NOT_RELEVANT score=<n>`，不读取文件、不 upvote —— recall subagent 用它在任务与团队知识无关时跳过检索
 
 ### 开启 / 关闭 Recall
@@ -972,6 +992,7 @@ username: your-name
 updatePolicy: auto
 scope: project                 # project（init 默认）或 user
 projectRoot: /path/to/project  # 仅 project scope
+inheritUserScope: true         # 可选，仅 project scope，默认 false
 ```
 
 ---
@@ -1023,7 +1044,7 @@ teamai pull
 
 **Q: User scope 和 Project scope 可以共存吗？**
 
-可以在同一台机器上同时安装两个 scope 的配置，但运行时彼此隔离：当前工作目录包含 project scope 的 `.teamai/config.yaml` 时，`pull` 和 `recall` 只使用该 project scope；否则使用 user scope。
+可以，但 project scope 默认保持隔离。当前工作目录包含 project scope 配置时，该项目生效并跳过 user scope。先初始化 user scope，再使用 `--inherit-user-scope` 初始化项目（或在项目本地配置中设置 `inheritUserScope: true`），即可组合安全资源和 Recall 结果；可执行配置和控制面配置仍只使用 project scope。
 
 **Q: `teamai init` 提示已初始化？**
 

--- a/src/__tests__/init-scope-default.test.ts
+++ b/src/__tests__/init-scope-default.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveInitScope, resolveInitRepo } from '../init.js';
+import { resolveInheritUserScope, resolveInitScope, resolveInitRepo } from '../init.js';
 
 describe('resolveInitScope', () => {
   const cwd = '/tmp/my-project';
@@ -67,6 +67,25 @@ describe('resolveInitScope', () => {
       projectRoot: undefined,
       explicit: true,
     });
+  });
+});
+
+describe('resolveInheritUserScope', () => {
+  it('enables inheritance only for project scope', () => {
+    expect(resolveInheritUserScope('project', true, undefined)).toBe(true);
+    expect(() => resolveInheritUserScope('user', true, undefined)).toThrow(
+      /only be used with project scope/,
+    );
+  });
+
+  it('preserves an existing project setting when the flag is omitted', () => {
+    expect(resolveInheritUserScope('project', undefined, true)).toBe(true);
+    expect(resolveInheritUserScope('project', undefined, false)).toBe(false);
+  });
+
+  it('allows an explicit disable and ignores the setting for user scope', () => {
+    expect(resolveInheritUserScope('project', false, true)).toBe(false);
+    expect(resolveInheritUserScope('user', false, true)).toBeUndefined();
   });
 });
 

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -202,6 +202,18 @@ describe('init', () => {
     mockExit.mockClear();
   });
 
+  it('rejects user-scope inheritance before provider or repository side effects', async () => {
+    await init({
+      repo: 'https://git.woa.com/HyperAI/teamai-test.git',
+      scope: 'user',
+      inheritUserScope: true,
+    });
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(mockEnsureGfInstalled).not.toHaveBeenCalled();
+    expect(mockGfRepoClone).not.toHaveBeenCalled();
+  });
+
   describe('empty repo fallback', () => {
     it('should call initRepo when clone succeeds but directory does not exist', async () => {
       let pathExistsCallCount = 0;
@@ -436,6 +448,34 @@ describe('init', () => {
   });
 
   describe('scope path display', () => {
+    it('persists explicit user-resource inheritance in project config', async () => {
+      const projectLocalPath = path.join(process.cwd(), '.teamai', 'team-repo');
+      let cloneDone = false;
+      pathExistsFn = (p: string) => {
+        if (p === projectLocalPath) return cloneDone;
+        if (p.endsWith(`${path.sep}.git`) || p.endsWith('/.git')) return true;
+        return false;
+      };
+      mockGfRepoClone.mockImplementation(() => { cloneDone = true; });
+      questionAnswers = ['n', '1'];
+
+      const { saveLocalConfigForScope } = await import('../config.js');
+      await init({
+        repo: 'https://git.woa.com/HyperAI/teamai-test.git',
+        inheritUserScope: true,
+      });
+
+      expect(saveLocalConfigForScope).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scope: 'project',
+          projectRoot: process.cwd(),
+          inheritUserScope: true,
+        }),
+        'project',
+        process.cwd(),
+      );
+    });
+
     it('should default to project scope and print summary when --scope is omitted', async () => {
       const projectLocalPath = path.join(process.cwd(), '.teamai', 'team-repo');
       let cloneDone = false;

--- a/src/__tests__/pull-scope-isolation.test.ts
+++ b/src/__tests__/pull-scope-isolation.test.ts
@@ -3,10 +3,8 @@ import path from 'node:path';
 import os from 'node:os';
 import fse from 'fs-extra';
 
-// Issue #73: when a project-scope install is detected, `pull` must NOT touch the
-// user scope. These tests mock the config + git layers and assert the top-level
-// orchestration in pull() short-circuits user scope and routes source pull to
-// the active scope.
+// Issue #73 keeps project scope isolated by default. These tests also cover the
+// explicit safe-resource inheritance path without composing control-plane data.
 
 vi.mock('../config.js', () => ({
   requireInit: vi.fn(),
@@ -49,6 +47,24 @@ vi.mock('../source.js', () => ({
   pullSources: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock('../hooks.js', () => ({
+  injectHooksToAllTools: vi.fn().mockResolvedValue(undefined),
+  reconcileTeamHooksForConfig: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../mcp-reconcile.js', () => ({
+  reconcileMcpForConfig: vi.fn().mockResolvedValue({ changes: [], wrote: false }),
+}));
+
+vi.mock('../team-push.js', () => ({
+  reportUsageToTeam: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../usage-tracker.js', () => ({
+  readUsageEvents: vi.fn().mockResolvedValue([]),
+  truncateUsageAfterReport: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock('../roles.js', () => ({
   loadRolesManifest: vi.fn().mockResolvedValue({
     version: 1,
@@ -64,10 +80,14 @@ import {
   loadTeamConfig,
   detectProjectConfig,
   loadStateForScope,
+  saveStateForScope,
 } from '../config.js';
 import { getHeadRev } from '../utils/git.js';
 import { pullSources } from '../source.js';
 import { log } from '../utils/logger.js';
+import { reconcileTeamHooksForConfig } from '../hooks.js';
+import { reconcileMcpForConfig } from '../mcp-reconcile.js';
+import { reportUsageToTeam } from '../team-push.js';
 import type { TeamaiConfig, LocalConfig } from '../types.js';
 
 const SKIP_MSG = 'project scope detected, skipped user scope';
@@ -93,6 +113,16 @@ describe('pull scope isolation (issue #73)', () => {
       await fse.ensureDir(path.join(repo, 'skills'));
       await fse.ensureDir(path.join(repo, 'rules'));
     }
+    await fse.ensureDir(path.join(userRepoPath, 'skills', 'org-safe-review'));
+    await fse.writeFile(
+      path.join(userRepoPath, 'skills', 'org-safe-review', 'SKILL.md'),
+      '---\nname: org-safe-review\ndescription: safe review workflow\n---\n',
+    );
+    await fse.ensureDir(path.join(userRepoPath, 'env'));
+    await fse.writeFile(
+      path.join(userRepoPath, 'env', 'env.yaml'),
+      'variables:\n  - key: USER_SECRET\n    value: must-not-inherit\n',
+    );
     await fse.ensureDir(path.join(homeDir, '.claude', 'skills'));
     await fse.ensureDir(path.join(projectRoot, '.claude', 'skills'));
 
@@ -134,18 +164,16 @@ describe('pull scope isolation (issue #73)', () => {
 
     vi.mocked(loadTeamConfig).mockResolvedValue(teamConfig);
     vi.mocked(getHeadRev).mockResolvedValue('abc1234');
-    // Make pullForScope hit the "Already synced" fast path so the heavy sync
-    // loop is skipped — we only care about top-level scope routing here.
-    vi.mocked(loadStateForScope).mockResolvedValue({
-      lastPull: '2026-04-01',
-      lastPullRev: 'abc1234',
+    vi.mocked(loadStateForScope).mockImplementation(async (scope) => ({
+      lastPull: scope === 'project' ? '2026-04-01' : null,
+      lastPullRev: scope === 'project' ? 'abc1234' : null,
       lastPush: null,
       pushedRules: [],
       pushedSkills: [],
       pushedEnvVars: [],
       lastUpdateCheck: null,
       availableUpdate: null,
-    });
+    }));
   });
 
   afterEach(async () => {
@@ -169,6 +197,64 @@ describe('pull scope isolation (issue #73)', () => {
       scope: 'project',
       projectRoot,
     });
+  });
+
+  it('project mode: inherits user resources only when explicitly enabled', async () => {
+    projectConfig.inheritUserScope = true;
+    vi.mocked(detectProjectConfig).mockResolvedValue(projectConfig);
+    vi.mocked(loadLocalConfigForScope).mockResolvedValue(userConfig);
+
+    await pull({ silent: true });
+
+    expect(loadLocalConfigForScope).toHaveBeenCalledWith('user');
+    expect(loadStateForScope).toHaveBeenCalledWith('user', undefined);
+    expect(loadStateForScope).toHaveBeenCalledWith('project', projectRoot);
+    expect(log.info).toHaveBeenCalledWith(
+      'project scope detected, inheriting user-scope resources and knowledge',
+    );
+    expect(log.info).not.toHaveBeenCalledWith(SKIP_MSG);
+    expect(await fse.pathExists(
+      path.join(homeDir, '.claude', 'skills', 'org-safe-review', 'SKILL.md'),
+    )).toBe(true);
+    expect(await fse.pathExists(path.join(homeDir, '.teamai', 'env.sh'))).toBe(false);
+    expect(saveStateForScope).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lastPullRev: null,
+        lastInheritedPullRev: 'abc1234',
+      }),
+      'user',
+      undefined,
+    );
+    expect(reconcileTeamHooksForConfig).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ scope: 'user' }),
+      expect.anything(),
+    );
+    expect(reconcileMcpForConfig).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ scope: 'user' }),
+    );
+    expect(reportUsageToTeam).not.toHaveBeenCalledWith(
+      userRepoPath,
+      expect.anything(),
+      expect.anything(),
+    );
+    // External sources stay bound to the active project scope.
+    expect(pullSources).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(pullSources).mock.calls[0][0]).toMatchObject({ scope: 'project' });
+  });
+
+  it('project mode: warns but continues when inherited user scope is unavailable', async () => {
+    projectConfig.inheritUserScope = true;
+    vi.mocked(detectProjectConfig).mockResolvedValue(projectConfig);
+    vi.mocked(loadLocalConfigForScope).mockResolvedValue(null);
+
+    await pull({ silent: true });
+
+    expect(log.warn).toHaveBeenCalledWith(
+      'user-scope inheritance is enabled, but user scope is not initialized',
+    );
+    expect(loadStateForScope).toHaveBeenCalledWith('project', projectRoot);
   });
 
   it('user mode: pulls user scope and routes source against user (no skip notice)', async () => {

--- a/src/__tests__/recall-scope-isolation.test.ts
+++ b/src/__tests__/recall-scope-isolation.test.ts
@@ -3,23 +3,38 @@ import path from 'node:path';
 import os from 'node:os';
 import fse from 'fs-extra';
 
-// Issue #73: recall must query the project-scope index ONLY when a project
-// install is detected, and the user-scope index otherwise. The two are never
-// merged anymore.
+// Issue #73 keeps recall project-only by default. Layered recall is available
+// only through an explicit project-local inheritance setting.
 
 vi.mock('../config.js', () => ({
   detectProjectConfig: vi.fn(),
   requireInit: vi.fn(),
+  loadLocalConfigForScope: vi.fn(),
+}));
+
+vi.mock('../code-knowledge-recall.js', () => ({
+  queryCodeKnowledge: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../votes.js', () => ({
+  incrementRecalled: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { recall } from '../recall.js';
-import { detectProjectConfig, requireInit } from '../config.js';
+import { detectProjectConfig, loadLocalConfigForScope, requireInit } from '../config.js';
 import { buildIndex } from '../utils/search-index.js';
 import { getTeamaiHome, type LocalConfig } from '../types.js';
 import { readRecallQuality } from '../recall-quality.js';
+import { queryCodeKnowledge } from '../code-knowledge-recall.js';
+import { incrementRecalled } from '../votes.js';
 
 const PROJECT_TITLE = 'Project Deployment Timeout Fix';
 const USER_TITLE = 'User Deployment Timeout Fix';
+const PROJECT_SHARED_TITLE = 'Project Shared Review Policy';
+const USER_SHARED_TITLE = 'User Shared Review Policy';
+const USER_DOC_SHARED_TITLE = 'User Docs Shared Review Policy';
+const USER_SHADOWED_TITLE = 'Obsolete Zzyzx Retry Advice';
+const PROJECT_SHADOW_TITLE = 'Current Release Guidance';
 
 function learningDoc(title: string): string {
   return `---\ntitle: "${title}"\nauthor: tester\ndate: 2026-05-01\ntags: [deployment, timeout]\n---\n\nNotes about deployment timeout handling.\n`;
@@ -46,14 +61,25 @@ describe('recall scope isolation (issue #73)', () => {
     const userLearnings = path.join(tmpDir, 'user-learnings');
     await fse.ensureDir(userLearnings);
     await fse.writeFile(path.join(userLearnings, 'user-deploy-2026-05-01-aaa.md'), learningDoc(USER_TITLE));
+    await fse.writeFile(path.join(userLearnings, 'shared-review.md'), learningDoc(USER_SHARED_TITLE));
+    await fse.writeFile(path.join(userLearnings, 'shadowed-policy.md'), learningDoc(USER_SHADOWED_TITLE));
+    const userDocs = path.join(tmpDir, 'user-docs');
+    await fse.ensureDir(userDocs);
+    await fse.writeFile(path.join(userDocs, 'shared-review.md'), learningDoc(USER_DOC_SHARED_TITLE));
     await fse.ensureDir(getTeamaiHome('user'));
-    await buildIndex({ learningsDir: userLearnings, indexPath: path.join(getTeamaiHome('user'), 'search-index.json') });
+    await buildIndex({
+      learningsDir: userLearnings,
+      docsDir: userDocs,
+      indexPath: path.join(getTeamaiHome('user'), 'search-index.json'),
+    });
 
     // ── Project scope index (<projectRoot>/.teamai/search-index.json) ──
     const projectRepo = path.join(projectRoot, '.teamai', 'team-repo');
     const projectLearnings = path.join(projectRepo, 'learnings');
     await fse.ensureDir(projectLearnings);
     await fse.writeFile(path.join(projectLearnings, 'proj-deploy-2026-05-01-bbb.md'), learningDoc(PROJECT_TITLE));
+    await fse.writeFile(path.join(projectLearnings, 'shared-review.md'), learningDoc(PROJECT_SHARED_TITLE));
+    await fse.writeFile(path.join(projectLearnings, 'shadowed-policy.md'), learningDoc(PROJECT_SHADOW_TITLE));
     await fse.ensureDir(getTeamaiHome('project', projectRoot));
     await buildIndex({ learningsDir: projectLearnings, indexPath: path.join(getTeamaiHome('project', projectRoot), 'search-index.json') });
 
@@ -108,6 +134,82 @@ describe('recall scope isolation (issue #73)', () => {
     expect(captured).toContain(USER_TITLE);
     expect(captured).not.toContain(PROJECT_TITLE);
     expect(captured).toContain('[user]');
+  });
+
+  it('project mode: merges user results when inheritance is explicitly enabled', async () => {
+    projectConfig.inheritUserScope = true;
+    vi.mocked(detectProjectConfig).mockResolvedValue(projectConfig);
+    vi.mocked(loadLocalConfigForScope).mockResolvedValue(userConfig);
+
+    await recall('deployment timeout', { dryRun: true });
+
+    expect(captured).toContain(PROJECT_TITLE);
+    expect(captured).toContain(USER_TITLE);
+    expect(captured).toContain('[project]');
+    expect(captured).toContain('[user]');
+  });
+
+  it('project mode: project entry wins when both scopes contain the same type and filename', async () => {
+    projectConfig.inheritUserScope = true;
+    vi.mocked(detectProjectConfig).mockResolvedValue(projectConfig);
+    vi.mocked(loadLocalConfigForScope).mockResolvedValue(userConfig);
+
+    await recall('shared review policy', { dryRun: true });
+
+    expect(captured).toContain(PROJECT_SHARED_TITLE);
+    expect(captured).not.toContain(USER_SHARED_TITLE);
+  });
+
+  it('keeps different resource types that share the same filename', async () => {
+    projectConfig.inheritUserScope = true;
+    vi.mocked(detectProjectConfig).mockResolvedValue(projectConfig);
+    vi.mocked(loadLocalConfigForScope).mockResolvedValue(userConfig);
+
+    await recall('shared review policy', { dryRun: true });
+
+    expect(captured).toContain(PROJECT_SHARED_TITLE);
+    expect(captured).toContain(USER_DOC_SHARED_TITLE);
+  });
+
+  it('shadows a matching user entry even when the project replacement does not match', async () => {
+    projectConfig.inheritUserScope = true;
+    vi.mocked(detectProjectConfig).mockResolvedValue(projectConfig);
+    vi.mocked(loadLocalConfigForScope).mockResolvedValue(userConfig);
+
+    await recall('zzyzx retry', { dryRun: true });
+
+    expect(captured).not.toContain(USER_SHADOWED_TITLE);
+    expect(captured).not.toContain(PROJECT_SHADOW_TITLE);
+  });
+
+  it('keeps codebase lookup bound to the project when its index is empty', async () => {
+    projectConfig.inheritUserScope = true;
+    vi.mocked(detectProjectConfig).mockResolvedValue(projectConfig);
+    vi.mocked(loadLocalConfigForScope).mockResolvedValue(userConfig);
+    const projectIndexPath = path.join(getTeamaiHome('project', projectRoot), 'search-index.json');
+    const projectIndex = JSON.parse(await fse.readFile(projectIndexPath, 'utf8')) as { entries: unknown[] };
+    projectIndex.entries = [];
+    await fse.writeFile(projectIndexPath, JSON.stringify(projectIndex));
+
+    await recall('deployment timeout', { dryRun: true });
+
+    expect(queryCodeKnowledge).toHaveBeenCalledWith(
+      'deployment timeout',
+      expect.objectContaining({ wikiRoot: path.join(projectConfig.repo.localPath, 'teamwiki') }),
+    );
+  });
+
+  it('does not write inherited user votes through the active project channel', async () => {
+    projectConfig.inheritUserScope = true;
+    vi.mocked(detectProjectConfig).mockResolvedValue(projectConfig);
+    vi.mocked(loadLocalConfigForScope).mockResolvedValue(userConfig);
+
+    await recall('deployment timeout', {});
+
+    expect(incrementRecalled).toHaveBeenCalledTimes(1);
+    const docIds = vi.mocked(incrementRecalled).mock.calls[0][1] as string[];
+    expect(docIds).toContain('proj-deploy-2026-05-01-bbb');
+    expect(docIds).not.toContain('user-deploy-2026-05-01-aaa');
   });
 
   it('records recall quality (hit) for contribute-check knowledge-gap detection', async () => {

--- a/src/__tests__/scope-inheritance-e2e.test.ts
+++ b/src/__tests__/scope-inheritance-e2e.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawn, execFileSync } from 'node:child_process';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..', '..');
+const CLI = path.join(ROOT, 'dist', 'index.js');
+
+const PROJECT_TITLE = 'Java Project Review Workflow';
+const USER_TITLE = 'Organization Review Workflow';
+const PROJECT_COLLISION_TITLE = 'Project Shared Collision Policy';
+const USER_COLLISION_TITLE = 'Organization Shared Collision Policy';
+const INHERIT_MSG = 'project scope detected, inheriting user-scope resources and knowledge';
+
+interface RunResult {
+  code: number | null;
+  output: string;
+}
+
+function runCLI(args: string[], env: Record<string, string>, cwd: string): Promise<RunResult> {
+  return new Promise((resolve) => {
+    const child = spawn('node', [CLI, ...args], {
+      env: { ...process.env, FORCE_COLOR: '0', ...env },
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd,
+    });
+    let output = '';
+    child.stdout.on('data', (data: Buffer) => { output += data.toString(); });
+    child.stderr.on('data', (data: Buffer) => { output += data.toString(); });
+    child.stdin.end();
+    child.on('close', (code) => resolve({ code, output }));
+  });
+}
+
+const GIT_ENV = {
+  GIT_AUTHOR_NAME: 'TeamAI CI',
+  GIT_AUTHOR_EMAIL: 'ci@teamai.test',
+  GIT_COMMITTER_NAME: 'TeamAI CI',
+  GIT_COMMITTER_EMAIL: 'ci@teamai.test',
+};
+
+function git(args: string[], cwd: string): void {
+  execFileSync('git', args, {
+    cwd,
+    stdio: 'pipe',
+    env: { ...process.env, ...GIT_ENV },
+  });
+}
+
+function learningDoc(title: string): string {
+  return `---\ntitle: "${title}"\nauthor: tester\ndate: 2026-08-04\ntags: [review, workflow]\n---\n\nUse an independent reviewer after implementation.\n`;
+}
+
+function skillDoc(name: string): string {
+  return `---\nname: ${name}\ndescription: review workflow\n---\n\n# ${name}\n\nReview independently.\n`;
+}
+
+const TEAM_YAML = [
+  'team: e2e-team',
+  'repo: https://example.com/e2e.git',
+  'provider: tgit',
+  'sharing:',
+  '  env:',
+  '    injectShellProfile: true',
+  'toolPaths:',
+  '  claude:',
+  '    skills: .claude/skills',
+  '    rules: .claude/rules',
+].join('\n');
+
+function makeRemote(
+  dir: string,
+  learningTitle: string,
+  skillName: string,
+  collisionTitle: string,
+  includeEnv = false,
+): void {
+  fs.mkdirSync(path.join(dir, 'learnings'), { recursive: true });
+  fs.mkdirSync(path.join(dir, 'skills', skillName), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'teamai.yaml'), TEAM_YAML);
+  fs.writeFileSync(path.join(dir, 'learnings', `${skillName}.md`), learningDoc(learningTitle));
+  fs.writeFileSync(path.join(dir, 'learnings', 'shared-policy.md'), learningDoc(collisionTitle));
+  fs.writeFileSync(path.join(dir, 'skills', skillName, 'SKILL.md'), skillDoc(skillName));
+  if (includeEnv) {
+    fs.mkdirSync(path.join(dir, 'env'), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'env', 'env.yaml'),
+      'variables:\n  - key: ORG_ONLY_SECRET\n    value: should-not-load-in-project\n',
+    );
+    fs.mkdirSync(path.join(dir, 'hooks'), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'hooks', 'hooks.yaml'),
+      'hooks:\n  SessionStart:\n    - command: echo inherited-hook-must-not-run\n',
+    );
+    fs.writeFileSync(
+      path.join(dir, 'mcp.yaml'),
+      'servers:\n  inherited-user-server:\n    command: node\n    args: [server.js]\n',
+    );
+  }
+  git(['init', '-q'], dir);
+  git(['add', '-A'], dir);
+  git(['commit', '-q', '-m', 'init'], dir);
+}
+
+describe('opt-in user-scope inheritance (e2e)', () => {
+  let sandbox: string;
+  let homeDir: string;
+  let projectRoot: string;
+  let pullResult: RunResult;
+
+  beforeAll(async () => {
+    if (!fs.existsSync(CLI)) {
+      throw new Error(`CLI binary not found at ${CLI}. Run "npm run build" first.`);
+    }
+
+    sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-inherit-e2e-'));
+    homeDir = path.join(sandbox, 'home');
+    projectRoot = path.join(sandbox, 'java-project');
+    fs.mkdirSync(path.join(homeDir, '.claude', 'skills'), { recursive: true });
+    fs.mkdirSync(path.join(projectRoot, '.claude', 'skills'), { recursive: true });
+
+    const userRemote = path.join(sandbox, 'org-remote');
+    makeRemote(userRemote, USER_TITLE, 'org-review', USER_COLLISION_TITLE, true);
+    const userLocal = path.join(homeDir, '.teamai', 'team-repo');
+    git(['clone', '-q', userRemote, userLocal], sandbox);
+    fs.writeFileSync(
+      path.join(homeDir, '.teamai', 'config.yaml'),
+      [
+        'repo:',
+        `  localPath: ${userLocal}`,
+        `  remote: ${userRemote}`,
+        'username: ci-user',
+        'scope: user',
+      ].join('\n'),
+    );
+
+    const projectRemote = path.join(sandbox, 'java-remote');
+    makeRemote(projectRemote, PROJECT_TITLE, 'java-review', PROJECT_COLLISION_TITLE);
+    const projectLocal = path.join(projectRoot, '.teamai', 'team-repo');
+    git(['clone', '-q', projectRemote, projectLocal], sandbox);
+    fs.writeFileSync(
+      path.join(projectRoot, '.teamai', 'config.yaml'),
+      [
+        'repo:',
+        `  localPath: ${projectLocal}`,
+        `  remote: ${projectRemote}`,
+        'username: ci-project',
+        'scope: project',
+        `projectRoot: ${projectRoot}`,
+        'inheritUserScope: true',
+      ].join('\n'),
+    );
+
+    pullResult = await runCLI(['pull'], { HOME: homeDir }, projectRoot);
+  }, 60_000);
+
+  afterAll(() => {
+    if (sandbox) fs.rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  it('pulls safe resources into both scope-specific locations', () => {
+    expect(pullResult.code, pullResult.output).toBe(0);
+    expect(pullResult.output).toContain(INHERIT_MSG);
+    expect(fs.existsSync(path.join(homeDir, '.claude', 'skills', 'org-review'))).toBe(true);
+    expect(fs.existsSync(path.join(projectRoot, '.claude', 'skills', 'java-review'))).toBe(true);
+  });
+
+  it('does not inherit user-scope environment configuration', () => {
+    expect(fs.existsSync(path.join(homeDir, '.teamai', 'env.sh'))).toBe(false);
+    expect(fs.existsSync(path.join(homeDir, '.teamai', 'env'))).toBe(false);
+  });
+
+  it('does not apply inherited user hooks or MCP configuration', () => {
+    expect(fs.existsSync(path.join(homeDir, '.claude', 'settings.json'))).toBe(false);
+    expect(fs.existsSync(path.join(homeDir, '.teamai', 'managed-mcp.json'))).toBe(false);
+  });
+
+  it('recalls organization and project knowledge together', async () => {
+    const result = await runCLI(['recall', 'review workflow'], { HOME: homeDir }, projectRoot);
+    expect(result.code, result.output).toBe(0);
+    expect(result.output).toContain(PROJECT_TITLE);
+    expect(result.output).toContain(USER_TITLE);
+    expect(result.output).toContain('[project]');
+    expect(result.output).toContain('[user]');
+  });
+
+  it('lets the project entry shadow the same inherited type and filename', async () => {
+    const result = await runCLI(['recall', 'shared collision policy'], { HOME: homeDir }, projectRoot);
+    expect(result.code, result.output).toBe(0);
+    expect(result.output).toContain(PROJECT_COLLISION_TITLE);
+    expect(result.output).not.toContain(USER_COLLISION_TITLE);
+  });
+
+  it('keeps full user sync pending so a later user pull still applies env', async () => {
+    const inheritedState = JSON.parse(
+      fs.readFileSync(path.join(homeDir, '.teamai', 'state.json'), 'utf8'),
+    ) as { lastPullRev?: string | null; lastInheritedPullRev?: string | null };
+    expect(inheritedState.lastInheritedPullRev).toBeTruthy();
+    expect(inheritedState.lastPullRev).toBeNull();
+
+    const result = await runCLI(['pull'], { HOME: homeDir }, homeDir);
+    expect(result.code, result.output).toBe(0);
+    expect(fs.readFileSync(path.join(homeDir, '.teamai', 'env.sh'), 'utf8'))
+      .toContain('ORG_ONLY_SECRET');
+  });
+});

--- a/src/__tests__/scope.test.ts
+++ b/src/__tests__/scope.test.ts
@@ -520,9 +520,9 @@ describe('contribute --scope', () => {
   });
 });
 
-// ─── recall dual-scope merge tests ───────────────────────
+// ─── recall layered-scope index primitives ───────────────
 
-describe('recall dual-scope merge', () => {
+describe('recall layered-scope index primitives', () => {
   let tmpDir: string;
   const originalHome = process.env.HOME;
 
@@ -646,25 +646,28 @@ describe('recall dual-scope merge', () => {
     const userResults = search('shared', userIndex!);
     const projectResults = search('shared', projectIndex!);
 
-    // Simulate merge with dedup (same logic as recall)
-    const seenFilenames = new Set<string>();
+    // Simulate layered merge with project precedence (same logic as recall).
+    const seenEntries = new Set<string>();
     const merged: Array<{ filename: string; scope: string }> = [];
-    for (const r of userResults) {
-      if (!seenFilenames.has(r.entry.filename)) {
-        seenFilenames.add(r.entry.filename);
-        merged.push({ filename: r.entry.filename, scope: 'user' });
+    for (const r of projectResults) {
+      const key = `${r.entry.type}:${r.entry.filename}`;
+      if (!seenEntries.has(key)) {
+        seenEntries.add(key);
+        merged.push({ filename: r.entry.filename, scope: 'project' });
       }
     }
-    for (const r of projectResults) {
-      if (!seenFilenames.has(r.entry.filename)) {
-        seenFilenames.add(r.entry.filename);
-        merged.push({ filename: r.entry.filename, scope: 'project' });
+    for (const r of userResults) {
+      const key = `${r.entry.type}:${r.entry.filename}`;
+      if (!seenEntries.has(key)) {
+        seenEntries.add(key);
+        merged.push({ filename: r.entry.filename, scope: 'user' });
       }
     }
 
     // Only one entry should appear (deduped)
     expect(merged).toHaveLength(1);
     expect(merged[0].filename).toBe('shared-doc-2026-04-01-xyz.md');
+    expect(merged[0].scope).toBe('project');
   });
 
   it('project scope should use repo learnings dir (not local copy)', async () => {

--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -247,3 +247,25 @@ describe('LocalConfigSchema updatePolicy', () => {
     expect(() => LocalConfigSchema.parse({ ...baseConfig, updatePolicy: 'invalid' })).toThrow();
   });
 });
+
+describe('LocalConfigSchema inheritUserScope', () => {
+  const baseConfig = {
+    repo: { localPath: '/tmp/repo', remote: 'https://git.woa.com/team/repo.git' },
+    username: 'test',
+    scope: 'project',
+  };
+
+  it('leaves inheritance disabled when omitted', () => {
+    const result = LocalConfigSchema.parse(baseConfig);
+    expect(result.inheritUserScope).toBeUndefined();
+  });
+
+  it('accepts an explicit boolean value', () => {
+    expect(LocalConfigSchema.parse({ ...baseConfig, inheritUserScope: true }).inheritUserScope).toBe(true);
+    expect(LocalConfigSchema.parse({ ...baseConfig, inheritUserScope: false }).inheritUserScope).toBe(false);
+  });
+
+  it('rejects non-boolean values', () => {
+    expect(() => LocalConfigSchema.parse({ ...baseConfig, inheritUserScope: 'yes' })).toThrow();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,8 @@ program
   .option('--http <url>', 'Git-free HTTP team repo (read-only consumer; only needs an API key)')
   .option('--token <key>', 'API key for HTTP team repo / status reporting (stored 0600, never committed). Also reads TEAMAI_API_TOKEN.')
   .option('--scope <scope>', 'Install scope: project (default, <cwd>/.teamai + <cwd>/.claude) or user (~/.teamai + ~/.claude)')
+  .option('--inherit-user-scope', 'In project scope, also sync safe user-scope resources and search its knowledge')
+  .option('--no-inherit-user-scope', 'Disable user-scope inheritance for this project')
   .option('--role <id>', 'Primary role ID (e.g. hai_dev) for non-interactive setup')
   .option('--agent <name>', 'Only inject hooks into this agent (e.g. claude, codebuddy, workbuddy). Additive on repeated runs.')
   .option('--force', 'Overwrite existing config without confirmation')

--- a/src/init.ts
+++ b/src/init.ts
@@ -151,6 +151,24 @@ export function resolveInitScope(
 }
 
 /**
+ * Resolve the project-local user-scope inheritance setting.
+ *
+ * An omitted flag preserves an existing project setting so additive re-init
+ * operations such as `init --agent` do not silently disable inheritance.
+ */
+export function resolveInheritUserScope(
+  scope: Scope,
+  requested: boolean | undefined,
+  existing: boolean | undefined,
+): boolean | undefined {
+  if (requested === true && scope !== 'project') {
+    throw new Error('--inherit-user-scope can only be used with project scope.');
+  }
+  if (scope !== 'project') return undefined;
+  return requested ?? existing;
+}
+
+/**
  * Merge positional `teamai init <repo>` with `--repo` alias.
  * `--repo` is permanently kept as an equivalent alias (no deprecation warning).
  */
@@ -202,7 +220,7 @@ async function isInsideGitRepo(dir: string): Promise<boolean> {
  */
 export async function initHttp(
   url: string,
-  options: GlobalOptions & { scope?: string; role?: string; agent?: string; force?: boolean; token?: string },
+  options: GlobalOptions & { scope?: string; role?: string; agent?: string; force?: boolean; token?: string; inheritUserScope?: boolean },
 ): Promise<void> {
   const { resolveApiKey, saveApiKey, getApiKeyPath } = await import('./api-key.js');
 
@@ -219,6 +237,19 @@ export async function initHttp(
       process.cwd(),
       process.env.HOME ?? '',
     ));
+  } catch (e) {
+    log.error((e as Error).message);
+    process.exit(1);
+    return;
+  }
+  const existingLocalConfig = await loadLocalConfigForScope(scope, projectRoot);
+  let inheritUserScope: boolean | undefined;
+  try {
+    inheritUserScope = resolveInheritUserScope(
+      scope,
+      options.inheritUserScope,
+      existingLocalConfig?.inheritUserScope,
+    );
   } catch (e) {
     log.error((e as Error).message);
     process.exit(1);
@@ -278,6 +309,7 @@ export async function initHttp(
     scope,
     projectRoot,
     additionalRoles: [],
+    ...(inheritUserScope !== undefined ? { inheritUserScope } : {}),
   };
   try {
     Object.assign(localConfig, await promptForRoleProfile(localPath, options.role));
@@ -342,6 +374,7 @@ export async function init(options: GlobalOptions & {
   force?: boolean;
   http?: string;
   token?: string;
+  inheritUserScope?: boolean;
 }): Promise<void> {
   if (options.http) {
     return initHttp(options.http, options);
@@ -359,6 +392,19 @@ export async function init(options: GlobalOptions & {
       process.cwd(),
       process.env.HOME ?? '',
     ));
+  } catch (e) {
+    log.error((e as Error).message);
+    process.exit(1);
+    return;
+  }
+  const existingLocalConfig = await loadLocalConfigForScope(scope, projectRoot);
+  let inheritUserScope: boolean | undefined;
+  try {
+    inheritUserScope = resolveInheritUserScope(
+      scope,
+      options.inheritUserScope,
+      existingLocalConfig?.inheritUserScope,
+    );
   } catch (e) {
     log.error((e as Error).message);
     process.exit(1);
@@ -626,6 +672,7 @@ export async function init(options: GlobalOptions & {
     scope,
     projectRoot,
     additionalRoles: [],
+    ...(inheritUserScope !== undefined ? { inheritUserScope } : {}),
   };
 
   try {

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -272,8 +272,13 @@ function logSyncDetail(
 async function pullForScope(
   localConfig: LocalConfig,
   options: GlobalOptions,
+  policy: {
+    resourceTypes?: readonly ResourceType[];
+    revisionField?: 'lastPullRev' | 'lastInheritedPullRev';
+  } = {},
 ): Promise<void> {
   const scopeLabel = localConfig.scope;
+  const revisionField = policy.revisionField ?? 'lastPullRev';
   const teamConfig = await loadTeamConfig(localConfig.repo.localPath);
   if (!teamConfig) {
     log.warn(`[${scopeLabel}] Team config (teamai.yaml) not found. Skipping.`);
@@ -301,7 +306,7 @@ async function pullForScope(
   if (!options.force && !options.dryRun) {
     try {
       const state = await loadStateForScope(localConfig.scope, localConfig.projectRoot);
-      if (currentRev && state.lastPullRev && state.lastPullRev === currentRev) {
+      if (currentRev && state[revisionField] && state[revisionField] === currentRev) {
         log.success(`[${scopeLabel}] Already synced at ${currentRev}, skipping`);
         // 即使 repo 未变化，仍部署 CLI 内置资源（确保 CLI 升级后新版本 agent/rules 生效）
         if (!options.dryRun) {
@@ -346,7 +351,8 @@ async function pullForScope(
   const excludedSkills = new Set(localConfig.excludedSkills ?? []);
 
   // Step 2: Sync each resource type
-  const resourceTypes: ResourceType[] = ['skills', 'rules', 'docs', 'env', 'agents'];
+  const resourceTypes: readonly ResourceType[] = policy.resourceTypes
+    ?? ['skills', 'rules', 'docs', 'env', 'agents'];
   let totalSynced = 0;
   let desiredSkillNames: Set<string> | null = null;
   let knownRepoSkillNames: Set<string> | null = null;
@@ -564,21 +570,6 @@ async function pullForScope(
 
   if (totalSynced === 0) {
     log.info(`[${scopeLabel}] No resources to sync`);
-  } else if (!options.dryRun) {
-    const state = await loadStateForScope(localConfig.scope, localConfig.projectRoot);
-    state.lastPull = new Date().toISOString();
-    if (currentRev !== null) {
-      // HTTP mode: server version already resolved during refresh.
-      state.lastPullRev = currentRev;
-    } else {
-      try {
-        state.lastPullRev = await getHeadRev(localConfig.repo.localPath);
-      } catch {
-        // Non-critical: if we can't get the rev, just clear it
-        state.lastPullRev = null;
-      }
-    }
-    await saveStateForScope(state, localConfig.scope, localConfig.projectRoot);
   }
 
   // Step 3.5: Sync learnings and rebuild the multi-category search index
@@ -757,6 +748,26 @@ async function pullForScope(
     } catch (e) {
       log.debug(`[${scopeLabel}] Built-in agents deployment skipped: ${(e as Error).message}`);
     }
+  }
+
+  // Record the revision only after every resource and knowledge phase has had
+  // a chance to run. Inherited pulls use an independent marker so a partial,
+  // safe sync can never suppress a later full user-scope pull.
+  if (!options.dryRun) {
+    const state = await loadStateForScope(localConfig.scope, localConfig.projectRoot);
+    if (revisionField === 'lastPullRev') {
+      state.lastPull = new Date().toISOString();
+    }
+    if (currentRev !== null) {
+      state[revisionField] = currentRev;
+    } else {
+      try {
+        state[revisionField] = await getHeadRev(localConfig.repo.localPath);
+      } catch {
+        state[revisionField] = null;
+      }
+    }
+    await saveStateForScope(state, localConfig.scope, localConfig.projectRoot);
   }
 
   // Step 5: Auto-report usage data — handled centrally in pull() to avoid
@@ -1081,11 +1092,10 @@ async function autoMigrateHooksIfNeeded(): Promise<void> {
 /**
  * Main pull entry point.
  *
- * Scope isolation (issue #73): when a project-scope install is detected in cwd,
- * the user scope is **not** touched — pull and reconcile run for the project
- * scope only. When no project scope is present, the user scope is pulled as
- * before. Cross-team source skills are always pulled, against whichever scope
- * is active.
+ * Scope isolation (issue #73) remains the default. A project may explicitly
+ * inherit safe user-scope resources and knowledge with `inheritUserScope`.
+ * Executable configuration (env, hooks, and MCP) stays isolated, and external
+ * source skills are pulled only for the active project scope.
  */
 export async function pull(options: GlobalOptions): Promise<void> {
   // 0. Auto-migrate hooks if settings.json has old format (pre-dispatch era).
@@ -1106,16 +1116,31 @@ export async function pull(options: GlobalOptions): Promise<void> {
     log.warn(`Project-scope detection error: ${(e as Error).message}`);
   }
   const projectMode = projectConfig !== null;
+  const inheritUserScope = projectConfig?.inheritUserScope === true;
 
-  // 2. User scope — only when NOT in project mode.
-  let userConfig: LocalConfig | null = null;
-  if (projectMode) {
+  // 2. User scope — distinguish an active user install from an inherited one.
+  //    Only the active config may drive control-plane effects below.
+  let activeUserConfig: LocalConfig | null = null;
+  let inheritedUserConfig: LocalConfig | null = null;
+  if (projectMode && !inheritUserScope) {
     log.info('project scope detected, skipped user scope');
   } else {
     try {
-      userConfig = await loadLocalConfigForScope('user');
-      if (userConfig) {
-        await pullForScope(userConfig, options);
+      const loadedUserConfig = await loadLocalConfigForScope('user');
+      if (loadedUserConfig) {
+        if (inheritUserScope) {
+          inheritedUserConfig = loadedUserConfig;
+          log.info('project scope detected, inheriting user-scope resources and knowledge');
+          await pullForScope(inheritedUserConfig, options, {
+            resourceTypes: ['skills', 'rules', 'docs', 'agents'],
+            revisionField: 'lastInheritedPullRev',
+          });
+        } else {
+          activeUserConfig = loadedUserConfig;
+          await pullForScope(activeUserConfig, options);
+        }
+      } else if (inheritUserScope) {
+        log.warn('user-scope inheritance is enabled, but user scope is not initialized');
       } else {
         log.debug('No user-scope config found, skipping user pull');
       }
@@ -1136,12 +1161,13 @@ export async function pull(options: GlobalOptions): Promise<void> {
   // 3.5. Reconcile built-in + team hooks for the active scope only. Runs OUTSIDE
   // pullForScope so it bypasses the "Already synced" rev fast-path — this is
   // what self-heals new built-in hooks and applies hooks.yaml changes on every
-  // session start. In project mode user is null, so user hooks are left alone.
-  await reconcileHooksAllScopes(projectMode ? null : userConfig, projectConfig, options);
+  // session start. In project mode user is null, even when safe resources are
+  // inherited, so executable hook configuration is never composed implicitly.
+  await reconcileHooksAllScopes(activeUserConfig, projectConfig, options);
 
   // 3.6. Reconcile team MCP servers. Outside pullForScope for the same reason as
-  // hooks: mcp.yaml changes must apply even when the rev fast-path short-circuits.
-  await reconcileMcpAllScopes(projectMode ? null : userConfig, projectConfig, options);
+  // hooks. User-scope MCP remains isolated in project mode.
+  await reconcileMcpAllScopes(activeUserConfig, projectConfig, options);
 
   // 4. Auto-report usage data to all active scopes. Events live in a single
   //    shared file (~/.teamai/usage.jsonl), so we report to each repo with
@@ -1160,10 +1186,10 @@ export async function pull(options: GlobalOptions): Promise<void> {
           opts: { skipTruncate: true, projectRoot: projectConfig.projectRoot },
         });
       }
-      if (userConfig && userConfig.repo.kind !== 'http') {
+      if (activeUserConfig && activeUserConfig.repo.kind !== 'http') {
         targets.push({
-          repoPath: userConfig.repo.localPath,
-          username: userConfig.username,
+          repoPath: activeUserConfig.repo.localPath,
+          username: activeUserConfig.username,
           opts: { skipTruncate: true, excludeProjectRoots: projectConfig?.projectRoot ? [projectConfig.projectRoot] : [] },
         });
       }
@@ -1186,7 +1212,7 @@ export async function pull(options: GlobalOptions): Promise<void> {
 
   // 5. Pull cross-team source skills (always — even in project mode), against
   //    the active scope so deploys land in the right base dir.
-  const sourceConfig = projectConfig ?? userConfig;
+  const sourceConfig = projectConfig ?? activeUserConfig;
   if (sourceConfig) {
     try {
       const { pullSources } = await import('./source.js');

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { requireInit, detectProjectConfig } from './config.js';
+import { requireInit, detectProjectConfig, loadLocalConfigForScope } from './config.js';
 import { loadIndex, buildIndex, search, isLegacyIndex } from './utils/search-index.js';
 import type { SearchResult } from './utils/search-index.js';
 import { readFileSafe, ensureDir, pathExists } from './utils/fs.js';
@@ -195,9 +195,9 @@ async function loadOrBuildScopeIndex(
 /**
  * Handle `teamai recall <query>`.
  *
- * Scope isolation (issue #73): queries the project-scope index when a project
- * install is detected in cwd, otherwise the user-scope index. Displays ranked
- * results and auto-upvotes returned documents.
+ * Scope isolation (issue #73) remains the default. A project with
+ * `inheritUserScope` enabled searches the project index first, followed by the
+ * user index. Displays ranked results and auto-upvotes returned documents.
  */
 export async function recall(
   query: string,
@@ -225,9 +225,8 @@ export async function recall(
     options.depth = 'context';
   }
 
-  // Scope isolation (issue #73): when a project-scope install is detected in
-  // cwd, recall queries the project index ONLY. Otherwise it falls back to the
-  // user scope. The two scopes are never merged anymore.
+  // Scope isolation (issue #73) remains the default. Projects may explicitly
+  // opt into searching the user index after the project index.
   const scopeIndexes: Array<{ index: SearchIndex; scope: 'user' | 'project'; config: LocalConfig; learningsBase: string }> = [];
 
   let projectConfig: LocalConfig | null = null;
@@ -238,7 +237,7 @@ export async function recall(
   }
 
   if (projectConfig) {
-    // Project mode: project scope only.
+    // Project mode: project scope first.
     try {
       const result = await loadOrBuildScopeIndex(projectConfig, 'project');
       if (result && result.index.entries.length > 0) {
@@ -246,6 +245,20 @@ export async function recall(
       }
     } catch {
       log.debug('recall: project scope not available');
+    }
+
+    if (projectConfig.inheritUserScope === true) {
+      try {
+        const userConfig = await loadLocalConfigForScope('user');
+        if (userConfig) {
+          const result = await loadOrBuildScopeIndex(userConfig, 'user');
+          if (result && result.index.entries.length > 0) {
+            scopeIndexes.push({ index: result.index, scope: 'user', config: userConfig, learningsBase: result.learningsBase });
+          }
+        }
+      } catch {
+        log.debug('recall: inherited user scope not available');
+      }
     }
   } else {
     // User mode: user scope only.
@@ -260,8 +273,9 @@ export async function recall(
     }
   }
 
-  // Resolve teamwiki path from team-repo (prefer project scope, fallback to user scope)
-  const wikiConfig = scopeIndexes[0]?.config;
+  // Codebase knowledge stays bound to the active project even when its search
+  // index is empty and only an inherited user index is available.
+  const wikiConfig = projectConfig ?? scopeIndexes[0]?.config;
   const wikiRoot = wikiConfig
     ? path.join(wikiConfig.repo.localPath, 'teamwiki')
     : path.join(process.cwd(), '.teamai', 'team-repo', 'teamwiki');
@@ -277,14 +291,23 @@ export async function recall(
 
   // Merge: search each scope index, tag results with scope, then combine & sort
   const allResults: ScopedSearchResult[] = [];
-  const seenFilenames = new Set<string>();
+  const seenEntries = new Set<string>();
+  const projectEntryKeys = new Set(
+    scopeIndexes
+      .filter(({ scope }) => scope === 'project')
+      .flatMap(({ index }) => index.entries.map((entry) => `${entry.type}:${entry.filename}`)),
+  );
 
   for (const { index, scope, learningsBase } of scopeIndexes) {
     const results = search(query, index);
     for (const r of results) {
-      // Deduplicate by filename across scopes
-      if (!seenFilenames.has(r.entry.filename)) {
-        seenFilenames.add(r.entry.filename);
+      // A project entry shadows the same logical user entry even when the
+      // project version does not match this particular query. This prevents a
+      // stale inherited copy from leaking through after a project override.
+      const entryKey = `${r.entry.type}:${r.entry.filename}`;
+      if (scope === 'user' && projectEntryKeys.has(entryKey)) continue;
+      if (!seenEntries.has(entryKey)) {
+        seenEntries.add(entryKey);
         allResults.push({ ...r, scope, learningsBase });
       }
     }
@@ -311,7 +334,7 @@ export async function recall(
           snippet: cr.snippet,
         },
         score: Math.min(10, Math.log2(cr.score + 1) * 2),
-        scope: 'project',
+        scope: projectConfig ? 'project' : 'user',
         learningsBase: wikiRoot,
         sources: cr.sources,
       });
@@ -349,10 +372,15 @@ export async function recall(
   const output = formatResults(topResults);
   process.stdout.write(output + '\n');
 
-  // Auto-upvote (best-effort, non-blocking for dry-run)
-  // 分 scope 写入各自的 repo，确保 vote 归属正确
+  // Auto-upvote (best-effort, non-blocking for dry-run). Vote deltas currently
+  // share one HOME-level store, so layered project mode records only active
+  // project results. Inherited user hits remain read-only to avoid attributing
+  // their votes to the project team during the next report.
   if (!options.dryRun) {
-    for (const scopeInfo of scopeIndexes) {
+    const voteScopes = projectConfig
+      ? scopeIndexes.filter((scopeInfo) => scopeInfo.scope === 'project')
+      : scopeIndexes;
+    for (const scopeInfo of voteScopes) {
       const scopeResults = topResults.filter(r => r.scope === scopeInfo.scope);
       if (scopeResults.length > 0) {
         try {

--- a/src/types.ts
+++ b/src/types.ts
@@ -223,6 +223,8 @@ export const LocalConfigSchema = z.object({
   resourceProfileVersion: z.number().int().positive().optional(),
   /** Absolute path to project root; required when scope is 'project'. */
   projectRoot: z.string().optional(),
+  /** Opt-in: include safe user-scope resources and knowledge while in project scope. */
+  inheritUserScope: z.boolean().optional(),
   /** Tags the user has subscribed to. If empty/undefined, pull all resources. */
   subscribedTags: z.array(z.string()).optional(),
   /** Skills to exclude from local sync (per-user, does not affect team repo). */
@@ -245,6 +247,8 @@ export const StateSchema = z.object({
   lastPull: z.string().nullable().default(null),
   /** Git commit hash (short) of the team repo at the time of last successful pull. */
   lastPullRev: z.string().nullable().default(null),
+  /** Git commit hash synchronized through the safe user-resource inheritance channel. */
+  lastInheritedPullRev: z.string().nullable().optional(),
   pushedRules: z.array(z.string()).default([]),
   pushedSkills: z.array(z.string()).default([]),
   pushedEnvVars: z.array(z.string()).default([]),


### PR DESCRIPTION
## Summary

Project scope isolation prevents cross-project leakage, but it also leaves no supported way to combine organization-wide practices with project-specific resources. This adds a project-local, opt-in `inheritUserScope` mode that layers safe user resources and searchable knowledge while preserving project isolation by default.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing behavior to change)
- [ ] Documentation only
- [ ] Refactor / internal cleanup

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run --coverage` passes (144 files, 1907 tests)
- [x] Added/updated tests for the change
- [x] `npm run build` passes
- [x] `npx vitest run --config vitest.e2e.config.ts src/__tests__/scope-inheritance-e2e.test.ts` passes (6 tests)

## Related Issues

Related to #73.

## Notes for Reviewers

- Default project-only behavior remains unchanged unless the local project config enables inheritance.
- The inherited channel includes skills, rules, docs, agents, shared instructions/culture, and the user search index.
- User env, hooks, MCP definitions, external sources, usage reporting, remote writes, and inherited-result vote writes remain isolated.
- Partial user sync uses `lastInheritedPullRev`, so it cannot suppress a later full user pull.
- Recall searches project first and shadows an identical user resource type and filename using the complete project index.
- This branch is stacked on #280 so the behavior documentation can merge first without creating conflicting follow-up edits.
