### PR TITLE
docs(readme): link teamai-hub template org from Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Create a shared-experience repo on your git host (GitHub, TGit, or CNB), **grant
 
 > Solo use needs no separate repo setup: `teamai init` checks the target repo and creates it automatically if it doesn't exist.
 
+> **No team repo yet?** Start from a template pre-loaded with production-ready skills, rules, and review agents. Browse the [teamai-hub](https://github.com/teamai-hub) org, click **Use this template**, then `teamai init` against your new repo.
+
 ### Team members
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -34,6 +34,8 @@ npm install -g teamai-cli
 
 > 个人使用无需单独建仓：`teamai init` 会检查目标仓库，不存在时自动创建。
 
+> **还没有团队仓库？** 可以从内置了成套 skills、rules、review agents 的模板起步。浏览 [teamai-hub](https://github.com/teamai-hub) org，点 **Use this template** 生成自己的仓库，再对它执行 `teamai init`。
+
 ### 团队成员
 
 ```bash


### PR DESCRIPTION
## What

Adds a short pointer in the Quick Start "Team admin / solo user" section (both `README.md` and `README.zh-CN.md`) for users who don't have a team repo yet: browse the [teamai-hub](https://github.com/teamai-hub) org, click **Use this template**, then `teamai init` against the new repo.

## Why

Resolves the discoverability ask in #206 — new teams had no entry point to the template library and were left assembling a team repo from scratch. The templates carry ready-made skills, rules, and review agents.

## Related changes (outside this repo)

- Enabled the template-repository flag on `teamai-hub/template-backend` so the **Use this template** button appears; updated its README from a fork-based flow accordingly.
- Added an org profile README at `teamai-hub/.github` so https://github.com/teamai-hub shows a bilingual intro.

## Test Plan

- [x] Rendered both READMEs locally; links resolve to https://github.com/teamai-hub
- [x] Verified `teamai-hub/template-backend` shows the **Use this template** button (is_template=true)
- [x] Verified the org profile page renders

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)