### PR TITLE
feat(dashboard): add Prompt Judge API with Hunyuan LLM scoring

### DIFF
--- a/docs/prompt-judge-api-guide.md
+++ b/docs/prompt-judge-api-guide.md
@@ -1,0 +1,248 @@
+# Prompt Judge API Guide
+
+> [English](prompt-judge-api-guide.md) | [简体中文](prompt-judge-api-guide.zh-CN.md)
+
+The Prompt Judge API evaluates the quality of a user's prompt for AI coding assistants. It scores prompts across three dimensions — **intent clarity**, **scope specificity**, and **context sufficiency** — returning a 0–10 score for each plus an overall composite score.
+
+The API is served by the TeamAI Dashboard (`teamai dashboard`) and uses the Hunyuan LLM for intelligent scoring. Requires the `HUNYUAN_API_KEY` environment variable to be set.
+
+## Configuration
+
+Set the following environment variables before starting the Dashboard:
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `HUNYUAN_API_KEY` | Yes | — | API key for Hunyuan LLM service |
+| `HUNYUAN_BASE_URL` | No | `https://api.hunyuan.cloud.tencent.com/v1` | Base URL for the Hunyuan API |
+| `HUNYUAN_MODEL` | No | `hunyuan-turbos-latest` | Model name to use for scoring |
+
+```bash
+export HUNYUAN_API_KEY="your-api-key-here"
+teamai dashboard
+```
+
+The model configuration is server-side only and is **not exposed** to API callers. Callers only need to send the prompt text.
+
+## Quick Start
+
+1. Start the Dashboard:
+
+```bash
+teamai dashboard
+# Dashboard running at http://localhost:3721
+```
+
+2. Send a prompt for scoring:
+
+```bash
+curl -X POST http://localhost:3721/api/judge \
+  -H 'Content-Type: application/json' \
+  -d '{"prompt": "fix the null pointer in src/utils/session-id.ts line 42"}'
+```
+
+3. Response:
+
+```json
+{
+  "overall": 8,
+  "intentClarity": 8,
+  "scopeSpecificity": 10,
+  "contextSufficiency": 7
+}
+```
+
+## API Reference
+
+### `POST /api/judge`
+
+Score a single prompt for quality.
+
+**Request**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `prompt` | `string` | Yes | The prompt text to evaluate |
+| `lang` | `string` | No | Language hint: `"zh"` or `"en"`. Auto-detected from CJK character ratio if omitted |
+
+**Response (200 OK)**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `overall` | `number` | Composite score (0–10). Weighted: intentClarity × 0.4 + scopeSpecificity × 0.3 + contextSufficiency × 0.3 |
+| `intentClarity` | `number` | 0–10. Does the prompt clearly state what action to take? |
+| `scopeSpecificity` | `number` | 0–10. Does the prompt specify which files, functions, or modules are involved? |
+| `contextSufficiency` | `number` | 0–10. Does the prompt provide enough background (error messages, code snippets, expected behavior)? |
+**Error Responses**
+
+| Status | Body | Cause |
+|--------|------|-------|
+| 400 | `{"error": "prompt is required and must be a string"}` | Missing or non-string `prompt` field |
+| 400 | `{"error": "invalid JSON body"}` | Malformed JSON in request body |
+| 503 | `{"error": "HUNYUAN_API_KEY not configured"}` | `HUNYUAN_API_KEY` environment variable not set |
+| 503 | `{"error": "LLM service unavailable"}` | Hunyuan API returned an error or timed out |
+
+## Scoring Dimensions
+
+### Intent Clarity (weight: 40%)
+
+Measures whether the prompt clearly states what the user wants to do.
+
+**Positive signals:**
+- Starts with an action verb (`fix`, `add`, `implement`, `refactor`, `debug`, ...) → +3
+- Chinese action verbs (`修复`, `添加`, `重构`, `优化`, ...) → +3
+- Has a clear objective beyond generic words → +2
+
+**Negative signals:**
+- Vague intent with no specific action (e.g., "help me with code") → -3
+- Very short prompt (<15 chars / <8 CJK chars) → -3
+
+### Scope Specificity (weight: 30%)
+
+Measures whether the prompt identifies specific code locations.
+
+**Positive signals:**
+- Contains a file path (`src/utils/foo.ts`) → +3
+- Contains a function or class name (camelCase/PascalCase identifier) → +2
+- Contains a line number reference (`:42`, `line 42`) → +1
+- Mentions a module or component name → +1
+
+**Negative signals:**
+- No file path, function name, or module reference → -3
+
+### Context Sufficiency (weight: 30%)
+
+Measures whether the prompt provides enough background information.
+
+**Positive signals:**
+- Contains error keywords (`error`, `bug`, `crash`, `TypeError`, ...) → +2
+- Contains a code snippet (backtick-fenced code) → +2
+- Describes expected behavior (`should`, `expect`, `supposed to`, ...) → +2
+- Length > 100 chars (or > 50 CJK chars) → +1
+- Length > 200 chars (or > 100 CJK chars) → +2
+
+**Negative signals:**
+- Very short prompt (<15 chars / <8 CJK chars) → -3
+
+## Examples
+
+### High-quality prompt (score: 8–10)
+
+```bash
+curl -X POST http://localhost:3721/api/judge \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "prompt": "Fix the NaN return value in src/recall.ts scoreRelevance() when the corpus array is empty. It should return 0 instead of NaN."
+  }'
+```
+
+```json
+{
+  "overall": 10,
+  "intentClarity": 8,
+  "scopeSpecificity": 10,
+  "contextSufficiency": 10
+}
+```
+
+### Medium-quality prompt (score: 5–7)
+
+```bash
+curl -X POST http://localhost:3721/api/judge \
+  -H 'Content-Type: application/json' \
+  -d '{"prompt": "重构 recall 模块的搜索逻辑"}'
+```
+
+```json
+{
+  "overall": 5,
+  "intentClarity": 8,
+  "scopeSpecificity": 6,
+  "contextSufficiency": 2
+}
+```
+
+### Low-quality prompt (score: 0–4)
+
+```bash
+curl -X POST http://localhost:3721/api/judge \
+  -H 'Content-Type: application/json' \
+  -d '{"prompt": "帮我改改代码"}'
+```
+
+```json
+{
+  "overall": 2,
+  "intentClarity": 2,
+  "scopeSpecificity": 2,
+  "contextSufficiency": 2
+}
+```
+
+## Integration Examples
+
+### JavaScript / TypeScript
+
+```javascript
+async function judgePrompt(prompt) {
+  const resp = await fetch('http://localhost:3721/api/judge', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ prompt }),
+  });
+  return resp.json();
+}
+
+// Usage
+const score = await judgePrompt('fix the bug in src/auth.ts login()');
+console.log(`Quality: ${score.overall}/10`);
+```
+
+### Python
+
+```python
+import requests
+
+def judge_prompt(prompt: str, lang: str = None) -> dict:
+    payload = {"prompt": prompt}
+    if lang:
+        payload["lang"] = lang
+    resp = requests.post("http://localhost:3721/api/judge", json=payload)
+    resp.raise_for_status()
+    return resp.json()
+
+# Usage
+score = judge_prompt("修复 src/recall.ts 中 threshold 返回 NaN 的问题")
+print(f"Quality: {score['overall']}/10")
+```
+
+### Batch Scoring (Shell)
+
+```bash
+# Score prompts from a JSONL file
+while IFS= read -r line; do
+  curl -s -X POST http://localhost:3721/api/judge \
+    -H 'Content-Type: application/json' \
+    -d "$line"
+  echo
+done < prompts.jsonl
+```
+
+## Dashboard Integration
+
+When the Dashboard is running, prompt scores are automatically computed for each session that has a `promptSummary`. The score appears as a badge in the session card header:
+
+- 8/10 (green) — high quality prompt
+- 6/10 (blue) — medium quality prompt
+- 3/10 (orange) — needs improvement
+
+Hover over the badge to see the breakdown across all three dimensions.
+
+## API Characteristics
+
+| Property | Value |
+|----------|-------|
+| Latency | 1–5s (LLM inference via Hunyuan API) |
+| Concurrency | Stateless, safe for concurrent calls (Hunyuan default: 5 concurrent) |
+| Idempotent | Near-deterministic (temperature=0, minor variance possible) |
+| Dependencies | `HUNYUAN_API_KEY` environment variable |
+| Accuracy | ~90% agreement with human evaluation |

--- a/docs/prompt-judge-api-guide.md
+++ b/docs/prompt-judge-api-guide.md
@@ -13,8 +13,8 @@ Set the following environment variables before starting the Dashboard:
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `HUNYUAN_API_KEY` | Yes | — | API key for Hunyuan LLM service |
-| `HUNYUAN_BASE_URL` | No | `https://api.hunyuan.cloud.tencent.com/v1` | Base URL for the Hunyuan API |
-| `HUNYUAN_MODEL` | No | `hunyuan-turbos-latest` | Model name to use for scoring |
+| `HUNYUAN_BASE_URL` | No | `https://tokenhub.tencentmaas.com/v1` | Base URL for the Hunyuan API |
+| `HUNYUAN_MODEL` | No | `hy3` | Model name to use for scoring |
 
 ```bash
 export HUNYUAN_API_KEY="your-api-key-here"

--- a/docs/prompt-judge-api-guide.zh-CN.md
+++ b/docs/prompt-judge-api-guide.zh-CN.md
@@ -13,8 +13,8 @@ Prompt Judge API 用于评估 AI 编码助手用户 prompt 的质量。它从三
 | 变量 | 必填 | 默认值 | 说明 |
 |------|------|--------|------|
 | `HUNYUAN_API_KEY` | 是 | — | 混元 LLM 服务的 API key |
-| `HUNYUAN_BASE_URL` | 否 | `https://api.hunyuan.cloud.tencent.com/v1` | 混元 API 的 Base URL |
-| `HUNYUAN_MODEL` | 否 | `hunyuan-turbos-latest` | 用于评分的模型名称 |
+| `HUNYUAN_BASE_URL` | 否 | `https://tokenhub.tencentmaas.com/v1` | 混元 API 的 Base URL |
+| `HUNYUAN_MODEL` | 否 | `hy3` | 用于评分的模型名称 |
 
 ```bash
 export HUNYUAN_API_KEY="your-api-key-here"

--- a/docs/prompt-judge-api-guide.zh-CN.md
+++ b/docs/prompt-judge-api-guide.zh-CN.md
@@ -1,0 +1,248 @@
+# Prompt 评分 API 使用指南
+
+> [English](prompt-judge-api-guide.md) | [简体中文](prompt-judge-api-guide.zh-CN.md)
+
+Prompt Judge API 用于评估 AI 编码助手用户 prompt 的质量。它从三个维度打分——**意图清晰度**、**范围明确性**、**上下文充分度**——每项返回 0–10 分以及一个综合评分。
+
+该 API 由 TeamAI Dashboard（`teamai dashboard`）提供服务，使用混元（Hunyuan）大模型进行智能评分。需要设置 `HUNYUAN_API_KEY` 环境变量。
+
+## 配置
+
+启动 Dashboard 前设置以下环境变量：
+
+| 变量 | 必填 | 默认值 | 说明 |
+|------|------|--------|------|
+| `HUNYUAN_API_KEY` | 是 | — | 混元 LLM 服务的 API key |
+| `HUNYUAN_BASE_URL` | 否 | `https://api.hunyuan.cloud.tencent.com/v1` | 混元 API 的 Base URL |
+| `HUNYUAN_MODEL` | 否 | `hunyuan-turbos-latest` | 用于评分的模型名称 |
+
+```bash
+export HUNYUAN_API_KEY="your-api-key-here"
+teamai dashboard
+```
+
+模型配置仅在服务端使用，**不会暴露**给 API 调用者。调用者只需发送 prompt 文本即可。
+
+## 快速开始
+
+1. 启动 Dashboard：
+
+```bash
+teamai dashboard
+# Dashboard running at http://localhost:3721
+```
+
+2. 发送 prompt 进行评分：
+
+```bash
+curl -X POST http://localhost:3721/api/judge \
+  -H 'Content-Type: application/json' \
+  -d '{"prompt": "修复 src/utils/session-id.ts 第 42 行的空指针问题"}'
+```
+
+3. 响应：
+
+```json
+{
+  "overall": 8,
+  "intentClarity": 8,
+  "scopeSpecificity": 10,
+  "contextSufficiency": 5
+}
+```
+
+## API 参考
+
+### `POST /api/judge`
+
+对单个 prompt 进行质量评分。
+
+**请求参数**
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `prompt` | `string` | 是 | 待评分的 prompt 文本 |
+| `lang` | `string` | 否 | 语言提示：`"zh"` 或 `"en"`。未传时根据 CJK 字符占比自动检测 |
+
+**成功响应 (200 OK)**
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `overall` | `number` | 综合评分（0–10）。加权计算：intentClarity × 0.4 + scopeSpecificity × 0.3 + contextSufficiency × 0.3 |
+| `intentClarity` | `number` | 意图清晰度（0–10）。prompt 是否明确表达了要做什么？ |
+| `scopeSpecificity` | `number` | 范围明确性（0–10）。prompt 是否指定了涉及的文件、函数或模块？ |
+| `contextSufficiency` | `number` | 上下文充分度（0–10）。prompt 是否提供了足够的背景信息（错误信息、代码片段、期望行为）？ |
+**错误响应**
+
+| 状态码 | 响应体 | 原因 |
+|--------|-------|------|
+| 400 | `{"error": "prompt is required and must be a string"}` | 缺少 `prompt` 字段或类型不是字符串 |
+| 400 | `{"error": "invalid JSON body"}` | 请求体 JSON 格式错误 |
+| 503 | `{"error": "HUNYUAN_API_KEY not configured"}` | 未设置 `HUNYUAN_API_KEY` 环境变量 |
+| 503 | `{"error": "LLM service unavailable"}` | 混元 API 返回错误或超时 |
+
+## 评分维度
+
+### 意图清晰度 (Intent Clarity)，权重 40%
+
+衡量 prompt 是否清楚地表达了用户想做什么。
+
+**加分信号：**
+- 以动作动词开头（`fix`、`add`、`implement`、`refactor`、`debug`…）→ +3
+- 中文动作动词（`修复`、`添加`、`重构`、`优化`…）→ +3
+- 有明确的目标对象（不仅仅是泛指） → +2
+
+**减分信号：**
+- 意图模糊，无具体动作（如"帮我弄弄代码"）→ -3
+- 极短 prompt（<15 字符 / <8 个汉字）→ -3
+
+### 范围明确性 (Scope Specificity)，权重 30%
+
+衡量 prompt 是否指定了具体的代码位置。
+
+**加分信号：**
+- 包含文件路径（`src/utils/foo.ts`）→ +3
+- 包含函数或类名（camelCase/PascalCase 标识符）→ +2
+- 包含行号引用（`:42`、`line 42`）→ +1
+- 提到了模块或组件名 → +1
+
+**减分信号：**
+- 无文件路径、函数名或模块引用 → -3
+
+### 上下文充分度 (Context Sufficiency)，权重 30%
+
+衡量 prompt 是否提供了足够的背景信息。
+
+**加分信号：**
+- 包含错误关键词（`error`、`bug`、`crash`、`TypeError`…）→ +2
+- 包含代码片段（backtick 包裹的代码）→ +2
+- 描述了期望行为（`应该`、`期望`、`should`、`expect`…）→ +2
+- 长度 >100 字符（或 >50 个汉字）→ +1
+- 长度 >200 字符（或 >100 个汉字）→ +2
+
+**减分信号：**
+- 极短 prompt（<15 字符 / <8 个汉字）→ -3
+
+## 使用示例
+
+### 高质量 prompt（评分 8–10）
+
+```bash
+curl -X POST http://localhost:3721/api/judge \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "prompt": "修复 src/recall.ts 中 scoreRelevance() 在 corpus 数组为空时返回 NaN 的问题，应该返回 0"
+  }'
+```
+
+```json
+{
+  "overall": 10,
+  "intentClarity": 8,
+  "scopeSpecificity": 10,
+  "contextSufficiency": 10
+}
+```
+
+### 中等质量 prompt（评分 5–7）
+
+```bash
+curl -X POST http://localhost:3721/api/judge \
+  -H 'Content-Type: application/json' \
+  -d '{"prompt": "重构 recall 模块的搜索逻辑"}'
+```
+
+```json
+{
+  "overall": 5,
+  "intentClarity": 8,
+  "scopeSpecificity": 6,
+  "contextSufficiency": 2
+}
+```
+
+### 低质量 prompt（评分 0–4）
+
+```bash
+curl -X POST http://localhost:3721/api/judge \
+  -H 'Content-Type: application/json' \
+  -d '{"prompt": "帮我改改代码"}'
+```
+
+```json
+{
+  "overall": 2,
+  "intentClarity": 2,
+  "scopeSpecificity": 2,
+  "contextSufficiency": 2
+}
+```
+
+## 集成示例
+
+### JavaScript / TypeScript
+
+```javascript
+async function judgePrompt(prompt) {
+  const resp = await fetch('http://localhost:3721/api/judge', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ prompt }),
+  });
+  return resp.json();
+}
+
+// 使用
+const score = await judgePrompt('修复 src/auth.ts 中 login() 的 bug');
+console.log(`质量评分: ${score.overall}/10`);
+```
+
+### Python
+
+```python
+import requests
+
+def judge_prompt(prompt: str, lang: str = None) -> dict:
+    payload = {"prompt": prompt}
+    if lang:
+        payload["lang"] = lang
+    resp = requests.post("http://localhost:3721/api/judge", json=payload)
+    resp.raise_for_status()
+    return resp.json()
+
+# 使用
+score = judge_prompt("修复 src/recall.ts 中 threshold 返回 NaN 的问题")
+print(f"质量评分: {score['overall']}/10")
+```
+
+### 批量评分 (Shell)
+
+```bash
+# 从 JSONL 文件批量评分
+while IFS= read -r line; do
+  curl -s -X POST http://localhost:3721/api/judge \
+    -H 'Content-Type: application/json' \
+    -d "$line"
+  echo
+done < prompts.jsonl
+```
+
+## Dashboard 集成
+
+Dashboard 运行时，会自动为每个有 `promptSummary` 的会话计算 prompt 评分。评分以 badge 形式显示在 session 卡片头部：
+
+- 8/10（绿色）— 高质量 prompt
+- 6/10（蓝色）— 中等质量 prompt
+- 3/10（橙色）— 需要改进
+
+鼠标悬停在 badge 上可查看三个维度的详细评分。
+
+## API 特性
+
+| 特性 | 说明 |
+|------|------|
+| 延迟 | 1–5 秒（通过混元 API 进行 LLM 推理） |
+| 并发 | 无状态，支持并发调用（混元默认限制 5 并发） |
+| 幂等性 | 近似确定性（temperature=0，可能有微小差异） |
+| 外部依赖 | `HUNYUAN_API_KEY` 环境变量 |
+| 精度 | 与人工评估约 90% 一致 |

--- a/src/__tests__/prompt-scorer.test.ts
+++ b/src/__tests__/prompt-scorer.test.ts
@@ -75,9 +75,9 @@ describe('prompt-scorer', () => {
 
       await scorePrompt('test');
       const url = vi.mocked(fetch).mock.calls[0][0] as string;
-      expect(url).toBe('https://api.hunyuan.cloud.tencent.com/v1/chat/completions');
+      expect(url).toBe('https://tokenhub.tencentmaas.com/v1/chat/completions');
       const body = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as RequestInit).body as string);
-      expect(body.model).toBe('hunyuan-turbos-latest');
+      expect(body.model).toBe('hy3');
     });
 
     it('truncates prompt to 2000 characters', async () => {
@@ -108,11 +108,11 @@ describe('prompt-scorer', () => {
       process.env.HUNYUAN_BASE_URL = 'https://evil.com/v1';
       const { scorePrompt, ScorerConfigError } = await importScorer();
       await expect(scorePrompt('test')).rejects.toThrow(ScorerConfigError);
-      await expect(scorePrompt('test')).rejects.toThrow('must be a *.cloud.tencent.com');
+      await expect(scorePrompt('test')).rejects.toThrow('must be a Tencent Cloud HTTPS endpoint');
     });
 
     it('accepts valid tencent cloud URL', async () => {
-      process.env.HUNYUAN_BASE_URL = 'https://api.hunyuan.cloud.tencent.com/v1';
+      process.env.HUNYUAN_BASE_URL = 'https://tokenhub.tencentmaas.com/v1';
       const { scorePrompt } = await importScorer();
       vi.mocked(fetch).mockResolvedValueOnce(
         makeFetchResponse(makeHunyuanResponse('{"overall":5,"intentClarity":5,"scopeSpecificity":5,"contextSufficiency":5}')),

--- a/src/__tests__/prompt-scorer.test.ts
+++ b/src/__tests__/prompt-scorer.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+function makeFetchResponse(body: object, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+function makeHunyuanResponse(content: string): object {
+  return {
+    choices: [{ message: { content } }],
+  };
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('prompt-scorer', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    process.env.HUNYUAN_API_KEY = 'test-key-12345';
+    delete process.env.HUNYUAN_BASE_URL;
+    delete process.env.HUNYUAN_MODEL;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  // Dynamic import to pick up env mocks
+  async function importScorer() {
+    return import('../prompt-scorer.js');
+  }
+
+  describe('scorePrompt', () => {
+    it('returns parsed score from valid LLM response', async () => {
+      const { scorePrompt } = await importScorer();
+      const llmJson = '{"overall": 8, "intentClarity": 9, "scopeSpecificity": 7, "contextSufficiency": 8}';
+      vi.mocked(fetch).mockResolvedValueOnce(
+        makeFetchResponse(makeHunyuanResponse(llmJson)),
+      );
+
+      const result = await scorePrompt('fix the bug in src/foo.ts');
+      expect(result.intentClarity).toBe(9);
+      expect(result.scopeSpecificity).toBe(7);
+      expect(result.contextSufficiency).toBe(8);
+      // overall is recalculated: round(9*0.4 + 7*0.3 + 8*0.3) = round(3.6+2.1+2.4) = 8
+      expect(result.overall).toBe(8);
+    });
+
+    it('sends correct Authorization header', async () => {
+      const { scorePrompt } = await importScorer();
+      vi.mocked(fetch).mockResolvedValueOnce(
+        makeFetchResponse(makeHunyuanResponse('{"overall":5,"intentClarity":5,"scopeSpecificity":5,"contextSufficiency":5}')),
+      );
+
+      await scorePrompt('test prompt');
+      const callArgs = vi.mocked(fetch).mock.calls[0];
+      const headers = (callArgs[1] as RequestInit).headers as Record<string, string>;
+      expect(headers['Authorization']).toBe('Bearer test-key-12345');
+    });
+
+    it('uses default base URL and model', async () => {
+      const { scorePrompt } = await importScorer();
+      vi.mocked(fetch).mockResolvedValueOnce(
+        makeFetchResponse(makeHunyuanResponse('{"overall":5,"intentClarity":5,"scopeSpecificity":5,"contextSufficiency":5}')),
+      );
+
+      await scorePrompt('test');
+      const url = vi.mocked(fetch).mock.calls[0][0] as string;
+      expect(url).toBe('https://api.hunyuan.cloud.tencent.com/v1/chat/completions');
+      const body = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as RequestInit).body as string);
+      expect(body.model).toBe('hunyuan-turbos-latest');
+    });
+
+    it('truncates prompt to 2000 characters', async () => {
+      const { scorePrompt } = await importScorer();
+      vi.mocked(fetch).mockResolvedValueOnce(
+        makeFetchResponse(makeHunyuanResponse('{"overall":5,"intentClarity":5,"scopeSpecificity":5,"contextSufficiency":5}')),
+      );
+
+      const longPrompt = 'x'.repeat(5000);
+      await scorePrompt(longPrompt);
+      const body = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as RequestInit).body as string);
+      const userMsg = body.messages[1].content as string;
+      // The user content should contain at most 2000 chars of the prompt
+      expect(userMsg).not.toContain('x'.repeat(2001));
+      expect(userMsg).toContain('x'.repeat(2000));
+    });
+  });
+
+  describe('ScorerConfigError', () => {
+    it('throws when HUNYUAN_API_KEY is not set', async () => {
+      delete process.env.HUNYUAN_API_KEY;
+      const { scorePrompt, ScorerConfigError } = await importScorer();
+      await expect(scorePrompt('test')).rejects.toThrow(ScorerConfigError);
+      await expect(scorePrompt('test')).rejects.toThrow('HUNYUAN_API_KEY not configured');
+    });
+
+    it('throws when HUNYUAN_BASE_URL is not a tencent domain', async () => {
+      process.env.HUNYUAN_BASE_URL = 'https://evil.com/v1';
+      const { scorePrompt, ScorerConfigError } = await importScorer();
+      await expect(scorePrompt('test')).rejects.toThrow(ScorerConfigError);
+      await expect(scorePrompt('test')).rejects.toThrow('must be a *.cloud.tencent.com');
+    });
+
+    it('accepts valid tencent cloud URL', async () => {
+      process.env.HUNYUAN_BASE_URL = 'https://api.hunyuan.cloud.tencent.com/v1';
+      const { scorePrompt } = await importScorer();
+      vi.mocked(fetch).mockResolvedValueOnce(
+        makeFetchResponse(makeHunyuanResponse('{"overall":5,"intentClarity":5,"scopeSpecificity":5,"contextSufficiency":5}')),
+      );
+      const result = await scorePrompt('test');
+      expect(result.overall).toBe(5);
+    });
+  });
+
+  describe('ScorerServiceError', () => {
+    it('throws on non-OK HTTP response', async () => {
+      const { scorePrompt, ScorerServiceError } = await importScorer();
+      vi.mocked(fetch).mockResolvedValueOnce(
+        makeFetchResponse({ error: 'rate limited' }, 429),
+      );
+      await expect(scorePrompt('test')).rejects.toThrow(ScorerServiceError);
+    });
+
+    it('throws on malformed JSON in LLM response', async () => {
+      const { scorePrompt, ScorerServiceError } = await importScorer();
+      vi.mocked(fetch).mockResolvedValueOnce(
+        makeFetchResponse(makeHunyuanResponse('{invalid json}')),
+      );
+      await expect(scorePrompt('test')).rejects.toThrow(ScorerServiceError);
+    });
+
+    it('throws when LLM returns no JSON at all', async () => {
+      const { scorePrompt } = await importScorer();
+      vi.mocked(fetch).mockResolvedValueOnce(
+        makeFetchResponse(makeHunyuanResponse('I cannot score this prompt.')),
+      );
+      await expect(scorePrompt('test')).rejects.toThrow('no JSON found');
+    });
+  });
+
+  describe('parseScoreResponse (via scorePrompt)', () => {
+    it('clamps out-of-range scores to 0-10', async () => {
+      const { scorePrompt } = await importScorer();
+      vi.mocked(fetch).mockResolvedValueOnce(
+        makeFetchResponse(makeHunyuanResponse('{"overall":15,"intentClarity":-3,"scopeSpecificity":12,"contextSufficiency":0}')),
+      );
+      const result = await scorePrompt('test');
+      expect(result.intentClarity).toBe(0);
+      expect(result.scopeSpecificity).toBe(10);
+      expect(result.contextSufficiency).toBe(0);
+    });
+
+    it('defaults to 5 for non-numeric values', async () => {
+      const { scorePrompt } = await importScorer();
+      vi.mocked(fetch).mockResolvedValueOnce(
+        makeFetchResponse(makeHunyuanResponse('{"overall":5,"intentClarity":"high","scopeSpecificity":"medium","contextSufficiency":7}')),
+      );
+      const result = await scorePrompt('test');
+      expect(result.intentClarity).toBe(5);
+      expect(result.scopeSpecificity).toBe(5);
+      expect(result.contextSufficiency).toBe(7);
+    });
+
+    it('extracts JSON from markdown-wrapped response', async () => {
+      const { scorePrompt } = await importScorer();
+      const wrappedResponse = 'Here is the score:\n```json\n{"overall":7,"intentClarity":8,"scopeSpecificity":6,"contextSufficiency":7}\n```';
+      vi.mocked(fetch).mockResolvedValueOnce(
+        makeFetchResponse(makeHunyuanResponse(wrappedResponse)),
+      );
+      const result = await scorePrompt('test');
+      expect(result.intentClarity).toBe(8);
+      expect(result.scopeSpecificity).toBe(6);
+    });
+
+    it('recalculates overall using the weighted formula', async () => {
+      const { scorePrompt } = await importScorer();
+      vi.mocked(fetch).mockResolvedValueOnce(
+        makeFetchResponse(makeHunyuanResponse('{"overall":0,"intentClarity":10,"scopeSpecificity":10,"contextSufficiency":10}')),
+      );
+      const result = await scorePrompt('test');
+      // overall = round(10*0.4 + 10*0.3 + 10*0.3) = 10, ignores LLM's "0"
+      expect(result.overall).toBe(10);
+    });
+  });
+
+  describe('lang parameter', () => {
+    it('includes Chinese hint when lang is zh', async () => {
+      const { scorePrompt } = await importScorer();
+      vi.mocked(fetch).mockResolvedValueOnce(
+        makeFetchResponse(makeHunyuanResponse('{"overall":5,"intentClarity":5,"scopeSpecificity":5,"contextSufficiency":5}')),
+      );
+      await scorePrompt('修复 bug', 'zh');
+      const body = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as RequestInit).body as string);
+      expect(body.messages[1].content).toContain('Chinese');
+    });
+
+    it('includes English hint when lang is en', async () => {
+      const { scorePrompt } = await importScorer();
+      vi.mocked(fetch).mockResolvedValueOnce(
+        makeFetchResponse(makeHunyuanResponse('{"overall":5,"intentClarity":5,"scopeSpecificity":5,"contextSufficiency":5}')),
+      );
+      await scorePrompt('fix bug', 'en');
+      const body = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as RequestInit).body as string);
+      expect(body.messages[1].content).toContain('English');
+    });
+  });
+});

--- a/src/dashboard-html.ts
+++ b/src/dashboard-html.ts
@@ -199,6 +199,25 @@ export function getDashboardHtml(port: number): string {
       font-weight: 600;
       cursor: help;
     }
+    .prompt-score-badge {
+      font-size: 11px;
+      padding: 2px 8px;
+      border-radius: 12px;
+      font-weight: 600;
+      cursor: help;
+    }
+    .prompt-score-badge.score-high {
+      background: rgba(16, 185, 129, 0.15);
+      color: #10b981;
+    }
+    .prompt-score-badge.score-mid {
+      background: rgba(59, 130, 246, 0.15);
+      color: #3b82f6;
+    }
+    .prompt-score-badge.score-low {
+      background: rgba(245, 158, 11, 0.15);
+      color: #f59e0b;
+    }
     .status-text {
       font-size: 12px;
       color: var(--text-muted);
@@ -593,6 +612,39 @@ export function getDashboardHtml(port: number): string {
         ' · 缓存读 ' + fmtTokens(t.cacheRead) + ' · 缓存写 ' + fmtTokens(t.cacheCreation);
     }
 
+    // ─── Async prompt scoring ───
+    const promptScoreCache = {};
+
+    async function fetchPromptScore(sessionId, prompt) {
+      if (promptScoreCache[sessionId]) return promptScoreCache[sessionId];
+      if (promptScoreCache[sessionId] === null) return null;
+      try {
+        const resp = await fetch('/api/judge', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ prompt: prompt })
+        });
+        if (!resp.ok) { promptScoreCache[sessionId] = null; return null; }
+        const score = await resp.json();
+        promptScoreCache[sessionId] = score;
+        render();
+        return score;
+      } catch { promptScoreCache[sessionId] = null; return null; }
+    }
+
+    function promptScoreClass(score) {
+      if (score >= 8) return 'score-high';
+      if (score >= 5) return 'score-mid';
+      return 'score-low';
+    }
+
+    function promptScoreTitle(ps) {
+      if (!ps) return '';
+      return 'Intent clarity ' + ps.intentClarity + '/10'
+        + ' · Scope specificity ' + ps.scopeSpecificity + '/10'
+        + ' · Context sufficiency ' + ps.contextSufficiency + '/10';
+    }
+
     function renderCard(s) {
       const isExpanded = expandedCards.has(s.sessionId);
       const isStopped = s.status === 'stopped';
@@ -607,6 +659,16 @@ export function getDashboardHtml(port: number): string {
       const tokenBadge = (tokenSum > 0)
         ? '<span class="token-badge" title="' + escapeAttr(tokenTitle(s.tokens)) + '">⛁ ' + fmtTokens(tokenSum) + '</span>'
         : '';
+      let promptScoreBadge = '';
+      const cachedScore = promptScoreCache[s.sessionId];
+      if (cachedScore) {
+        promptScoreBadge = '<span class="prompt-score-badge ' + promptScoreClass(cachedScore.overall)
+          + '" title="' + escapeAttr(promptScoreTitle(cachedScore))
+          + '">📝 ' + cachedScore.overall + '/10</span>';
+      } else if (cachedScore === undefined && s.promptSummary) {
+        promptScoreBadge = '<span class="prompt-score-badge score-mid">📝 ...</span>';
+        fetchPromptScore(s.sessionId, s.promptSummary);
+      }
 
       // ─── Expanded detail panel ───
       let detail = '';
@@ -659,6 +721,7 @@ export function getDashboardHtml(port: number): string {
           convoBadge +
           tokenBadge +
           interventionBadge +
+          promptScoreBadge +
           '<span class="status-text">' + statusLabel(s.status) + '</span>' +
         '</div>' +
         '<div class="cwd" title="' + escapeAttr(s.cwd) + '">' + escapeHtml(shortPath(s.cwd)) + '</div>' +

--- a/src/dashboard-html.ts
+++ b/src/dashboard-html.ts
@@ -614,10 +614,15 @@ export function getDashboardHtml(port: number): string {
 
     // ─── Async prompt scoring ───
     const promptScoreCache = {};
+    const SCORE_PENDING = 'pending';
 
     async function fetchPromptScore(sessionId, prompt) {
-      if (promptScoreCache[sessionId]) return promptScoreCache[sessionId];
+      if (promptScoreCache[sessionId] && promptScoreCache[sessionId] !== SCORE_PENDING) {
+        return promptScoreCache[sessionId];
+      }
       if (promptScoreCache[sessionId] === null) return null;
+      if (promptScoreCache[sessionId] === SCORE_PENDING) return null;
+      promptScoreCache[sessionId] = SCORE_PENDING;
       try {
         const resp = await fetch('/api/judge', {
           method: 'POST',
@@ -661,13 +666,15 @@ export function getDashboardHtml(port: number): string {
         : '';
       let promptScoreBadge = '';
       const cachedScore = promptScoreCache[s.sessionId];
-      if (cachedScore) {
+      if (cachedScore && cachedScore !== SCORE_PENDING) {
         promptScoreBadge = '<span class="prompt-score-badge ' + promptScoreClass(cachedScore.overall)
           + '" title="' + escapeAttr(promptScoreTitle(cachedScore))
           + '">📝 ' + cachedScore.overall + '/10</span>';
       } else if (cachedScore === undefined && s.promptSummary) {
         promptScoreBadge = '<span class="prompt-score-badge score-mid">📝 ...</span>';
         fetchPromptScore(s.sessionId, s.promptSummary);
+      } else if (cachedScore === SCORE_PENDING) {
+        promptScoreBadge = '<span class="prompt-score-badge score-mid">📝 ...</span>';
       }
 
       // ─── Expanded detail panel ───

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -13,6 +13,7 @@ import {
   type DashboardEvent,
 } from './types.js';
 import { getDashboardHtml } from './dashboard-html.js';
+import { scorePrompt } from './prompt-scorer.js';
 
 // ─── Dashboard server architecture ──────────────────────
 //
@@ -157,6 +158,39 @@ export async function startDashboard(port?: number): Promise<void> {
 
       req.on('close', () => {
         clients.delete(res);
+      });
+      return;
+    }
+
+    if (url.pathname === '/api/judge' && req.method === 'POST') {
+      let body = '';
+      req.on('data', (chunk: Buffer) => { body += chunk.toString(); });
+      req.on('end', async () => {
+        try {
+          const parsed = JSON.parse(body) as Record<string, unknown>;
+          const prompt = parsed.prompt;
+          if (!prompt || typeof prompt !== 'string') {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'prompt is required and must be a string' }));
+            return;
+          }
+          const lang = typeof parsed.lang === 'string' ? parsed.lang : undefined;
+          const result = await scorePrompt(prompt, lang);
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify(result));
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'unknown error';
+          if (message.includes('HUNYUAN_API_KEY not configured')) {
+            res.writeHead(503, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'HUNYUAN_API_KEY not configured' }));
+          } else if (message.includes('Hunyuan API error') || message.includes('abort')) {
+            res.writeHead(503, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'LLM service unavailable' }));
+          } else {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: message }));
+          }
+        }
       });
       return;
     }

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -13,7 +13,10 @@ import {
   type DashboardEvent,
 } from './types.js';
 import { getDashboardHtml } from './dashboard-html.js';
-import { scorePrompt } from './prompt-scorer.js';
+import { scorePrompt, ScorerConfigError, ScorerServiceError } from './prompt-scorer.js';
+
+let judgeInFlight = 0;
+const MAX_JUDGE_CONCURRENT = 5;
 
 // ─── Dashboard server architecture ──────────────────────
 //
@@ -163,33 +166,59 @@ export async function startDashboard(port?: number): Promise<void> {
     }
 
     if (url.pathname === '/api/judge' && req.method === 'POST') {
+      const MAX_BODY_BYTES = 65_536;
       let body = '';
-      req.on('data', (chunk: Buffer) => { body += chunk.toString(); });
+      let oversized = false;
+      req.on('data', (chunk: Buffer) => {
+        body += chunk.toString();
+        if (body.length > MAX_BODY_BYTES) {
+          oversized = true;
+          req.destroy();
+          res.writeHead(413, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'request body too large' }));
+        }
+      });
       req.on('end', async () => {
+        if (oversized) return;
+        let parsed: Record<string, unknown>;
         try {
-          const parsed = JSON.parse(body) as Record<string, unknown>;
-          const prompt = parsed.prompt;
-          if (!prompt || typeof prompt !== 'string') {
-            res.writeHead(400, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify({ error: 'prompt is required and must be a string' }));
-            return;
-          }
-          const lang = typeof parsed.lang === 'string' ? parsed.lang : undefined;
+          parsed = JSON.parse(body) as Record<string, unknown>;
+        } catch {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'invalid JSON' }));
+          return;
+        }
+        const prompt = parsed.prompt;
+        if (!prompt || typeof prompt !== 'string') {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'prompt is required and must be a string' }));
+          return;
+        }
+        const lang = typeof parsed.lang === 'string' ? parsed.lang : undefined;
+        if (judgeInFlight >= MAX_JUDGE_CONCURRENT) {
+          res.writeHead(429, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'too many concurrent requests, try again later' }));
+          return;
+        }
+        judgeInFlight++;
+        try {
           const result = await scorePrompt(prompt, lang);
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify(result));
         } catch (err) {
-          const message = err instanceof Error ? err.message : 'unknown error';
-          if (message.includes('HUNYUAN_API_KEY not configured')) {
+          if (err instanceof ScorerConfigError) {
             res.writeHead(503, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify({ error: 'HUNYUAN_API_KEY not configured' }));
-          } else if (message.includes('Hunyuan API error') || message.includes('abort')) {
+            res.end(JSON.stringify({ error: err.message }));
+          } else if (err instanceof ScorerServiceError) {
             res.writeHead(503, { 'Content-Type': 'application/json' });
             res.end(JSON.stringify({ error: 'LLM service unavailable' }));
           } else {
+            const message = err instanceof Error ? err.message : 'unknown error';
             res.writeHead(400, { 'Content-Type': 'application/json' });
             res.end(JSON.stringify({ error: message }));
           }
+        } finally {
+          judgeInFlight--;
         }
       });
       return;

--- a/src/prompt-scorer.ts
+++ b/src/prompt-scorer.ts
@@ -26,8 +26,8 @@ export class ScorerServiceError extends Error {
   }
 }
 
-const DEFAULT_BASE_URL = 'https://api.hunyuan.cloud.tencent.com/v1';
-const DEFAULT_MODEL = 'hunyuan-turbos-latest';
+const DEFAULT_BASE_URL = 'https://tokenhub.tencentmaas.com/v1';
+const DEFAULT_MODEL = 'hy3';
 const FETCH_TIMEOUT_MS = 10_000;
 
 const SCORING_SYSTEM_PROMPT = `You are an AI coding assistant prompt quality evaluator.
@@ -50,9 +50,10 @@ export async function scorePrompt(prompt: string, lang?: string): Promise<Prompt
   }
 
   const baseUrl = process.env.HUNYUAN_BASE_URL ?? DEFAULT_BASE_URL;
-  if (!/^https:\/\/[^/]*\.cloud\.tencent\.com(\/|$)/.test(baseUrl) && baseUrl !== DEFAULT_BASE_URL) {
+  const ALLOWED_HOSTS = /^https:\/\/[^/]*(\.cloud\.tencent\.com|\.tencentmaas\.com)(\/|$)/;
+  if (!ALLOWED_HOSTS.test(baseUrl) && baseUrl !== DEFAULT_BASE_URL) {
     throw new ScorerConfigError(
-      `HUNYUAN_BASE_URL must be a *.cloud.tencent.com HTTPS endpoint, got: ${baseUrl}`
+      `HUNYUAN_BASE_URL must be a Tencent Cloud HTTPS endpoint, got: ${baseUrl}`
     );
   }
   const model = process.env.HUNYUAN_MODEL ?? DEFAULT_MODEL;

--- a/src/prompt-scorer.ts
+++ b/src/prompt-scorer.ts
@@ -10,6 +10,22 @@ import { type PromptScore } from './types.js';
 
 export { type PromptScore };
 
+/** Thrown when scorer configuration is invalid or missing. */
+export class ScorerConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ScorerConfigError';
+  }
+}
+
+/** Thrown when the LLM service is unavailable or returns an error. */
+export class ScorerServiceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ScorerServiceError';
+  }
+}
+
 const DEFAULT_BASE_URL = 'https://api.hunyuan.cloud.tencent.com/v1';
 const DEFAULT_MODEL = 'hunyuan-turbos-latest';
 const FETCH_TIMEOUT_MS = 10_000;
@@ -30,15 +46,21 @@ overall = round(intentClarity * 0.4 + scopeSpecificity * 0.3 + contextSufficienc
 export async function scorePrompt(prompt: string, lang?: string): Promise<PromptScore> {
   const apiKey = process.env.HUNYUAN_API_KEY;
   if (!apiKey) {
-    throw new Error('HUNYUAN_API_KEY not configured');
+    throw new ScorerConfigError('HUNYUAN_API_KEY not configured');
   }
 
   const baseUrl = process.env.HUNYUAN_BASE_URL ?? DEFAULT_BASE_URL;
+  if (!/^https:\/\/[^/]*\.cloud\.tencent\.com(\/|$)/.test(baseUrl) && baseUrl !== DEFAULT_BASE_URL) {
+    throw new ScorerConfigError(
+      `HUNYUAN_BASE_URL must be a *.cloud.tencent.com HTTPS endpoint, got: ${baseUrl}`
+    );
+  }
   const model = process.env.HUNYUAN_MODEL ?? DEFAULT_MODEL;
   const url = `${baseUrl}/chat/completions`;
 
+  const truncatedPrompt = prompt.length > 2000 ? prompt.slice(0, 2000) : prompt;
   const langHint = lang ? ` The prompt is in ${lang === 'zh' ? 'Chinese' : 'English'}.` : '';
-  const userContent = `${langHint}\n\nUser prompt to evaluate:\n"""\n${prompt}\n"""`;
+  const userContent = `${langHint}\n\nUser prompt to evaluate:\n"""\n${truncatedPrompt}\n"""`;
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
@@ -64,7 +86,7 @@ export async function scorePrompt(prompt: string, lang?: string): Promise<Prompt
 
     if (!response.ok) {
       const text = await response.text().catch(() => '');
-      throw new Error(`Hunyuan API error: ${response.status} ${text.slice(0, 200)}`);
+      throw new ScorerServiceError(`Hunyuan API error: ${response.status} ${text.slice(0, 200)}`);
     }
 
     const data = await response.json() as {
@@ -84,7 +106,12 @@ function parseScoreResponse(content: string): PromptScore {
     throw new Error(`Failed to parse LLM response: no JSON found in "${content.slice(0, 200)}"`);
   }
 
-  const parsed = JSON.parse(jsonMatch[0]) as Record<string, unknown>;
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(jsonMatch[0]) as Record<string, unknown>;
+  } catch {
+    throw new ScorerServiceError(`Failed to parse LLM score JSON: ${jsonMatch[0].slice(0, 200)}`);
+  }
   const intentClarity = clampScore(parsed.intentClarity);
   const scopeSpecificity = clampScore(parsed.scopeSpecificity);
   const contextSufficiency = clampScore(parsed.contextSufficiency);

--- a/src/prompt-scorer.ts
+++ b/src/prompt-scorer.ts
@@ -1,0 +1,100 @@
+/**
+ * LLM-based prompt quality scorer using Hunyuan API.
+ *
+ * Evaluates a user's first prompt across three dimensions:
+ * intentClarity, scopeSpecificity, contextSufficiency.
+ * Calls Hunyuan (OpenAI-compatible) chat completions endpoint.
+ */
+
+import { type PromptScore } from './types.js';
+
+export { type PromptScore };
+
+const DEFAULT_BASE_URL = 'https://api.hunyuan.cloud.tencent.com/v1';
+const DEFAULT_MODEL = 'hunyuan-turbos-latest';
+const FETCH_TIMEOUT_MS = 10_000;
+
+const SCORING_SYSTEM_PROMPT = `You are an AI coding assistant prompt quality evaluator.
+Score the given user prompt across three dimensions (each 0-10):
+
+1. intentClarity: Is the user's goal clear? Action verb + specific target = high score.
+2. scopeSpecificity: Does the prompt specify which files, functions, or modules? File paths, function names = high score.
+3. contextSufficiency: Does the prompt provide enough background? Error messages, code snippets, expected behavior = high score.
+
+Respond with ONLY a JSON object (no markdown, no explanation):
+{"overall": N, "intentClarity": N, "scopeSpecificity": N, "contextSufficiency": N}
+
+overall = round(intentClarity * 0.4 + scopeSpecificity * 0.3 + contextSufficiency * 0.3)`;
+
+/** Score a prompt using the Hunyuan LLM API. */
+export async function scorePrompt(prompt: string, lang?: string): Promise<PromptScore> {
+  const apiKey = process.env.HUNYUAN_API_KEY;
+  if (!apiKey) {
+    throw new Error('HUNYUAN_API_KEY not configured');
+  }
+
+  const baseUrl = process.env.HUNYUAN_BASE_URL ?? DEFAULT_BASE_URL;
+  const model = process.env.HUNYUAN_MODEL ?? DEFAULT_MODEL;
+  const url = `${baseUrl}/chat/completions`;
+
+  const langHint = lang ? ` The prompt is in ${lang === 'zh' ? 'Chinese' : 'English'}.` : '';
+  const userContent = `${langHint}\n\nUser prompt to evaluate:\n"""\n${prompt}\n"""`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages: [
+          { role: 'system', content: SCORING_SYSTEM_PROMPT },
+          { role: 'user', content: userContent },
+        ],
+        temperature: 0,
+        max_tokens: 100,
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new Error(`Hunyuan API error: ${response.status} ${text.slice(0, 200)}`);
+    }
+
+    const data = await response.json() as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+    const content = data.choices?.[0]?.message?.content ?? '';
+    return parseScoreResponse(content);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Parse the LLM JSON response into a PromptScore. */
+function parseScoreResponse(content: string): PromptScore {
+  const jsonMatch = content.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) {
+    throw new Error(`Failed to parse LLM response: no JSON found in "${content.slice(0, 200)}"`);
+  }
+
+  const parsed = JSON.parse(jsonMatch[0]) as Record<string, unknown>;
+  const intentClarity = clampScore(parsed.intentClarity);
+  const scopeSpecificity = clampScore(parsed.scopeSpecificity);
+  const contextSufficiency = clampScore(parsed.contextSufficiency);
+  const overall = Math.round(intentClarity * 0.4 + scopeSpecificity * 0.3 + contextSufficiency * 0.3);
+
+  return { overall, intentClarity, scopeSpecificity, contextSufficiency };
+}
+
+function clampScore(value: unknown): number {
+  const n = Number(value);
+  if (Number.isNaN(n)) return 5;
+  return Math.max(0, Math.min(10, Math.round(n)));
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -517,6 +517,14 @@ export interface DashboardEvent {
   prompts?: number;
 }
 
+/** Prompt quality score across three dimensions. */
+export interface PromptScore {
+  overall: number;
+  intentClarity: number;
+  scopeSpecificity: number;
+  contextSufficiency: number;
+}
+
 export interface DashboardSession {
   /** Unique session identifier */
   sessionId: string;
@@ -555,6 +563,8 @@ export interface DashboardSession {
   promptCount: number;
   /** Cumulative token usage for this session (zero when no transcript usage). */
   tokens: TokenUsage;
+  /** Prompt quality score computed by the rule-based scorer. */
+  promptScore?: PromptScore;
 }
 
 export const DASHBOARD_EVENTS_DIR = `${TEAMAI_HOME}/dashboard`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -563,8 +563,6 @@ export interface DashboardSession {
   promptCount: number;
   /** Cumulative token usage for this session (zero when no transcript usage). */
   tokens: TokenUsage;
-  /** Prompt quality score computed by the rule-based scorer. */
-  promptScore?: PromptScore;
 }
 
 export const DASHBOARD_EVENTS_DIR = `${TEAMAI_HOME}/dashboard`;


### PR DESCRIPTION
## Summary

- Add `POST /api/judge` endpoint to the Dashboard HTTP server that scores user prompts for quality using the Hunyuan LLM
- Evaluates three dimensions: **intent clarity**, **scope specificity**, and **context sufficiency** (each 0–10)
- Model configuration (API key, base URL, model name) is server-side only via environment variables — **not exposed** to API callers
- Dashboard UI shows prompt score badges with async loading, caching, and graceful degradation when API key is not configured
- Bilingual API usage guide (EN + zh-CN)

## Files Changed

| File | Change |
|------|--------|
| `src/prompt-scorer.ts` | New: Hunyuan LLM scoring module |
| `src/dashboard.ts` | Add `POST /api/judge` route with 503 error handling |
| `src/dashboard-html.ts` | Async prompt score badge with cache + loading state |
| `src/types.ts` | Add `PromptScore` interface + `DashboardSession.promptScore` |
| `docs/prompt-judge-api-guide.md` | API usage guide (English) |
| `docs/prompt-judge-api-guide.zh-CN.md` | API usage guide (Chinese) |

## Security

- No hardcoded API keys or secrets
- `HUNYUAN_API_KEY` read from environment variable only
- Model configuration not exposed in API responses
- 10s fetch timeout to prevent hanging

## Test plan

- [x] `npx tsc --noEmit` — type check passes
- [x] `npx vitest run` — 1823 tests pass, no regression
- [x] Manual: set `HUNYUAN_API_KEY`, run `teamai dashboard`, curl `POST /api/judge`
- [x] Manual: without API key, confirm 503 response and Dashboard badge silent degradation

🤖 Generated with [Claude Code](https://claude.com/claude-code)