### PR TITLE
fix(tgit): clone/fetch must use OAuth token, never a REST-only PAT

### DIFF
--- a/src/__tests__/tgit-rest-auth.test.ts
+++ b/src/__tests__/tgit-rest-auth.test.ts
@@ -16,7 +16,7 @@ vi.mock('../utils/logger.js', () => ({
     },
 }));
 
-import { getTGitToken, tgitAuthHeaders, tgitFetch, tgitGitUser, tryGetTGitToken } from '../providers/tgit/rest-auth.js';
+import { getTGitToken, tgitAuthHeaders, tgitFetch, tgitGitCloneUrl, tryGetTGitToken } from '../providers/tgit/rest-auth.js';
 import { gfGetOAuthToken } from '../providers/tgit/gf-cli.js';
 
 function makeResponse(status: number): Response {
@@ -64,13 +64,31 @@ describe('rest-auth', () => {
         });
     });
 
-    describe('tgitGitUser', () => {
-        it("'private-token' → 'private'", () => {
-            expect(tgitGitUser('private-token')).toBe('private');
+    describe('tgitGitCloneUrl', () => {
+        const base = 'https://git.woa.com/owner/repo.git';
+
+        it('OAuth token present → embeds it as oauth2:<token>@', () => {
+            (gfGetOAuthToken as Mock).mockReturnValue('oauth-x');
+            expect(tgitGitCloneUrl(base)).toBe('https://oauth2:oauth-x@git.woa.com/owner/repo.git');
         });
 
-        it("'bearer' → 'oauth2'", () => {
-            expect(tgitGitUser('bearer')).toBe('oauth2');
+        it('no OAuth token → returns null (caller falls back to gf)', () => {
+            (gfGetOAuthToken as Mock).mockReturnValue(null);
+            expect(tgitGitCloneUrl(base)).toBeNull();
+        });
+
+        it('a PAT in TGIT_TOKEN does NOT enable git clone (REST-only, ignored here)', () => {
+            // Regression guard: a stray PAT must not shadow the (absent) OAuth token.
+            // git.woa.com's git endpoint rejects the PAT, so clone must report "no cred".
+            process.env['TGIT_TOKEN'] = 'pat-123';
+            (gfGetOAuthToken as Mock).mockReturnValue(null);
+            expect(tgitGitCloneUrl(base)).toBeNull();
+        });
+
+        it('OAuth wins even when a PAT is also present', () => {
+            process.env['TGIT_TOKEN'] = 'pat-123';
+            (gfGetOAuthToken as Mock).mockReturnValue('oauth-x');
+            expect(tgitGitCloneUrl(base)).toBe('https://oauth2:oauth-x@git.woa.com/owner/repo.git');
         });
     });
 

--- a/src/clone.ts
+++ b/src/clone.ts
@@ -3,7 +3,7 @@ import { spawn } from 'node:child_process';
 import fs from 'fs-extra';
 
 import { getGitHubToken } from './providers/github/gh-cli.js';
-import { tryGetTGitToken, tgitGitUser } from './providers/tgit/rest-auth.js';
+import { tgitGitCloneUrl } from './providers/tgit/rest-auth.js';
 import { log } from './utils/logger.js';
 
 // ─── Types ──────────────────────────────────────────────
@@ -189,17 +189,18 @@ export async function shallowClone(
             log.debug(`shallowClone: 使用匿名 HTTPS 克隆 github 仓库`);
         }
     } else if (provider === 'tgit') {
-        // TGit: 使用 token 嵌入 URL（netrc 非标准字段导致 git credential 不稳定）
-        // git 用户名取决于 token 类型：PAT → private，OAuth → oauth2。
-        const creds = tryGetTGitToken();
-        cloneUrl = url.replace(/^http:\/\//, 'https://');
-        if (creds) {
-            cloneUrl = cloneUrl.replace('https://', `https://${tgitGitUser(creds.scheme)}:${creds.token}@`);
+        // TGit 的 git 协议只认 gf 登录的 OAuth token（oauth2:<token>@ 嵌入 URL）；
+        // TGIT_TOKEN PAT 仅用于 REST API,对 git clone 无效,故此处不使用（见 tgitGitCloneUrl）。
+        const httpsUrl = url.replace(/^http:\/\//, 'https://');
+        const authed = tgitGitCloneUrl(httpsUrl);
+        if (authed) {
+            cloneUrl = authed;
             cloneMethod = 'https-token';
-            log.debug(`shallowClone: 使用 HTTPS+token 克隆 tgit 仓库`);
+            log.debug(`shallowClone: 使用 HTTPS+OAuth token 克隆 tgit 仓库`);
         } else {
+            cloneUrl = httpsUrl;
             cloneMethod = 'https-anonymous';
-            log.debug(`shallowClone: 无 TGit token，尝试匿名 HTTPS 克隆`);
+            log.debug(`shallowClone: 无 TGit OAuth token，尝试匿名 HTTPS 克隆`);
         }
     } else {
         // 其他 provider，依赖 ~/.netrc

--- a/src/providers/tgit/gf-cli.ts
+++ b/src/providers/tgit/gf-cli.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { pathExists, ensureDir } from '../../utils/fs.js';
 import { log, spinner } from '../../utils/logger.js';
 import { TEAMAI_HOME } from '../../types.js';
-import { tgitFetch, tryGetTGitToken, tgitGitUser } from './rest-auth.js';
+import { tgitFetch, tgitGitCloneUrl } from './rest-auth.js';
 
 /** Path where gf CLI is installed */
 const GF_INSTALL_DIR = path.join(TEAMAI_HOME, 'gf');
@@ -318,22 +318,20 @@ function gitOutputSaysRepoMissing(output: string): boolean {
 /**
  * Clone a repo from git.woa.com.
  *
- * When a TGit credential is available, clone via `git clone` with the token
- * embedded in the URL. The git username depends on the token scheme: a PAT
- * ('private-token') authenticates as `private`, an OAuth token as `oauth2`
- * (see {@link tgitGitUser}). This path handles both two-segment and
- * multi-segment group paths uniformly.
+ * When an OAuth credential is available (from `gf auth login`), clone via
+ * `git clone` with the token embedded as `oauth2:<token>@`. A `TGIT_TOKEN` PAT
+ * is intentionally NOT used here: it is REST-API-only and git.woa.com's git
+ * endpoint rejects it (see {@link tgitGitCloneUrl}). This path handles both
+ * two-segment and multi-segment group paths uniformly.
  *
- * When no credential is available, fall back to `gf repo clone` (the
+ * When no OAuth credential is available, fall back to `gf repo clone` (the
  * interactive/user path, which relies on gf's own stored auth).
  *
  * Throws RepoNotFoundError when the remote repo does not exist.
  */
 export function gfRepoClone(repo: string, localPath: string): void {
-  const creds = tryGetTGitToken();
-  if (creds) {
-    const user = tgitGitUser(creds.scheme);
-    const cloneUrl = `https://${user}:${creds.token}@git.woa.com/${repo}.git`;
+  const cloneUrl = tgitGitCloneUrl(`https://git.woa.com/${repo}.git`);
+  if (cloneUrl) {
     const result = spawnSync('git', ['clone', cloneUrl, localPath], {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -345,13 +343,13 @@ export function gfRepoClone(repo: string, localPath: string): void {
     }
     if (result.status !== 0) {
       // Sanitize output to avoid leaking the token
-      const sanitized = allOutput.replace(/(oauth2|private):[^@]+@/g, '$1:***@');
+      const sanitized = allOutput.replace(/oauth2:[^@]+@/g, 'oauth2:***@');
       throw new Error(`git clone failed: ${sanitized.trim()}`);
     }
     return;
   }
 
-  // No token available → fall back to `gf repo clone` (interactive/user path).
+  // No OAuth credential → fall back to `gf repo clone` (interactive/user path).
   const result = gfExec(['repo', 'clone', repo, localPath]);
   const allOutput = `${result.stderr} ${result.stdout}`;
   // Only match gf's own "not found" message, not git's object stats (e.g. "reused 404")

--- a/src/providers/tgit/rest-auth.ts
+++ b/src/providers/tgit/rest-auth.ts
@@ -43,11 +43,32 @@ export function getTGitToken(): { token: string; scheme: TGitAuthScheme } {
 }
 
 /**
- * git-over-HTTPS username for the given auth scheme.
- * A PAT ('private-token') authenticates git as `private`; an OAuth token as `oauth2`.
+ * Build an authenticated git.woa.com clone/fetch URL, or null when no usable
+ * git credential exists.
+ *
+ * IMPORTANT — git protocol vs REST API use different credentials on TGit:
+ *
+ * - **git-over-HTTPS (clone/fetch)** only accepts the OAuth token from
+ *   `gf auth login` (stored in ~/.netrc), presented as in-URL basic-auth
+ *   `https://oauth2:<token>@…`. This is the only form git.woa.com's git
+ *   endpoint honours.
+ * - A `TGIT_TOKEN` **Personal Access Token is REST-API-only** — git.woa.com's
+ *   git endpoint rejects it in every form (in-URL basic-auth *and*
+ *   `PRIVATE-TOKEN` header both get a 401 `www-authenticate: Basic`). So the
+ *   PAT is deliberately ignored here; it is used only by {@link tgitFetch}.
+ *
+ * Consequently a stray `TGIT_TOKEN` in the environment must NOT shadow the
+ * OAuth token for clone — doing so is exactly the bug this function prevents.
+ *
+ * @param httpsUrl - the base `https://git.woa.com/…` clone URL (no credentials)
+ * @returns the authenticated URL, or null when only a PAT / nothing is available
  */
-export function tgitGitUser(scheme: TGitAuthScheme): string {
-  return scheme === 'private-token' ? 'private' : 'oauth2';
+export function tgitGitCloneUrl(httpsUrl: string): string | null {
+  const oauthToken = gfGetOAuthToken();
+  if (!oauthToken) {
+    return null;
+  }
+  return httpsUrl.replace(/^https:\/\//, `https://oauth2:${oauthToken}@`);
 }
 
 /**


### PR DESCRIPTION
## Problem

A `TGIT_TOKEN` set in the environment makes `teamai init` / `teamai pull` fail with `Authentication failed` when cloning the team repo:

```
- Cloning team repo...
✖ Clone failed: git clone failed: ... fatal: Authentication failed for 'https://git.woa.com/…'
```

The clone path treated `TGIT_TOKEN` as a git credential (`https://private:<pat>@git.woa.com/…`). But **git.woa.com's git-over-HTTPS endpoint rejects a PAT in every form** — both in-URL basic-auth and a `PRIVATE-TOKEN` header return `401 www-authenticate: Basic`. The PAT is **REST-API-only**; git protocol only accepts the OAuth token from `gf auth login` (`~/.netrc`), presented as `oauth2:<token>@`.

This bit anyone with a `TGIT_TOKEN` exported (e.g. for REST/CI), and the error message ("Authentication failed") gave no hint that the token type was the problem.

## Evidence

Verified directly against `git.woa.com`:

| credential | REST `/api/v3/user` | `git clone` |
|---|---|---|
| PAT (`TGIT_TOKEN`) | ✅ via `PRIVATE-TOKEN` | ❌ rejected in all forms (401) |
| OAuth (`~/.netrc`) | ✅ via `Bearer` | ✅ via `oauth2:<token>@` |

`GIT_CURL_VERBOSE` trace confirmed the git endpoint answers a `PRIVATE-TOKEN` header with `401` + `www-authenticate: Basic`.

## Fix

- Add `tgitGitCloneUrl(httpsUrl)` in `rest-auth.ts`: resolves the **OAuth token only**, embeds it as `oauth2:<token>@`, and returns `null` when no OAuth token exists. A stray PAT is deliberately ignored — it can no longer shadow OAuth.
- Route both clone sites through it: `gfRepoClone` (team repo) and `shallowClone` (`teamai import`). `gfRepoClone` still falls back to `gf repo clone` when there is no OAuth token.
- REST paths (`members`, org listing, MR fetch) are untouched — they keep using `getTGitToken`, where the PAT is valid.

## Test Plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 1948 passed (incl. 4 new regression guards: PAT must not enable/shadow clone; OAuth wins when both present)
- [x] `npm run build` — success
- [x] **E2E with `TGIT_TOKEN` set** against internal team repo: `teamai init` + `teamai pull` now succeed (previously failed) — repo cloned, 46 skills / 3 rules / 3 docs / 8 env / 84 learnings synced
- [x] **E2E without `TGIT_TOKEN`** (pure OAuth): still succeeds — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)