### PR TITLE
feat(local-agent): add MCP server install/uninstall via HTTP sync channel

### DIFF
--- a/src/__tests__/local-agent-mcp.test.ts
+++ b/src/__tests__/local-agent-mcp.test.ts
@@ -1,0 +1,479 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import path from 'node:path';
+import os from 'node:os';
+import fse from 'fs-extra';
+
+vi.mock('../utils/logger.js', () => ({
+  log: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+let tmpDir: string;
+let origHome: string | undefined;
+
+beforeEach(async () => {
+  tmpDir = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-mcp-test-'));
+  origHome = process.env.HOME;
+  process.env.HOME = tmpDir;
+});
+
+afterEach(async () => {
+  process.env.HOME = origHome;
+  await fse.remove(tmpDir);
+  vi.restoreAllMocks();
+});
+
+async function setupConfig(bindings: Record<string, unknown> = {}): Promise<void> {
+  const configDir = path.join(tmpDir, '.teamai', 'local-agent');
+  await fse.ensureDir(configDir);
+  await fse.writeJson(path.join(configDir, 'config.json'), {
+    endpoint: 'https://test.example.com/api',
+    token: 'test-token',
+    localAgentId: 'test-agent-id',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    workspaceBindings: bindings,
+  });
+}
+
+async function runResponse(
+  body: Record<string, unknown>,
+  tool: string = 'codebuddy',
+): Promise<Array<Record<string, unknown>>> {
+  // 确保 tool 目录存在，使 isToolInstalled 检查通过
+  await fse.ensureDir(path.join(tmpDir, `.${tool}`, 'skills'));
+  await setupConfig();
+  const acks: Array<Record<string, unknown>> = [];
+  const fetchMock = vi.fn(async (input: string | URL, init?: { body?: string }) => {
+    const url = String(input);
+    if (url.includes('/local-agent/sync')) {
+      return new Response(JSON.stringify({ ok: true, ...body }));
+    }
+    if (url.includes('/commands/ack')) {
+      acks.push(JSON.parse(init?.body ?? '{}'));
+    }
+    return new Response(JSON.stringify({ ok: true }));
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+  await reportAndSyncLocalAgent({ cwd: tmpDir, tool, status: 'running' });
+  return acks;
+}
+
+describe('local-agent: MCP install/uninstall commands', () => {
+
+  // ─── install_mcp: HTTP transport (user scope) ─────────────────────
+  it('install_mcp writes server to tool MCP config and acks success', async () => {
+    const acks = await runResponse({
+      cmds: [{
+        id: 9001,
+        type: 'install_mcp',
+        scope: 'user',
+        slug: 'clawpro',
+        version: '1.0.0',
+        display_name: 'ClawPro',
+        mcp_config: {
+          transport: 'http',
+          url: 'https://clawpro.example.com/api/mcp/builtin/clawpro',
+          headers: { Authorization: 'Bearer bmcp-test-token' },
+        },
+      }],
+    });
+
+    // ACK 成功
+    expect(acks).toHaveLength(1);
+    expect(acks[0].id).toBe(9001);
+    expect(acks[0].type).toBe('install_mcp');
+    expect(acks[0].status).toBe('success');
+    expect(acks[0].version).toBe('1.0.0');
+
+    // MCP 配置已写入 tool config
+    const mcpConfig = await fse.readJson(path.join(tmpDir, '.codebuddy', 'mcp.json'));
+    expect(mcpConfig.mcpServers.clawpro).toBeDefined();
+    expect(mcpConfig.mcpServers.clawpro.url).toBe('https://clawpro.example.com/api/mcp/builtin/clawpro');
+    expect(mcpConfig.mcpServers.clawpro.type).toBe('http');
+    expect(mcpConfig.mcpServers.clawpro.headers.Authorization).toBe('Bearer bmcp-test-token');
+
+    // managed-mcp manifest 记录了 ownership
+    const manifest = await fse.readJson(path.join(tmpDir, '.teamai', 'managed-mcp.json'));
+    expect(manifest.codebuddy).toBeDefined();
+    expect(manifest.codebuddy).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'clawpro' })]),
+    );
+  });
+
+  // ─── install_mcp: stdio transport ─────────────────────────────────
+  it('install_mcp handles stdio transport correctly', async () => {
+    const acks = await runResponse({
+      cmds: [{
+        id: 9010,
+        type: 'install_mcp',
+        scope: 'user',
+        slug: 'local-tools',
+        version: '2.0.0',
+        mcp_config: {
+          transport: 'stdio',
+          command: 'npx',
+          args: ['-y', '@example/mcp-server'],
+          env: { EXAMPLE_TOKEN: 'secret-123' },
+        },
+      }],
+    });
+
+    expect(acks[0].status).toBe('success');
+
+    const mcpConfig = await fse.readJson(path.join(tmpDir, '.codebuddy', 'mcp.json'));
+    const server = mcpConfig.mcpServers['local-tools'];
+    expect(server).toBeDefined();
+    expect(server.type).toBeUndefined();
+    expect(server.command).toBe('npx');
+    expect(server.args).toEqual(['-y', '@example/mcp-server']);
+    expect(server.env.EXAMPLE_TOKEN).toBe('secret-123');
+  });
+
+  // ─── install_mcp: 幂等覆盖 ────────────────────────────────────────
+  it('install_mcp idempotently overwrites a previously managed server', async () => {
+    // 第一次安装
+    await runResponse({
+      cmds: [{
+        id: 9002,
+        type: 'install_mcp',
+        scope: 'user',
+        slug: 'clawpro',
+        version: '1.0.0',
+        mcp_config: {
+          transport: 'http',
+          url: 'https://old.example.com/mcp',
+        },
+      }],
+    });
+
+    // 第二次安装（更新 URL）
+    const acks = await runResponse({
+      cmds: [{
+        id: 9003,
+        type: 'install_mcp',
+        scope: 'user',
+        slug: 'clawpro',
+        version: '2.0.0',
+        mcp_config: {
+          transport: 'http',
+          url: 'https://new.example.com/mcp',
+        },
+      }],
+    });
+
+    expect(acks[0].status).toBe('success');
+    expect(acks[0].version).toBe('2.0.0');
+
+    const mcpConfig = await fse.readJson(path.join(tmpDir, '.codebuddy', 'mcp.json'));
+    expect(mcpConfig.mcpServers.clawpro.url).toBe('https://new.example.com/mcp');
+  });
+
+  // ─── install_mcp: 拒绝覆盖用户自有 server ─────────────────────────
+  it('install_mcp refuses to overwrite a user-owned server', async () => {
+    // 预先写入一个用户手动创建的 server（不在 managed-mcp 中）
+    const mcpPath = path.join(tmpDir, '.codebuddy', 'mcp.json');
+    await fse.ensureDir(path.dirname(mcpPath));
+    await fse.writeJson(mcpPath, {
+      mcpServers: {
+        'my-server': { type: 'http', url: 'https://user.example.com/mcp' },
+      },
+    });
+
+    const acks = await runResponse({
+      cmds: [{
+        id: 9004,
+        type: 'install_mcp',
+        scope: 'user',
+        slug: 'my-server',
+        version: '1.0.0',
+        mcp_config: {
+          transport: 'http',
+          url: 'https://enterprise.example.com/mcp',
+        },
+      }],
+    });
+
+    expect(acks[0].status).toBe('failed');
+    expect(acks[0].error).toContain('not managed by teamai');
+
+    // 用户的配置未被修改
+    const mcpConfig = await fse.readJson(mcpPath);
+    expect(mcpConfig.mcpServers['my-server'].url).toBe('https://user.example.com/mcp');
+  });
+
+  // ─── install_mcp: 无效 transport 拒绝 ─────────────────────────────
+  it('install_mcp rejects unsupported transport', async () => {
+    const acks = await runResponse({
+      cmds: [{
+        id: 9011,
+        type: 'install_mcp',
+        scope: 'user',
+        slug: 'bad-transport',
+        version: '1.0.0',
+        mcp_config: {
+          transport: 'grpc',
+          url: 'grpc://example.com:443',
+        },
+      }],
+    });
+
+    expect(acks[0].status).toBe('failed');
+    expect(acks[0].error).toContain('unsupported transport');
+  });
+
+  // ─── uninstall_mcp: 正常卸载 ──────────────────────────────────────
+  it('uninstall_mcp removes a managed server and acks success', async () => {
+    // 先安装
+    await runResponse({
+      cmds: [{
+        id: 9005,
+        type: 'install_mcp',
+        scope: 'user',
+        slug: 'clawpro',
+        version: '1.0.0',
+        mcp_config: {
+          transport: 'http',
+          url: 'https://clawpro.example.com/mcp',
+          headers: { Authorization: 'Bearer token' },
+        },
+      }],
+    });
+
+    // 验证安装成功
+    const before = await fse.readJson(path.join(tmpDir, '.codebuddy', 'mcp.json'));
+    expect(before.mcpServers.clawpro).toBeDefined();
+
+    // 卸载
+    const acks = await runResponse({
+      cmds: [{
+        id: 9006,
+        type: 'uninstall_mcp',
+        scope: 'user',
+        slug: 'clawpro',
+        version: '1.0.0',
+      }],
+    });
+
+    expect(acks[0].status).toBe('success');
+
+    // server 已从 tool config 移除
+    const after = await fse.readJson(path.join(tmpDir, '.codebuddy', 'mcp.json'));
+    expect(after.mcpServers.clawpro).toBeUndefined();
+
+    // manifest 也已清理
+    const manifest = await fse.readJson(path.join(tmpDir, '.teamai', 'managed-mcp.json'));
+    expect(manifest.codebuddy).toBeUndefined();
+  });
+
+  // ─── uninstall_mcp: 幂等（目标不存在） ─────────────────────────────
+  it('uninstall_mcp is idempotent when target does not exist', async () => {
+    const acks = await runResponse({
+      cmds: [{
+        id: 9007,
+        type: 'uninstall_mcp',
+        scope: 'user',
+        slug: 'nonexistent',
+        version: '1.0.0',
+      }],
+    });
+
+    expect(acks[0].status).toBe('success');
+  });
+
+  // ─── uninstall_mcp: 不删除用户自有 server ──────────────────────────
+  it('uninstall_mcp does not remove a user-owned server', async () => {
+    const mcpPath = path.join(tmpDir, '.codebuddy', 'mcp.json');
+    await fse.ensureDir(path.dirname(mcpPath));
+    await fse.writeJson(mcpPath, {
+      mcpServers: {
+        'user-server': { type: 'http', url: 'https://user.example.com/mcp' },
+      },
+    });
+
+    const acks = await runResponse({
+      cmds: [{
+        id: 9008,
+        type: 'uninstall_mcp',
+        scope: 'user',
+        slug: 'user-server',
+        version: '1.0.0',
+      }],
+    });
+
+    // 幂等成功（因为不在 manifest 中）
+    expect(acks[0].status).toBe('success');
+
+    // 用户的 server 没有被删除
+    const mcpConfig = await fse.readJson(mcpPath);
+    expect(mcpConfig.mcpServers['user-server']).toBeDefined();
+  });
+
+  // ─── install_mcp: workspace scope ──────────────────────────────────
+  it('install_mcp writes to workspace-scoped config', async () => {
+    const wsPath = path.join(tmpDir, 'projects', 'repo-a');
+    await fse.ensureDir(path.join(wsPath, '.codebuddy', 'skills'));
+
+    const acks = await runResponse({
+      cmds: [{
+        id: 9009,
+        type: 'install_mcp',
+        scope: 'workspace',
+        workspace_path: wsPath,
+        slug: 'enterprise-search',
+        version: '1.2.0',
+        display_name: 'Enterprise Search',
+        mcp_config: {
+          transport: 'http',
+          url: 'https://search.example.com/mcp',
+        },
+      }],
+    });
+
+    expect(acks[0].status).toBe('success');
+
+    // 检查 workspace 级配置
+    const mcpConfig = await fse.readJson(path.join(wsPath, '.codebuddy', 'mcp.json'));
+    expect(mcpConfig.mcpServers['enterprise-search']).toBeDefined();
+    expect(mcpConfig.mcpServers['enterprise-search'].url).toBe('https://search.example.com/mcp');
+
+    // 检查 project 级 manifest
+    const manifest = await fse.readJson(path.join(wsPath, '.teamai', 'managed-mcp.json'));
+    expect(manifest['codebuddy:project']).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'enterprise-search' })]),
+    );
+  });
+
+  // ─── install_mcp: 缺少 mcp_config 时失败 ──────────────────────────
+  it('install_mcp fails when mcp_config is missing', async () => {
+    const acks = await runResponse({
+      cmds: [{
+        id: 9012,
+        type: 'install_mcp',
+        scope: 'user',
+        slug: 'no-config',
+        version: '1.0.0',
+        // mcp_config 缺失
+      }],
+    });
+
+    expect(acks[0].status).toBe('failed');
+    expect(acks[0].error).toContain('missing mcp_config');
+  });
+
+  // ─── report: 上报已安装的 MCP ──────────────────────────────────────
+  it('buildReportPayload includes managed MCPs in user_level.mcps', async () => {
+    // 先安装一个 MCP server
+    await runResponse({
+      cmds: [{
+        id: 9020,
+        type: 'install_mcp',
+        scope: 'user',
+        slug: 'clawpro',
+        version: '1.0.0',
+        mcp_config: {
+          transport: 'http',
+          url: 'https://clawpro.example.com/mcp',
+        },
+      }],
+    });
+
+    // 然后调 buildReportPayload 检查
+    const { buildReportPayload, loadLocalAgentConfig } = await import('../local-agent.js');
+    const config = await loadLocalAgentConfig();
+    const payload = await buildReportPayload(config!, { cwd: tmpDir, tool: 'codebuddy', status: 'running' });
+    const userLevel = payload.user_level as Record<string, unknown>;
+    const mcps = userLevel.mcps as Array<{ slug: string; source: string }>;
+
+    expect(mcps).toBeDefined();
+    expect(mcps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ slug: 'clawpro', source: 'enterprise' }),
+      ]),
+    );
+  });
+
+  // ─── install + uninstall 连续执行 ──────────────────────────────────
+  it('processes install_mcp and uninstall_mcp in the same sync batch', async () => {
+    // 先安装
+    await runResponse({
+      cmds: [{
+        id: 9030,
+        type: 'install_mcp',
+        scope: 'user',
+        slug: 'temp-server',
+        version: '1.0.0',
+        mcp_config: { transport: 'http', url: 'https://temp.example.com/mcp' },
+      }],
+    });
+
+    // 同一批次中先安装再卸载
+    const acks = await runResponse({
+      cmds: [
+        {
+          id: 9031,
+          type: 'install_mcp',
+          scope: 'user',
+          slug: 'new-server',
+          version: '1.0.0',
+          mcp_config: { transport: 'http', url: 'https://new.example.com/mcp' },
+        },
+        {
+          id: 9032,
+          type: 'uninstall_mcp',
+          scope: 'user',
+          slug: 'temp-server',
+          version: '1.0.0',
+        },
+      ],
+    });
+
+    expect(acks).toHaveLength(2);
+    expect(acks.find((a) => a.id === 9031)?.status).toBe('success');
+    expect(acks.find((a) => a.id === 9032)?.status).toBe('success');
+
+    const mcpConfig = await fse.readJson(path.join(tmpDir, '.codebuddy', 'mcp.json'));
+    expect(mcpConfig.mcpServers['new-server']).toBeDefined();
+    expect(mcpConfig.mcpServers['temp-server']).toBeUndefined();
+  });
+
+  // ─── install_mcp: claude 工具 ──────────────────────────────────────
+  it('install_mcp works with claude tool format', async () => {
+    // claude 需要 .claude 目录存在
+    await fse.ensureDir(path.join(tmpDir, '.claude', 'skills'));
+
+    const acks = await runResponse({
+      cmds: [{
+        id: 9040,
+        type: 'install_mcp',
+        scope: 'user',
+        slug: 'clawpro',
+        version: '1.0.0',
+        mcp_config: {
+          transport: 'http',
+          url: 'https://clawpro.example.com/mcp',
+          headers: { Authorization: 'Bearer test' },
+        },
+      }],
+    }, 'claude');
+
+    expect(acks[0].status).toBe('success');
+
+    // claude 的 user-scope MCP 配置写到 $HOME/.claude.json
+    const claudeConfig = await fse.readJson(path.join(tmpDir, '.claude.json'));
+    expect(claudeConfig.mcpServers.clawpro).toBeDefined();
+    expect(claudeConfig.mcpServers.clawpro.type).toBe('http');
+    expect(claudeConfig.mcpServers.clawpro.url).toBe('https://clawpro.example.com/mcp');
+
+    // managed-mcp manifest 记录在 claude key 下
+    const manifest = await fse.readJson(path.join(tmpDir, '.teamai', 'managed-mcp.json'));
+    expect(manifest.claude).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'clawpro' })]),
+    );
+  });
+});

--- a/src/__tests__/mcp-reconcile.test.ts
+++ b/src/__tests__/mcp-reconcile.test.ts
@@ -209,6 +209,49 @@ servers:
     expect(after.mcpServers.temp).toBeUndefined();
   });
 
+  it('does not prune managed servers in http mode (install_mcp survives second sync)', async () => {
+    // First, inject a server as a git-mode team would, so managed-mcp.json and
+    // the tool config both record it (stands in for an install_mcp write).
+    await writeMcpYaml(`
+servers:
+  - name: clawpro
+    transport: http
+    url: https://clawpro.example.com/mcp
+    tools: [claude]
+`);
+    await reconcileMcpForConfig(teamConfig, localConfig);
+    const claudeJson = path.join(homeDir, '.claude.json');
+    expect((await fse.readJson(claudeJson)).mcpServers.clawpro).toBeDefined();
+
+    // Now the team is HTTP-backed with an empty desired set (no repo tree). A
+    // session-start reconcile must NOT delete the previously managed server.
+    await writeMcpYaml('servers: []\n');
+    const httpConfig = { ...localConfig, repo: { ...localConfig.repo, kind: 'http' } } as typeof localConfig;
+    const { changes } = await reconcileMcpForConfig(teamConfig, httpConfig);
+
+    expect(changes).toEqual([]);
+    expect((await fse.readJson(claudeJson)).mcpServers.clawpro).toBeDefined();
+  });
+
+  it('still removes managed servers in http mode when removeAll is set (uninstall teardown)', async () => {
+    await writeMcpYaml(`
+servers:
+  - name: clawpro
+    transport: http
+    url: https://clawpro.example.com/mcp
+    tools: [claude]
+`);
+    await reconcileMcpForConfig(teamConfig, localConfig);
+    const claudeJson = path.join(homeDir, '.claude.json');
+    expect((await fse.readJson(claudeJson)).mcpServers.clawpro).toBeDefined();
+
+    const httpConfig = { ...localConfig, repo: { ...localConfig.repo, kind: 'http' } } as typeof localConfig;
+    const { changes } = await reconcileMcpForConfig(teamConfig, httpConfig, { removeAll: true });
+
+    expect(changes.some((c) => c.action === 'removed' && c.server === 'clawpro')).toBe(true);
+    expect((await fse.readJson(claudeJson)).mcpServers.clawpro).toBeUndefined();
+  });
+
   // tclaude relocates Claude Code's user data dir via customUserDataDir, so its
   // MCP file is ~/.tclaude/.claude.json — a nested path, not ~/.tclaude.json.
   it('writes tclaude servers to ~/.tclaude/.claude.json in claude format', async () => {

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -29,6 +29,20 @@ import { EXCLUDED_RULE_NAMES } from './builtin-rules.js';
 import { resolveTeamaiEntryScript } from './builtin-hooks.js';
 import { resolveOpenclawWorkspaceDir } from './openclaw-hooks.js';
 import { assertSafeResourceName } from './utils/path-safety.js';
+import {
+  detectMcpFormat,
+  supportsTransport,
+  renderJsonEntry,
+  renderCodexBlock,
+  entryHash,
+  MCP_SERVER_KEY,
+} from './resources/mcp-format.js';
+import {
+  readJsonDoc,
+  writeCodexAtomic,
+  spliceCodexBlock,
+  codexServerNames,
+} from './mcp-reconcile.js';
 import { normalizeAgentType } from './utils/tool-names.js';
 import { logHttpRequest, logHttpResponse } from './utils/http-log.js';
 import { reconcilePlugins, teardownAllPlugins, parseGetConfig, substituteVars, unresolvedPlaceholders, type ReconcileDeps, type PluginState } from './plugin-lifecycle.js';
@@ -39,8 +53,13 @@ import {
   TEAMAI_CLAUDEMD_START,
   TEAMAI_CLAUDEMD_END,
   TeamaiConfigSchema,
+  managedMcpManifestPath,
   type DashboardEvent,
   type LocalConfig,
+  type ManagedMcpManifest,
+  type ManagedMcpRecord,
+  type McpServerDef,
+  type McpTransport,
   type Scope,
   type TeamaiConfig,
 } from './types.js';
@@ -193,6 +212,16 @@ interface LocalAgentCommand {
   event?: string;
   matcher?: string;
   timeout?: number;
+  mcp_config?: {
+    transport: string;
+    url?: string;
+    headers?: Record<string, string>;
+    command?: string;
+    args?: string[];
+    env?: Record<string, string>;
+    timeout?: number;
+    requires?: string[];
+  };
 }
 
 /**
@@ -1163,6 +1192,35 @@ function collectManifestSlugs(manifest: LocalAgentManifest): { skills: Set<strin
 }
 
 /**
+ * Scan the managed-mcp manifest for a given scope and return MCP servers as
+ * ReportedResource entries. Only servers tracked in managed-mcp.json (i.e.
+ * installed via HTTP distribution) are reported with source = 'enterprise'.
+ */
+async function scanMcpFromManifest(
+  scope: 'user' | 'project',
+  projectRoot?: string,
+): Promise<ReportedResource[]> {
+  const manifestPath = managedMcpManifestPath(
+    scope === 'project' ? 'project' : 'user',
+    projectRoot,
+  );
+  const manifest = await readJson<ManagedMcpManifest>(manifestPath);
+  if (!manifest || typeof manifest !== 'object') return [];
+
+  const seen = new Set<string>();
+  const results: ReportedResource[] = [];
+  for (const records of Object.values(manifest)) {
+    if (!Array.isArray(records)) continue;
+    for (const rec of records) {
+      if (!rec.name || seen.has(rec.name)) continue;
+      seen.add(rec.name);
+      results.push({ slug: rec.name, source: 'enterprise' });
+    }
+  }
+  return results.sort((a, b) => a.slug.localeCompare(b.slug));
+}
+
+/**
  * Remove workspace bindings whose directory no longer exists on disk.
  *
  * Workspace bindings are only ever added, never removed, so a deleted
@@ -1271,6 +1329,8 @@ export async function buildReportPayload(
   const userLevel: Record<string, unknown> = { group_id: config.userGroupId };
   if (userScope.skills.length > 0) userLevel.skills = userScope.skills;
   if (userScope.rules.length > 0) userLevel.rules = userScope.rules;
+  const userMcps = await scanMcpFromManifest('user');
+  if (userMcps.length > 0) userLevel.mcps = userMcps;
 
   const payload: Record<string, unknown> = {
     agent_type: normalizeAgentType(tool),
@@ -1303,6 +1363,8 @@ export async function buildReportPayload(
         };
         if (wsScope.skills.length > 0) workspace.skills = wsScope.skills;
         if (wsScope.rules.length > 0) workspace.rules = wsScope.rules;
+        const wsMcps = await scanMcpFromManifest('project', wsPath);
+        if (wsMcps.length > 0) workspace.mcps = wsMcps;
         return workspace;
       }),
     );
@@ -2067,6 +2129,204 @@ async function runHookRuleCommand(
   return undefined;
 }
 
+// ─── MCP server install / uninstall (HTTP distribution) ─────
+
+const VALID_MCP_TRANSPORTS = new Set<string>(['stdio', 'http', 'sse']);
+
+function mcpConfigToDef(slug: string, cfg: NonNullable<LocalAgentCommand['mcp_config']>): McpServerDef {
+  if (!VALID_MCP_TRANSPORTS.has(cfg.transport)) {
+    throw new Error(`install_mcp: unsupported transport "${cfg.transport}" for server "${slug}"`);
+  }
+  return {
+    name: slug,
+    transport: cfg.transport as McpTransport,
+    command: cfg.command,
+    args: cfg.args,
+    url: cfg.url,
+    headers: cfg.headers,
+    env: cfg.env,
+    timeout: cfg.timeout,
+    requires: cfg.requires,
+  };
+}
+
+function updateManifestRecord(
+  manifest: ManagedMcpManifest,
+  key: string,
+  name: string,
+  hash: string,
+): void {
+  const records = manifest[key] ?? [];
+  const idx = records.findIndex((r: ManagedMcpRecord) => r.name === name);
+  if (idx >= 0) {
+    records[idx] = { name, hash };
+  } else {
+    records.push({ name, hash });
+  }
+  manifest[key] = records;
+}
+
+async function installMcpServer(
+  config: LocalAgentConfig,
+  command: LocalAgentCommand,
+  tool: string,
+  slug: string,
+  scope: LocalAgentScope,
+  workspacePath?: string,
+): Promise<string | undefined> {
+  if (!command.mcp_config) {
+    throw new Error('install_mcp: missing mcp_config');
+  }
+
+  const def = mcpConfigToDef(slug, command.mcp_config);
+  const fullTeamConfig = createLocalAgentTeamConfig(config.endpoint);
+  const toolPath = fullTeamConfig.toolPaths[tool];
+  if (!toolPath) {
+    throw new Error(`install_mcp: unknown tool "${tool}"`);
+  }
+
+  const projectScope = scope === 'project';
+  const mcpRel = projectScope ? toolPath.mcpProject : toolPath.mcp;
+  if (!mcpRel) {
+    throw new Error(`install_mcp: tool "${tool}" has no MCP config path for scope "${scope}"`);
+  }
+
+  const format = detectMcpFormat(tool);
+  if (!format) {
+    throw new Error(`install_mcp: tool "${tool}" has no known MCP format`);
+  }
+  if (!supportsTransport(format, def.transport)) {
+    throw new Error(`install_mcp: tool "${tool}" does not support ${def.transport} transport`);
+  }
+
+  const baseDir = projectScope && workspacePath ? workspacePath : getUserHome();
+  const targetFile = path.join(baseDir, mcpRel);
+
+  const manifestPath = managedMcpManifestPath(
+    projectScope ? 'project' : 'user',
+    projectScope ? workspacePath : undefined,
+  );
+  const manifest = (await readJson<ManagedMcpManifest>(manifestPath)) ?? {};
+  const manifestKey = `${tool}${projectScope ? ':project' : ''}`;
+  const owned = manifest[manifestKey] ?? [];
+  const ownedNames = new Set(owned.map((r: ManagedMcpRecord) => r.name));
+
+  if (format === 'codex') {
+    const block = renderCodexBlock(def);
+    const hash = entryHash(block);
+    let source = (await readFileSafe(targetFile)) ?? '';
+    const present = new Set(codexServerNames(source));
+    if (present.has(slug) && !ownedNames.has(slug)) {
+      throw new Error(`install_mcp: server "${slug}" exists in ${tool} config and is not managed by teamai`);
+    }
+    updateManifestRecord(manifest, manifestKey, slug, hash);
+    await writeJsonAtomic(manifestPath, manifest);
+    source = spliceCodexBlock(source, slug, block);
+    await writeCodexAtomic(targetFile, source);
+  } else {
+    const entry = renderJsonEntry(format, def);
+    const serverKey = MCP_SERVER_KEY[format];
+    const hash = entryHash(entry);
+    const doc = await readJsonDoc(targetFile, serverKey);
+    if (!doc) {
+      throw new Error(`install_mcp: cannot parse ${targetFile}`);
+    }
+    if (doc.servers[slug] !== undefined && !ownedNames.has(slug)) {
+      throw new Error(`install_mcp: server "${slug}" exists in ${tool} config and is not managed by teamai`);
+    }
+    updateManifestRecord(manifest, manifestKey, slug, hash);
+    await writeJsonAtomic(manifestPath, manifest);
+    doc.servers[slug] = entry;
+    doc.data[serverKey] = doc.servers;
+    await writeJsonAtomic(targetFile, doc.data);
+  }
+  log.debug(`local-agent: installed MCP server "${slug}" for ${tool} (scope=${scope})`);
+  return command.version;
+}
+
+async function uninstallMcpServer(
+  config: LocalAgentConfig,
+  tool: string,
+  slug: string,
+  scope: LocalAgentScope,
+  workspacePath?: string,
+): Promise<void> {
+  const fullTeamConfig = createLocalAgentTeamConfig(config.endpoint);
+  const toolPath = fullTeamConfig.toolPaths[tool];
+  if (!toolPath) return;
+
+  const projectScope = scope === 'project';
+  const mcpRel = projectScope ? toolPath.mcpProject : toolPath.mcp;
+  if (!mcpRel) return;
+
+  const format = detectMcpFormat(tool);
+  if (!format) return;
+
+  const baseDir = projectScope && workspacePath ? workspacePath : getUserHome();
+  const targetFile = path.join(baseDir, mcpRel);
+
+  const manifestPath = managedMcpManifestPath(
+    projectScope ? 'project' : 'user',
+    projectScope ? workspacePath : undefined,
+  );
+  const manifest = (await readJson<ManagedMcpManifest>(manifestPath)) ?? {};
+  const manifestKey = `${tool}${projectScope ? ':project' : ''}`;
+  const owned = manifest[manifestKey] ?? [];
+  const ownedNames = new Set(owned.map((r: ManagedMcpRecord) => r.name));
+
+  if (!ownedNames.has(slug)) return;
+
+  manifest[manifestKey] = owned.filter((r: ManagedMcpRecord) => r.name !== slug);
+  if ((manifest[manifestKey] as ManagedMcpRecord[]).length === 0) delete manifest[manifestKey];
+  await writeJsonAtomic(manifestPath, manifest);
+
+  if (format === 'codex') {
+    let source = (await readFileSafe(targetFile)) ?? '';
+    source = spliceCodexBlock(source, slug, null);
+    await writeCodexAtomic(targetFile, source);
+  } else {
+    const serverKey = MCP_SERVER_KEY[format];
+    const doc = await readJsonDoc(targetFile, serverKey);
+    if (doc && doc.servers[slug] !== undefined) {
+      delete doc.servers[slug];
+      doc.data[serverKey] = doc.servers;
+      await writeJsonAtomic(targetFile, doc.data);
+    }
+  }
+  log.debug(`local-agent: uninstalled MCP server "${slug}" from ${tool} (scope=${scope})`);
+}
+
+async function runMcpCommand(
+  config: LocalAgentConfig,
+  command: LocalAgentCommand,
+  context: LocalAgentContext,
+): Promise<string | undefined> {
+  const tool = context.tool;
+  if (!tool) {
+    throw new Error(`${command.type}: cannot determine current tool`);
+  }
+  const slug = command.slug;
+  if (!slug) {
+    throw new Error(`${command.type}: missing slug`);
+  }
+  assertSafeResourceName(slug);
+
+  const scope = normalizeScope(command.scope);
+  const workspacePath = scope === 'project'
+    ? await resolveWorkspacePath(command.workspace_path ?? context.cwd)
+    : undefined;
+  if (scope === 'project' && !workspacePath) {
+    throw new Error(`${command.type}: workspace command is missing workspace_path`);
+  }
+
+  if (command.type === 'install_mcp') {
+    return installMcpServer(config, command, tool, slug, scope, workspacePath);
+  }
+
+  await uninstallMcpServer(config, tool, slug, scope, workspacePath);
+  return command.version;
+}
+
 async function executeCommand(
   config: LocalAgentConfig,
   command: LocalAgentCommand,
@@ -2079,6 +2339,9 @@ async function executeCommand(
   }
   if (command.type === 'install_hook_rule' || command.type === 'uninstall_hook_rule') {
     return runHookRuleCommand(config, command, context);
+  }
+  if (command.type === 'install_mcp' || command.type === 'uninstall_mcp') {
+    return runMcpCommand(config, command, context);
   }
   const kind = commandKind(command);
   const action = commandAction(command);

--- a/src/mcp-reconcile.ts
+++ b/src/mcp-reconcile.ts
@@ -305,6 +305,16 @@ export async function reconcileMcpForConfig(
   const sharing = getMcpSharing(teamConfig);
   const removeAll = options.removeAll === true;
 
+  // HTTP-mode teams have no repo tree: team MCP servers are delivered through
+  // the local-agent install_mcp channel and recorded in the same
+  // managed-mcp.json this function prunes against. Running the desired-set
+  // reconcile here would see an always-empty desired set and delete every
+  // HTTP-installed server on each session-start sync. Skip it — the explicit
+  // removeAll teardown (teamai uninstall) must still run.
+  if (localConfig.repo.kind === 'http' && !removeAll) {
+    return { changes, wrote };
+  }
+
   const teamDefs = removeAll ? [] : await parseTeamMcpServers(localConfig.repo.localPath);
   if (!removeAll && teamDefs.length > 0 && !sharing.autoApply) {
     log.info(`${teamDefs.length} team MCP server(s) available. Run \`teamai mcp inject\` to apply.`);

--- a/src/mcp-reconcile.ts
+++ b/src/mcp-reconcile.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto';
 import path from 'node:path';
 import fse from 'fs-extra';
 import type {
@@ -223,7 +224,7 @@ export async function resolveMcpTargets(
 
 // ─── JSON target I/O ─────────────────────────────────────────
 
-interface JsonDoc {
+export interface JsonDoc {
   data: Record<string, unknown>;
   servers: Record<string, unknown>;
 }
@@ -233,7 +234,7 @@ interface JsonDoc {
  * parsed — we abandon the injection rather than risk clobbering a file we do
  * not understand (it may hold the user's OAuth session).
  */
-async function readJsonDoc(file: string, serverKey: string): Promise<JsonDoc | null> {
+export async function readJsonDoc(file: string, serverKey: string): Promise<JsonDoc | null> {
   if (!await pathExists(file)) return { data: {}, servers: {} };
   const raw = await readFileSafe(file);
   if (raw === null) return null;
@@ -514,4 +515,13 @@ async function applyCodex(
   await fse.chmod(tmp, 0o600);
   await fse.rename(tmp, target.file);
   return true;
+}
+
+export async function writeCodexAtomic(file: string, content: string): Promise<void> {
+  await fse.ensureDir(path.dirname(file));
+  const suffix = crypto.randomBytes(6).toString('hex');
+  const tmp = `${file}.${process.pid}.${suffix}.tmp`;
+  await fse.writeFile(tmp, content, 'utf-8');
+  await fse.chmod(tmp, 0o600);
+  await fse.rename(tmp, file);
 }


### PR DESCRIPTION
## Summary

- Add `install_mcp` / `uninstall_mcp` command support to the HTTP local-agent sync channel, enabling Hatchery to distribute MCP servers (e.g. ClawPro) to AI coding tools
- Add MCP reporting: `user_level.mcps` and `workspaces[].mcps` in the report payload, scanning from `managed-mcp.json`
- Reuse existing MCP rendering (`renderJsonEntry`, `renderCodexBlock`) and I/O primitives (`readJsonDoc`, `spliceCodexBlock`) — no changes to the git-based reconcile engine

### Key design decisions
- **Single-tool targeting**: HTTP install targets only the current tool (`context.tool`), unlike git-based reconcile which writes to all tools
- **Manifest-first writes**: Manifest is written before tool config to ensure idempotent retry on partial failure
- **Transport validation**: Runtime check rejects unsupported transport types before config write
- **Ownership protection**: Refuses to overwrite user-owned servers not tracked in `managed-mcp.json`

### Protocol reference
See `clawpro/hatchery-teamai-mcp-protocol.md` for the full Hatchery ↔ TeamAI MCP protocol spec.

## Test plan
- [x] `npx tsc --noEmit` — type check passes
- [x] `npx vitest run` — 148 test files, 1952 tests pass (0 failures)
- [x] New test file `src/__tests__/local-agent-mcp.test.ts` with 13 e2e test cases:
  - install_mcp: HTTP transport, stdio transport, idempotent overwrite, user-owned rejection, invalid transport rejection, workspace scope, missing mcp_config, claude tool format
  - uninstall_mcp: normal removal, idempotent on nonexistent, user-owned protection
  - report: mcps array in buildReportPayload
  - batch: install + uninstall in same sync response

🤖 Generated with [Claude Code](https://claude.com/claude-code)