### PR TITLE
feat(init): single-repo mode — business repo is the team repo (#198)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,22 @@ teamai init https://github.com/yourorg/project-repo --inherit-user-scope
 
 Once initialized, every AI session automatically pulls the latest skills / rules and other Harness updates published by admins — no manual sync needed.
 
+### Single-repo mode (the business repo *is* the team repo)
+
+No separate team repo. Run `teamai init .` inside an existing project and its own git repo becomes the team repo:
+
+```bash
+cd /path/to/my-project
+teamai init .          # or: teamai init --self
+```
+
+- **Knowledge** (skills / rules / docs / learnings) is committed to your repo's **main branch** under `.teamai/`, so a plain `git clone` already carries the whole team setup.
+- **Reports** (member registrations, session summaries, votes, usage stats) go to a separate **`teamai-reports` orphan branch** — they never touch main.
+- **Clone = initialized.** When a teammate clones the repo, the next `teamai` command (or AI session) auto-detects the `mode: self` marker in `.teamai/teamai.yaml` and finishes local setup automatically — no need to re-type repo/role.
+- All of teamai's git operations run in isolated worktrees, so your working tree and current branch are never touched.
+
+After `teamai init .`, commit `.teamai/` (skills, rules, docs, learnings, `teamai.yaml`, `.gitignore`) and `.claude/settings.json` to main so teammates get auto-initialized on clone.
+
 > **Full usage guide:** [docs/usage-guide.md](docs/usage-guide.md) ([中文版](docs/usage-guide.zh-CN.md)) — covers everything from team creation to day-to-day use.
 
 ## Harness Management & Distribution

--- a/README.md
+++ b/README.md
@@ -60,15 +60,17 @@ No separate team repo. Run `teamai init .` inside an existing project and its ow
 
 ```bash
 cd /path/to/my-project
-teamai init .          # or: teamai init --self
+teamai init .                        # interactive: pick which AI tools to set up
+teamai init . --agent claude,codex   # non-interactive: Claude Code + Codex
 ```
 
 - **Knowledge** (skills / rules / docs / learnings) is committed to your repo's **main branch** under `.teamai/`, so a plain `git clone` already carries the whole team setup.
 - **Reports** (member registrations, session summaries, votes, usage stats) go to a separate **`teamai-reports` orphan branch** — they never touch main.
+- **You choose which AI tools to set up.** `--agent claude,codex` (repeatable/comma-separated), an interactive picker when omitted, or — in non-interactive contexts — whichever tools you already use under `~/`. teamai creates each selected tool's dir, injects hooks, and commits its settings.
 - **Clone = initialized.** When a teammate clones the repo, the next `teamai` command (or AI session) auto-detects the `mode: self` marker in `.teamai/teamai.yaml` and finishes local setup automatically — no need to re-type repo/role.
 - All of teamai's git operations run in isolated worktrees, so your working tree and current branch are never touched.
 
-After `teamai init .`, commit `.teamai/` (skills, rules, docs, learnings, `teamai.yaml`, `.gitignore`) and `.claude/settings.json` to main so teammates get auto-initialized on clone.
+`teamai init .` commits `.teamai/` (skills, rules, docs, learnings, `teamai.yaml`, `.gitignore`) plus each selected tool's settings (e.g. `.claude/settings.json`, `.codex/hooks.json`) for you; just push main so teammates get auto-initialized on clone.
 
 > **Full usage guide:** [docs/usage-guide.md](docs/usage-guide.md) ([中文版](docs/usage-guide.zh-CN.md)) — covers everything from team creation to day-to-day use.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -54,6 +54,22 @@ teamai init https://github.com/yourorg/project-repo --inherit-user-scope
 
 初始化完成后，每次开启 AI 会话时都会自动拉取管理员发布的 skills / rules 等 Harness 更新，无需手动同步。
 
+### 单仓模式（业务仓即团队仓）
+
+无需单独的团队仓库。在已有项目里运行 `teamai init .`，让它自己的 git 仓库直接充当团队仓：
+
+```bash
+cd /path/to/my-project
+teamai init .          # 或：teamai init --self
+```
+
+- **知识资产**（skills / rules / docs / learnings）提交到仓库 **main 分支**的 `.teamai/` 目录，因此一次普通 `git clone` 就带上了整套团队配置。
+- **上报数据**（成员注册、会话摘要、投票、使用统计）走独立的 **`teamai-reports` 孤儿分支** —— 永不污染 main。
+- **克隆即初始化。** 团队成员 clone 仓库后，下一条 `teamai` 命令（或 AI 会话）会自动识别 `.teamai/teamai.yaml` 里的 `mode: self` 标记并自动完成本机初始化 —— 无需手抄 repo/role 参数。
+- teamai 的所有 git 操作都在隔离的 worktree 中进行，绝不触碰你的工作区和当前分支。
+
+执行 `teamai init .` 后，把 `.teamai/`（skills、rules、docs、learnings、`teamai.yaml`、`.gitignore`）和 `.claude/settings.json` 提交到 main，团队成员 clone 后即可自动初始化。
+
 > **完整使用指南**：[docs/usage-guide.zh-CN.md](docs/usage-guide.zh-CN.md)（[English](docs/usage-guide.md)）— 涵盖从团队创建到日常使用的全流程。
 
 ## Harness 管理和分发

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -60,15 +60,17 @@ teamai init https://github.com/yourorg/project-repo --inherit-user-scope
 
 ```bash
 cd /path/to/my-project
-teamai init .          # 或：teamai init --self
+teamai init .                        # 交互式：选择要启用哪些 AI 工具
+teamai init . --agent claude,codex   # 非交互:启用 Claude Code + Codex
 ```
 
 - **知识资产**（skills / rules / docs / learnings）提交到仓库 **main 分支**的 `.teamai/` 目录，因此一次普通 `git clone` 就带上了整套团队配置。
 - **上报数据**（成员注册、会话摘要、投票、使用统计）走独立的 **`teamai-reports` 孤儿分支** —— 永不污染 main。
+- **由你选择启用哪些 AI 工具。** `--agent claude,codex`（可重复/逗号分隔）,省略时弹交互选择框,非交互场景则按你本机 `~/` 下已装的工具来建。teamai 为每个所选工具建目录、注入 hooks、并提交其 settings。
 - **克隆即初始化。** 团队成员 clone 仓库后，下一条 `teamai` 命令（或 AI 会话）会自动识别 `.teamai/teamai.yaml` 里的 `mode: self` 标记并自动完成本机初始化 —— 无需手抄 repo/role 参数。
 - teamai 的所有 git 操作都在隔离的 worktree 中进行，绝不触碰你的工作区和当前分支。
 
-执行 `teamai init .` 后，把 `.teamai/`（skills、rules、docs、learnings、`teamai.yaml`、`.gitignore`）和 `.claude/settings.json` 提交到 main，团队成员 clone 后即可自动初始化。
+`teamai init .` 会帮你把 `.teamai/`（skills、rules、docs、learnings、`teamai.yaml`、`.gitignore`）以及每个所选工具的 settings（如 `.claude/settings.json`、`.codex/hooks.json`）提交好;推送 main 后团队成员 clone 即可自动初始化。
 
 > **完整使用指南**：[docs/usage-guide.zh-CN.md](docs/usage-guide.zh-CN.md)（[English](docs/usage-guide.md)）— 涵盖从团队创建到日常使用的全流程。
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -175,8 +175,15 @@ Instead of a separate team repo, you can make an existing project's own git repo
 
 ```bash
 cd /path/to/my-project
-teamai init .            # or: teamai init --self
+teamai init .                        # interactive: pick which AI tools to set up
+teamai init . --agent claude,codex   # non-interactive: set up Claude Code + Codex
 ```
+
+**Choosing which AI tools to set up.** Single-repo mode creates a per-tool directory in your repo (e.g. `.claude/`, `.codex/`) — it seeds the skills dir, injects the teamai hooks, and commits that tool's settings to main so teammates get them on clone. You control which tools:
+
+- **`--agent <name...>`** — explicit list, repeatable or comma-separated: `--agent claude`, `--agent claude,codex`, `--agent claude --agent cursor`. Supported ids: `claude`, `codex`, `cursor`, `codebuddy`, `workbuddy`.
+- **Interactive (no `--agent`, a terminal)** — teamai shows a multi-select of those tools; press Enter to accept the default (Claude Code).
+- **Non-interactive (no `--agent`, no terminal — CI, hooks, clone-time bootstrap)** — teamai mirrors the tools you already use under your home dir (`~/.claude`, `~/.codex`, …). If none are found, it creates nothing (you still get the knowledge; run `teamai init .` later to pick tools).
 
 **How it splits data across branches:**
 
@@ -192,7 +199,7 @@ teamai init .            # or: teamai init --self
 
 **Admin checklist after `teamai init .`:**
 
-1. Commit `.teamai/` (skills, rules, docs, learnings, `teamai.yaml`, `.gitignore`) and `.claude/settings.json` to main.
+1. `teamai init .` already commits `.teamai/` (skills, rules, docs, learnings, `teamai.yaml`, `.gitignore`) plus each selected tool's settings (e.g. `.claude/settings.json`, `.codex/hooks.json`) to the current branch for you.
 2. Push main so teammates can clone.
 3. Add knowledge later with `teamai push` — it opens a PR against your repo (via an isolated worktree) rather than committing to your working tree. In single-repo mode you can author knowledge either in an AI tool dir (e.g. `~/.claude/skills/`) **or** by editing `.teamai/skills/` and `.teamai/rules/` directly in your repo; `teamai push` scans both and only surfaces genuine additions or edits (already-committed knowledge is skipped).
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -201,7 +201,19 @@ teamai init . --agent claude,codex   # non-interactive: set up Claude Code + Cod
 
 1. `teamai init .` already commits `.teamai/` (skills, rules, docs, learnings, `teamai.yaml`, `.gitignore`) plus each selected tool's settings (e.g. `.claude/settings.json`, `.codex/hooks.json`) to the current branch for you.
 2. Push main so teammates can clone.
-3. Add knowledge later with `teamai push` — it opens a PR against your repo (via an isolated worktree) rather than committing to your working tree. In single-repo mode you can author knowledge either in an AI tool dir (e.g. `~/.claude/skills/`) **or** by editing `.teamai/skills/` and `.teamai/rules/` directly in your repo; `teamai push` scans both and only surfaces genuine additions or edits (already-committed knowledge is skipped).
+3. Add resources later with `teamai push` — it opens a PR against your repo (via an isolated worktree) rather than committing to your working tree. In single-repo mode you can author them either in an AI tool dir (e.g. `~/.claude/skills/`) **or** by dropping them straight into `.teamai/` in your repo:
+   - `.teamai/skills/` — team skills
+   - `.teamai/rules/` — shared rules
+   - `.teamai/agents/` — subagent definitions (`<name>.yaml`, or legacy `<name>.md`)
+   - `.teamai/env/env.yaml` — shared env vars
+
+   `teamai push` scans all of these plus your AI tool dirs, and only surfaces genuine additions or edits (already-committed content is skipped). If you rename an agent's extension (e.g. `helper.md` → `helper.yaml`), delete the old file — `teamai push` won't remove it for you, and two files with the same stem would collide on pull.
+4. **docs / hooks / mcp** are contributed by editing their file directly — they don't go through `teamai push`; a normal `git commit` + push ships them:
+   - `.teamai/docs/` — team docs
+   - `.teamai/hooks/hooks.yaml` — team hooks
+   - `.teamai/mcp/mcp.yaml` — shared MCP servers
+
+> **Heads-up on `env`.** In single-repo mode `.teamai/env/env.yaml` **is committed to main** (unlike standalone mode's per-machine env), so it travels to everyone who clones the repo. `env.yaml` stores plaintext key/value pairs — put only non-secret shared config there, and keep real secrets in your own untracked environment.
 
 > **Limitation.** Single-repo mode ties one team setup to one business repo. If you need to share one team knowledge base across many business repos, use a standalone team repo (`teamai init <repo>`) instead.
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -16,6 +16,7 @@
   - [Project Scope](#project-scope)
   - [User Scope](#user-scope)
   - [How to Choose a Scope?](#how-to-choose-a-scope)
+  - [Single-repo mode (business repo is the team repo)](#single-repo-mode-business-repo-is-the-team-repo)
   - [Layer an organization repo under a project repo](#layer-an-organization-repo-under-a-project-repo)
 - [Member Onboarding](#member-onboarding)
 - [Day-to-Day Use](#day-to-day-use)
@@ -167,6 +168,35 @@ Resulting directory structure:
 | **Can coexist** | ✅ Yes; project stays active and can opt into safe user resources | ✅ Yes; remains a separate home-level install |
 
 > **Local install location** is decided only by `teamai init`'s `--scope` (default `project`). A `scope` field in remote `teamai.yaml`, if present, is ignored.
+
+### Single-repo mode (business repo is the team repo)
+
+Instead of a separate team repo, you can make an existing project's own git repo double as the team repo. Run this inside the project:
+
+```bash
+cd /path/to/my-project
+teamai init .            # or: teamai init --self
+```
+
+**How it splits data across branches:**
+
+| Data | Where it lives | Travels with `git clone`? |
+|------|----------------|---------------------------|
+| Knowledge: `skills/` `rules/` `docs/` `learnings/`, `teamai.yaml` | `.teamai/` on the **main** branch | ✅ Yes |
+| Reports: `members/` `sessions/` `votes/` `stats/` | `teamai-reports` **orphan branch** | Pushed to `origin` (separate history) |
+| Machine-local: `config.yaml`, `token`, `state.json`, worktrees | `.teamai/` (gitignored) | ❌ No (per-machine) |
+
+**Clone = initialized.** Because knowledge and the `mode: self` marker in `.teamai/teamai.yaml` are committed to main, a teammate who clones the repo is auto-initialized: the next `teamai` command or AI session detects the marker, and (when their git provider is already authenticated) writes their local config, injects hooks, and registers them on the reports branch — no need to re-type repo/role. If they aren't authenticated yet, teamai prompts them to run `teamai init .` once.
+
+**Safety.** Every git write teamai performs in single-repo mode (knowledge PRs and the reports orphan branch) runs in an isolated git worktree under `.teamai/`. Your working tree and current branch are never checked out, reset, or switched.
+
+**Admin checklist after `teamai init .`:**
+
+1. Commit `.teamai/` (skills, rules, docs, learnings, `teamai.yaml`, `.gitignore`) and `.claude/settings.json` to main.
+2. Push main so teammates can clone.
+3. Add knowledge later with `teamai push` — it opens a PR against your repo (via an isolated worktree) rather than committing to your working tree.
+
+> **Limitation.** Single-repo mode ties one team setup to one business repo. If you need to share one team knowledge base across many business repos, use a standalone team repo (`teamai init <repo>`) instead.
 
 ### Layer an organization repo under a project repo
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -182,7 +182,7 @@ teamai init . --agent claude,codex   # non-interactive: set up Claude Code + Cod
 **Choosing which AI tools to set up.** Single-repo mode creates a per-tool directory in your repo (e.g. `.claude/`, `.codex/`) — it seeds the skills dir, injects the teamai hooks, and commits that tool's settings to main so teammates get them on clone. You control which tools:
 
 - **`--agent <name...>`** — explicit list, repeatable or comma-separated: `--agent claude`, `--agent claude,codex`, `--agent claude --agent cursor`. Supported ids: `claude`, `codex`, `cursor`, `codebuddy`, `workbuddy`.
-- **Interactive (no `--agent`, a terminal)** — teamai shows a multi-select of those tools; press Enter to accept the default (Claude Code).
+- **Interactive (no `--agent`, a terminal)** — teamai shows a multi-select. Option 1 is **Auto**, which lists the AI tools already installed on your machine (`~/.claude`, `~/.codex`, …) and is the Enter default; the remaining options are the individual tools. Auto and specific tools can be combined.
 - **Non-interactive (no `--agent`, no terminal — CI, hooks, clone-time bootstrap)** — teamai mirrors the tools you already use under your home dir (`~/.claude`, `~/.codex`, …). If none are found, it creates nothing (you still get the knowledge; run `teamai init .` later to pick tools).
 
 **How it splits data across branches:**

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -194,7 +194,7 @@ teamai init .            # or: teamai init --self
 
 1. Commit `.teamai/` (skills, rules, docs, learnings, `teamai.yaml`, `.gitignore`) and `.claude/settings.json` to main.
 2. Push main so teammates can clone.
-3. Add knowledge later with `teamai push` — it opens a PR against your repo (via an isolated worktree) rather than committing to your working tree.
+3. Add knowledge later with `teamai push` — it opens a PR against your repo (via an isolated worktree) rather than committing to your working tree. In single-repo mode you can author knowledge either in an AI tool dir (e.g. `~/.claude/skills/`) **or** by editing `.teamai/skills/` and `.teamai/rules/` directly in your repo; `teamai push` scans both and only surfaces genuine additions or edits (already-committed knowledge is skipped).
 
 > **Limitation.** Single-repo mode ties one team setup to one business repo. If you need to share one team knowledge base across many business repos, use a standalone team repo (`teamai init <repo>`) instead.
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -16,6 +16,7 @@
   - [项目级（Project Scope）](#项目级project-scope)
   - [用户级（User Scope）](#用户级user-scope)
   - [如何选择 Scope？](#如何选择-scope)
+  - [单仓模式（业务仓即团队仓）](#单仓模式业务仓即团队仓)
   - [在项目仓库下叠加组织级仓库](#在项目仓库下叠加组织级仓库)
 - [成员接入](#成员接入)
 - [日常使用](#日常使用)
@@ -165,6 +166,35 @@ teamai init <group>/TeamAi-<team> --scope user
 | **能否共存** | ✅ 可以；project 保持当前 scope，并可选择继承安全的 user 资源 | ✅ 可以；仍是独立的用户主目录级安装 |
 
 > **本机安装位置**仅由 `teamai init` 的 `--scope`（默认 `project`）决定。远端 `teamai.yaml` 中若仍有 `scope` 字段会被忽略。
+
+### 单仓模式（业务仓即团队仓）
+
+无需单独的团队仓库，可以让某个已有项目自己的 git 仓库直接充当团队仓。在项目内运行：
+
+```bash
+cd /path/to/my-project
+teamai init .            # 或：teamai init --self
+```
+
+**数据如何在分支间拆分：**
+
+| 数据 | 存放位置 | 随 `git clone` 一起带走？ |
+|------|----------|---------------------------|
+| 知识资产：`skills/` `rules/` `docs/` `learnings/`、`teamai.yaml` | **main** 分支的 `.teamai/` | ✅ 会 |
+| 上报数据：`members/` `sessions/` `votes/` `stats/` | `teamai-reports` **孤儿分支** | 推送到 `origin`（独立历史） |
+| 本机私有：`config.yaml`、`token`、`state.json`、worktree | `.teamai/`（已 gitignore） | ❌ 不会（每台机器本地） |
+
+**克隆即初始化。** 由于知识资产和 `.teamai/teamai.yaml` 里的 `mode: self` 标记都提交在 main 上，团队成员 clone 仓库后会被自动初始化：下一条 `teamai` 命令或 AI 会话会识别该标记，并（在其 git provider 已认证的前提下）自动写入本机配置、注入 hooks、在孤儿分支上注册成员 —— 无需手抄 repo/role 参数。若尚未认证，teamai 会提示其运行一次 `teamai init .`。
+
+**安全性。** 单仓模式下 teamai 的每一次 git 写操作（知识 PR 和上报孤儿分支）都在 `.teamai/` 下的隔离 git worktree 中进行，绝不会 checkout、reset 或切换你的工作区和当前分支。
+
+**管理员在 `teamai init .` 之后的清单：**
+
+1. 把 `.teamai/`（skills、rules、docs、learnings、`teamai.yaml`、`.gitignore`）和 `.claude/settings.json` 提交到 main。
+2. 推送 main，供团队成员 clone。
+3. 之后新增知识用 `teamai push` —— 它会（通过隔离 worktree）向你的仓库开 PR，而不是直接改动你的工作区。
+
+> **限制。** 单仓模式把一套团队配置绑定到一个业务仓。如果需要一套团队知识库被多个业务仓共享，请改用独立团队仓（`teamai init <repo>`）。
 
 ### 在项目仓库下叠加组织级仓库
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -173,8 +173,15 @@ teamai init <group>/TeamAi-<team> --scope user
 
 ```bash
 cd /path/to/my-project
-teamai init .            # 或：teamai init --self
+teamai init .                        # 交互式：选择要启用哪些 AI 工具
+teamai init . --agent claude,codex   # 非交互:启用 Claude Code + Codex
 ```
+
+**选择启用哪些 AI 工具。** 单仓模式会在你的仓库里为每个工具创建一个目录（如 `.claude/`、`.codex/`）—— 建好 skills 目录、注入 teamai hooks,并把该工具的 settings 提交到 main,让队友 clone 后即可获得。由你决定启用哪些工具:
+
+- **`--agent <name...>`** —— 显式列表,可重复或逗号分隔:`--agent claude`、`--agent claude,codex`、`--agent claude --agent cursor`。支持的 id:`claude`、`codex`、`cursor`、`codebuddy`、`workbuddy`。
+- **交互式（无 `--agent`、有终端）** —— teamai 弹出这些工具的多选列表;直接回车即采用默认（Claude Code）。
+- **非交互（无 `--agent`、无终端 —— CI、hook、clone 时自愈 bootstrap）** —— teamai 会按你本机 home 目录下已装的工具（`~/.claude`、`~/.codex`……）来建。若一个都没检测到,则什么都不建（你仍拿到知识,可稍后运行 `teamai init .` 再选工具）。
 
 **数据如何在分支间拆分：**
 
@@ -190,7 +197,7 @@ teamai init .            # 或：teamai init --self
 
 **管理员在 `teamai init .` 之后的清单：**
 
-1. 把 `.teamai/`（skills、rules、docs、learnings、`teamai.yaml`、`.gitignore`）和 `.claude/settings.json` 提交到 main。
+1. `teamai init .` 已经帮你把 `.teamai/`（skills、rules、docs、learnings、`teamai.yaml`、`.gitignore`）以及每个所选工具的 settings（如 `.claude/settings.json`、`.codex/hooks.json`）提交到当前分支。
 2. 推送 main，供团队成员 clone。
 3. 之后新增知识用 `teamai push` —— 它会（通过隔离 worktree）向你的仓库开 PR，而不是直接改动你的工作区。单仓模式下，你既可以在 AI 工具目录（如 `~/.claude/skills/`）里编写知识,**也可以**直接编辑仓库里的 `.teamai/skills/`、`.teamai/rules/`；`teamai push` 会同时扫描两者,只呈现真正的新增或修改（已提交的知识会被跳过）。
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -180,7 +180,7 @@ teamai init . --agent claude,codex   # 非交互:启用 Claude Code + Codex
 **选择启用哪些 AI 工具。** 单仓模式会在你的仓库里为每个工具创建一个目录（如 `.claude/`、`.codex/`）—— 建好 skills 目录、注入 teamai hooks,并把该工具的 settings 提交到 main,让队友 clone 后即可获得。由你决定启用哪些工具:
 
 - **`--agent <name...>`** —— 显式列表,可重复或逗号分隔:`--agent claude`、`--agent claude,codex`、`--agent claude --agent cursor`。支持的 id:`claude`、`codex`、`cursor`、`codebuddy`、`workbuddy`。
-- **交互式（无 `--agent`、有终端）** —— teamai 弹出这些工具的多选列表;直接回车即采用默认（Claude Code）。
+- **交互式（无 `--agent`、有终端）** —— teamai 弹出多选列表。第 1 项是 **Auto**,会列出你本机已安装的 AI 工具（`~/.claude`、`~/.codex`……）并作为回车默认项;其余各项是具体工具。Auto 与具体工具可以组合勾选。
 - **非交互（无 `--agent`、无终端 —— CI、hook、clone 时自愈 bootstrap）** —— teamai 会按你本机 home 目录下已装的工具（`~/.claude`、`~/.codex`……）来建。若一个都没检测到,则什么都不建（你仍拿到知识,可稍后运行 `teamai init .` 再选工具）。
 
 **数据如何在分支间拆分：**

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -199,7 +199,19 @@ teamai init . --agent claude,codex   # 非交互:启用 Claude Code + Codex
 
 1. `teamai init .` 已经帮你把 `.teamai/`（skills、rules、docs、learnings、`teamai.yaml`、`.gitignore`）以及每个所选工具的 settings（如 `.claude/settings.json`、`.codex/hooks.json`）提交到当前分支。
 2. 推送 main，供团队成员 clone。
-3. 之后新增知识用 `teamai push` —— 它会（通过隔离 worktree）向你的仓库开 PR，而不是直接改动你的工作区。单仓模式下，你既可以在 AI 工具目录（如 `~/.claude/skills/`）里编写知识,**也可以**直接编辑仓库里的 `.teamai/skills/`、`.teamai/rules/`；`teamai push` 会同时扫描两者,只呈现真正的新增或修改（已提交的知识会被跳过）。
+3. 之后新增资源用 `teamai push` —— 它会（通过隔离 worktree）向你的仓库开 PR，而不是直接改动你的工作区。单仓模式下，你既可以在 AI 工具目录（如 `~/.claude/skills/`）里编写,**也可以**直接把资源放进仓库里的 `.teamai/`：
+   - `.teamai/skills/` —— 团队 skills
+   - `.teamai/rules/` —— 共享 rules
+   - `.teamai/agents/` —— subagent 定义（`<name>.yaml`,或旧版 `<name>.md`）
+   - `.teamai/env/env.yaml` —— 共享环境变量
+
+   `teamai push` 会同时扫描这些目录和你的 AI 工具目录,只呈现真正的新增或修改（已提交的内容会被跳过）。如果你改了某个 agent 的扩展名（如 `helper.md` → `helper.yaml`）,请手动删掉旧文件 —— `teamai push` 不会替你删除,同 stem 的两个文件会在 pull 时冲突。
+4. **docs / hooks / mcp** 通过直接编辑对应文件来贡献 —— 它们不走 `teamai push`,用普通的 `git commit` + push 即可分发：
+   - `.teamai/docs/` —— 团队文档
+   - `.teamai/hooks/hooks.yaml` —— 团队 hooks
+   - `.teamai/mcp/mcp.yaml` —— 共享 MCP servers
+
+> **关于 `env` 的提醒。** 单仓模式下 `.teamai/env/env.yaml` **会被提交到 main**（不同于独立模式的每机本地 env），因此会随 clone 分发给所有人。`env.yaml` 存的是明文键值对 —— 只放非敏感的共享配置,真正的密钥请留在你自己未追踪的环境里。
 
 > **限制。** 单仓模式把一套团队配置绑定到一个业务仓。如果需要一套团队知识库被多个业务仓共享，请改用独立团队仓（`teamai init <repo>`）。
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -192,7 +192,7 @@ teamai init .            # 或：teamai init --self
 
 1. 把 `.teamai/`（skills、rules、docs、learnings、`teamai.yaml`、`.gitignore`）和 `.claude/settings.json` 提交到 main。
 2. 推送 main，供团队成员 clone。
-3. 之后新增知识用 `teamai push` —— 它会（通过隔离 worktree）向你的仓库开 PR，而不是直接改动你的工作区。
+3. 之后新增知识用 `teamai push` —— 它会（通过隔离 worktree）向你的仓库开 PR，而不是直接改动你的工作区。单仓模式下，你既可以在 AI 工具目录（如 `~/.claude/skills/`）里编写知识,**也可以**直接编辑仓库里的 `.teamai/skills/`、`.teamai/rules/`；`teamai push` 会同时扫描两者,只呈现真正的新增或修改（已提交的知识会被跳过）。
 
 > **限制。** 单仓模式把一套团队配置绑定到一个业务仓。如果需要一套团队知识库被多个业务仓共享，请改用独立团队仓（`teamai init <repo>`）。
 

--- a/src/__tests__/bootstrap-self.test.ts
+++ b/src/__tests__/bootstrap-self.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import YAML from 'yaml';
+import { bootstrapSelfRepo } from '../bootstrap.js';
+import { detectProjectConfig } from '../config.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-bootstrap-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('bootstrapSelfRepo', () => {
+  it("returns 'skip' when there is no .teamai/teamai.yaml (not a teamai project)", async () => {
+    const result = await bootstrapSelfRepo(tmpDir, { silent: true });
+    expect(result).toBe('skip');
+  });
+
+  it("returns 'skip' when teamai.yaml exists but has no mode: self (standalone team repo marker absent)", async () => {
+    const teamaiDir = path.join(tmpDir, '.teamai');
+    fs.mkdirSync(teamaiDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(teamaiDir, 'teamai.yaml'),
+      YAML.stringify({ team: 'x', repo: 'https://github.com/acme/app.git' }),
+    );
+    const result = await bootstrapSelfRepo(tmpDir, { silent: true });
+    expect(result).toBe('skip');
+  });
+
+  it("returns 'already' when a local config.yaml is already present", async () => {
+    const teamaiDir = path.join(tmpDir, '.teamai');
+    fs.mkdirSync(teamaiDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(teamaiDir, 'teamai.yaml'),
+      YAML.stringify({ team: 'x', mode: 'self', repo: 'https://github.com/acme/app.git' }),
+    );
+    fs.writeFileSync(
+      path.join(teamaiDir, 'config.yaml'),
+      YAML.stringify({
+        repo: { localPath: teamaiDir, remote: 'r', kind: 'self' },
+        username: 'alice',
+        scope: 'project',
+        projectRoot: tmpDir,
+      }),
+    );
+    const result = await bootstrapSelfRepo(tmpDir, { silent: true });
+    expect(result).toBe('already');
+  });
+});
+
+describe('detectProjectConfig self-heal', () => {
+  it('returns null (no crash) for a self-mode marker when a provider cannot be derived', async () => {
+    // teamai.yaml has mode: self but no repo field, and the temp dir is not inside
+    // a git repo — so there is no remote to derive a provider from. The
+    // non-interactive bootstrap degrades to skip and detect returns null without
+    // writing a config. (Deterministic regardless of local gh/git auth.)
+    const teamaiDir = path.join(tmpDir, '.teamai');
+    fs.mkdirSync(teamaiDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(teamaiDir, 'teamai.yaml'),
+      YAML.stringify({ team: 'x', mode: 'self' }),
+    );
+    const result = await detectProjectConfig(tmpDir);
+    expect(result).toBeNull();
+    // Must NOT have written a config (bootstrap did not complete).
+    expect(fs.existsSync(path.join(teamaiDir, 'config.yaml'))).toBe(false);
+  });
+
+  it('returns the config when config.yaml already exists (no bootstrap needed)', async () => {
+    const teamaiDir = path.join(tmpDir, '.teamai');
+    fs.mkdirSync(teamaiDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(teamaiDir, 'config.yaml'),
+      YAML.stringify({
+        repo: { localPath: teamaiDir, remote: 'r', kind: 'self', businessRepoRoot: tmpDir },
+        username: 'alice',
+        scope: 'project',
+        projectRoot: tmpDir,
+      }),
+    );
+    const result = await detectProjectConfig(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result?.repo.kind).toBe('self');
+    expect(result?.username).toBe('alice');
+  });
+});

--- a/src/__tests__/git-commit-paths.test.ts
+++ b/src/__tests__/git-commit-paths.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { hasCommits, commitPaths } from '../utils/git.js';
+
+// Real-git integration tests for the single-repo init-commit helpers.
+// (git.test.ts mocks simple-git globally, so these live in their own file.)
+
+let dir: string;
+function git(args: string[]) {
+  execFileSync('git', args, { cwd: dir, stdio: 'ignore' });
+}
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-commitpaths-'));
+  git(['init', '-q', '-b', 'main']);
+  git(['config', 'user.email', 't@t.co']);
+  git(['config', 'user.name', 't']);
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('hasCommits', () => {
+  it('is false for a freshly-init repo (unborn HEAD)', async () => {
+    expect(await hasCommits(dir)).toBe(false);
+  });
+
+  it('is true once a commit exists', async () => {
+    fs.writeFileSync(path.join(dir, 'f.txt'), 'x');
+    git(['add', '.']);
+    git(['commit', '-qm', 'init']);
+    expect(await hasCommits(dir)).toBe(true);
+  });
+});
+
+describe('commitPaths', () => {
+  it('creates the first commit in an empty repo from the given paths', async () => {
+    fs.mkdirSync(path.join(dir, '.teamai', 'skills'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '.teamai', 'skills', '.gitkeep'), '');
+    fs.writeFileSync(path.join(dir, '.teamai', 'teamai.yaml'), 'team: x\nmode: self\n');
+
+    const committed = await commitPaths(dir, 'init skeleton', ['.teamai/skills', '.teamai/teamai.yaml']);
+    expect(committed).toBe(true);
+    expect(await hasCommits(dir)).toBe(true);
+
+    const tracked = execFileSync('git', ['ls-tree', '-r', '--name-only', 'HEAD'], { cwd: dir, encoding: 'utf-8' });
+    expect(tracked).toContain('.teamai/skills/.gitkeep');
+    expect(tracked).toContain('.teamai/teamai.yaml');
+  });
+
+  it('returns false when none of the paths exist', async () => {
+    const committed = await commitPaths(dir, 'nothing', ['.teamai/does-not-exist']);
+    expect(committed).toBe(false);
+    expect(await hasCommits(dir)).toBe(false);
+  });
+
+  it('skips a gitignored path instead of aborting the whole commit', async () => {
+    // env/ is gitignored (single-repo layout), skills/ is not — the commit must
+    // still succeed with the non-ignored path.
+    fs.writeFileSync(path.join(dir, '.gitignore'), 'ignored-dir/\n');
+    fs.mkdirSync(path.join(dir, 'ignored-dir'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'ignored-dir', 'x'), 'x');
+    fs.mkdirSync(path.join(dir, 'kept'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'kept', 'y'), 'y');
+
+    const committed = await commitPaths(dir, 'mixed', ['ignored-dir', 'kept']);
+    expect(committed).toBe(true);
+    const tracked = execFileSync('git', ['ls-tree', '-r', '--name-only', 'HEAD'], { cwd: dir, encoding: 'utf-8' });
+    expect(tracked).toContain('kept/y');
+    expect(tracked).not.toContain('ignored-dir/x');
+  });
+});

--- a/src/__tests__/git.test.ts
+++ b/src/__tests__/git.test.ts
@@ -186,6 +186,23 @@ describe('checkoutMaster', () => {
     await checkoutMaster('/repo-main');
     expect(mockGit.checkout).toHaveBeenCalledWith('main');
   });
+
+  it('tolerates the "already used by worktree" conflict (single-repo knowledge worktree)', async () => {
+    // In self mode the knowledge worktree shares `main` with the user's active
+    // tree; git refuses `checkout main` there. checkoutMaster must swallow it
+    // rather than throw, so the knowledge-PR flow completes.
+    mockGit.revparse.mockResolvedValue('main');
+    mockGit.checkout.mockRejectedValueOnce(
+      new Error("fatal: 'main' is already used by worktree at '/repo/primary'"),
+    );
+    await expect(checkoutMaster('/repo-main/.teamai/knowledge-wt')).resolves.toBeUndefined();
+  });
+
+  it('still throws on unrelated checkout failures', async () => {
+    mockGit.revparse.mockResolvedValue('main');
+    mockGit.checkout.mockRejectedValueOnce(new Error('fatal: some other git error'));
+    await expect(checkoutMaster('/repo-main')).rejects.toThrow('some other git error');
+  });
 });
 
 describe('pushRepoDirectly', () => {

--- a/src/__tests__/self-mode-agents.test.ts
+++ b/src/__tests__/self-mode-agents.test.ts
@@ -13,6 +13,7 @@ import {
   seedSelfModeToolDirs,
   SELF_MODE_AGENT_CHOICES,
 } from '../known-agents.js';
+import { resolveSelfModeSelection } from '../init.js';
 import type { LocalConfig, TeamaiConfig } from '../types.js';
 
 describe('normalizeAgentList', () => {
@@ -140,5 +141,40 @@ describe('seedSelfModeToolDirs (no hardcoded claude default)', () => {
     const seeded = await seedSelfModeToolDirs(config, teamConfig);
     expect(seeded).toEqual(['claude']);
     expect(await fse.pathExists(path.join(repoRoot, '.codex'))).toBe(false);
+  });
+});
+
+describe('resolveSelfModeSelection (interactive picker: option 1 = Auto)', () => {
+  // Option order in the picker: 0 = Auto, 1..5 = SELF_MODE_AGENT_CHOICES.
+  const detected = ['claude', 'codex'];
+
+  it('Auto (index 0) expands to the detected tools', () => {
+    expect(resolveSelfModeSelection([0], detected)).toEqual(['claude', 'codex']);
+  });
+
+  it('Auto with nothing detected falls back to [claude]', () => {
+    expect(resolveSelfModeSelection([0], [])).toEqual(['claude']);
+  });
+
+  it('a specific tool maps by (index - 1) into the choices list', () => {
+    // index 2 → SELF_MODE_AGENT_CHOICES[1] = codex
+    expect(resolveSelfModeSelection([2], detected)).toEqual(['codex']);
+    // index 4 → SELF_MODE_AGENT_CHOICES[3] = codebuddy
+    expect(resolveSelfModeSelection([4], detected)).toEqual(['codebuddy']);
+  });
+
+  it('multiple specific tools preserve choice order', () => {
+    // indices 4 (codebuddy) + 2 (codex) → order follows the input
+    expect(resolveSelfModeSelection([4, 2], detected)).toEqual(['codebuddy', 'codex']);
+  });
+
+  it('Auto + a specific tool merges detected first, then extras, deduped', () => {
+    // Auto → [claude, codex]; index 3 → cursor. codex already present, not dup.
+    expect(resolveSelfModeSelection([0, 3, 2], detected)).toEqual(['claude', 'codex', 'cursor']);
+  });
+
+  it('"all" (every index incl. Auto) yields the full choice set once', () => {
+    const allIndices = [0, 1, 2, 3, 4, 5]; // Auto + 5 tools
+    expect(resolveSelfModeSelection(allIndices, detected)).toEqual([...SELF_MODE_AGENT_CHOICES]);
   });
 });

--- a/src/__tests__/self-mode-agents.test.ts
+++ b/src/__tests__/self-mode-agents.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import os from 'node:os';
+import fse from 'fs-extra';
+
+vi.mock('../utils/logger.js', () => ({
+  log: { info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), dim: vi.fn() },
+}));
+
+import {
+  normalizeAgentList,
+  detectHomeInstalledAgents,
+  seedSelfModeToolDirs,
+  SELF_MODE_AGENT_CHOICES,
+} from '../known-agents.js';
+import type { LocalConfig, TeamaiConfig } from '../types.js';
+
+describe('normalizeAgentList', () => {
+  it('returns [] for undefined', () => {
+    expect(normalizeAgentList(undefined)).toEqual([]);
+  });
+
+  it('splits a comma-separated string', () => {
+    expect(normalizeAgentList('claude,codex')).toEqual(['claude', 'codex']);
+  });
+
+  it('passes through a variadic array', () => {
+    expect(normalizeAgentList(['claude', 'codex'])).toEqual(['claude', 'codex']);
+  });
+
+  it('handles a mix of array + comma-separated elements', () => {
+    expect(normalizeAgentList(['claude,codex', 'cursor'])).toEqual(['claude', 'codex', 'cursor']);
+  });
+
+  it('trims blanks and dedupes, preserving first-seen order', () => {
+    expect(normalizeAgentList(' claude , , codex ,claude')).toEqual(['claude', 'codex']);
+  });
+});
+
+describe('detectHomeInstalledAgents', () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-home-'));
+    vi.stubEnv('HOME', home);
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await fse.remove(home);
+  });
+
+  it('returns [] when no candidate tool dir exists under HOME', async () => {
+    expect(await detectHomeInstalledAgents()).toEqual([]);
+  });
+
+  it('returns only the tools whose root dir exists, in candidate order', async () => {
+    await fse.ensureDir(path.join(home, '.codex'));
+    await fse.ensureDir(path.join(home, '.claude'));
+    const found = await detectHomeInstalledAgents();
+    // candidate order is claude, codex, cursor, codebuddy, workbuddy
+    expect(found).toEqual(['claude', 'codex']);
+  });
+
+  it('respects a custom candidate list', async () => {
+    await fse.ensureDir(path.join(home, '.cursor'));
+    await fse.ensureDir(path.join(home, '.claude'));
+    expect(await detectHomeInstalledAgents(['cursor'])).toEqual(['cursor']);
+  });
+
+  it('SELF_MODE_AGENT_CHOICES is the 5 common coding agents', () => {
+    expect([...SELF_MODE_AGENT_CHOICES]).toEqual(['claude', 'codex', 'cursor', 'codebuddy', 'workbuddy']);
+  });
+});
+
+describe('seedSelfModeToolDirs (no hardcoded claude default)', () => {
+  let tmp: string;
+  let repoRoot: string;
+  let teamConfig: TeamaiConfig;
+
+  function makeConfig(enabledAgents?: string[]): LocalConfig {
+    return {
+      repo: { localPath: path.join(repoRoot, '.teamai'), remote: 'r', kind: 'self', businessRepoRoot: repoRoot },
+      username: 'alice',
+      scope: 'project',
+      projectRoot: repoRoot,
+      additionalRoles: [],
+      ...(enabledAgents ? { enabledAgents } : {}),
+    };
+  }
+
+  beforeEach(async () => {
+    tmp = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-seed-'));
+    repoRoot = path.join(tmp, 'biz');
+    await fse.ensureDir(repoRoot);
+    teamConfig = {
+      team: 't', description: '', repo: 'r', provider: 'github' as const, reviewers: [],
+      sharing: { skills: {}, rules: { enforced: [] }, docs: { localDir: '' }, env: { injectShellProfile: true } },
+      toolPaths: {
+        claude: { skills: '.claude/skills' },
+        codex: { skills: '.codex/skills' },
+        cursor: { skills: '.cursor/skills' },
+      },
+    };
+  });
+
+  afterEach(async () => {
+    await fse.remove(tmp);
+  });
+
+  it('seeds nothing when enabledAgents is empty (no default claude)', async () => {
+    const seeded = await seedSelfModeToolDirs(makeConfig([]), teamConfig);
+    expect(seeded).toEqual([]);
+    expect(await fse.pathExists(path.join(repoRoot, '.claude'))).toBe(false);
+  });
+
+  it('seeds nothing when enabledAgents is undefined (no default claude)', async () => {
+    const seeded = await seedSelfModeToolDirs(makeConfig(undefined), teamConfig);
+    expect(seeded).toEqual([]);
+    expect(await fse.pathExists(path.join(repoRoot, '.claude'))).toBe(false);
+  });
+
+  it('seeds exactly the enabled agents, and no others', async () => {
+    const seeded = await seedSelfModeToolDirs(makeConfig(['codex']), teamConfig);
+    expect(seeded).toEqual(['codex']);
+    expect(await fse.pathExists(path.join(repoRoot, '.codex/skills'))).toBe(true);
+    expect(await fse.pathExists(path.join(repoRoot, '.claude'))).toBe(false);
+  });
+
+  it('seeds multiple selected agents', async () => {
+    const seeded = await seedSelfModeToolDirs(makeConfig(['claude', 'cursor']), teamConfig);
+    expect(new Set(seeded)).toEqual(new Set(['claude', 'cursor']));
+    expect(await fse.pathExists(path.join(repoRoot, '.claude/skills'))).toBe(true);
+    expect(await fse.pathExists(path.join(repoRoot, '.cursor/skills'))).toBe(true);
+  });
+
+  it('never seeds an explicitly disabled agent', async () => {
+    const config = makeConfig(['claude', 'codex']);
+    config.disabledAgents = ['codex'];
+    const seeded = await seedSelfModeToolDirs(config, teamConfig);
+    expect(seeded).toEqual(['claude']);
+    expect(await fse.pathExists(path.join(repoRoot, '.codex'))).toBe(false);
+  });
+});

--- a/src/__tests__/self-mode-digest-skillpath.test.ts
+++ b/src/__tests__/self-mode-digest-skillpath.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { buildSkillChangePathspec } from '../digest.js';
+
+/**
+ * Regression for the self-mode digest bug: `getRecentSkillChanges` ran git log at
+ * <repo>/.teamai (a subdirectory), so git emitted repo-root-relative paths like
+ * `.teamai/skills/foo/SKILL.md` that never matched a bare `^skills/...` regex —
+ * leaving the skill changelog permanently blank. buildSkillChangePathspec derives
+ * both the pathspec and the match regex from the subdir so both layouts work.
+ */
+describe('buildSkillChangePathspec', () => {
+  it('standalone team repo (no subdir): bare skills/ pathspec + regex', () => {
+    const { pathspec, skillRe } = buildSkillChangePathspec();
+    expect(pathspec).toBe('skills/*/SKILL.md');
+    const m = 'skills/my-skill/SKILL.md'.match(skillRe);
+    expect(m?.[1]).toBe('my-skill');
+    // A .teamai-prefixed path must NOT match in standalone mode.
+    expect('.teamai/skills/my-skill/SKILL.md'.match(skillRe)).toBeNull();
+  });
+
+  it('single-repo mode (.teamai subdir): prefixed pathspec + regex', () => {
+    const { pathspec, skillRe } = buildSkillChangePathspec('.teamai');
+    expect(pathspec).toBe('.teamai/skills/*/SKILL.md');
+    // This is exactly the path git emits from the business-repo root — must match.
+    const m = '.teamai/skills/my-skill/SKILL.md'.match(skillRe);
+    expect(m?.[1]).toBe('my-skill');
+    // A bare skills/ path (some other repo layout) must NOT match here.
+    expect('skills/my-skill/SKILL.md'.match(skillRe)).toBeNull();
+  });
+
+  it('tolerates a trailing slash on subdir', () => {
+    const { pathspec, skillRe } = buildSkillChangePathspec('.teamai/');
+    expect(pathspec).toBe('.teamai/skills/*/SKILL.md');
+    expect('.teamai/skills/x/SKILL.md'.match(skillRe)?.[1]).toBe('x');
+  });
+
+  it('does not match nested or partial paths', () => {
+    const { skillRe } = buildSkillChangePathspec('.teamai');
+    expect('.teamai/skills/a/b/SKILL.md'.match(skillRe)).toBeNull(); // too deep
+    expect('.teamai/skills/a/README.md'.match(skillRe)).toBeNull();  // not SKILL.md
+    expect('.teamai/skills/SKILL.md'.match(skillRe)).toBeNull();     // no skill dir
+  });
+});

--- a/src/__tests__/self-mode-env-agents.test.ts
+++ b/src/__tests__/self-mode-env-agents.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import os from 'node:os';
+import fse from 'fs-extra';
+
+vi.mock('../utils/logger.js', () => ({
+  log: { info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), dim: vi.fn() },
+}));
+
+import { EnvHandler } from '../resources/env.js';
+import { AgentsHandler } from '../resources/agents.js';
+import type { TeamaiConfig, LocalConfig } from '../types.js';
+
+/**
+ * Single-repo mode: users drop env/agents straight into <repo>/.teamai/{env,agents}.
+ * push runs in the knowledge worktree, so localConfig.repo.localPath is the
+ * origin/<default> checkout (the diff baseline) while projectRoot is the active
+ * tree. These tests mirror that exact shape.
+ */
+describe('single-repo mode: env + agents direct .teamai scan', () => {
+  let tmp: string;
+  let bizRoot: string;       // active tree (projectRoot)
+  let worktreeTeamai: string; // baseline (localConfig.repo.localPath = <wt>/.teamai)
+  let teamConfig: TeamaiConfig;
+  let localConfig: LocalConfig;
+
+  beforeEach(async () => {
+    tmp = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-selfea-'));
+    bizRoot = path.join(tmp, 'biz');
+    worktreeTeamai = path.join(tmp, 'biz', '.teamai', 'knowledge-wt', '.teamai');
+    await fse.ensureDir(path.join(bizRoot, '.teamai', 'env'));
+    await fse.ensureDir(path.join(bizRoot, '.teamai', 'agents'));
+    await fse.ensureDir(path.join(worktreeTeamai, 'env'));
+    await fse.ensureDir(path.join(worktreeTeamai, 'agents'));
+
+    teamConfig = {
+      team: 't', description: '', repo: 'https://github.com/acme/app.git',
+      provider: 'github' as const, reviewers: [],
+      sharing: { skills: {}, rules: { enforced: [] }, docs: { localDir: '' }, env: { injectShellProfile: true } },
+      toolPaths: { claude: { agents: '.claude/agents' } },
+    };
+    localConfig = {
+      repo: {
+        localPath: worktreeTeamai,
+        remote: 'https://github.com/acme/app.git',
+        kind: 'self',
+        businessRepoRoot: path.join(tmp, 'biz', '.teamai', 'knowledge-wt'),
+      },
+      username: 'alice',
+      scope: 'project',
+      projectRoot: bizRoot,
+      additionalRoles: [],
+    };
+  });
+
+  afterEach(async () => {
+    await fse.remove(tmp);
+  });
+
+  // ── env ────────────────────────────────────────────────────────────────
+  it('env: detects a hand-placed .teamai/env/env.yaml as pushable', async () => {
+    await fse.writeFile(
+      path.join(bizRoot, '.teamai', 'env', 'env.yaml'),
+      'variables:\n  - key: API_BASE\n    value: https://api.example.com\n',
+    );
+    const items = await new EnvHandler().scanLocalForPush(teamConfig, localConfig);
+    expect(items).toHaveLength(1);
+    expect(items[0].type).toBe('env');
+    expect(items[0].sourcePath).toBe(path.join(bizRoot, '.teamai', 'env', 'env.yaml'));
+  });
+
+  it('env: skips when active copy equals the committed baseline', async () => {
+    const content = 'variables:\n  - key: A\n    value: "1"\n';
+    await fse.writeFile(path.join(bizRoot, '.teamai', 'env', 'env.yaml'), content);
+    await fse.writeFile(path.join(worktreeTeamai, 'env', 'env.yaml'), content);
+    const items = await new EnvHandler().scanLocalForPush(teamConfig, localConfig);
+    expect(items).toHaveLength(0);
+  });
+
+  it('env: detects an edit vs the baseline as pushable', async () => {
+    await fse.writeFile(path.join(worktreeTeamai, 'env', 'env.yaml'), 'variables:\n  - key: A\n    value: "1"\n');
+    await fse.writeFile(path.join(bizRoot, '.teamai', 'env', 'env.yaml'), 'variables:\n  - key: A\n    value: "2"\n');
+    const items = await new EnvHandler().scanLocalForPush(teamConfig, localConfig);
+    expect(items).toHaveLength(1);
+  });
+
+  it('env: pushItem copies the active env.yaml into the worktree', async () => {
+    const active = path.join(bizRoot, '.teamai', 'env', 'env.yaml');
+    await fse.writeFile(active, 'variables:\n  - key: X\n    value: "y"\n');
+    const [item] = await new EnvHandler().scanLocalForPush(teamConfig, localConfig);
+    await new EnvHandler().pushItem(item, teamConfig, localConfig);
+    const committed = await fse.readFile(path.join(worktreeTeamai, 'env', 'env.yaml'), 'utf8');
+    expect(committed).toContain('key: X');
+  });
+
+  // Regression: a teammate who clones a self-mode repo has .teamai/env/ as a
+  // committed DIRECTORY (holding env.yaml). pullItem must NOT try to write its
+  // KEY=value backup at <teamaiHome>/env (that path is the dir → EISDIR). It must
+  // use env.local instead. This is the pull/consumer half the push-only E2E missed.
+  it('env: pullItem does not EISDIR-crash when .teamai/env is a directory (writes env.local)', async () => {
+    // Simulate the teammate: teamaiHome = <projectRoot>/.teamai, with env/ a real dir.
+    const pullConfig: LocalConfig = {
+      ...localConfig,
+      repo: { ...localConfig.repo, localPath: path.join(bizRoot, '.teamai') },
+    };
+    const envYaml = path.join(bizRoot, '.teamai', 'env', 'env.yaml');
+    await fse.ensureDir(path.dirname(envYaml));
+    await fse.writeFile(envYaml, 'variables:\n  - key: TEAM_API\n    value: https://api.example.com\n');
+    const item = {
+      name: 'env.yaml', type: 'env' as const,
+      sourcePath: envYaml, relativePath: 'env/env.yaml',
+    };
+    // Disable shell-profile injection so the test has no side effects on the host.
+    const noInject: TeamaiConfig = {
+      ...teamConfig,
+      sharing: { ...teamConfig.sharing, env: { injectShellProfile: false } },
+    };
+    // Must not throw (previously threw EISDIR on <teamaiHome>/env).
+    await expect(
+      new EnvHandler().pullItem(item, noInject, pullConfig),
+    ).resolves.not.toThrow();
+    // Backup landed at env.local, NOT clobbering the env/ directory.
+    const backup = await fse.readFile(path.join(bizRoot, '.teamai', 'env.local'), 'utf8');
+    expect(backup).toContain('TEAM_API=https://api.example.com');
+    expect((await fse.stat(path.join(bizRoot, '.teamai', 'env'))).isDirectory()).toBe(true);
+  });
+
+  // ── agents ─────────────────────────────────────────────────────────────
+  it('agents: picks up a canonical .yaml placed in .teamai/agents as new', async () => {
+    await fse.writeFile(
+      path.join(bizRoot, '.teamai', 'agents', 'reviewer.yaml'),
+      'name: reviewer\ndescription: Reviews code\n',
+    );
+    const items = await new AgentsHandler().scanLocalForPush(teamConfig, localConfig);
+    const item = items.find((i) => i.name === 'reviewer');
+    expect(item).toBeDefined();
+    expect(item!.status).toBe('new');
+    expect(item!.relativePath).toBe('agents/reviewer.yaml');
+    expect(item!.legacy).toBe(false);
+  });
+
+  it('agents: picks up a legacy .md as legacy=true', async () => {
+    await fse.writeFile(path.join(bizRoot, '.teamai', 'agents', 'helper.md'), '# Helper\n');
+    const items = await new AgentsHandler().scanLocalForPush(teamConfig, localConfig);
+    const item = items.find((i) => i.name === 'helper');
+    expect(item).toBeDefined();
+    expect(item!.legacy).toBe(true);
+    expect(item!.relativePath).toBe('agents/helper.md');
+  });
+
+  it('agents: skips a canonical file identical to the baseline', async () => {
+    const content = 'name: same\ndescription: d\n';
+    await fse.writeFile(path.join(worktreeTeamai, 'agents', 'same.yaml'), content);
+    await fse.writeFile(path.join(bizRoot, '.teamai', 'agents', 'same.yaml'), content);
+    const items = await new AgentsHandler().scanLocalForPush(teamConfig, localConfig);
+    expect(items.map((i) => i.name)).not.toContain('same');
+  });
+
+  it('agents: pushItem preserves the .yaml extension (no .md corruption)', async () => {
+    await fse.writeFile(
+      path.join(bizRoot, '.teamai', 'agents', 'canon.yaml'),
+      'name: canon\ndescription: d\n',
+    );
+    const [item] = await new AgentsHandler().scanLocalForPush(teamConfig, localConfig);
+    await new AgentsHandler().pushItem(item, teamConfig, localConfig);
+    expect(await fse.pathExists(path.join(worktreeTeamai, 'agents', 'canon.yaml'))).toBe(true);
+    expect(await fse.pathExists(path.join(worktreeTeamai, 'agents', 'canon.md'))).toBe(false);
+  });
+});

--- a/src/__tests__/self-mode-prompt.test.ts
+++ b/src/__tests__/self-mode-prompt.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../utils/logger.js', () => ({
+  log: { info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), dim: vi.fn() },
+}));
+
+// Mock the prompt module so we control the interactive selection deterministically.
+vi.mock('../utils/prompt.js', () => ({
+  askQuestion: vi.fn(),
+  askConfirmation: vi.fn(),
+  askSelection: vi.fn(),
+  closePrompt: vi.fn(),
+}));
+
+// Mock HOME detection so the picker's "Auto" row + expansion are deterministic.
+vi.mock('../known-agents.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../known-agents.js')>();
+  return { ...actual, detectHomeInstalledAgents: vi.fn() };
+});
+
+import { promptForSelfModeAgents } from '../init.js';
+import { askSelection } from '../utils/prompt.js';
+import { detectHomeInstalledAgents } from '../known-agents.js';
+
+describe('promptForSelfModeAgents — interactive Auto option', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let originalIsTTY: boolean | undefined;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    originalIsTTY = process.stdin.isTTY;
+    // Force the interactive branch.
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+    vi.mocked(detectHomeInstalledAgents).mockResolvedValue(['claude', 'codex']);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
+    vi.clearAllMocks();
+  });
+
+  it('renders an Auto row (option 1) listing the detected tools', async () => {
+    vi.mocked(askSelection).mockResolvedValueOnce([0]); // pick Auto
+    await promptForSelfModeAgents({});
+    const printed = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(printed).toContain('1. Auto');
+    expect(printed).toContain('Claude Code'); // detected labels shown inline
+    expect(printed).toContain('Codex');
+  });
+
+  it('Enter (null selection) defaults to Auto → detected tools', async () => {
+    vi.mocked(askSelection).mockResolvedValueOnce(null);
+    const result = await promptForSelfModeAgents({});
+    expect(result).toEqual(['claude', 'codex']);
+  });
+
+  it('picking Auto (index 0) returns the detected tools', async () => {
+    vi.mocked(askSelection).mockResolvedValueOnce([0]);
+    const result = await promptForSelfModeAgents({});
+    expect(result).toEqual(['claude', 'codex']);
+  });
+
+  it('picking a specific tool (index 3 = Cursor) returns just that tool', async () => {
+    vi.mocked(askSelection).mockResolvedValueOnce([3]); // 1=Auto,2=claude,3=codex... wait: index maps -1
+    const result = await promptForSelfModeAgents({});
+    // resolveSelfModeSelection: index 3 → SELF_MODE_AGENT_CHOICES[2] = cursor
+    expect(result).toEqual(['cursor']);
+  });
+
+  it('offers exactly 6 options (Auto + 5 tools)', async () => {
+    vi.mocked(askSelection).mockResolvedValueOnce([0]);
+    await promptForSelfModeAgents({});
+    const [, itemCount] = vi.mocked(askSelection).mock.calls[0];
+    expect(itemCount).toBe(6);
+  });
+
+  it('renders "none detected" when HOME has no known tools, and Auto → claude', async () => {
+    vi.mocked(detectHomeInstalledAgents).mockResolvedValue([]);
+    vi.mocked(askSelection).mockResolvedValueOnce(null); // Enter → Auto
+    const result = await promptForSelfModeAgents({});
+    const printed = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(printed).toContain('none detected');
+    expect(result).toEqual(['claude']);
+  });
+
+  it('--agent bypasses the picker entirely', async () => {
+    const result = await promptForSelfModeAgents({ agent: 'workbuddy' });
+    expect(result).toEqual(['workbuddy']);
+    expect(askSelection).not.toHaveBeenCalled();
+  });
+
+  it('--force skips the picker and mirrors HOME detection', async () => {
+    const result = await promptForSelfModeAgents({ force: true });
+    expect(result).toEqual(['claude', 'codex']);
+    expect(askSelection).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/self-mode-push-scan.test.ts
+++ b/src/__tests__/self-mode-push-scan.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import os from 'node:os';
+import fse from 'fs-extra';
+
+vi.mock('../utils/logger.js', () => ({
+  log: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    dim: vi.fn(),
+  },
+}));
+
+import { SkillsHandler } from '../resources/skills.js';
+import { RulesHandler } from '../resources/rules.js';
+import type { TeamaiConfig, LocalConfig } from '../types.js';
+
+/**
+ * Regression for single-repo mode: users edit team knowledge directly under
+ * <repo>/.teamai/skills (it lives in their own repo), NOT in an AI tool dir like
+ * ~/.claude/skills. `teamai push` must scan the active tree's .teamai/{skills,rules}
+ * as a source, diffed against the knowledge worktree (origin/<default>), so a
+ * hand-placed skill surfaces as "new" instead of "No new or modified resources".
+ *
+ * These tests exercise the exact scanner input pushCore builds in self mode: a
+ * synthetic toolPaths entry pointing at '.teamai/skills' / '.teamai/rules', with
+ * baseDir = business repo root (project scope) and localConfig.repo.localPath =
+ * the worktree checkout that represents origin/<default>.
+ */
+describe('single-repo mode: push scans .teamai knowledge dir', () => {
+  let tmpDir: string;
+  let bizRoot: string; // business repo root (= project scope baseDir)
+  let worktreeTeamai: string; // knowledge worktree's .teamai (= localConfig.repo.localPath)
+  let teamConfig: TeamaiConfig;
+  let localConfig: LocalConfig;
+
+  // Mirrors the synthetic key pushCore injects for self-mode scanning.
+  const SELF_KEY = '__teamai_self_knowledge__';
+
+  beforeEach(async () => {
+    tmpDir = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-self-push-'));
+    bizRoot = path.join(tmpDir, 'biz');
+    // The knowledge worktree checkout of origin/<default>; its .teamai is the diff base.
+    worktreeTeamai = path.join(tmpDir, 'biz', '.teamai', 'knowledge-wt', '.teamai');
+
+    await fse.ensureDir(path.join(bizRoot, '.teamai', 'skills'));
+    await fse.ensureDir(path.join(bizRoot, '.teamai', 'rules'));
+    await fse.ensureDir(path.join(worktreeTeamai, 'skills'));
+    await fse.ensureDir(path.join(worktreeTeamai, 'rules'));
+
+    teamConfig = {
+      team: 'test',
+      description: '',
+      repo: 'https://github.com/acme/app.git',
+      provider: 'github' as const,
+      reviewers: [],
+      sharing: { skills: {}, rules: { enforced: [] }, docs: { localDir: '' }, env: { injectShellProfile: true } },
+      // Self-mode scan config: the synthetic entry pushCore adds.
+      toolPaths: {
+        [SELF_KEY]: { skills: '.teamai/skills', rules: '.teamai/rules' },
+      },
+    };
+
+    localConfig = {
+      repo: {
+        localPath: worktreeTeamai,
+        remote: 'https://github.com/acme/app.git',
+        kind: 'self',
+        businessRepoRoot: path.join(tmpDir, 'biz', '.teamai', 'knowledge-wt'),
+      },
+      username: 'alice',
+      scope: 'project',
+      projectRoot: bizRoot,
+      additionalRoles: [],
+    };
+  });
+
+  afterEach(async () => {
+    await fse.remove(tmpDir);
+  });
+
+  it('detects a skill hand-placed under .teamai/skills as "new"', async () => {
+    // User did: cp -rf ~/.claude/skills/handoff <repo>/.teamai/skills/
+    const handoff = path.join(bizRoot, '.teamai', 'skills', 'handoff');
+    await fse.ensureDir(handoff);
+    await fse.writeFile(path.join(handoff, 'SKILL.md'), '# Handoff\nHand off work between sessions.');
+
+    const items = await new SkillsHandler().scanLocalForPush(teamConfig, localConfig);
+    const item = items.find((i) => i.name === 'handoff');
+    expect(item).toBeDefined();
+    expect(item!.status).toBe('new');
+  });
+
+  it('detects an edited skill under .teamai/skills as "modified"', async () => {
+    // Base (origin/main) has v1; user edited the copy in the active tree to v2.
+    const baseSkill = path.join(worktreeTeamai, 'skills', 'handoff');
+    await fse.ensureDir(baseSkill);
+    await fse.writeFile(path.join(baseSkill, 'SKILL.md'), '# Handoff v1');
+
+    const activeSkill = path.join(bizRoot, '.teamai', 'skills', 'handoff');
+    await fse.ensureDir(activeSkill);
+    await fse.writeFile(path.join(activeSkill, 'SKILL.md'), '# Handoff v2');
+
+    const items = await new SkillsHandler().scanLocalForPush(teamConfig, localConfig);
+    const item = items.find((i) => i.name === 'handoff');
+    expect(item).toBeDefined();
+    expect(item!.status).toBe('modified');
+  });
+
+  it('does NOT surface a skill already committed to main (identical content)', async () => {
+    const content = '# Handoff\nsame';
+    const baseSkill = path.join(worktreeTeamai, 'skills', 'handoff');
+    await fse.ensureDir(baseSkill);
+    await fse.writeFile(path.join(baseSkill, 'SKILL.md'), content);
+
+    const activeSkill = path.join(bizRoot, '.teamai', 'skills', 'handoff');
+    await fse.ensureDir(activeSkill);
+    await fse.writeFile(path.join(activeSkill, 'SKILL.md'), content);
+
+    const items = await new SkillsHandler().scanLocalForPush(teamConfig, localConfig);
+    expect(items.map((i) => i.name)).not.toContain('handoff');
+  });
+
+  it('detects a rule hand-placed under .teamai/rules as "new"', async () => {
+    await fse.writeFile(
+      path.join(bizRoot, '.teamai', 'rules', 'coding-standards.md'),
+      '# Coding Standards\nUse tabs.',
+    );
+
+    const items = await new RulesHandler().scanLocalForPush(teamConfig, localConfig);
+    const item = items.find((i) => i.name === 'coding-standards');
+    expect(item).toBeDefined();
+    expect(item!.status).toBe('new');
+  });
+});

--- a/src/__tests__/single-repo-mode.test.ts
+++ b/src/__tests__/single-repo-mode.test.ts
@@ -9,7 +9,7 @@ import {
   TeamaiConfigSchema,
   type LocalConfig,
 } from '../types.js';
-import { buildSelfModeGitignore } from '../init.js';
+import { buildSelfModeGitignore, migrateSelfModeGitignoreContent } from '../init.js';
 
 function makeConfig(kind: 'git' | 'http' | 'self', localPath = '/repo/.teamai'): LocalConfig {
   return {
@@ -131,5 +131,52 @@ describe('buildSelfModeGitignore', () => {
 
   it('still ignores the locally-generated env.sh (only env.yaml is shared)', () => {
     expect(gi.split('\n').map((l) => l.trim())).toContain('env.sh');
+  });
+});
+
+describe('migrateSelfModeGitignoreContent (self-heal old gitignore)', () => {
+  it('removes a standalone `env` line and adds env.local', () => {
+    const old = ['config.yaml', 'env', 'env.sh', 'members/'].join('\n');
+    const { changed, content } = migrateSelfModeGitignoreContent(old);
+    expect(changed).toBe(true);
+    const lines = content.split('\n').map((l) => l.trim());
+    expect(lines).not.toContain('env');
+    expect(lines).toContain('env.local');
+    // env.local inserted right after env.sh
+    expect(content).toContain('env.sh\nenv.local');
+  });
+
+  it('does not touch env.sh, env.local, or env/', () => {
+    const old = ['env.sh', 'env.local', 'env/'].join('\n');
+    const { changed, content } = migrateSelfModeGitignoreContent(old);
+    expect(changed).toBe(false); // nothing to remove, env.local already present
+    const lines = content.split('\n').map((l) => l.trim());
+    expect(lines).toContain('env.sh');
+    expect(lines).toContain('env.local');
+    expect(lines).toContain('env/');
+  });
+
+  it('is a no-op on a current gitignore (already migrated)', () => {
+    const current = buildSelfModeGitignore();
+    const { changed, content } = migrateSelfModeGitignoreContent(current);
+    expect(changed).toBe(false);
+    expect(content).toBe(current);
+  });
+
+  it('adds env.local even when there is no env.sh to anchor to', () => {
+    const old = ['config.yaml', 'env', 'token'].join('\n');
+    const { changed, content } = migrateSelfModeGitignoreContent(old);
+    expect(changed).toBe(true);
+    const lines = content.split('\n').map((l) => l.trim());
+    expect(lines).not.toContain('env');
+    expect(lines).toContain('env.local');
+  });
+
+  it('ignores commented lines containing env', () => {
+    const old = ['# env is machine-local', 'config.yaml', 'env.local'].join('\n');
+    const { changed, content } = migrateSelfModeGitignoreContent(old);
+    // No bare `env` line, env.local already present → unchanged.
+    expect(changed).toBe(false);
+    expect(content).toContain('# env is machine-local');
   });
 });

--- a/src/__tests__/single-repo-mode.test.ts
+++ b/src/__tests__/single-repo-mode.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import {
+  getReportsDir,
+  getKnowledgeDir,
+  isSelfMode,
+  REPORTS_WORKTREE_DIRNAME,
+  LocalConfigSchema,
+  TeamaiConfigSchema,
+  type LocalConfig,
+} from '../types.js';
+import { buildSelfModeGitignore } from '../init.js';
+
+function makeConfig(kind: 'git' | 'http' | 'self', localPath = '/repo/.teamai'): LocalConfig {
+  return {
+    repo: {
+      localPath,
+      remote: 'https://github.com/acme/app.git',
+      kind,
+      ...(kind === 'self' ? { businessRepoRoot: '/repo' } : {}),
+    },
+    username: 'alice',
+    scope: 'project',
+    projectRoot: '/repo',
+    additionalRoles: [],
+  };
+}
+
+describe('single-repo mode path helpers', () => {
+  it('isSelfMode is true only for kind: self', () => {
+    expect(isSelfMode(makeConfig('self'))).toBe(true);
+    expect(isSelfMode(makeConfig('git'))).toBe(false);
+    expect(isSelfMode(makeConfig('http'))).toBe(false);
+  });
+
+  it('getKnowledgeDir returns localPath in every mode', () => {
+    expect(getKnowledgeDir(makeConfig('self'))).toBe('/repo/.teamai');
+    expect(getKnowledgeDir(makeConfig('git', '/home/alice/.teamai/team-repo'))).toBe(
+      '/home/alice/.teamai/team-repo',
+    );
+  });
+
+  it('getReportsDir points at the reports worktree only in self mode', () => {
+    expect(getReportsDir(makeConfig('self'))).toBe(
+      path.join('/repo/.teamai', REPORTS_WORKTREE_DIRNAME),
+    );
+    // Non-self modes keep reports alongside knowledge (localPath) — unchanged behavior.
+    expect(getReportsDir(makeConfig('git', '/home/alice/.teamai/team-repo'))).toBe(
+      '/home/alice/.teamai/team-repo',
+    );
+    expect(getReportsDir(makeConfig('http', '/home/alice/.teamai/team-repo'))).toBe(
+      '/home/alice/.teamai/team-repo',
+    );
+  });
+});
+
+describe('LocalConfigSchema: kind self + businessRepoRoot', () => {
+  it('accepts kind: self with businessRepoRoot', () => {
+    const parsed = LocalConfigSchema.parse({
+      repo: {
+        localPath: '/repo/.teamai',
+        remote: 'https://github.com/acme/app.git',
+        kind: 'self',
+        businessRepoRoot: '/repo',
+      },
+      username: 'alice',
+      scope: 'project',
+      projectRoot: '/repo',
+    });
+    expect(parsed.repo.kind).toBe('self');
+    expect(parsed.repo.businessRepoRoot).toBe('/repo');
+  });
+
+  it('still accepts legacy git/http configs without the new fields', () => {
+    const parsed = LocalConfigSchema.parse({
+      repo: { localPath: '/x/team-repo', remote: 'r' },
+      username: 'bob',
+    });
+    expect(parsed.repo.kind).toBeUndefined();
+    expect(parsed.repo.businessRepoRoot).toBeUndefined();
+  });
+});
+
+describe('TeamaiConfigSchema: mode marker', () => {
+  it('accepts mode: self (the clone-time self-heal marker)', () => {
+    const parsed = TeamaiConfigSchema.parse({
+      team: 'app',
+      repo: 'https://github.com/acme/app.git',
+      mode: 'self',
+    });
+    expect(parsed.mode).toBe('self');
+  });
+
+  it('leaves mode undefined for standalone team repos', () => {
+    const parsed = TeamaiConfigSchema.parse({
+      team: 'app',
+      repo: 'https://github.com/acme/app.git',
+    });
+    expect(parsed.mode).toBeUndefined();
+  });
+});
+
+describe('buildSelfModeGitignore', () => {
+  const gi = buildSelfModeGitignore();
+
+  it('ignores machine-local state and worktrees', () => {
+    for (const entry of ['config.yaml', 'state.json', 'token', 'reports-wt/', 'knowledge-wt/', '.reports-lock', '.bootstrap-lock']) {
+      expect(gi).toContain(entry);
+    }
+  });
+
+  it('ignores report data (it lives on the orphan branch, not main)', () => {
+    for (const entry of ['members/', 'sessions/', 'votes/', 'stats/', 'pending-review.jsonl']) {
+      expect(gi).toContain(`\n${entry}`);
+    }
+  });
+
+  it('does NOT ignore knowledge (skills/rules/docs/learnings stay on main)', () => {
+    // These must not appear as ignore lines (they are committed to main).
+    const lines = gi.split('\n').map((l) => l.trim());
+    expect(lines).not.toContain('skills/');
+    expect(lines).not.toContain('rules/');
+    expect(lines).not.toContain('docs/');
+    expect(lines).not.toContain('learnings/');
+  });
+});

--- a/src/__tests__/single-repo-mode.test.ts
+++ b/src/__tests__/single-repo-mode.test.ts
@@ -115,12 +115,21 @@ describe('buildSelfModeGitignore', () => {
     }
   });
 
-  it('does NOT ignore knowledge (skills/rules/docs/learnings stay on main)', () => {
+  it('does NOT ignore knowledge (skills/rules/docs/learnings/env stay on main)', () => {
     // These must not appear as ignore lines (they are committed to main).
+    // env is intentionally committed in single-repo mode (unlike standalone mode's
+    // per-machine env), so `teamai push` can carry team env vars — it must NOT be
+    // an ignore line. env.sh (generated locally) stays ignored, checked below.
     const lines = gi.split('\n').map((l) => l.trim());
     expect(lines).not.toContain('skills/');
     expect(lines).not.toContain('rules/');
     expect(lines).not.toContain('docs/');
     expect(lines).not.toContain('learnings/');
+    expect(lines).not.toContain('env');
+    expect(lines).not.toContain('env/');
+  });
+
+  it('still ignores the locally-generated env.sh (only env.yaml is shared)', () => {
+    expect(gi.split('\n').map((l) => l.trim())).toContain('env.sh');
   });
 });

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -133,12 +133,20 @@ export async function bootstrapSelfRepo(
       return 'skip';
     }
 
+    // Bootstrap is fully non-interactive (clone-time self-heal), so we can't ask
+    // which tools to set up. Mirror whatever this developer already uses under
+    // their HOME (~/.claude, ~/.codex, ...). Empty means "seed nothing" — they
+    // get the knowledge, and can run `teamai init .` to pick tools explicitly.
+    const { detectHomeInstalledAgents } = await import('./known-agents.js');
+    const enabledAgents = await detectHomeInstalledAgents();
+
     const localConfig: LocalConfig = {
       repo: { localPath, remote: repoInfo.httpsUrl, kind: 'self', businessRepoRoot },
       username,
       scope: 'project',
       projectRoot: businessRepoRoot,
       additionalRoles: [],
+      ...(enabledAgents.length > 0 ? { enabledAgents } : {}),
     };
 
     // Role (non-interactive): auto-select when the repo defines exactly one role.

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,0 +1,215 @@
+/**
+ * Self-heal bootstrap for single-repo mode (issue #198).
+ *
+ * When an admin runs `teamai init .`, the knowledge skeleton and
+ * `.teamai/teamai.yaml` (carrying `mode: self`) are committed to main and travel
+ * with `git clone`. But the machine-local `config.yaml` / `token` / `state.json`
+ * are gitignored and do NOT travel. So a teammate who clones the repo has the
+ * team knowledge on disk but no local config — teamai would otherwise treat the
+ * project as uninitialized.
+ *
+ * `bootstrapSelfRepo` fills that gap: on any teamai command or session-start
+ * hook, when `.teamai/teamai.yaml` says `mode: self` but there is no local
+ * config, it non-interactively writes the local config, injects hooks, and
+ * registers the member — no need to re-type repo/role. Best-effort and locked so
+ * concurrent hooks don't race.
+ */
+import path from 'node:path';
+import YAML from 'yaml';
+import {
+  BOOTSTRAP_LOCK_FILENAME,
+  getConfigPath,
+  type LocalConfig,
+  type TeamaiConfig,
+} from './types.js';
+import { readFileSafe, pathExists, ensureDir, writeFile } from './utils/fs.js';
+import { getRemoteUrl } from './utils/git.js';
+import { log } from './utils/logger.js';
+import { acquireLock, releaseLock } from './update.js';
+
+export type BootstrapResult = 'bootstrapped' | 'already' | 'skip';
+
+/**
+ * Read `.teamai/teamai.yaml` at dir and return it iff it declares `mode: self`.
+ * Returns null otherwise (not a single-repo project). Purely a marker read — no
+ * schema validation beyond the mode field so a partial/older file still triggers.
+ */
+async function readSelfModeMarker(dir: string): Promise<{ repo?: string; provider?: string } | null> {
+  const yamlPath = path.join(dir, '.teamai', 'teamai.yaml');
+  const content = await readFileSafe(yamlPath);
+  if (!content) return null;
+  try {
+    const raw = YAML.parse(content) as Partial<TeamaiConfig> | null;
+    if (raw && raw.mode === 'self') {
+      return { repo: raw.repo, provider: raw.provider };
+    }
+  } catch {
+    // malformed yaml — not our concern here
+  }
+  return null;
+}
+
+/**
+ * If `dir` is a single-repo teamai project (teamai.yaml has `mode: self`) but has
+ * no local config yet, non-interactively bootstrap the machine side. Idempotent.
+ *
+ * @param dir business repo root (defaults to cwd)
+ * @param opts.silent suppress user-facing logs (session-start hook path)
+ */
+export async function bootstrapSelfRepo(
+  dir?: string,
+  opts?: { silent?: boolean },
+): Promise<BootstrapResult> {
+  const businessRepoRoot = dir ?? process.cwd();
+  const silent = opts?.silent ?? false;
+  const info = (msg: string) => { if (!silent) log.info(msg); };
+
+  // Fast path: already initialized.
+  const configPath = getConfigPath('project', businessRepoRoot);
+  if (await pathExists(configPath)) return 'already';
+
+  // Only self-mode projects auto-bootstrap.
+  const marker = await readSelfModeMarker(businessRepoRoot);
+  if (!marker) return 'skip';
+
+  const lockPath = path.join(businessRepoRoot, '.teamai', BOOTSTRAP_LOCK_FILENAME);
+  const locked = await acquireLock(lockPath);
+  if (!locked) {
+    log.debug('[bootstrap] another bootstrap is in progress; skipping');
+    return 'skip';
+  }
+
+  try {
+    // Re-check under the lock — a concurrent run may have finished.
+    if (await pathExists(configPath)) return 'already';
+
+    const localPath = path.join(businessRepoRoot, '.teamai');
+
+    // Derive provider/remote: prefer the business repo origin, fall back to the
+    // repo recorded in teamai.yaml.
+    const remoteUrl = (await getRemoteUrl(businessRepoRoot)) ?? marker.repo ?? '';
+    if (!remoteUrl) {
+      log.debug('[bootstrap] no remote/repo to derive provider from; skipping');
+      return 'skip';
+    }
+
+    const { getProvider, detectProvider } = await import('./providers/index.js');
+    const providerName = marker.provider ?? detectProvider(remoteUrl);
+    const provider = getProvider(providerName);
+
+    // Non-interactive gate: only proceed if already authenticated. Never trigger
+    // an interactive login from a hook — degrade to skip and let an explicit
+    // `teamai init .` handle first-time auth.
+    if (!provider.isAuthenticated()) {
+      if (!silent) {
+        log.warn('This is a teamai single-repo project, but you are not authenticated yet.');
+        log.warn(`Run \`teamai init .\` (or authenticate with your git provider) to finish setup.`);
+      }
+      return 'skip';
+    }
+
+    let username: string;
+    try {
+      username = await provider.authenticate();
+    } catch {
+      log.debug('[bootstrap] could not resolve username; skipping');
+      return 'skip';
+    }
+
+    let repoInfo;
+    try {
+      repoInfo = provider.parseRepoInput(remoteUrl);
+    } catch {
+      log.debug('[bootstrap] could not parse remote; skipping');
+      return 'skip';
+    }
+
+    info('Detected a teamai single-repo project — finishing local setup...');
+
+    const { loadTeamConfig, saveLocalConfigForScope, loadStateForScope, saveStateForScope } = await import('./config.js');
+    const teamConfig = await loadTeamConfig(localPath);
+    if (!teamConfig) {
+      log.debug('[bootstrap] teamai.yaml not loadable; skipping');
+      return 'skip';
+    }
+
+    const localConfig: LocalConfig = {
+      repo: { localPath, remote: repoInfo.httpsUrl, kind: 'self', businessRepoRoot },
+      username,
+      scope: 'project',
+      projectRoot: businessRepoRoot,
+      additionalRoles: [],
+    };
+
+    // Role (non-interactive): auto-select when the repo defines exactly one role.
+    // Multi-role repos leave role unset — the member can set it later with
+    // `teamai roles set`. A repo without a manifest just skips this.
+    try {
+      const { loadRolesManifest } = await import('./roles.js');
+      const manifest = await loadRolesManifest(localPath);
+      if (manifest.roles.length === 1) {
+        localConfig.primaryRole = manifest.roles[0].id;
+        localConfig.resourceProfileVersion = manifest.version;
+      }
+    } catch {
+      // no roles manifest — leave role unset
+    }
+
+    await ensureDir(localPath);
+    await saveLocalConfigForScope(localConfig, 'project', businessRepoRoot);
+
+    // Invalidate pull cache so the next pull does a full sync.
+    try {
+      const state = await loadStateForScope('project', businessRepoRoot);
+      state.lastPullRev = null;
+      await saveStateForScope(state, 'project', businessRepoRoot);
+    } catch {
+      // state may not exist yet
+    }
+
+    // Seed the tool skills-dir so hooks + skills inject on this fresh clone
+    // (isToolInstalled would otherwise skip everything — no <repo>/.claude yet).
+    try {
+      const { seedSelfModeToolDirs } = await import('./known-agents.js');
+      await seedSelfModeToolDirs(localConfig, teamConfig);
+    } catch (e) {
+      log.debug(`[bootstrap] tool-dir seeding skipped: ${(e as Error).message}`);
+    }
+
+    // Inject hooks so session-start pull/report fire from now on.
+    try {
+      const { reconcileTeamHooksForConfig } = await import('./hooks.js');
+      await reconcileTeamHooksForConfig(teamConfig, localConfig, {});
+    } catch (e) {
+      log.debug(`[bootstrap] hook injection failed (non-blocking): ${(e as Error).message}`);
+    }
+
+    // Register member on the reports orphan branch. Best-effort: no write access
+    // just means the member isn't listed — they still get the knowledge.
+    try {
+      const { ensureReportsWorktree, commitAndPushReports } = await import('./utils/reports-branch.js');
+      const wt = await ensureReportsWorktree(localConfig);
+      const memberDir = path.join(wt, 'members');
+      await ensureDir(memberDir);
+      const memberPath = path.join(memberDir, `${username}.yaml`);
+      if (!(await pathExists(memberPath))) {
+        await writeFile(memberPath, YAML.stringify({
+          username,
+          displayName: username,
+          registeredAt: new Date().toISOString(),
+        }));
+        await commitAndPushReports(localConfig, `[teamai] Register member: ${username}`, ['members/']);
+      }
+    } catch (e) {
+      log.debug(`[bootstrap] member registration skipped (non-blocking): ${(e as Error).message}`);
+    }
+
+    info('teamai single-repo project initialized locally. Team skills/rules are now active.');
+    return 'bootstrapped';
+  } catch (e) {
+    log.debug(`[bootstrap] failed (non-blocking): ${(e as Error).message}`);
+    return 'skip';
+  } finally {
+    await releaseLock(lockPath);
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -189,7 +189,21 @@ export async function saveStateForScope(state: State, scope: Scope, projectRoot?
 export async function detectProjectConfig(cwd?: string): Promise<LocalConfig | null> {
   const dir = cwd ?? process.cwd();
   const configPath = path.join(dir, '.teamai', 'config.yaml');
-  if (!(await pathExists(configPath))) return null;
+  if (!(await pathExists(configPath))) {
+    // Single-repo mode self-heal (issue #198): a teammate who cloned a repo
+    // carrying `.teamai/teamai.yaml` with `mode: self` has the team knowledge on
+    // disk but no local config (it is gitignored, not cloned). Auto-bootstrap the
+    // machine side, then re-read. bootstrapSelfRepo is a no-op ('skip') for any
+    // dir that is not a self-mode project, so this stays cheap on the hot path.
+    try {
+      const { bootstrapSelfRepo } = await import('./bootstrap.js');
+      const result = await bootstrapSelfRepo(dir, { silent: true });
+      if (result !== 'bootstrapped') return null;
+    } catch {
+      return null;
+    }
+    if (!(await pathExists(configPath))) return null;
+  }
   const content = await readFileSafe(configPath);
   if (!content) return null;
   try {

--- a/src/contribute.ts
+++ b/src/contribute.ts
@@ -244,17 +244,46 @@ async function contributeSelf(
 
       // Mirror the worktree's learnings into the machine-local dir + rebuild the
       // index so recall sees this contribution immediately — without touching the
-      // user's active tree.
+      // user's active tree. Index ALL categories (not just learnings) — a
+      // learnings-only rebuild would clobber the project index and drop
+      // docs/rules/skills/votes until the next full pull.
+      //
+      // IMPORTANT: source docs/rules/skills from the PERSISTENT active tree
+      // (localConfig.repo.localPath/.teamai), NOT the disposable knowledge
+      // worktree — withKnowledgeWorktree deletes wtRepo on teardown, and buildIndex
+      // bakes absolute paths into search-index.json, so worktree paths would leave
+      // recall printing `File: <deleted>` pointers. learnings come from the
+      // persistent LEARNINGS_LOCAL_DIR mirror; votes from the reports worktree.
+      // This matches the other index-build sites (pull.ts / recall.ts).
       try {
+        const { pathExists } = await import('./utils/fs.js');
         const wtLearnings = path.join(wtRepo, 'learnings');
         await fse.copy(wtLearnings, LEARNINGS_LOCAL_DIR, {
           overwrite: true,
           filter: (src: string) => !path.basename(src).startsWith('.'),
         });
+
+        const repoPath = localConfig.repo.localPath; // persistent active-tree .teamai
+        const docsDir = path.join(repoPath, 'docs');
+        const rulesDir = path.join(repoPath, 'rules');
+        const skillsDir = path.join(repoPath, 'skills');
+
+        // votes are on the teamai-reports orphan branch, not in the knowledge worktree.
+        let votesDir: string | undefined;
+        try {
+          const { ensureReportsWorktree } = await import('./utils/reports-branch.js');
+          const candidate = path.join(await ensureReportsWorktree(localConfig), 'votes');
+          if (await pathExists(candidate)) votesDir = candidate;
+        } catch { /* reports worktree unavailable — index without votes */ }
+
         const teamaiHome = getTeamaiHome(localConfig.scope, localConfig.projectRoot);
         const { buildIndex } = await import('./utils/search-index.js');
         await buildIndex({
-          learningsDir: LEARNINGS_LOCAL_DIR,
+          learningsDir: await pathExists(LEARNINGS_LOCAL_DIR) ? LEARNINGS_LOCAL_DIR : undefined,
+          docsDir: await pathExists(docsDir) ? docsDir : undefined,
+          rulesDir: await pathExists(rulesDir) ? rulesDir : undefined,
+          skillsDir: await pathExists(skillsDir) ? skillsDir : undefined,
+          votesDir,
           indexPath: path.join(teamaiHome, 'search-index.json'),
         });
       } catch (e) {

--- a/src/contribute.ts
+++ b/src/contribute.ts
@@ -142,6 +142,13 @@ export async function contribute(
     return;
   }
 
+  // Single-repo mode: learnings are knowledge on main → contribute via a PR from
+  // an isolated worktree (never the active tree / direct push to main).
+  if (localConfig.repo.kind === 'self') {
+    await contributeSelf(localConfig, content, options);
+    return;
+  }
+
   const pushSpin = spinner('Contributing session knowledge...').start();
   const filename = generateFilename(options.title);
 
@@ -200,5 +207,84 @@ export async function contribute(
       pushSpin.fail(`Contribution failed: ${(e as Error).message}`);
       log.info('You can retry with: teamai contribute --file <path>');
     }
+  }
+}
+
+/**
+ * Single-repo mode contribution: learnings are knowledge on main, so we open a
+ * PR from an isolated knowledge worktree instead of pushing to main directly.
+ *
+ * The user's active working tree is never written to. For immediate local recall,
+ * we mirror the worktree's learnings/ (committed main learnings + the new one)
+ * into the machine-local LEARNINGS_LOCAL_DIR and index from there — the same
+ * pattern user scope uses. The contribution lands in the active tree only when the
+ * PR merges and the user pulls.
+ */
+async function contributeSelf(
+  localConfig: LocalConfig,
+  content: string,
+  options: GlobalOptions & { file?: string; title?: string; sessionId?: string; scope?: string },
+): Promise<void> {
+  const username = localConfig.username;
+  const filename = generateFilename(options.title);
+  const relPath = `learnings/${filename}`;
+  const commitMsg = `[teamai] Contribute session knowledge from ${username}`;
+  const spin = spinner('Contributing session knowledge...').start();
+
+  try {
+    const { withKnowledgeWorktree } = await import('./utils/reports-branch.js');
+    const { pushRepoBranch, checkoutMaster, generateBranchName } = await import('./utils/git.js');
+    const { createPrWithFallback } = await import('./push.js');
+    const teamConfig = await loadTeamConfig(localConfig.repo.localPath);
+
+    await withKnowledgeWorktree(localConfig, async (wtConfig) => {
+      const wtRepo = wtConfig.repo.localPath;
+      await ensureDir(path.join(wtRepo, 'learnings'));
+      await fs.promises.writeFile(path.join(wtRepo, relPath), content, 'utf-8');
+
+      // Mirror the worktree's learnings into the machine-local dir + rebuild the
+      // index so recall sees this contribution immediately — without touching the
+      // user's active tree.
+      try {
+        const wtLearnings = path.join(wtRepo, 'learnings');
+        await fse.copy(wtLearnings, LEARNINGS_LOCAL_DIR, {
+          overwrite: true,
+          filter: (src: string) => !path.basename(src).startsWith('.'),
+        });
+        const teamaiHome = getTeamaiHome(localConfig.scope, localConfig.projectRoot);
+        const { buildIndex } = await import('./utils/search-index.js');
+        await buildIndex({
+          learningsDir: LEARNINGS_LOCAL_DIR,
+          indexPath: path.join(teamaiHome, 'search-index.json'),
+        });
+      } catch (e) {
+        log.debug(`contribute(self): local index refresh skipped: ${(e as Error).message}`);
+      }
+
+      const branchName = generateBranchName(username);
+      const hasChanges = await pushRepoBranch(wtRepo, commitMsg, [relPath], branchName);
+      if (!hasChanges) {
+        spin.info('Contribution already present — nothing to push.');
+        return;
+      }
+      if (teamConfig) {
+        await createPrWithFallback(
+          teamConfig,
+          wtConfig,
+          branchName,
+          commitMsg,
+          `Contribute session knowledge: ${options.title ?? filename}`,
+        );
+      }
+      await checkoutMaster(wtRepo);
+      spin.succeed(`Contributed via PR: ${relPath}`);
+    });
+
+    const sessionId = options.sessionId || process.env.CLAUDE_SESSION_ID || '';
+    if (sessionId) await markContributed(sessionId);
+    log.info('Your session knowledge has been shared with the team (PR opened).');
+  } catch (e) {
+    spin.fail(`Contribution failed: ${(e as Error).message}`);
+    log.info('You can retry with: teamai contribute --file <path>');
   }
 }

--- a/src/digest.ts
+++ b/src/digest.ts
@@ -348,7 +348,17 @@ export async function generateDigest(options: GlobalOptions): Promise<void> {
     const localConfig = projectConfig ?? (await requireInit()).localConfig;
     const repoPath = localConfig.repo.localPath;
 
-    const teamStats = await loadTeamStats(repoPath);
+    // In self mode, knowledge (learnings, skill git-log) lives under localPath on
+    // main, but report data (stats, sessions) lives on the teamai-reports orphan
+    // branch — read those from the reports worktree, refreshed from origin.
+    let reportsRoot = repoPath;
+    if (localConfig.repo.kind === 'self') {
+      const { ensureReportsWorktree, refreshReportsWorktree } = await import('./utils/reports-branch.js');
+      await refreshReportsWorktree(localConfig);
+      reportsRoot = await ensureReportsWorktree(localConfig);
+    }
+
+    const teamStats = await loadTeamStats(reportsRoot);
 
     if (teamStats.length === 0) {
       console.log('No team usage data available yet.');
@@ -357,7 +367,7 @@ export async function generateDigest(options: GlobalOptions): Promise<void> {
     }
 
     const health = calculateTeamHealth(teamStats);
-    const sessions = await getRecentSessions(repoPath);
+    const sessions = await getRecentSessions(reportsRoot);
 
     // Header
     const now = new Date();

--- a/src/digest.ts
+++ b/src/digest.ts
@@ -94,12 +94,35 @@ function parseGitLogOutput(output: string): Array<{ author: string; message: str
 }
 
 /**
+ * Build the git pathspec + match regex for a team repo's skills SKILL.md files,
+ * accounting for a repo-root-relative `subdir` prefix. Exported for testing —
+ * this is the exact spot that broke in single-repo mode (git emitted
+ * ".teamai/skills/..." paths that never matched a bare "skills/..." regex).
+ */
+export function buildSkillChangePathspec(subdir = ''): { pathspec: string; skillRe: RegExp } {
+  const prefix = subdir ? `${subdir.replace(/\/+$/, '')}/` : '';
+  const pathspec = `${prefix}skills/*/SKILL.md`;
+  const escaped = prefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const skillRe = new RegExp(`^${escaped}skills/([^/]+)/SKILL\\.md$`);
+  return { pathspec, skillRe };
+}
+
+/**
  * Detect new and updated skills in the team repo from the past 7 days
  * by inspecting git log for changes under skills/SKILL.md paths.
+ *
+ * `subdir` is the repo-root-relative directory holding the team repo's `skills/`.
+ * It's '' for standalone team repos (git log runs at the repo root, paths are
+ * `skills/foo/SKILL.md`), but '.teamai' in single-repo mode — there the git log
+ * must run at the BUSINESS repo root with a `.teamai/skills/...` pathspec, and
+ * git emits repo-root-relative paths like `.teamai/skills/foo/SKILL.md`. We build
+ * the pathspec and the match regex from `subdir` so both layouts work.
  */
-async function getRecentSkillChanges(repoPath: string): Promise<SkillChange[]> {
+async function getRecentSkillChanges(repoPath: string, subdir = ''): Promise<SkillChange[]> {
   const seen = new Set<string>();
   const changes: SkillChange[] = [];
+
+  const { pathspec, skillRe } = buildSkillChangePathspec(subdir);
 
   try {
     const git = createGit(repoPath);
@@ -108,7 +131,7 @@ async function getRecentSkillChanges(repoPath: string): Promise<SkillChange[]> {
     const rawOutput = await git.raw([
       'log', '--since=7 days ago', '--diff-filter=AM',
       '--name-only', '--pretty=format:%H|%an|%s',
-      '--', 'skills/*/SKILL.md',
+      '--', pathspec,
     ]);
 
     if (!rawOutput.trim()) return changes;
@@ -117,7 +140,7 @@ async function getRecentSkillChanges(repoPath: string): Promise<SkillChange[]> {
 
     for (const commit of commits) {
       for (const file of commit.files) {
-        const match = file.match(/^skills\/([^/]+)\/SKILL\.md$/);
+        const match = file.match(skillRe);
         if (!match) continue;
         const skillName = match[1];
         if (seen.has(skillName)) continue;
@@ -136,7 +159,7 @@ async function getRecentSkillChanges(repoPath: string): Promise<SkillChange[]> {
       const addedOutput = await git.raw([
         'log', '--since=7 days ago', '--diff-filter=A',
         '--name-only', '--pretty=format:%H|%an|%s',
-        '--', 'skills/*/SKILL.md',
+        '--', pathspec,
       ]);
 
       const newSkills = new Set<string>();
@@ -144,7 +167,7 @@ async function getRecentSkillChanges(repoPath: string): Promise<SkillChange[]> {
         const addedCommits = parseGitLogOutput(addedOutput);
         for (const commit of addedCommits) {
           for (const file of commit.files) {
-            const match = file.match(/^skills\/([^/]+)\/SKILL\.md$/);
+            const match = file.match(skillRe);
             if (match) {
               newSkills.add(match[1]);
             }
@@ -422,8 +445,16 @@ export async function generateDigest(options: GlobalOptions): Promise<void> {
       console.log('');
     }
 
-    // Skill changelog
-    const skillChanges = await getRecentSkillChanges(repoPath);
+    // Skill changelog. In self mode skills live at <businessRepoRoot>/.teamai/skills,
+    // so run the git log at the business repo root with a `.teamai` subdir prefix —
+    // running it at repoPath (a subdirectory) makes git emit `.teamai/skills/...`
+    // paths that never match the bare `skills/...` regex (blank changelog).
+    const skillChanges = localConfig.repo.kind === 'self'
+      ? await getRecentSkillChanges(
+        localConfig.repo.businessRepoRoot ?? path.dirname(repoPath),
+        '.teamai',
+      )
+      : await getRecentSkillChanges(repoPath);
     const newSkills = skillChanges.filter((c) => c.type === 'new');
     const updatedSkills = skillChanges.filter((c) => c.type === 'updated');
 

--- a/src/hook-handlers.ts
+++ b/src/hook-handlers.ts
@@ -202,10 +202,12 @@ const votesSyncHandler: HookHandler = {
     try {
       const { parseTranscriptForVotes } = await import('./transcript-parser.js');
       const { incrementUpvoted, syncVotesToTeam } = await import('./votes.js');
-      const { requireInit } = await import('./config.js');
+      const { autoDetectInit } = await import('./config.js');
 
       const voteData = await parseTranscriptForVotes(transcriptPath);
-      const { localConfig } = await requireInit();
+      // autoDetectInit picks project scope when present (so self-mode configs are
+      // honored), falling back to user scope otherwise.
+      const { localConfig } = await autoDetectInit();
       const { VOTES_LOCAL_DIR, TEAMAI_SESSIONS_DIR } = await import('./types.js');
       const votesDir = VOTES_LOCAL_DIR;
       const votePath = path.join(votesDir, `${localConfig.username}.yaml`);
@@ -214,9 +216,24 @@ const votesSyncHandler: HookHandler = {
       if (voteData.referencedDocIds.length > 0) {
         await incrementUpvoted(votePath, voteData.referencedDocIds);
       }
-      await syncVotesToTeam(localConfig.repo.localPath, localConfig.username, votesDir).catch(() => {
-        // Push failed — will retry next session
-      });
+      if (localConfig.repo.kind === 'self') {
+        // Self mode: votes are report data → the teamai-reports orphan branch,
+        // written through an isolated worktree (never the active tree).
+        try {
+          const { ensureReportsWorktree, commitAndPushReports } = await import('./utils/reports-branch.js');
+          const wt = await ensureReportsWorktree(localConfig);
+          const synced = await syncVotesToTeam(wt, localConfig.username, votesDir);
+          if (synced) {
+            await commitAndPushReports(localConfig, `[teamai] Update votes for ${localConfig.username}`, [`votes/${localConfig.username}.yaml`]);
+          }
+        } catch {
+          // Push failed — will retry next session
+        }
+      } else {
+        await syncVotesToTeam(localConfig.repo.localPath, localConfig.username, votesDir).catch(() => {
+          // Push failed — will retry next session
+        });
+      }
 
       // Enforcement: recall happened but nothing was declared → nudge the model
       // once to declare which recalled docs it actually used. The nudge makes the

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,11 @@ program
   .option('--inherit-user-scope', 'In project scope, also sync safe user-scope resources and search its knowledge')
   .option('--no-inherit-user-scope', 'Disable user-scope inheritance for this project')
   .option('--role <id>', 'Primary role ID (e.g. hai_dev) for non-interactive setup')
-  .option('--agent <name>', 'Only inject hooks into this agent (e.g. claude, codebuddy, workbuddy). Additive on repeated runs.')
+  // Non-variadic + a collecting coercer: repeatable (`--agent a --agent b`) and
+  // comma-separated (`--agent a,b`, split later by normalizeAgentList) both work,
+  // WITHOUT the greedy `<name...>` variadic that would swallow the `[repo]`
+  // positional (e.g. `init --agent claude .` must keep `.` as the repo arg).
+  .option('--agent <name>', 'AI tools to set up (e.g. claude, codex, cursor, codebuddy, workbuddy). Repeatable or comma-separated. In single-repo mode, selects which tool dirs to create; omit for an interactive picker. Additive on repeated runs.', (val: string, acc: string[]) => acc.concat(val), [] as string[])
   .option('--force', 'Overwrite existing config without confirmation')
   .action(async (repoArg, cmdOpts) => {
     const globalOpts = program.opts() as GlobalOptions;

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,9 +22,10 @@ program
 program
   .command('init')
   .description('Initialize teamai (configure TGit, clone repo, register member)')
-  .argument('[repo]', 'Team repo (owner/repo or full URL)')
+  .argument('[repo]', 'Team repo (owner/repo or full URL). Pass "." for single-repo mode (the current git repo is the team repo).')
   .option('--repo <repo>', 'Team repo (alias of the positional argument)')
   .option('--http <url>', 'Git-free HTTP team repo (read-only consumer; only needs an API key)')
+  .option('--self', 'Single-repo mode: the current git repo is the team repo (equivalent to `teamai init .`). Knowledge lives on main under .teamai/; reports go to the teamai-reports orphan branch.')
   .option('--token <key>', 'API key for HTTP team repo / status reporting (stored 0600, never committed). Also reads TEAMAI_API_TOKEN.')
   .option('--scope <scope>', 'Install scope: project (default, <cwd>/.teamai + <cwd>/.claude) or user (~/.teamai + ~/.claude)')
   .option('--inherit-user-scope', 'In project scope, also sync safe user-scope resources and search its knowledge')

--- a/src/init.ts
+++ b/src/init.ts
@@ -409,14 +409,43 @@ export function buildSelfModeGitignore(): string {
 }
 
 /**
+ * Map an interactive selection to a concrete agent-id list. Pure (no I/O) so it
+ * can be unit-tested. The picker's option order is:
+ *   index 0            → "Auto" (mirror the tools detected under HOME)
+ *   index 1..N         → SELF_MODE_AGENT_CHOICES[index - 1] (a specific tool)
+ *
+ * Picking Auto expands to `detected`; picking Auto with nothing detected falls
+ * back to ['claude'] so the "clone = initialized" loop is never left with zero
+ * tools. Auto and specific tools can be combined; the result is deduped in the
+ * choice order (detected first, then any explicitly-picked tools).
+ */
+export function resolveSelfModeSelection(indices: number[], detected: string[]): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const add = (id: string) => { if (id && !seen.has(id)) { seen.add(id); out.push(id); } };
+
+  const pickedAuto = indices.includes(0);
+  if (pickedAuto) {
+    if (detected.length > 0) detected.forEach(add);
+    else add('claude'); // Auto but nothing installed → keep the guarantee.
+  }
+  for (const i of indices) {
+    if (i === 0) continue; // Auto handled above
+    const id = SELF_MODE_AGENT_CHOICES[i - 1];
+    if (id) add(id);
+  }
+  return out;
+}
+
+/**
  * Decide which AI tools single-repo init should set up (seed skills dir, inject
  * hooks, commit their settings). Priority:
  *   1. `--agent` given → use exactly that (explicit wins, no prompt).
- *   2. Non-interactive (no TTY) → mirror the tools already installed under the
- *      user's HOME; if none, return [] (create nothing — no `.claude/` conjured).
- *   3. Interactive → present a multi-select of the common coding agents; Enter
- *      accepts the default (claude); an empty/cancelled selection falls back to
- *      [claude] so the "clone = initialized" loop is never left with zero tools.
+ *   2. Non-interactive (no TTY / --silent / --force) → mirror the tools already
+ *      installed under the user's HOME; if none, return [] (create nothing).
+ *   3. Interactive → multi-select. Option 1 is "Auto" (the tools detected under
+ *      HOME, listed inline) and is the Enter default; options 2+ are the specific
+ *      tools. Empty/cancelled falls back to Auto/[claude].
  */
 export async function promptForSelfModeAgents(options: {
   agent?: string | string[];
@@ -433,35 +462,43 @@ export async function promptForSelfModeAgents(options: {
     return detectHomeInstalledAgents();
   }
 
-  const choices = SELF_MODE_AGENT_CHOICES.map((id) => {
+  const detected = await detectHomeInstalledAgents();
+  const tools = SELF_MODE_AGENT_CHOICES.map((id) => {
     const meta = KNOWN_AGENTS.find((a) => a.id === id);
     const root = meta?.skillsPath.split('/')[0] ?? `.${id}`;
     return { id, label: meta?.displayName ?? id, root };
   });
 
+  const detectedLabels = detected
+    .map((id) => tools.find((t) => t.id === id)?.label ?? id)
+    .join(', ');
+  const autoLabel = detected.length > 0
+    ? `Auto — the AI tools already installed here: ${detectedLabels}`
+    : 'Auto — none detected (will set up Claude Code)';
+
   console.log('');
   console.log('Which AI tools should teamai set up in this repo?');
   console.log('(creates the skills dir, injects hooks, commits settings to main)');
   console.log('');
-  choices.forEach((c, i) => {
-    console.log(`  ${i + 1}. ${c.label}  (${c.root})`);
+  console.log(`  1. ${autoLabel}`);
+  tools.forEach((t, i) => {
+    console.log(`  ${i + 2}. ${t.label}  (${t.root})`);
   });
   console.log('');
 
-  // defaultAll=false: a bare Enter returns null (not "everything"). We map that —
-  // and any cancel/empty — to [claude], the sensible default. Explicit "all" still
-  // works via the parser.
+  const optionCount = tools.length + 1; // +1 for the Auto row
+  // defaultAll=false: a bare Enter returns null (not "everything"). We map Enter /
+  // cancel / empty to Auto (option 1). Explicit "all" still works via the parser.
   const indices = await askSelection(
-    `Select [1-${choices.length}, comma/range, or "all"] (default: 1 = ${choices[0].label}): `,
-    choices.length,
+    `Select [1-${optionCount}, comma/range, or "all"] (default: 1 = Auto): `,
+    optionCount,
     false,
   );
   if (!indices || indices.length === 0) {
-    // Enter / cancelled / empty → default to claude so the clone-is-initialized
-    // guarantee is never left with zero tools.
-    return ['claude'];
+    // Enter / cancelled → Auto.
+    return resolveSelfModeSelection([0], detected);
   }
-  return indices.map((i) => choices[i].id);
+  return resolveSelfModeSelection(indices, detected);
 }
 
 /**

--- a/src/init.ts
+++ b/src/init.ts
@@ -10,7 +10,13 @@ import { ensureDir, writeFile, pathExists, expandHome, readFileSafe, remove } fr
 import { log, spinner } from './utils/logger.js';
 import { TEAMAI_HOME, REPORTS_BRANCH, type GlobalOptions, type LocalConfig, type Scope, getTeamaiHome, getConfigPath } from './types.js';
 import { describeRoles, loadRolesManifest } from './roles.js';
-import { askQuestion, askConfirmation, closePrompt } from './utils/prompt.js';
+import { askQuestion, askConfirmation, askSelection, closePrompt } from './utils/prompt.js';
+import {
+  normalizeAgentList,
+  detectHomeInstalledAgents,
+  SELF_MODE_AGENT_CHOICES,
+  KNOWN_AGENTS,
+} from './known-agents.js';
 
 /** Resolve + realpath so macOS /var → /private/var (and similar) compare equal. */
 function resolveRealPath(p: string): string {
@@ -220,7 +226,7 @@ async function isInsideGitRepo(dir: string): Promise<boolean> {
  */
 export async function initHttp(
   url: string,
-  options: GlobalOptions & { scope?: string; role?: string; agent?: string; force?: boolean; token?: string; inheritUserScope?: boolean },
+  options: GlobalOptions & { scope?: string; role?: string; agent?: string | string[]; force?: boolean; token?: string; inheritUserScope?: boolean },
 ): Promise<void> {
   const { resolveApiKey, saveApiKey, getApiKeyPath } = await import('./api-key.js');
 
@@ -321,11 +327,12 @@ export async function initHttp(
   }
 
   // Persist --agent into enabledAgents (additive across runs)
-  if (options.agent) {
+  const requestedAgents = normalizeAgentList(options.agent);
+  if (requestedAgents.length > 0) {
     const existing = await loadLocalConfigForScope(scope, projectRoot);
     const prev = existing?.enabledAgents ?? [];
-    localConfig.enabledAgents = [...new Set([...prev, options.agent])];
-    localConfig.disabledAgents = (existing?.disabledAgents ?? []).filter((t) => t !== options.agent);
+    localConfig.enabledAgents = [...new Set([...prev, ...requestedAgents])];
+    localConfig.disabledAgents = (existing?.disabledAgents ?? []).filter((t) => !requestedAgents.includes(t));
   }
 
   await ensureDir(teamaiHome);
@@ -348,7 +355,7 @@ export async function initHttp(
 
   // Step 5: inject hooks (built-in dispatch incl. the reporter) via the same
   // authoritative path the git init uses, so HTTP consumers behave identically.
-  const filterAgents = options.agent ? [options.agent] : undefined;
+  const filterAgents = requestedAgents.length > 0 ? requestedAgents : undefined;
   await reconcileTeamHooksForConfig(teamConfig, localConfig, { filterAgents });
 
   // Step 6: also initialize local-agent config so the new hook-dispatch --stdin
@@ -402,6 +409,62 @@ export function buildSelfModeGitignore(): string {
 }
 
 /**
+ * Decide which AI tools single-repo init should set up (seed skills dir, inject
+ * hooks, commit their settings). Priority:
+ *   1. `--agent` given → use exactly that (explicit wins, no prompt).
+ *   2. Non-interactive (no TTY) → mirror the tools already installed under the
+ *      user's HOME; if none, return [] (create nothing — no `.claude/` conjured).
+ *   3. Interactive → present a multi-select of the common coding agents; Enter
+ *      accepts the default (claude); an empty/cancelled selection falls back to
+ *      [claude] so the "clone = initialized" loop is never left with zero tools.
+ */
+export async function promptForSelfModeAgents(options: {
+  agent?: string | string[];
+  silent?: boolean;
+  force?: boolean;
+}): Promise<string[]> {
+  const explicit = normalizeAgentList(options.agent);
+  if (explicit.length > 0) return explicit;
+
+  // Non-interactive when there's no TTY, or when the caller opted out of prompts
+  // (--silent / --force, matching the convention in init()): mirror HOME-installed
+  // tools rather than blocking on the picker.
+  if (options.silent || options.force || !process.stdin.isTTY) {
+    return detectHomeInstalledAgents();
+  }
+
+  const choices = SELF_MODE_AGENT_CHOICES.map((id) => {
+    const meta = KNOWN_AGENTS.find((a) => a.id === id);
+    const root = meta?.skillsPath.split('/')[0] ?? `.${id}`;
+    return { id, label: meta?.displayName ?? id, root };
+  });
+
+  console.log('');
+  console.log('Which AI tools should teamai set up in this repo?');
+  console.log('(creates the skills dir, injects hooks, commits settings to main)');
+  console.log('');
+  choices.forEach((c, i) => {
+    console.log(`  ${i + 1}. ${c.label}  (${c.root})`);
+  });
+  console.log('');
+
+  // defaultAll=false: a bare Enter returns null (not "everything"). We map that —
+  // and any cancel/empty — to [claude], the sensible default. Explicit "all" still
+  // works via the parser.
+  const indices = await askSelection(
+    `Select [1-${choices.length}, comma/range, or "all"] (default: 1 = ${choices[0].label}): `,
+    choices.length,
+    false,
+  );
+  if (!indices || indices.length === 0) {
+    // Enter / cancelled / empty → default to claude so the clone-is-initialized
+    // guarantee is never left with zero tools.
+    return ['claude'];
+  }
+  return indices.map((i) => choices[i].id);
+}
+
+/**
  * Single-repo mode init (`teamai init .` / `--self`). The current git repo IS
  * the team repo. No clone: knowledge lives on main under <repo>/.teamai/, and
  * report data (members/sessions/votes/stats) goes to the `teamai-reports` orphan
@@ -411,7 +474,7 @@ export async function initSelfRepo(options: GlobalOptions & {
   repo?: string;
   repoPositional?: string;
   role?: string;
-  agent?: string;
+  agent?: string | string[];
   force?: boolean;
   inheritUserScope?: boolean;
 }): Promise<void> {
@@ -543,11 +606,16 @@ export async function initSelfRepo(options: GlobalOptions & {
       log.debug(`Role selection skipped: ${msg}`);
     }
   }
-  if (options.agent) {
+  // Which AI tools to set up in this repo (create skills dir + inject hooks +
+  // commit their settings.json). Resolved from --agent, else HOME detection
+  // (non-interactive), else an interactive picker. Written to enabledAgents,
+  // which drives seedSelfModeToolDirs and hook injection alike.
+  const selectedAgents = await promptForSelfModeAgents(options);
+  if (selectedAgents.length > 0) {
     const existing = await loadLocalConfigForScope('project', businessRepoRoot);
     const prev = existing?.enabledAgents ?? [];
-    localConfig.enabledAgents = [...new Set([...prev, options.agent])];
-    localConfig.disabledAgents = (existing?.disabledAgents ?? []).filter((t) => t !== options.agent);
+    localConfig.enabledAgents = [...new Set([...prev, ...selectedAgents])];
+    localConfig.disabledAgents = (existing?.disabledAgents ?? []).filter((t) => !selectedAgents.includes(t));
   }
 
   // Step 5: write local config + single-repo gitignore.
@@ -559,13 +627,32 @@ export async function initSelfRepo(options: GlobalOptions & {
   await writeFile(gitignorePath, buildSelfModeGitignore());
   log.debug('Generated single-repo .teamai/.gitignore');
 
-  // Step 5.5: commit the .teamai/ knowledge skeleton to the current branch.
-  // Single-repo mode keeps knowledge on main, and knowledge PRs branch off a base
-  // commit — a freshly `git init`'d repo has none, so `teamai push` would fail.
-  // Committing the skeleton here (a) seeds that base commit, (b) makes `mode: self`
-  // travel with `git clone` so teammates auto-bootstrap, (c) is exactly what the
-  // mode intends ("knowledge lives on main"). We commit but never push — the user
-  // pushes their business repo themselves.
+  // Step 5.3: seed the selected tools' skills dir so first-run hook + skill
+  // injection lands. Single-repo mode must inject into the project even on a
+  // brand-new clone where no <repo>/.claude exists yet (isToolInstalled would
+  // otherwise skip everything).
+  const filterAgents = selectedAgents.length > 0 ? selectedAgents : undefined;
+  try {
+    const { seedSelfModeToolDirs } = await import('./known-agents.js');
+    const seeded = await seedSelfModeToolDirs(localConfig, teamConfig);
+    if (seeded.length > 0) log.debug(`Seeded tool dirs for: ${seeded.join(', ')}`);
+  } catch (e) {
+    log.debug(`Tool-dir seeding skipped: ${(e as Error).message}`);
+  }
+
+  // Step 5.4: inject hooks BEFORE the skeleton commit, so each selected tool's
+  // settings file exists on disk and can be committed to main below. This is what
+  // makes a teammate's fresh clone carry the session-start hook that triggers the
+  // self-heal bootstrap — the core of "clone = initialized".
+  await reconcileTeamHooksForConfig(teamConfig, localConfig, { filterAgents });
+
+  // Step 5.5: commit the .teamai/ knowledge skeleton + selected tools' hook
+  // settings to the current branch. Single-repo mode keeps knowledge on main, and
+  // knowledge PRs branch off a base commit — a freshly `git init`'d repo has none,
+  // so `teamai push` would fail. Committing here (a) seeds that base commit,
+  // (b) makes `mode: self` + hooks travel with `git clone` so teammates
+  // auto-bootstrap, (c) is exactly what the mode intends. We commit but never
+  // push — the user pushes their business repo themselves.
   if (!options.dryRun) {
     try {
       const { commitPaths, hasCommits } = await import('./utils/git.js');
@@ -577,8 +664,15 @@ export async function initSelfRepo(options: GlobalOptions & {
       const skeletonPaths = [
         '.teamai/skills', '.teamai/rules', '.teamai/docs', '.teamai/learnings',
         '.teamai/teamai.yaml', '.teamai/.gitignore',
-        '.claude/settings.json',
       ];
+      // Each selected tool's settings file (path varies: claude/codebuddy use
+      // settings.json, codex/cursor use hooks.json), resolved from toolPaths so
+      // teammates get the hooks on clone. Tools without a settings path are seeded
+      // (skills dir) but have nothing to commit.
+      for (const id of selectedAgents) {
+        const settingsPath = teamConfig.toolPaths?.[id]?.settings;
+        if (settingsPath) skeletonPaths.push(settingsPath);
+      }
       const committed = await commitPaths(
         businessRepoRoot,
         '[teamai] Initialize single-repo mode (skills/rules/docs/learnings skeleton)',
@@ -631,21 +725,6 @@ export async function initSelfRepo(options: GlobalOptions & {
     // state may not exist yet
   }
 
-  // Step 6.7: seed the tool skills-dir so first-run hook + skill injection lands.
-  // Single-repo mode must inject into the project even on a brand-new clone where
-  // no <repo>/.claude exists yet (isToolInstalled would otherwise skip everything).
-  try {
-    const { seedSelfModeToolDirs } = await import('./known-agents.js');
-    const seeded = await seedSelfModeToolDirs(localConfig, teamConfig);
-    if (seeded.length > 0) log.debug(`Seeded tool dirs for: ${seeded.join(', ')}`);
-  } catch (e) {
-    log.debug(`Tool-dir seeding skipped: ${(e as Error).message}`);
-  }
-
-  // Step 7: inject hooks.
-  const filterAgents = options.agent ? [options.agent] : undefined;
-  await reconcileTeamHooksForConfig(teamConfig, localConfig, { filterAgents });
-
   log.success('teamai initialized (single-repo mode)!');
   log.info('Push your business repo (e.g. `git push -u origin HEAD`) so teammates get the .teamai/ knowledge and are auto-initialized on clone.');
   log.info('Add skills/rules later with `teamai push` — it opens a PR against your repo without touching your working tree.');
@@ -657,7 +736,7 @@ export async function init(options: GlobalOptions & {
   repoPositional?: string;
   scope?: string;
   role?: string;
-  agent?: string;
+  agent?: string | string[];
   force?: boolean;
   http?: string;
   token?: string;
@@ -983,11 +1062,12 @@ export async function init(options: GlobalOptions & {
   }
 
   // Persist --agent into enabledAgents (additive across runs)
-  if (options.agent) {
+  const requestedAgents = normalizeAgentList(options.agent);
+  if (requestedAgents.length > 0) {
     const existing = await loadLocalConfigForScope(scope, projectRoot);
     const prev = existing?.enabledAgents ?? [];
-    localConfig.enabledAgents = [...new Set([...prev, options.agent])];
-    localConfig.disabledAgents = (existing?.disabledAgents ?? []).filter((t) => t !== options.agent);
+    localConfig.enabledAgents = [...new Set([...prev, ...requestedAgents])];
+    localConfig.disabledAgents = (existing?.disabledAgents ?? []).filter((t) => !requestedAgents.includes(t));
   }
 
   await ensureDir(teamaiHome);
@@ -1038,7 +1118,7 @@ export async function init(options: GlobalOptions & {
   // Step 7: Inject built-in + team hooks into AI tools
   const reloadedTeamConfig = await loadTeamConfig(localPath);
   if (reloadedTeamConfig) {
-    const filterAgents = options.agent ? [options.agent] : undefined;
+    const filterAgents = requestedAgents.length > 0 ? requestedAgents : undefined;
     await reconcileTeamHooksForConfig(reloadedTeamConfig, localConfig, { filterAgents });
   }
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -3,12 +3,12 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { saveLocalConfig, loadTeamConfig, saveLocalConfigForScope, loadLocalConfigForScope, loadStateForScope, saveStateForScope } from './config.js';
 import { reconcileTeamHooksForConfig } from './hooks.js';
-import { configureGitUser, initRepo, isGitRepo } from './utils/git.js';
+import { configureGitUser, initRepo, isGitRepo, getRemoteUrl } from './utils/git.js';
 import { pushRepoDirectly } from './utils/git.js';
 import { getProvider, detectProvider, RepoNotFoundError } from './providers/index.js';
 import { ensureDir, writeFile, pathExists, expandHome, readFileSafe, remove } from './utils/fs.js';
 import { log, spinner } from './utils/logger.js';
-import { TEAMAI_HOME, type GlobalOptions, type LocalConfig, type Scope, getTeamaiHome, getConfigPath } from './types.js';
+import { TEAMAI_HOME, REPORTS_BRANCH, type GlobalOptions, type LocalConfig, type Scope, getTeamaiHome, getConfigPath } from './types.js';
 import { describeRoles, loadRolesManifest } from './roles.js';
 import { askQuestion, askConfirmation, closePrompt } from './utils/prompt.js';
 
@@ -365,6 +365,293 @@ export async function initHttp(
   closePrompt();
 }
 
+/**
+ * Build the .teamai/.gitignore for single-repo mode. Unlike the standalone
+ * project-scope gitignore, knowledge (skills/rules/docs/learnings) is COMMITTED
+ * to main here, so it must NOT be ignored. Only machine-local state, worktrees,
+ * and orphan-branch report data are ignored.
+ */
+export function buildSelfModeGitignore(): string {
+  return [
+    '# teamai single-repo mode — machine-local state (never commit)',
+    'config.yaml',
+    'state.json',
+    'token',
+    '.update-lock',
+    '.reports-lock',
+    '.bootstrap-lock',
+    'env',
+    'env.sh',
+    'usage.jsonl',
+    'known-skills.json',
+    'search-index.json',
+    'dashboard/',
+    '# git worktrees for reports (orphan branch) and knowledge PRs',
+    'reports-wt/',
+    'knowledge-wt/',
+    '# report data lives on the teamai-reports orphan branch, not on main',
+    'members/',
+    'sessions/',
+    'votes/',
+    'stats/',
+    'pending-review.jsonl',
+    '',
+    '# Knowledge (skills/, rules/, docs/, learnings/) is intentionally committed to main.',
+    '',
+  ].join('\n');
+}
+
+/**
+ * Single-repo mode init (`teamai init .` / `--self`). The current git repo IS
+ * the team repo. No clone: knowledge lives on main under <repo>/.teamai/, and
+ * report data (members/sessions/votes/stats) goes to the `teamai-reports` orphan
+ * branch via an isolated worktree so the user's active tree is never touched.
+ */
+export async function initSelfRepo(options: GlobalOptions & {
+  repo?: string;
+  repoPositional?: string;
+  role?: string;
+  agent?: string;
+  force?: boolean;
+  inheritUserScope?: boolean;
+}): Promise<void> {
+  log.info('Initializing teamai (single-repo mode)...');
+
+  const cwd = process.cwd();
+
+  // Step 0: single-repo mode is always project scope, rooted at the business repo.
+  if (!(await isInsideGitRepo(cwd))) {
+    log.error('Single-repo mode requires a git repository. Run `teamai init .` inside your project repo.');
+    process.exit(1);
+    return;
+  }
+  const businessRepoRoot = cwd;
+  const teamaiHome = path.join(businessRepoRoot, '.teamai');
+  const localPath = teamaiHome; // knowledge lives under <repo>/.teamai (localPath convention)
+
+  let inheritUserScope: boolean | undefined;
+  try {
+    const existing = await loadLocalConfigForScope('project', businessRepoRoot);
+    inheritUserScope = resolveInheritUserScope('project', options.inheritUserScope, existing?.inheritUserScope);
+  } catch (e) {
+    log.error((e as Error).message);
+    process.exit(1);
+    return;
+  }
+
+  log.info(`Scope: project (${businessRepoRoot})`);
+  log.info(`  knowledge → ${localPath}/{skills,rules,docs,learnings} (committed to main)`);
+  log.info(`  reports   → ${REPORTS_BRANCH} orphan branch (members/sessions/votes/stats)`);
+
+  // Re-init guard
+  const existingConfigPath = getConfigPath('project', businessRepoRoot);
+  if (await pathExists(existingConfigPath)) {
+    log.warn(`teamai is already initialized (project scope) at ${existingConfigPath}`);
+    if (options.force) {
+      log.info('Overwriting existing config (--force)');
+    } else {
+      const confirmed = await askConfirmation('Overwrite existing config? [y/N] ');
+      if (!confirmed) {
+        log.info('Aborted. Existing config is unchanged.');
+        return;
+      }
+    }
+  }
+
+  // Step 1: derive provider + remote from the business repo's origin.
+  const remoteUrl = await getRemoteUrl(businessRepoRoot);
+  if (!remoteUrl) {
+    log.error('Could not read the business repo `origin` remote. Add a remote first, then re-run `teamai init .`.');
+    process.exit(1);
+    return;
+  }
+  const providerName = detectProvider(remoteUrl);
+  const provider = getProvider(providerName);
+  log.debug(`Detected provider: ${providerName} (from ${remoteUrl})`);
+
+  let repoInfo;
+  try {
+    repoInfo = provider.parseRepoInput(remoteUrl);
+  } catch (e) {
+    log.error(`Could not parse the business repo remote "${remoteUrl}": ${(e as Error).message}`);
+    process.exit(1);
+    return;
+  }
+
+  // Step 2: authenticate (needed to push reports + open knowledge PRs).
+  await provider.ensureInstalled();
+  const authSpin = spinner('Checking authentication...').start();
+  let username: string;
+  try {
+    username = await provider.authenticate();
+    authSpin.succeed(`Authenticated as ${username}`);
+  } catch (e) {
+    authSpin.fail(`Authentication failed: ${(e as Error).message}`);
+    process.exit(1);
+    return;
+  }
+
+  // Step 3: build the .teamai/ knowledge skeleton on the active tree (committed to main).
+  await ensureDir(localPath);
+  for (const dir of ['skills', 'rules', 'docs', 'learnings', 'env']) {
+    await ensureDir(path.join(localPath, dir));
+    const gitkeep = path.join(localPath, dir, '.gitkeep');
+    if (!await pathExists(gitkeep)) {
+      await writeFile(gitkeep, '');
+    }
+  }
+
+  // teamai.yaml carries `mode: self` so teammates auto-bootstrap after clone.
+  const teamaiYamlPath = path.join(localPath, 'teamai.yaml');
+  if (!await pathExists(teamaiYamlPath)) {
+    const defaultConfig = YAML.stringify({
+      team: repoInfo.repo,
+      mode: 'self',
+      description: 'TeamAI single-repo (knowledge on main, reports on teamai-reports)',
+      repo: repoInfo.httpsUrl,
+      provider: providerName,
+      sharing: {
+        rules: { enforced: [] },
+        docs: { localDir: './.teamai/docs' },
+        env: { injectShellProfile: true },
+      },
+    });
+    await writeFile(teamaiYamlPath, defaultConfig);
+    log.success('Created .teamai/teamai.yaml (mode: self)');
+  }
+  const teamConfig = await loadTeamConfig(localPath);
+  if (!teamConfig) {
+    log.error('Failed to write a valid .teamai/teamai.yaml. Check filesystem permissions.');
+    process.exit(1);
+    return;
+  }
+
+  // Step 4: assemble local config (kind: self).
+  const localConfig: LocalConfig = {
+    repo: { localPath, remote: repoInfo.httpsUrl, kind: 'self', businessRepoRoot },
+    username,
+    scope: 'project',
+    projectRoot: businessRepoRoot,
+    additionalRoles: [],
+    ...(inheritUserScope !== undefined ? { inheritUserScope } : {}),
+  };
+  try {
+    Object.assign(localConfig, await promptForRoleProfile(localPath, options.role));
+  } catch (error) {
+    const msg = (error as Error).message;
+    if (!msg.includes('Roles manifest not found')) {
+      log.debug(`Role selection skipped: ${msg}`);
+    }
+  }
+  if (options.agent) {
+    const existing = await loadLocalConfigForScope('project', businessRepoRoot);
+    const prev = existing?.enabledAgents ?? [];
+    localConfig.enabledAgents = [...new Set([...prev, options.agent])];
+    localConfig.disabledAgents = (existing?.disabledAgents ?? []).filter((t) => t !== options.agent);
+  }
+
+  // Step 5: write local config + single-repo gitignore.
+  await ensureDir(teamaiHome);
+  await saveLocalConfigForScope(localConfig, 'project', businessRepoRoot);
+  log.success(`Local config saved to ${teamaiHome}/config.yaml`);
+
+  const gitignorePath = path.join(teamaiHome, '.gitignore');
+  await writeFile(gitignorePath, buildSelfModeGitignore());
+  log.debug('Generated single-repo .teamai/.gitignore');
+
+  // Step 5.5: commit the .teamai/ knowledge skeleton to the current branch.
+  // Single-repo mode keeps knowledge on main, and knowledge PRs branch off a base
+  // commit — a freshly `git init`'d repo has none, so `teamai push` would fail.
+  // Committing the skeleton here (a) seeds that base commit, (b) makes `mode: self`
+  // travel with `git clone` so teammates auto-bootstrap, (c) is exactly what the
+  // mode intends ("knowledge lives on main"). We commit but never push — the user
+  // pushes their business repo themselves.
+  if (!options.dryRun) {
+    try {
+      const { commitPaths, hasCommits } = await import('./utils/git.js');
+      const hadCommits = await hasCommits(businessRepoRoot);
+      // Only the committable, portable knowledge parts of .teamai/. Machine-local
+      // items (config.yaml, token, state.json, env, worktrees, report dirs) are
+      // gitignored via buildSelfModeGitignore and must NOT be listed here — adding
+      // an explicitly-gitignored path makes `git add` error out.
+      const skeletonPaths = [
+        '.teamai/skills', '.teamai/rules', '.teamai/docs', '.teamai/learnings',
+        '.teamai/teamai.yaml', '.teamai/.gitignore',
+        '.claude/settings.json',
+      ];
+      const committed = await commitPaths(
+        businessRepoRoot,
+        '[teamai] Initialize single-repo mode (skills/rules/docs/learnings skeleton)',
+        skeletonPaths,
+      );
+      if (committed) {
+        log.success(
+          hadCommits
+            ? 'Committed .teamai/ skeleton to the current branch'
+            : 'Created initial commit with the .teamai/ skeleton',
+        );
+      }
+    } catch (e) {
+      log.warn(`Could not commit the .teamai/ skeleton (do it manually before \`teamai push\`): ${(e as Error).message}`);
+    }
+  }
+
+  // Step 6: register member on the reports orphan branch (never touches main / active tree).
+  if (!options.dryRun) {
+    try {
+      const { ensureReportsWorktree, commitAndPushReports } = await import('./utils/reports-branch.js');
+      const wt = await ensureReportsWorktree(localConfig);
+      const memberDir = path.join(wt, 'members');
+      await ensureDir(memberDir);
+      const memberPath = path.join(memberDir, `${username}.yaml`);
+      if (!await pathExists(memberPath)) {
+        await writeFile(memberPath, YAML.stringify({
+          username,
+          displayName: username,
+          registeredAt: new Date().toISOString(),
+        }));
+        const pushed = await commitAndPushReports(localConfig, `[teamai] Register member: ${username}`, ['members/']);
+        if (pushed) {
+          log.success('Member registered on the teamai-reports branch');
+        } else {
+          log.warn('Member registration could not be pushed (no write access?). You are still set up locally.');
+        }
+      }
+    } catch (e) {
+      log.warn(`Member registration skipped (non-blocking): ${(e as Error).message}`);
+    }
+  }
+
+  // Step 6.5: invalidate pull cache so next pull does a full sync.
+  try {
+    const state = await loadStateForScope('project', businessRepoRoot);
+    state.lastPullRev = null;
+    await saveStateForScope(state, 'project', businessRepoRoot);
+  } catch {
+    // state may not exist yet
+  }
+
+  // Step 6.7: seed the tool skills-dir so first-run hook + skill injection lands.
+  // Single-repo mode must inject into the project even on a brand-new clone where
+  // no <repo>/.claude exists yet (isToolInstalled would otherwise skip everything).
+  try {
+    const { seedSelfModeToolDirs } = await import('./known-agents.js');
+    const seeded = await seedSelfModeToolDirs(localConfig, teamConfig);
+    if (seeded.length > 0) log.debug(`Seeded tool dirs for: ${seeded.join(', ')}`);
+  } catch (e) {
+    log.debug(`Tool-dir seeding skipped: ${(e as Error).message}`);
+  }
+
+  // Step 7: inject hooks.
+  const filterAgents = options.agent ? [options.agent] : undefined;
+  await reconcileTeamHooksForConfig(teamConfig, localConfig, { filterAgents });
+
+  log.success('teamai initialized (single-repo mode)!');
+  log.info('Push your business repo (e.g. `git push -u origin HEAD`) so teammates get the .teamai/ knowledge and are auto-initialized on clone.');
+  log.info('Add skills/rules later with `teamai push` — it opens a PR against your repo without touching your working tree.');
+  closePrompt();
+}
+
 export async function init(options: GlobalOptions & {
   repo?: string;
   repoPositional?: string;
@@ -375,9 +662,17 @@ export async function init(options: GlobalOptions & {
   http?: string;
   token?: string;
   inheritUserScope?: boolean;
+  self?: boolean;
 }): Promise<void> {
   if (options.http) {
     return initHttp(options.http, options);
+  }
+  // Single-repo mode: `teamai init .` or `teamai init --self`. The current git
+  // repo IS the team repo; knowledge lives on main under .teamai/, reports go to
+  // the teamai-reports orphan branch. No separate team repo is cloned.
+  const repoArg = (options.repoPositional ?? options.repo ?? '').trim();
+  if (options.self || repoArg === '.') {
+    return initSelfRepo(options);
   }
   log.info('Initializing teamai...');
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -415,6 +415,71 @@ export function buildSelfModeGitignore(): string {
 }
 
 /**
+ * Migrate an existing single-repo `.teamai/.gitignore` written by an older teamai
+ * (≤ beta.4), which ignored `env` — that hid `.teamai/env/env.yaml` from push and
+ * kept it off main. Pure (no I/O) so it can be unit-tested.
+ *
+ * Removes a standalone `env` ignore line (NOT `env.sh` / `env.local` / `env/`, and
+ * not commented lines), and ensures `env.local` is ignored (the machine-local
+ * backup pull now writes). Returns whether anything changed plus the new content.
+ */
+export function migrateSelfModeGitignoreContent(content: string): { changed: boolean; content: string } {
+  const lines = content.split('\n');
+  let changed = false;
+
+  // Drop a bare `env` ignore line (trimmed exact match). Keep env.sh/env.local/env/.
+  const filtered = lines.filter((line) => {
+    if (line.trim() === 'env') {
+      changed = true;
+      return false;
+    }
+    return true;
+  });
+
+  // Ensure env.local is present (older files predate it). Insert next to env.sh if
+  // found, else append before the trailing blank/knowledge comment.
+  const hasEnvLocal = filtered.some((l) => l.trim() === 'env.local');
+  if (!hasEnvLocal) {
+    const envShIdx = filtered.findIndex((l) => l.trim() === 'env.sh');
+    if (envShIdx >= 0) {
+      filtered.splice(envShIdx + 1, 0, 'env.local');
+    } else {
+      // Append at a sensible spot: before a trailing empty line if any.
+      const lastNonEmpty = filtered.reduce((acc, l, i) => (l.trim() ? i : acc), -1);
+      filtered.splice(lastNonEmpty + 1, 0, 'env.local');
+    }
+    changed = true;
+  }
+
+  return { changed, content: filtered.join('\n') };
+}
+
+/**
+ * Self-heal an older single-repo `.teamai/.gitignore` in place (see
+ * migrateSelfModeGitignoreContent). Best-effort: rewrites the ACTIVE tree's file
+ * and logs a one-line hint to commit it — teamai never commits it for the user
+ * here (the file is on main; the user owns that commit). No-op for non-self mode,
+ * a missing file, or an already-current file. Safe to call on every pull/push.
+ */
+export async function migrateSelfModeGitignore(localConfig: LocalConfig): Promise<void> {
+  if (localConfig.repo.kind !== 'self' || !localConfig.projectRoot) return;
+  const gitignorePath = path.join(localConfig.projectRoot, '.teamai', '.gitignore');
+  try {
+    const current = await readFileSafe(gitignorePath);
+    if (current === null) return; // no gitignore to migrate
+    const { changed, content } = migrateSelfModeGitignoreContent(current);
+    if (!changed) return;
+    await writeFile(gitignorePath, content);
+    log.info(
+      'Updated .teamai/.gitignore so team env vars (.teamai/env/env.yaml) can be shared — '
+      + 'please `git add .teamai/.gitignore` and commit it.',
+    );
+  } catch (e) {
+    log.debug(`[self-mode] gitignore migration skipped: ${(e as Error).message}`);
+  }
+}
+
+/**
  * Map an interactive selection to a concrete agent-id list. Pure (no I/O) so it
  * can be unit-tested. The picker's option order is:
  *   index 0            → "Auto" (mirror the tools detected under HOME)

--- a/src/init.ts
+++ b/src/init.ts
@@ -387,8 +387,14 @@ export function buildSelfModeGitignore(): string {
     '.update-lock',
     '.reports-lock',
     '.bootstrap-lock',
-    'env',
+    // NB: env/ is intentionally NOT ignored in single-repo mode — team env vars
+    // (.teamai/env/env.yaml) are committed to main so `teamai push` can carry them
+    // and teammates get them on clone. env.yaml holds plaintext key/value pairs, so
+    // only put non-secret config there; keep real secrets out of the repo.
     'env.sh',
+    // env.local is the machine-local KEY=value backup pull writes for ${VAR}
+    // resolution (self mode uses this name to avoid colliding with the env/ dir).
+    'env.local',
     'usage.jsonl',
     'known-skills.json',
     'search-index.json',
@@ -592,8 +598,11 @@ export async function initSelfRepo(options: GlobalOptions & {
   }
 
   // Step 3: build the .teamai/ knowledge skeleton on the active tree (committed to main).
+  // Includes hooks/ and mcp/ too: in single-repo mode those are contributed by
+  // editing .teamai/{hooks/hooks.yaml,mcp/mcp.yaml} directly and committing (they
+  // don't go through `teamai push`), so seeding the dirs makes that path obvious.
   await ensureDir(localPath);
-  for (const dir of ['skills', 'rules', 'docs', 'learnings', 'env']) {
+  for (const dir of ['skills', 'rules', 'docs', 'learnings', 'env', 'agents', 'hooks', 'mcp']) {
     await ensureDir(path.join(localPath, dir));
     const gitkeep = path.join(localPath, dir, '.gitkeep');
     if (!await pathExists(gitkeep)) {
@@ -699,7 +708,8 @@ export async function initSelfRepo(options: GlobalOptions & {
       // gitignored via buildSelfModeGitignore and must NOT be listed here — adding
       // an explicitly-gitignored path makes `git add` error out.
       const skeletonPaths = [
-        '.teamai/skills', '.teamai/rules', '.teamai/docs', '.teamai/learnings',
+        '.teamai/skills', '.teamai/rules', '.teamai/docs', '.teamai/learnings', '.teamai/env',
+        '.teamai/agents', '.teamai/hooks', '.teamai/mcp',
         '.teamai/teamai.yaml', '.teamai/.gitignore',
       ];
       // Each selected tool's settings file (path varies: claude/codebuddy use
@@ -763,8 +773,18 @@ export async function initSelfRepo(options: GlobalOptions & {
   }
 
   log.success('teamai initialized (single-repo mode)!');
-  log.info('Push your business repo (e.g. `git push -u origin HEAD`) so teammates get the .teamai/ knowledge and are auto-initialized on clone.');
-  log.info('Add skills/rules later with `teamai push` — it opens a PR against your repo without touching your working tree.');
+  log.info('Next steps:');
+  log.info('  1. Add team resources by dropping them into .teamai/ (or author them in your AI tool as usual):');
+  log.info('       .teamai/skills/    team skills');
+  log.info('       .teamai/rules/     shared rules');
+  log.info('       .teamai/agents/    subagent definitions (<name>.yaml)');
+  log.info('       .teamai/env/env.yaml   shared env vars — committed to main, so keep real secrets out');
+  log.info('  2. Run `teamai push` for the above — it scans .teamai/{skills,rules,agents,env} plus your AI tool dirs and opens a PR against your repo, without touching your working tree.');
+  log.info('  3. docs / hooks / mcp are edited directly and shipped with a normal commit — no push needed:');
+  log.info('       .teamai/docs/          team docs');
+  log.info('       .teamai/hooks/hooks.yaml   team hooks');
+  log.info('       .teamai/mcp/mcp.yaml       shared MCP servers');
+  log.info('  4. Push your business repo (e.g. `git push -u origin HEAD`) so teammates get the .teamai/ knowledge and are auto-initialized on clone.');
   closePrompt();
 }
 

--- a/src/known-agents.ts
+++ b/src/known-agents.ts
@@ -3,6 +3,40 @@ import { pathExists, ensureDir } from './utils/fs.js';
 import { resolveBaseDir, isAgentDisabled } from './types.js';
 import type { LocalConfig, TeamaiConfig } from './types.js';
 
+/**
+ * Single-repo mode: the AI tools offered when `teamai init .` asks which tool
+ * directories to create (interactive multi-select), and the candidate set probed
+ * against the user's HOME in non-interactive contexts. Order is the display order.
+ * Kept small on purpose — the common coding agents, not the full KNOWN_AGENTS list.
+ */
+export const SELF_MODE_AGENT_CHOICES = ['claude', 'codex', 'cursor', 'codebuddy', 'workbuddy'] as const;
+
+/**
+ * Normalize the `--agent` option into a deduplicated id list.
+ *
+ * Accepts commander's variadic array (`--agent claude --agent codex` → ['claude',
+ * 'codex']), a single string (legacy `--agent claude`), or a comma-separated
+ * string (`--agent claude,codex`). Any element may itself be comma-separated, so
+ * both invocation styles compose. Blank entries are dropped; order/first-seen is
+ * preserved. Returns [] for undefined/empty.
+ */
+export function normalizeAgentList(agent?: string | string[]): string[] {
+  if (agent === undefined) return [];
+  const raw = Array.isArray(agent) ? agent : [agent];
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const part of raw) {
+    for (const piece of String(part).split(',')) {
+      const id = piece.trim();
+      if (id && !seen.has(id)) {
+        seen.add(id);
+        out.push(id);
+      }
+    }
+  }
+  return out;
+}
+
 // ─── Known AI coding agents registry ────────────────────
 //
 //  Curated list of agents whose skills directory layout is
@@ -97,9 +131,12 @@ export interface ResolvedAgent extends KnownAgent {
  * fresh clone has no <repo>/.claude yet, so nothing would ever inject. Seeding
  * the dir here makes hooks + skills deploy on the first pull.
  *
- * Which agents: `--agent`/enabledAgents when set; otherwise just `claude` (the
- * primary) — we deliberately do NOT create dirs for every configured tool, to
- * avoid littering the repo with .cursor/.codebuddy/... the teammate doesn't use.
+ * Which agents: strictly `localConfig.enabledAgents`. The caller decides that set
+ * — interactively (multi-select in `teamai init .`), from `--agent`, or by probing
+ * the user's HOME in non-interactive contexts (see detectHomeInstalledAgents).
+ * We deliberately do NOT fall back to a hardcoded default here: an empty
+ * enabledAgents means "create nothing", so no `.claude/` is conjured for someone
+ * who never asked for it.
  *
  * Returns the list of agent ids whose dirs were ensured.
  */
@@ -110,9 +147,7 @@ export async function seedSelfModeToolDirs(
   const baseDir = resolveBaseDir(localConfig);
   const configured = teamConfig.toolPaths ?? {};
 
-  let targets = localConfig.enabledAgents && localConfig.enabledAgents.length > 0
-    ? localConfig.enabledAgents
-    : ['claude'];
+  let targets = localConfig.enabledAgents ?? [];
   // Never seed an explicitly disabled agent.
   targets = targets.filter((id) => !isAgentDisabled(localConfig, id));
 
@@ -125,6 +160,37 @@ export async function seedSelfModeToolDirs(
     seeded.push(id);
   }
   return seeded;
+}
+
+/**
+ * Detect which candidate AI tools are already installed under the user's HOME.
+ *
+ * Used by single-repo mode in non-interactive contexts (CI, session-start hook,
+ * clone-time bootstrap) to decide which tool dirs to seed when the user cannot be
+ * asked: we mirror whatever tools they already use globally (~/.claude, ~/.codex,
+ * ...). Returns [] when none are present — the caller then seeds nothing rather
+ * than conjuring a `.claude/` nobody uses.
+ *
+ * Note this probes HOME, not resolveBaseDir(localConfig) (which in project scope
+ * is the repo root). The whole point is "what does this developer use elsewhere".
+ */
+export async function detectHomeInstalledAgents(
+  candidateIds: readonly string[] = SELF_MODE_AGENT_CHOICES,
+): Promise<string[]> {
+  const home = process.env.HOME;
+  if (!home) return [];
+
+  const found: string[] = [];
+  for (const id of candidateIds) {
+    const skillsPath = KNOWN_AGENTS.find((a) => a.id === id)?.skillsPath;
+    if (!skillsPath) continue;
+    const rootSegment = skillsPath.split('/')[0]; // e.g. ".claude"
+    if (!rootSegment) continue;
+    if (await pathExists(path.join(home, rootSegment))) {
+      found.push(id);
+    }
+  }
+  return found;
 }
 
 export function getEffectiveAgents(teamConfig: TeamaiConfig): KnownAgent[] {

--- a/src/known-agents.ts
+++ b/src/known-agents.ts
@@ -1,5 +1,6 @@
-import { pathExists } from './utils/fs.js';
-import { resolveBaseDir } from './types.js';
+import path from 'node:path';
+import { pathExists, ensureDir } from './utils/fs.js';
+import { resolveBaseDir, isAgentDisabled } from './types.js';
 import type { LocalConfig, TeamaiConfig } from './types.js';
 
 // ─── Known AI coding agents registry ────────────────────
@@ -86,6 +87,46 @@ export interface ResolvedAgent extends KnownAgent {
  * config. Entries that share the same id prefer the team config's
  * skillsPath (admin can override the default location).
  */
+/**
+ * Single-repo mode: seed the tool skills-directory root for the agents this
+ * project should sync to, so that first-run injection actually lands.
+ *
+ * In git/user modes, `teamai pull` only injects into AI tools whose root dir
+ * already exists (isToolInstalled) — the user "opts in" by having e.g. ~/.claude.
+ * But single-repo mode's whole promise is "clone → auto-inject": a teammate's
+ * fresh clone has no <repo>/.claude yet, so nothing would ever inject. Seeding
+ * the dir here makes hooks + skills deploy on the first pull.
+ *
+ * Which agents: `--agent`/enabledAgents when set; otherwise just `claude` (the
+ * primary) — we deliberately do NOT create dirs for every configured tool, to
+ * avoid littering the repo with .cursor/.codebuddy/... the teammate doesn't use.
+ *
+ * Returns the list of agent ids whose dirs were ensured.
+ */
+export async function seedSelfModeToolDirs(
+  localConfig: LocalConfig,
+  teamConfig: TeamaiConfig,
+): Promise<string[]> {
+  const baseDir = resolveBaseDir(localConfig);
+  const configured = teamConfig.toolPaths ?? {};
+
+  let targets = localConfig.enabledAgents && localConfig.enabledAgents.length > 0
+    ? localConfig.enabledAgents
+    : ['claude'];
+  // Never seed an explicitly disabled agent.
+  targets = targets.filter((id) => !isAgentDisabled(localConfig, id));
+
+  const seeded: string[] = [];
+  for (const id of targets) {
+    const skillsPath = configured[id]?.skills
+      ?? KNOWN_AGENTS.find((a) => a.id === id)?.skillsPath;
+    if (!skillsPath) continue;
+    await ensureDir(path.join(baseDir, skillsPath));
+    seeded.push(id);
+  }
+  return seeded;
+}
+
 export function getEffectiveAgents(teamConfig: TeamaiConfig): KnownAgent[] {
   const byId = new Map<string, KnownAgent & { fromTeamConfig?: boolean }>();
 

--- a/src/mcp-reconcile.ts
+++ b/src/mcp-reconcile.ts
@@ -9,7 +9,7 @@ import type {
 } from './types.js';
 import {
   getMcpSharing,
-  getTeamaiHome,
+  getEnvBackupPath,
   managedMcpManifestPath,
   resolveBaseDir,
 } from './types.js';
@@ -86,7 +86,9 @@ async function readManifest(manifestPath: string): Promise<ManagedMcpManifest> {
  */
 export async function buildVarTable(localConfig: LocalConfig): Promise<Record<string, string>> {
   const table: Record<string, string> = {};
-  const envFile = path.join(getTeamaiHome(localConfig.scope, localConfig.projectRoot), 'env');
+  // Must use the same path the env channel wrote (getEnvBackupPath) — self mode
+  // uses env.local, not env (which is a committed directory there).
+  const envFile = getEnvBackupPath(localConfig);
   const content = await readFileSafe(envFile);
   if (content) {
     for (const line of content.split('\n')) {

--- a/src/members.ts
+++ b/src/members.ts
@@ -25,9 +25,18 @@ export async function getMemberConfig(repoPath: string, username: string): Promi
 export async function listMembers(options: GlobalOptions): Promise<void> {
   const projectConfig = await detectProjectConfig();
   const localConfig = projectConfig ?? (await requireInit()).localConfig;
-  const repoPath = localConfig.repo.localPath;
 
-  await pullRepo(repoPath);
+  // Members live on the teamai-reports orphan branch in self mode; read them from
+  // the reports worktree (refreshed from origin) instead of the team repo clone.
+  let repoPath: string;
+  if (localConfig.repo.kind === 'self') {
+    const { ensureReportsWorktree, refreshReportsWorktree } = await import('./utils/reports-branch.js');
+    await refreshReportsWorktree(localConfig);
+    repoPath = await ensureReportsWorktree(localConfig);
+  } else {
+    repoPath = localConfig.repo.localPath;
+    await pullRepo(repoPath);
+  }
 
   const membersDir = path.join(repoPath, 'members');
   const files = await listFiles(membersDir);

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -60,6 +60,21 @@ async function refreshTeamRepo(
     return { label: 'HTTP (report/sync delivery)', version: null, reportingOnly: true };
   }
 
+  if (localConfig.repo.kind === 'self') {
+    // Single-repo mode: knowledge lives under <business-repo>/.teamai on main and
+    // arrives with the business repo's own `git clone`/`git pull`. teamai must NOT
+    // run `git pull` on localPath here — that would operate on the business repo
+    // root and touch the user's active working tree. Just read the current HEAD as
+    // the cache version and let the deploy step inject from the on-disk .teamai/.
+    let version: string | null = null;
+    try {
+      version = await getHeadRev(localConfig.repo.localPath);
+    } catch {
+      version = null;
+    }
+    return { label: 'single-repo (knowledge on main)', version, reportingOnly: false };
+  }
+
   const result = await pullRepo(localConfig.repo.localPath);
   let version: string | null = null;
   try {
@@ -1181,12 +1196,17 @@ export async function pull(options: GlobalOptions): Promise<void> {
     try {
       const { reportUsageToTeam } = await import('./team-push.js');
       const { truncateUsageAfterReport, readUsageEvents } = await import('./usage-tracker.js');
-      const targets: Array<{ repoPath: string; username: string; opts: { skipTruncate: true; projectRoot?: string; excludeProjectRoots?: string[] } }> = [];
+      const targets: Array<{ repoPath: string; username: string; opts: { skipTruncate: true; projectRoot?: string; excludeProjectRoots?: string[]; selfConfig?: LocalConfig } }> = [];
       if (projectConfig) {
         targets.push({
           repoPath: projectConfig.repo.localPath,
           username: projectConfig.username,
-          opts: { skipTruncate: true, projectRoot: projectConfig.projectRoot },
+          opts: {
+            skipTruncate: true,
+            projectRoot: projectConfig.projectRoot,
+            // Self mode routes stats/votes to the teamai-reports orphan branch.
+            ...(projectConfig.repo.kind === 'self' ? { selfConfig: projectConfig } : {}),
+          },
         });
       }
       if (activeUserConfig && activeUserConfig.repo.kind !== 'http') {

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -66,6 +66,15 @@ async function refreshTeamRepo(
     // run `git pull` on localPath here — that would operate on the business repo
     // root and touch the user's active working tree. Just read the current HEAD as
     // the cache version and let the deploy step inject from the on-disk .teamai/.
+    //
+    // Self-heal an older .teamai/.gitignore that still ignores `env` (pre-beta.5),
+    // which would keep team env vars off main. Best-effort; prompts the user to
+    // commit the change.
+    try {
+      const { migrateSelfModeGitignore } = await import('./init.js');
+      await migrateSelfModeGitignore(localConfig);
+    } catch { /* best-effort */ }
+
     let version: string | null = null;
     try {
       version = await getHeadRev(localConfig.repo.localPath);

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -604,7 +604,19 @@ async function pullForScope(
       const docsRepoDir = path.join(localConfig.repo.localPath, 'docs');
       const rulesRepoDir = path.join(localConfig.repo.localPath, 'rules');
       const skillsRepoDir = path.join(localConfig.repo.localPath, 'skills');
-      const votesDir = path.join(localConfig.repo.localPath, 'votes');
+      // votes/ lives on the teamai-reports orphan branch in self mode (gitignored
+      // under localPath), so vote-weighted recall must read it from the reports
+      // worktree — otherwise ranking is silently disabled. Best-effort: fall back
+      // to localPath/votes (empty) if the worktree can't be resolved.
+      let votesDir = path.join(localConfig.repo.localPath, 'votes');
+      if (localConfig.repo.kind === 'self') {
+        try {
+          const { ensureReportsWorktree } = await import('./utils/reports-branch.js');
+          votesDir = path.join(await ensureReportsWorktree(localConfig), 'votes');
+        } catch (e) {
+          log.debug(`[self] reports worktree for votes unavailable: ${(e as Error).message}`);
+        }
+      }
 
       // user scope: sync learnings to ~/.teamai/learnings/ (legacy behavior)
       // project scope: use learnings directly from repo
@@ -804,7 +816,18 @@ async function pullForScope(
       const YAML = (await import('yaml')).default;
       const { listFiles, readFileSafe } = await import('./utils/fs.js');
       const { getRecommendations, displayRecommendations } = await import('./skill-recommend.js');
-      const statsDir = path.join(localConfig.repo.localPath, 'stats');
+      // stats/ lives on the teamai-reports orphan branch in self mode (gitignored
+      // under localPath), so recommendations must read it from the reports worktree
+      // — otherwise they never appear. Best-effort fallback to localPath/stats.
+      let statsDir = path.join(localConfig.repo.localPath, 'stats');
+      if (localConfig.repo.kind === 'self') {
+        try {
+          const { ensureReportsWorktree } = await import('./utils/reports-branch.js');
+          statsDir = path.join(await ensureReportsWorktree(localConfig), 'stats');
+        } catch (e) {
+          log.debug(`[self] reports worktree for stats unavailable: ${(e as Error).message}`);
+        }
+      }
       const files = await listFiles(statsDir);
       const teamStats = [];
       for (const file of files) {

--- a/src/push.ts
+++ b/src/push.ts
@@ -14,6 +14,14 @@ import { askQuestion, askSelection } from './utils/prompt.js';
 import { pathExists } from './utils/fs.js';
 
 /**
+ * Synthetic toolPaths key used only to make `teamai push` scan the active tree's
+ * .teamai/{skills,rules} in single-repo mode (see pushCore). It is never written
+ * to disk and never used by pull — the leading marker keeps it from colliding
+ * with any real agent id.
+ */
+const SELF_KNOWLEDGE_SCAN_KEY = '__teamai_self_knowledge__';
+
+/**
  * Filter a list of repo-root-relative paths (e.g. "rules/", "env/") down to
  * those that actually exist on disk. `git add` throws `pathspec did not match
  * any files` when any argument doesn't exist, so we guard against that when
@@ -170,6 +178,30 @@ async function pushCore(
 
   const spin = spinner('Scanning local resources...').start();
 
+  // In single-repo mode the team knowledge dirs (.teamai/skills, .teamai/rules)
+  // live inside the user's own repo, so people naturally add or edit skills there
+  // directly (e.g. `cp my-skill .teamai/skills/`) instead of in an AI tool dir
+  // like ~/.claude/skills. The default scanner only treats AI tool dirs as push
+  // "sources", so a skill hand-placed under .teamai/skills would be invisible to
+  // push ("No new or modified resources"). Add the ACTIVE tree's .teamai/{skills,
+  // rules} as extra scan sources; they are diffed against the worktree checkout of
+  // origin/<default> (localConfig.repo.localPath here), so already-committed
+  // knowledge is skipped and only genuine additions/edits surface.
+  //
+  // Scan-only: we deliberately do NOT persist this into teamConfig.toolPaths — pull
+  // and pre-push sync must never target .teamai/skills (that would copy knowledge
+  // back onto itself). getHandler(type).scanLocalForPush reads toolPaths for the
+  // source list only; pushItem writes via localConfig.repo.localPath, unaffected.
+  const scanTeamConfig: TeamaiConfig = selfMode
+    ? {
+      ...teamConfig,
+      toolPaths: {
+        ...teamConfig.toolPaths,
+        [SELF_KNOWLEDGE_SCAN_KEY]: { skills: '.teamai/skills', rules: '.teamai/rules' },
+      },
+    }
+    : teamConfig;
+
   // Scan for pushable resources first, then resolve namespace for new skills only.
   // Modified skills already carry their namespace from scanLocalForPush.
   const pushableTypes: ResourceType[] = ['skills', 'rules', 'env', 'agents'];
@@ -177,7 +209,7 @@ async function pushCore(
 
   for (const type of pushableTypes) {
     const handler = getHandler(type);
-    const items = await handler.scanLocalForPush(teamConfig, localConfig);
+    const items = await handler.scanLocalForPush(scanTeamConfig, localConfig);
     allItems.push(...items);
   }
 

--- a/src/push.ts
+++ b/src/push.ts
@@ -121,6 +121,14 @@ export async function push(options: GlobalOptions & { all?: boolean; role?: stri
   // branch/commit/reset never touch the user's active tree. withKnowledgeWorktree
   // hands pushCore a config whose localPath is the worktree's .teamai.
   if (localConfig.repo.kind === 'self') {
+    // Self-heal an older .teamai/.gitignore that still ignores `env` (pre-beta.5).
+    // Run against the ACTIVE tree (original localConfig, projectRoot intact) BEFORE
+    // swapping into the worktree, so the fixed .gitignore lets env changes surface.
+    try {
+      const { migrateSelfModeGitignore } = await import('./init.js');
+      await migrateSelfModeGitignore(localConfig);
+    } catch { /* best-effort */ }
+
     const { withKnowledgeWorktree, EmptyRepoError } = await import('./utils/reports-branch.js');
     try {
       await withKnowledgeWorktree(localConfig, (wtConfig) => pushCore(wtConfig, teamConfig, options));

--- a/src/push.ts
+++ b/src/push.ts
@@ -7,7 +7,7 @@ import { getProvider } from './providers/index.js';
 import { log, spinner } from './utils/logger.js';
 import { getHandler } from './resources/index.js';
 import { scanTeamRepoNamespaces } from './resources/skills.js';
-import type { GlobalOptions, ResourceItem, ResourceType } from './types.js';
+import type { GlobalOptions, ResourceItem, ResourceType, LocalConfig, TeamaiConfig } from './types.js';
 import { assertSafePath, assertSafeResourceName, defaultAllowedRoots } from './utils/path-safety.js';
 import { loadRolesManifest, resolveRoleResourceNamespaces } from './roles.js';
 import { askQuestion, askSelection } from './utils/prompt.js';
@@ -108,6 +108,33 @@ export async function push(options: GlobalOptions & { all?: boolean; role?: stri
   // Auto-detect scope: project scope if cwd has project config, else user scope
   const { localConfig, teamConfig } = await autoDetectInit();
   assertNotReadOnly(localConfig, 'teamai push');
+
+  // Single-repo mode: knowledge PRs must run in an isolated worktree so the
+  // branch/commit/reset never touch the user's active tree. withKnowledgeWorktree
+  // hands pushCore a config whose localPath is the worktree's .teamai.
+  if (localConfig.repo.kind === 'self') {
+    const { withKnowledgeWorktree, EmptyRepoError } = await import('./utils/reports-branch.js');
+    try {
+      await withKnowledgeWorktree(localConfig, (wtConfig) => pushCore(wtConfig, teamConfig, options));
+    } catch (e) {
+      if (e instanceof EmptyRepoError) {
+        log.error(e.message);
+      } else {
+        log.error(`Push failed: ${(e as Error).message}`);
+      }
+    }
+    return;
+  }
+
+  await pushCore(localConfig, teamConfig, options);
+}
+
+async function pushCore(
+  localConfig: LocalConfig,
+  teamConfig: TeamaiConfig,
+  options: GlobalOptions & { all?: boolean; role?: string },
+): Promise<void> {
+  const selfMode = localConfig.repo.kind === 'self';
   const scopeLabel = localConfig.scope;
 
   // Pull latest default branch BEFORE scanning so detection runs against up-to-date repo.
@@ -116,15 +143,20 @@ export async function push(options: GlobalOptions & { all?: boolean; role?: stri
   //   - Stuck on a stale push branch instead of master
   //   - Uncommitted changes (e.g. votes written by autoUpvote)
   // We recover from all of these before pulling.
-  const pullSpin = spinner('Pulling latest changes...').start();
-  try {
-    const repoPath = localConfig.repo.localPath;
-    const git = createGit(repoPath);
-    await resetToCleanMaster(git, repoPath);
-    await pullRepo(repoPath);
-    pullSpin.succeed('Up to date');
-  } catch (e) {
-    pullSpin.warn(`Pull failed: ${(e as Error).message}`);
+  // In self mode the worktree is already a fresh detached checkout of
+  // origin/<default>, so resetToCleanMaster/pullRepo (which assume a normal
+  // clone on a branch) are neither needed nor safe — skip them.
+  if (!selfMode) {
+    const pullSpin = spinner('Pulling latest changes...').start();
+    try {
+      const repoPath = localConfig.repo.localPath;
+      const git = createGit(repoPath);
+      await resetToCleanMaster(git, repoPath);
+      await pullRepo(repoPath);
+      pullSpin.succeed('Up to date');
+    } catch (e) {
+      pullSpin.warn(`Pull failed: ${(e as Error).message}`);
+    }
   }
 
   // Sync team repo updates to local tool directories before scanning.

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -288,7 +288,11 @@ async function loadOrBuildScopeIndex(
   // condition triggers rebuild when the file is missing entirely.
   const needsRebuild = !index || isLegacyIndex(index);
   if (needsRebuild && (effectiveLearningsDir || await pathExists(path.join(localConfig.repo.localPath, 'docs')) || await pathExists(path.join(localConfig.repo.localPath, 'rules')) || await pathExists(path.join(localConfig.repo.localPath, 'skills')))) {
-    const votesDir = path.join(localConfig.repo.localPath, 'votes');
+    // Votes live on the teamai-reports orphan branch in self mode; getReportsDir
+    // points at the worktree. If it isn't materialized yet, votesExist is false
+    // and vote-weighted ranking is simply skipped (graceful degradation).
+    const { getReportsDir } = await import('./types.js');
+    const votesDir = path.join(getReportsDir(localConfig), 'votes');
     const votesExist = await pathExists(votesDir);
     const docsDir = path.join(localConfig.repo.localPath, 'docs');
     const rulesDir = path.join(localConfig.repo.localPath, 'rules');

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -4,7 +4,7 @@ import { pullRepo, pushRepoBranch, checkoutMaster, generateBranchName } from './
 import { createPrWithFallback, filterExistingTopLevelPaths } from './push.js';
 import { log, spinner } from './utils/logger.js';
 import { getHandler } from './resources/index.js';
-import type { GlobalOptions, ResourceType } from './types.js';
+import type { GlobalOptions, ResourceType, LocalConfig, TeamaiConfig } from './types.js';
 import { askConfirmation } from './utils/prompt.js';
 
 const REMOVABLE_TYPES: ResourceType[] = ['skills', 'rules', 'agents', 'mcp'];
@@ -28,10 +28,41 @@ export async function remove(
   const { localConfig, teamConfig } = await autoDetectInit();
   assertNotReadOnly(localConfig, 'teamai remove');
 
-  // Pull latest before making changes
-  try {
-    await pullRepo(localConfig.repo.localPath);
-  } catch { /* continue even if pull fails */ }
+  // Single-repo mode: run the removal PR in an isolated knowledge worktree so the
+  // branch/commit never touches the user's active tree.
+  if (localConfig.repo.kind === 'self') {
+    const { withKnowledgeWorktree, EmptyRepoError } = await import('./utils/reports-branch.js');
+    try {
+      await withKnowledgeWorktree(localConfig, (wtConfig) => removeCore(type, names, options, wtConfig, teamConfig));
+    } catch (e) {
+      if (e instanceof EmptyRepoError) {
+        log.error(e.message);
+      } else {
+        log.error(`Remove failed: ${(e as Error).message}`);
+      }
+    }
+    return;
+  }
+
+  await removeCore(type, names, options, localConfig, teamConfig);
+}
+
+async function removeCore(
+  type: string,
+  names: string[],
+  options: GlobalOptions,
+  localConfig: LocalConfig,
+  teamConfig: TeamaiConfig,
+): Promise<void> {
+  const selfMode = localConfig.repo.kind === 'self';
+
+  // Pull latest before making changes. In self mode the worktree is already a
+  // fresh checkout of origin/<default>, so skip the pull.
+  if (!selfMode) {
+    try {
+      await pullRepo(localConfig.repo.localPath);
+    } catch { /* continue even if pull fails */ }
+  }
 
   const handler = getHandler(type as ResourceType);
 

--- a/src/resources/agents.ts
+++ b/src/resources/agents.ts
@@ -3,7 +3,7 @@ import { ResourceHandler } from './base.js';
 import type { ResourceItem, ResourceItemStatus, TeamaiConfig, LocalConfig } from '../types.js';
 import { listFiles, pathExists, copyFile, ensureDir, remove, fileContentEqual, getFileMtime, writeFile, readFileSafe } from '../utils/fs.js';
 import { log } from '../utils/logger.js';
-import { resolveBaseDir, isAgentDisabled } from '../types.js';
+import { resolveBaseDir, isAgentDisabled, isSelfMode } from '../types.js';
 import { BUILTIN_AGENT_NAMES } from '../builtin-agents.js';
 import {
   parseAgentYaml,
@@ -55,6 +55,44 @@ export class AgentsHandler extends ResourceHandler {
     const tombstones = await this.readTombstones(localConfig);
     const baseDir = resolveBaseDir(localConfig);
 
+    // Single-repo mode: users drop canonical agent files straight into the repo's
+    // own .teamai/agents/ (<name>.yaml, or legacy <name>.md) rather than authoring
+    // them in a tool's agents dir. Those are ALREADY in team-repo format, so we
+    // pick them up directly (no reverse/merge) — diffed against the worktree's
+    // origin/<default> checkout so only genuine additions/edits surface. These win
+    // over the reverse-parse path below on name conflicts (explicit canonical is
+    // authoritative). Active tree = projectRoot (kept intact by withKnowledgeWorktree).
+    const directItems: AgentResourceItem[] = [];
+    const directStems = new Set<string>();
+    if (isSelfMode(localConfig) && localConfig.projectRoot) {
+      const activeAgentsDir = path.join(localConfig.projectRoot, '.teamai', 'agents');
+      if (await pathExists(activeAgentsDir)) {
+        for (const file of await listFiles(activeAgentsDir)) {
+          const isYaml = file.endsWith('.yaml');
+          const isMd = file.endsWith('.md');
+          if (!isYaml && !isMd) continue;
+          const stem = file.replace(/\.(yaml|md)$/, '');
+          if (tombstones.has(stem)) continue;
+          if (BUILTIN_AGENT_NAMES.has(stem)) continue;
+
+          const activePath = path.join(activeAgentsDir, file);
+          const basePath = path.join(teamAgentsDir, file);
+          const baseExists = await pathExists(basePath);
+          if (baseExists && await fileContentEqual(activePath, basePath)) continue; // unchanged
+
+          directItems.push({
+            name: stem,
+            type: 'agents',
+            sourcePath: activePath,
+            relativePath: `agents/${file}`,
+            status: (baseExists ? 'modified' : 'new') as ResourceItemStatus,
+            legacy: isMd,
+          });
+          directStems.add(stem);
+        }
+      }
+    }
+
     // Collect all local agent files grouped by stem
     const grouped = new Map<string, Map<string, string>>(); // stem → (tool → filePath)
 
@@ -69,6 +107,7 @@ export class AgentsHandler extends ResourceHandler {
         if (stem === null) continue;
         if (tombstones.has(stem)) continue;
         if (BUILTIN_AGENT_NAMES.has(stem)) continue;
+        if (directStems.has(stem)) continue; // canonical direct-pickup wins (self mode)
 
         const filePath = path.join(agentsDir, file);
         let toolGroup = grouped.get(stem);
@@ -83,7 +122,9 @@ export class AgentsHandler extends ResourceHandler {
       }
     }
 
-    const items: AgentResourceItem[] = [];
+    // Seed with the canonical direct-pickup items (self mode); reverse-parsed
+    // items for other stems are appended below.
+    const items: AgentResourceItem[] = [...directItems];
 
     for (const [stem, toolFiles] of grouped) {
       const teamYamlPath = path.join(teamAgentsDir, `${stem}.yaml`);
@@ -242,13 +283,17 @@ export class AgentsHandler extends ResourceHandler {
       return;
     }
 
-    // Legacy: copy raw .md
-    const dest = path.join(localConfig.repo.localPath, 'agents', `${item.name}.md`);
+    // Direct-pickup (self mode) or legacy .md: copy the source verbatim, PRESERVING
+    // its extension. The old code hardcoded `.md`, which would corrupt a canonical
+    // `<name>.yaml` a user placed directly under .teamai/agents/. Derive the ext
+    // from the source so both .yaml and .md round-trip correctly.
+    const ext = item.sourcePath.endsWith('.yaml') ? '.yaml' : '.md';
+    const dest = path.join(localConfig.repo.localPath, 'agents', `${item.name}${ext}`);
     if (item.sourcePath !== dest) {
       await ensureDir(path.dirname(dest));
       await copyFile(item.sourcePath, dest);
     }
-    log.debug(`Copied agent ${item.name} → team repo (legacy MD format)`);
+    log.debug(`Copied agent ${item.name} → team repo (${ext} verbatim)`);
   }
 
   /**

--- a/src/resources/env.ts
+++ b/src/resources/env.ts
@@ -3,8 +3,8 @@ import { z } from 'zod';
 import YAML from 'yaml';
 import { ResourceHandler } from './base.js';
 import type { ResourceItem, TeamaiConfig, LocalConfig } from '../types.js';
-import { TEAMAI_ENV_START, TEAMAI_ENV_END, getTeamaiHome } from '../types.js';
-import { pathExists, readFileSafe, writeFile, ensureDir } from '../utils/fs.js';
+import { TEAMAI_ENV_START, TEAMAI_ENV_END, getTeamaiHome, getEnvBackupPath, isSelfMode } from '../types.js';
+import { pathExists, readFileSafe, writeFile, ensureDir, fileContentEqual } from '../utils/fs.js';
 import { log } from '../utils/logger.js';
 
 // ─── Schema for env.yaml ────────────────────────────────
@@ -51,6 +51,27 @@ export class EnvHandler extends ResourceHandler {
    * Compares local env/env.yaml against the committed version.
    */
   async scanLocalForPush(_teamConfig: TeamaiConfig, localConfig: LocalConfig): Promise<ResourceItem[]> {
+    // Single-repo mode: users edit team env directly at <repo>/.teamai/env/env.yaml
+    // (it lives in their own repo). push runs in the knowledge worktree, so
+    // localConfig.repo.localPath here is the origin/<default> checkout — diff the
+    // ACTIVE tree's copy against it and surface genuine additions/edits. (Active
+    // tree = projectRoot, which withKnowledgeWorktree deliberately leaves intact.)
+    if (isSelfMode(localConfig) && localConfig.projectRoot) {
+      const activeEnv = path.join(localConfig.projectRoot, '.teamai', 'env', 'env.yaml');
+      if (!await pathExists(activeEnv)) return [];
+      const baseEnv = path.join(localConfig.repo.localPath, 'env', 'env.yaml');
+      // Not in the baseline → new; present but different → modified; equal → skip.
+      if (await pathExists(baseEnv) && await fileContentEqual(activeEnv, baseEnv)) {
+        return [];
+      }
+      return [{
+        name: 'env.yaml',
+        type: 'env',
+        sourcePath: activeEnv,
+        relativePath: 'env/env.yaml',
+      }];
+    }
+
     const envYamlPath = path.join(localConfig.repo.localPath, 'env', 'env.yaml');
     if (!await pathExists(envYamlPath)) return [];
 
@@ -93,8 +114,23 @@ export class EnvHandler extends ResourceHandler {
     }];
   }
 
-  async pushItem(_item: ResourceItem, _teamConfig: TeamaiConfig, _localConfig: LocalConfig): Promise<void> {
-    // No-op — env.yaml is already in the repo dir; push.ts handles git commit
+  async pushItem(item: ResourceItem, _teamConfig: TeamaiConfig, localConfig: LocalConfig): Promise<void> {
+    // Non-self modes: env.yaml already lives in the repo dir; push.ts commits it
+    // via the env/ sweeper — nothing to copy.
+    //
+    // Single-repo mode: the source is the ACTIVE tree's .teamai/env/env.yaml, but
+    // the commit happens in the knowledge worktree (localConfig.repo.localPath).
+    // Copy the active copy into the worktree so the PR actually carries the change;
+    // otherwise the env/ sweeper would commit the stale baseline. (Guarded on the
+    // paths differing so non-self stays a no-op.)
+    if (isSelfMode(localConfig)) {
+      const dest = path.join(localConfig.repo.localPath, 'env', 'env.yaml');
+      if (item.sourcePath !== dest) {
+        await ensureDir(path.dirname(dest));
+        const content = await readFileSafe(item.sourcePath);
+        if (content !== null) await writeFile(dest, content);
+      }
+    }
   }
 
   /**
@@ -115,11 +151,14 @@ export class EnvHandler extends ResourceHandler {
 
     if (envConfig.variables.length === 0) return;
 
-    // Write <teamaiHome>/env (KEY=VALUE backup for loadEnvFile compatibility)
+    // Write the machine-local KEY=VALUE backup (for loadEnvFile / buildVarTable).
+    // getEnvBackupPath returns <teamaiHome>/env normally, but <teamaiHome>/env.local
+    // in self mode — where <teamaiHome>/env is a committed DIRECTORY (env/env.yaml)
+    // and writing a file there would throw EISDIR.
     const teamaiHome = getTeamaiHome(localConfig.scope, localConfig.projectRoot);
     const backupLines = envConfig.variables.map(v => `${v.key}=${v.value}`);
     await ensureDir(teamaiHome);
-    await writeFile(path.join(teamaiHome, 'env'), backupLines.join('\n') + '\n');
+    await writeFile(getEnvBackupPath(localConfig), backupLines.join('\n') + '\n');
 
     // Write <teamaiHome>/env.sh (sourceable export file)
     const envShContent = this.generateEnvFile(envConfig.variables);

--- a/src/roles-cmd.ts
+++ b/src/roles-cmd.ts
@@ -32,6 +32,33 @@ async function pullLatest(repoPath: string): Promise<void> {
     }
 }
 
+/**
+ * Run a roles-manifest admin edit (write manifest + open PR) against the right
+ * repo. In single-repo mode the manifest is knowledge on main, so the edit runs
+ * inside an isolated knowledge worktree (never the user's active tree). `fn`
+ * receives the repoPath to read/write the manifest and the localConfig to use for
+ * the PR — both already scoped to the worktree in self mode.
+ */
+async function runRolesEdit(
+    localConfig: LocalConfig,
+    fn: (repoPath: string, editConfig: LocalConfig) => Promise<void>,
+): Promise<void> {
+    if (localConfig.repo.kind === 'self') {
+        const { withKnowledgeWorktree, EmptyRepoError } = await import('./utils/reports-branch.js');
+        try {
+            await withKnowledgeWorktree(localConfig, (wtConfig) => fn(wtConfig.repo.localPath, wtConfig));
+        } catch (e) {
+            if (e instanceof EmptyRepoError) {
+                log.error(e.message);
+            } else {
+                log.error(`Roles update failed: ${(e as Error).message}`);
+            }
+        }
+        return;
+    }
+    await fn(localConfig.repo.localPath, localConfig);
+}
+
 async function pushManifestChange(input: {
     repoPath: string;
     teamConfig: TeamaiConfig;
@@ -76,8 +103,13 @@ async function pushManifestChange(input: {
 export async function rolesInit(options: GlobalOptions): Promise<void> {
     const { localConfig, teamConfig } = await autoDetectInit();
     const repoPath = localConfig.repo.localPath;
+    const selfMode = localConfig.repo.kind === 'self';
 
-    await pullLatest(repoPath);
+    // In self mode the manifest is knowledge on main; the on-disk .teamai already
+    // reflects main, so we read the existence check from there and only run the
+    // actual write+PR inside an isolated worktree (below). Non-self modes pull the
+    // team repo clone first.
+    if (!selfMode) await pullLatest(repoPath);
 
     // Check if manifest already exists
     const manifestPath = path.join(repoPath, 'manifest', 'roles.yaml');
@@ -159,9 +191,6 @@ export async function rolesInit(options: GlobalOptions): Promise<void> {
         return;
     }
 
-    await saveRolesManifest(repoPath, manifest);
-    log.success(`Manifest written to ${manifestPath}`);
-
     // Show reminder about directory structure
     const allNamespaces = [...new Set(roles.flatMap((r) => r.resources.skills))];
     log.info('');
@@ -173,12 +202,16 @@ export async function rolesInit(options: GlobalOptions): Promise<void> {
     log.info('Example: mv skills/hai-deploy-test skills/hai/hai-deploy-test');
 
     const commitMsg = `[teamai] Initialize roles manifest with ${roles.length} role(s)`;
-    await pushManifestChange({
-        repoPath,
-        teamConfig,
-        localConfig,
-        commitMsg,
-        prDescription: `Initialize roles manifest:\n${roles.map((r) => `- ${r.id} (namespaces: ${r.resources.skills.join(', ')})`).join('\n')}`,
+    await runRolesEdit(localConfig, async (editRepoPath, editConfig) => {
+        await saveRolesManifest(editRepoPath, manifest);
+        log.success(`Manifest written to ${path.join(editRepoPath, 'manifest', 'roles.yaml')}`);
+        await pushManifestChange({
+            repoPath: editRepoPath,
+            teamConfig,
+            localConfig: editConfig,
+            commitMsg,
+            prDescription: `Initialize roles manifest:\n${roles.map((r) => `- ${r.id} (namespaces: ${r.resources.skills.join(', ')})`).join('\n')}`,
+        });
     });
 }
 
@@ -298,54 +331,55 @@ export async function rolesAdd(
     }
 
     const { localConfig, teamConfig } = await autoDetectInit();
-    const repoPath = localConfig.repo.localPath;
 
-    await pullLatest(repoPath);
+    await runRolesEdit(localConfig, async (repoPath, editConfig) => {
+        if (editConfig.repo.kind !== 'self') await pullLatest(repoPath);
 
-    let manifest: RolesManifest;
-    try {
-        manifest = await loadRolesManifest(repoPath);
-    } catch (e) {
-        log.error((e as Error).message);
-        log.info('Run `teamai roles init` to create a roles manifest first.');
-        return;
-    }
+        let manifest: RolesManifest;
+        try {
+            manifest = await loadRolesManifest(repoPath);
+        } catch (e) {
+            log.error((e as Error).message);
+            log.info('Run `teamai roles init` to create a roles manifest first.');
+            return;
+        }
 
-    // Check duplicate
-    if (findRole(manifest, roleId)) {
-        log.error(`Role "${roleId}" already exists. Use \`teamai roles update ${roleId}\` to modify it.`);
-        return;
-    }
+        // Check duplicate
+        if (findRole(manifest, roleId)) {
+            log.error(`Role "${roleId}" already exists. Use \`teamai roles update ${roleId}\` to modify it.`);
+            return;
+        }
 
-    const newRole: TeamRole = {
-        id: roleId,
-        description: options.description ?? '',
-        resources: {
-            knowledge: namespaces,
-            skills: namespaces,
-        },
-    };
+        const newRole: TeamRole = {
+            id: roleId,
+            description: options.description ?? '',
+            resources: {
+                knowledge: namespaces,
+                skills: namespaces,
+            },
+        };
 
-    const updatedManifest: RolesManifest = {
-        ...manifest,
-        roles: [...manifest.roles, newRole],
-    };
+        const updatedManifest: RolesManifest = {
+            ...manifest,
+            roles: [...manifest.roles, newRole],
+        };
 
-    if (options.dryRun) {
-        log.info(`[dry-run] Would add role "${roleId}" with namespaces: ${namespaces.join(', ')}`);
-        return;
-    }
+        if (options.dryRun) {
+            log.info(`[dry-run] Would add role "${roleId}" with namespaces: ${namespaces.join(', ')}`);
+            return;
+        }
 
-    await saveRolesManifest(repoPath, updatedManifest);
-    log.success(`Added role: ${roleId} (namespaces: ${namespaces.join(', ')})`);
+        await saveRolesManifest(repoPath, updatedManifest);
+        log.success(`Added role: ${roleId} (namespaces: ${namespaces.join(', ')})`);
 
-    const commitMsg = `[teamai] Add role "${roleId}"`;
-    await pushManifestChange({
-        repoPath,
-        teamConfig,
-        localConfig,
-        commitMsg,
-        prDescription: `Add role "${roleId}" with namespaces: ${namespaces.join(', ')}${options.description ? `\nDescription: ${options.description}` : ''}`,
+        const commitMsg = `[teamai] Add role "${roleId}"`;
+        await pushManifestChange({
+            repoPath,
+            teamConfig,
+            localConfig: editConfig,
+            commitMsg,
+            prDescription: `Add role "${roleId}" with namespaces: ${namespaces.join(', ')}${options.description ? `\nDescription: ${options.description}` : ''}`,
+        });
     });
 }
 
@@ -356,51 +390,52 @@ export async function rolesRemove(
     options: GlobalOptions,
 ): Promise<void> {
     const { localConfig, teamConfig } = await autoDetectInit();
-    const repoPath = localConfig.repo.localPath;
 
-    await pullLatest(repoPath);
+    await runRolesEdit(localConfig, async (repoPath, editConfig) => {
+        if (editConfig.repo.kind !== 'self') await pullLatest(repoPath);
 
-    let manifest: RolesManifest;
-    try {
-        manifest = await loadRolesManifest(repoPath);
-    } catch (e) {
-        log.error((e as Error).message);
-        log.info('Run `teamai roles init` to create a roles manifest first.');
-        return;
-    }
+        let manifest: RolesManifest;
+        try {
+            manifest = await loadRolesManifest(repoPath);
+        } catch (e) {
+            log.error((e as Error).message);
+            log.info('Run `teamai roles init` to create a roles manifest first.');
+            return;
+        }
 
-    if (!findRole(manifest, roleId)) {
-        log.error(`Role "${roleId}" not found. Valid roles: ${listRoleIds(manifest).join(', ')}`);
-        return;
-    }
+        if (!findRole(manifest, roleId)) {
+            log.error(`Role "${roleId}" not found. Valid roles: ${listRoleIds(manifest).join(', ')}`);
+            return;
+        }
 
-    const remaining = manifest.roles.filter((r) => r.id !== roleId);
-    if (remaining.length === 0) {
-        log.error('Cannot remove the last role. The manifest requires at least one role.');
-        return;
-    }
+        const remaining = manifest.roles.filter((r) => r.id !== roleId);
+        if (remaining.length === 0) {
+            log.error('Cannot remove the last role. The manifest requires at least one role.');
+            return;
+        }
 
-    const updatedManifest: RolesManifest = {
-        ...manifest,
-        roles: remaining,
-    };
+        const updatedManifest: RolesManifest = {
+            ...manifest,
+            roles: remaining,
+        };
 
-    if (options.dryRun) {
-        log.info(`[dry-run] Would remove role "${roleId}". Remaining: ${remaining.map((r) => r.id).join(', ')}`);
-        return;
-    }
+        if (options.dryRun) {
+            log.info(`[dry-run] Would remove role "${roleId}". Remaining: ${remaining.map((r) => r.id).join(', ')}`);
+            return;
+        }
 
-    await saveRolesManifest(repoPath, updatedManifest);
-    log.success(`Removed role: ${roleId}`);
-    log.warn(`Members with primaryRole="${roleId}" will fall back to unfiltered sync on next pull.`);
+        await saveRolesManifest(repoPath, updatedManifest);
+        log.success(`Removed role: ${roleId}`);
+        log.warn(`Members with primaryRole="${roleId}" will fall back to unfiltered sync on next pull.`);
 
-    const commitMsg = `[teamai] Remove role "${roleId}"`;
-    await pushManifestChange({
-        repoPath,
-        teamConfig,
-        localConfig,
-        commitMsg,
-        prDescription: `Remove role "${roleId}". Remaining roles: ${remaining.map((r) => r.id).join(', ')}`,
+        const commitMsg = `[teamai] Remove role "${roleId}"`;
+        await pushManifestChange({
+            repoPath,
+            teamConfig,
+            localConfig: editConfig,
+            commitMsg,
+            prDescription: `Remove role "${roleId}". Remaining roles: ${remaining.map((r) => r.id).join(', ')}`,
+        });
     });
 }
 
@@ -424,84 +459,85 @@ export async function rolesUpdate(
     }
 
     const { localConfig, teamConfig } = await autoDetectInit();
-    const repoPath = localConfig.repo.localPath;
 
-    await pullLatest(repoPath);
+    await runRolesEdit(localConfig, async (repoPath, editConfig) => {
+        if (editConfig.repo.kind !== 'self') await pullLatest(repoPath);
 
-    let manifest: RolesManifest;
-    try {
-        manifest = await loadRolesManifest(repoPath);
-    } catch (e) {
-        log.error((e as Error).message);
-        log.info('Run `teamai roles init` to create a roles manifest first.');
-        return;
-    }
+        let manifest: RolesManifest;
+        try {
+            manifest = await loadRolesManifest(repoPath);
+        } catch (e) {
+            log.error((e as Error).message);
+            log.info('Run `teamai roles init` to create a roles manifest first.');
+            return;
+        }
 
-    const existingRole = findRole(manifest, roleId);
-    if (!existingRole) {
-        log.error(`Role "${roleId}" not found. Valid roles: ${listRoleIds(manifest).join(', ')}`);
-        return;
-    }
+        const existingRole = findRole(manifest, roleId);
+        if (!existingRole) {
+            log.error(`Role "${roleId}" not found. Valid roles: ${listRoleIds(manifest).join(', ')}`);
+            return;
+        }
 
-    // Build updated namespaces (immutable)
-    let updatedNamespaces = [...existingRole.resources.skills];
+        // Build updated namespaces (immutable)
+        let updatedNamespaces = [...existingRole.resources.skills];
 
-    if (hasAddNs) {
-        const toAdd = parseNamespaces(options.addNamespaces!);
-        const existing = new Set(updatedNamespaces);
-        for (const ns of toAdd) {
-            if (!existing.has(ns)) {
-                updatedNamespaces.push(ns);
-                existing.add(ns);
+        if (hasAddNs) {
+            const toAdd = parseNamespaces(options.addNamespaces!);
+            const existing = new Set(updatedNamespaces);
+            for (const ns of toAdd) {
+                if (!existing.has(ns)) {
+                    updatedNamespaces.push(ns);
+                    existing.add(ns);
+                }
             }
         }
-    }
 
-    if (hasRemoveNs) {
-        const toRemove = new Set(parseNamespaces(options.removeNamespaces!));
-        updatedNamespaces = updatedNamespaces.filter((ns) => !toRemove.has(ns));
-    }
+        if (hasRemoveNs) {
+            const toRemove = new Set(parseNamespaces(options.removeNamespaces!));
+            updatedNamespaces = updatedNamespaces.filter((ns) => !toRemove.has(ns));
+        }
 
-    if (updatedNamespaces.length === 0) {
-        log.error('Cannot remove all namespaces. A role must have at least one namespace.');
-        return;
-    }
+        if (updatedNamespaces.length === 0) {
+            log.error('Cannot remove all namespaces. A role must have at least one namespace.');
+            return;
+        }
 
-    const updatedRole: TeamRole = {
-        ...existingRole,
-        description: hasDesc ? options.description! : existingRole.description,
-        resources: {
-            knowledge: updatedNamespaces,
-            skills: updatedNamespaces,
-        },
-    };
+        const updatedRole: TeamRole = {
+            ...existingRole,
+            description: hasDesc ? options.description! : existingRole.description,
+            resources: {
+                knowledge: updatedNamespaces,
+                skills: updatedNamespaces,
+            },
+        };
 
-    const updatedManifest: RolesManifest = {
-        ...manifest,
-        roles: manifest.roles.map((r) => (r.id === roleId ? updatedRole : r)),
-    };
+        const updatedManifest: RolesManifest = {
+            ...manifest,
+            roles: manifest.roles.map((r) => (r.id === roleId ? updatedRole : r)),
+        };
 
-    if (options.dryRun) {
-        log.info(`[dry-run] Would update role "${roleId}":`);
-        log.info(`  namespaces: ${updatedNamespaces.join(', ')}`);
-        if (hasDesc) log.info(`  description: ${options.description}`);
-        return;
-    }
+        if (options.dryRun) {
+            log.info(`[dry-run] Would update role "${roleId}":`);
+            log.info(`  namespaces: ${updatedNamespaces.join(', ')}`);
+            if (hasDesc) log.info(`  description: ${options.description}`);
+            return;
+        }
 
-    await saveRolesManifest(repoPath, updatedManifest);
-    log.success(`Updated role: ${roleId} (namespaces: ${updatedNamespaces.join(', ')})`);
+        await saveRolesManifest(repoPath, updatedManifest);
+        log.success(`Updated role: ${roleId} (namespaces: ${updatedNamespaces.join(', ')})`);
 
-    const changes: string[] = [];
-    if (hasAddNs) changes.push(`added namespaces: ${options.addNamespaces}`);
-    if (hasRemoveNs) changes.push(`removed namespaces: ${options.removeNamespaces}`);
-    if (hasDesc) changes.push(`description: ${options.description}`);
+        const changes: string[] = [];
+        if (hasAddNs) changes.push(`added namespaces: ${options.addNamespaces}`);
+        if (hasRemoveNs) changes.push(`removed namespaces: ${options.removeNamespaces}`);
+        if (hasDesc) changes.push(`description: ${options.description}`);
 
-    const commitMsg = `[teamai] Update role "${roleId}"`;
-    await pushManifestChange({
-        repoPath,
-        teamConfig,
-        localConfig,
-        commitMsg,
-        prDescription: `Update role "${roleId}": ${changes.join(', ')}`,
+        const commitMsg = `[teamai] Update role "${roleId}"`;
+        await pushManifestChange({
+            repoPath,
+            teamConfig,
+            localConfig: editConfig,
+            commitMsg,
+            prDescription: `Update role "${roleId}": ${changes.join(', ')}`,
+        });
     });
 }

--- a/src/save-session.ts
+++ b/src/save-session.ts
@@ -124,14 +124,45 @@ export async function saveSession(options: SaveSessionOptions): Promise<void> {
     return;
   }
 
-  const repoPath = localConfig.repo.localPath;
   const username = localConfig.username;
-  const teamDir = path.join(repoPath, 'sessions', username);
+  const commitMsg = `[teamai] Session summary from ${username} (${monthKey(summary)})`;
 
   if (options.dryRun) {
     log.info(`[dry-run] Would push session summary to sessions/${username}/${monthKey(summary)}.md`);
     return;
   }
+
+  // Single-repo mode: session summaries are report data → the teamai-reports
+  // orphan branch, written through an isolated worktree so main / the user's
+  // active tree is never touched.
+  if (localConfig.repo.kind === 'self') {
+    const spin = spinner('Pushing session summary to team...').start();
+    try {
+      const { ensureReportsWorktree, commitAndPushReports } = await import('./utils/reports-branch.js');
+      const wt = await ensureReportsWorktree(localConfig);
+      const teamDir = path.join(wt, 'sessions', username);
+      const written = await appendMonthlyLog(teamDir, summary, { includePrompt: options.includePrompt });
+      if (!written) {
+        spin.info('Session already present in the team log — nothing to push.');
+        return;
+      }
+      const rel = path.relative(wt, written);
+      const pushed = await withTimeout(
+        commitAndPushReports(localConfig, commitMsg, [rel]),
+        10_000,
+        'Push timeout (10s)',
+      );
+      if (pushed) spin.succeed(`Pushed: ${rel}`);
+      else spin.info('Nothing new to push.');
+    } catch (e) {
+      spin.fail(`Team push failed: ${(e as Error).message}`);
+      log.info('The local log was still saved. Retry later with: teamai session save --push');
+    }
+    return;
+  }
+
+  const repoPath = localConfig.repo.localPath;
+  const teamDir = path.join(repoPath, 'sessions', username);
 
   const spin = spinner('Pushing session summary to team...').start();
   try {
@@ -149,7 +180,6 @@ export async function saveSession(options: SaveSessionOptions): Promise<void> {
       return;
     }
     const rel = path.relative(repoPath, written);
-    const commitMsg = `[teamai] Session summary from ${username} (${monthKey(summary)})`;
 
     await withTimeout(pushRepoDirectly(repoPath, commitMsg, [rel]), 10_000, 'Push timeout (10s)');
 

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -51,7 +51,13 @@ async function loadReportedStats(): Promise<UserStats | null> {
   try {
     const config = await detectProjectConfig() ?? await loadLocalConfig();
     if (!config) return null;
-    const statsPath = path.join(config.repo.localPath, 'stats', `${config.username}.yaml`);
+    // Self mode: stats live on the teamai-reports orphan branch worktree.
+    let statsRoot = config.repo.localPath;
+    if (config.repo.kind === 'self') {
+      const { ensureReportsWorktree } = await import('./utils/reports-branch.js');
+      statsRoot = await ensureReportsWorktree(config);
+    }
+    const statsPath = path.join(statsRoot, 'stats', `${config.username}.yaml`);
     const content = await readFileSafe(statsPath);
     if (!content) return null;
     const parsed = YAML.parse(content) as UserStats;

--- a/src/team-push.ts
+++ b/src/team-push.ts
@@ -7,7 +7,7 @@ import { createGit, pushRepoDirectly, pullRepo, resetToCleanMaster } from './uti
 import { withTimeout } from './utils/async.js';
 import { writeFile, readFileSafe, ensureDir, pathExists, readJson, writeJson } from './utils/fs.js';
 import { log } from './utils/logger.js';
-import type { UserStats, UserInterventionStats, SessionMetrics, TokenUsage, DashboardEvent } from './types.js';
+import type { UserStats, UserInterventionStats, SessionMetrics, TokenUsage, DashboardEvent, LocalConfig } from './types.js';
 import { VOTES_LOCAL_DIR, emptyTokenUsage, addTokenUsage } from './types.js';
 
 /** Snapshot of already-reported per-session intervention counts (idempotency basis). */
@@ -299,8 +299,15 @@ export function filterEventsByScope(
 export async function reportUsageToTeam(
   repoPath: string,
   username: string,
-  options?: { skipTruncate?: boolean; projectRoot?: string; excludeProjectRoots?: string[] },
+  options?: { skipTruncate?: boolean; projectRoot?: string; excludeProjectRoots?: string[]; selfConfig?: LocalConfig },
 ): Promise<void> {
+  // Single-repo mode: stats + votes are report data → the teamai-reports orphan
+  // branch (isolated worktree). We must NOT resetToCleanMaster / pullRepo /
+  // pushRepoDirectly on the business repo root — that would touch the user's
+  // active working tree. The dedicated writer handles the worktree + rebase race.
+  const selfConfig = options?.selfConfig;
+  const selfMode = selfConfig?.repo.kind === 'self';
+
   try {
     const events = await readUsageEvents();
     const filesToPush: string[] = [];
@@ -331,15 +338,23 @@ export async function reportUsageToTeam(
     const hasInterventions = hasInterventionDelta(interventionDelta);
     const hasPromptTokens = hasPromptTokenDelta(promptTokenDelta);
 
-    // Reset any dirty/conflicted state and ensure we're on the default branch before pulling.
-    // Same pattern as push.ts — the team repo is a cache, safe to discard local state.
-    const git = createGit(repoPath);
-    await resetToCleanMaster(git, repoPath);
-    await pullRepo(repoPath);
+    // Resolve where report data is written. In self mode this is the reports
+    // orphan-branch worktree; in git mode it is the team repo clone.
+    let writeRoot = repoPath;
+    if (selfMode && selfConfig) {
+      const { ensureReportsWorktree } = await import('./utils/reports-branch.js');
+      writeRoot = await ensureReportsWorktree(selfConfig);
+    } else {
+      // Reset any dirty/conflicted state and ensure we're on the default branch before pulling.
+      // Same pattern as push.ts — the team repo is a cache, safe to discard local state.
+      const git = createGit(repoPath);
+      await resetToCleanMaster(git, repoPath);
+      await pullRepo(repoPath);
+    }
 
     // Process usage and/or intervention/prompt/token stats if anything is new to report.
     if (hasUsage || hasInterventions || hasPromptTokens) {
-      const statsDir = path.join(repoPath, 'stats');
+      const statsDir = path.join(writeRoot, 'stats');
       await ensureDir(statsDir);
       const statsPath = path.join(statsDir, `${username}.yaml`);
 
@@ -365,7 +380,7 @@ export async function reportUsageToTeam(
     try {
       if (await pathExists(VOTES_LOCAL_DIR)) {
         const { syncVotesToTeam } = await import('./votes.js');
-        const synced = await syncVotesToTeam(repoPath, username, VOTES_LOCAL_DIR);
+        const synced = await syncVotesToTeam(writeRoot, username, VOTES_LOCAL_DIR);
         if (synced) {
           filesToPush.push(`votes/${username}.yaml`);
         }
@@ -389,11 +404,20 @@ export async function reportUsageToTeam(
     // Guard the push with a 5s timeout. withTimeout clears its timer once the
     // push settles, so a fast success does not leave a 5s timer pinning the
     // event loop (and hanging `teamai pull`) after the work is done.
-    await withTimeout(
-      pushRepoDirectly(repoPath, commitMsg, filesToPush),
-      5000,
-      'Auto-report timeout (5s)',
-    );
+    if (selfMode && selfConfig) {
+      const { commitAndPushReports } = await import('./utils/reports-branch.js');
+      await withTimeout(
+        commitAndPushReports(selfConfig, commitMsg, filesToPush),
+        5000,
+        'Auto-report timeout (5s)',
+      );
+    } else {
+      await withTimeout(
+        pushRepoDirectly(repoPath, commitMsg, filesToPush),
+        5000,
+        'Auto-report timeout (5s)',
+      );
+    }
 
     // Success — truncate reported usage events (only if caller allows it)
     if (hasUsage && !options?.skipTruncate) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -156,6 +156,14 @@ export const TeamaiConfigSchema = z.object({
    * decided only by CLI `--scope` / default. Kept optional for old teamai.yaml files.
    */
   scope: ScopeEnum.optional(),
+  /**
+   * Single-repo mode marker. Committed to main inside <repo>/.teamai/teamai.yaml
+   * so it travels with `git clone`. When a teammate clones a repo carrying
+   * `mode: self` but has no local config yet, teamai auto-bootstraps the machine
+   * side (write local config, inject hooks, register member). undefined = a
+   * standalone team repo (existing behavior). See detectProjectConfig / bootstrapSelfRepo.
+   */
+  mode: z.enum(['self']).optional(),
   reviewers: z.array(z.string()).default([]),
   /** Skills this team makes available to other teams via cross-team subscription. */
   publicSkills: z.array(z.string()).optional(),
@@ -208,10 +216,25 @@ export const LocalConfigSchema = z.object({
   repo: z.object({
     localPath: z.string(),
     remote: z.string(),
-    /** Team repo backend. Defaults to 'git' for backward compatibility. */
-    kind: z.enum(['git', 'http']).optional(),
+    /**
+     * Team repo backend. Defaults to 'git' for backward compatibility.
+     * - 'git':  a standalone team repo cloned to <home>/team-repo.
+     * - 'http': a git-free HTTP team repo (read-only consumer).
+     * - 'self': single-repo mode — the business repo IS the team repo.
+     *           Knowledge lives on main under <businessRepoRoot>/.teamai/;
+     *           reports (members/sessions/votes/stats) live on the
+     *           `teamai-reports` orphan branch. localPath = <businessRepoRoot>/.teamai.
+     */
+    kind: z.enum(['git', 'http', 'self']).optional(),
     /** Base URL of the HTTP team repo (only when kind === 'http'). */
     url: z.string().optional(),
+    /**
+     * Git root of the business repo (only when kind === 'self').
+     * Equals the parent directory of localPath. All git write operations
+     * (knowledge PRs, reports orphan branch) run in isolated worktrees under
+     * this repo so the user's active working tree is never touched.
+     */
+    businessRepoRoot: z.string().optional(),
   }),
   username: z.string(),
   updatePolicy: z.enum(['auto', 'prompt', 'skip']).optional(),
@@ -993,6 +1016,48 @@ export function resolveBaseDir(localConfig: LocalConfig): string {
 /** True when `tool` is in localConfig.disabledAgents (excluded from teamai sync). */
 export function isAgentDisabled(localConfig: { disabledAgents?: string[] }, tool: string): boolean {
   return localConfig.disabledAgents?.includes(tool) ?? false;
+}
+
+/** True when the local config is single-repo mode (the business repo is the team repo). */
+export function isSelfMode(localConfig: { repo: { kind?: string } }): boolean {
+  return localConfig.repo.kind === 'self';
+}
+
+/** Orphan branch that carries reports (members/sessions/votes/stats) in single-repo mode. */
+export const REPORTS_BRANCH = 'teamai-reports';
+/** Worktree directory (under .teamai) that checks out the reports orphan branch. */
+export const REPORTS_WORKTREE_DIRNAME = 'reports-wt';
+/** Worktree directory (under .teamai) used to stage knowledge PRs off the active tree. */
+export const KNOWLEDGE_WORKTREE_DIRNAME = 'knowledge-wt';
+/** Lock filename (under <repo>/.teamai) guarding concurrent reports-branch writes. */
+export const REPORTS_LOCK_FILENAME = '.reports-lock';
+/** Lock filename (under <repo>/.teamai) guarding concurrent self-mode bootstrap. */
+export const BOOTSTRAP_LOCK_FILENAME = '.bootstrap-lock';
+
+/**
+ * Directory holding team knowledge assets (skills/rules/docs/learnings/...).
+ * All modes read/write knowledge under localConfig.repo.localPath:
+ * - git/http: <home>/team-repo
+ * - self:     <businessRepoRoot>/.teamai  (committed to main)
+ * This is why the ~230 `path.join(localPath, 'skills'|...)` sites need no change.
+ */
+export function getKnowledgeDir(localConfig: LocalConfig): string {
+  return localConfig.repo.localPath;
+}
+
+/**
+ * Directory holding reports data (members/sessions/votes/stats).
+ * - git/http: same as knowledge (localPath) — reports live alongside knowledge.
+ * - self:     <localPath>/reports-wt — a git worktree checked out on the
+ *             `teamai-reports` orphan branch, so reports never land on main.
+ * Callers must ensure the worktree exists first (see ensureReportsWorktree)
+ * when the returned path is the self-mode worktree.
+ */
+export function getReportsDir(localConfig: LocalConfig): string {
+  if (isSelfMode(localConfig)) {
+    return path.join(localConfig.repo.localPath, REPORTS_WORKTREE_DIRNAME);
+  }
+  return localConfig.repo.localPath;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1079,6 +1079,22 @@ export function getTeamaiHome(scope: Scope, projectRoot?: string): string {
 }
 
 /**
+ * Path of the machine-local KEY=value env backup file that the env channel writes
+ * on pull and mcp-reconcile reads for ${VAR} resolution.
+ *
+ * Normally this is `<teamaiHome>/env`. But in single-repo mode `<teamaiHome>` is
+ * `<repo>/.teamai`, where `env/` is a committed DIRECTORY holding the shared
+ * `env.yaml` — writing a file at `<teamaiHome>/env` there would collide with that
+ * directory (EISDIR). So self mode uses `env.local`, which is gitignored (see
+ * buildSelfModeGitignore) and never committed. Readers and writers MUST both go
+ * through this helper so they never disagree on the path.
+ */
+export function getEnvBackupPath(localConfig: LocalConfig): string {
+  const home = getTeamaiHome(localConfig.scope, localConfig.projectRoot);
+  return path.join(home, isSelfMode(localConfig) ? 'env.local' : 'env');
+}
+
+/**
  * Get the config.yaml path for a given scope.
  */
 export function getConfigPath(scope: Scope, projectRoot?: string): string {

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -79,6 +79,76 @@ export async function getHeadRev(localPath: string): Promise<string> {
   return git.revparse(['--short', 'HEAD']);
 }
 
+/**
+ * Read the `origin` remote URL of the repo at localPath (or its enclosing repo).
+ * Returns null when there is no origin remote or the path is not a git repo.
+ * Used by single-repo mode to derive the provider/remote from the business repo.
+ */
+export async function getRemoteUrl(localPath: string, remoteName = 'origin'): Promise<string | null> {
+  const git = createGit(localPath);
+  try {
+    const url = (await git.raw(['remote', 'get-url', remoteName])).trim();
+    return url || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether the repo at localPath has at least one commit reachable from HEAD.
+ * A freshly `git init`'d repo (HEAD points at an unborn branch) returns false.
+ * Used by single-repo mode: knowledge worktrees/PRs need a base commit to exist.
+ */
+export async function hasCommits(localPath: string): Promise<boolean> {
+  const git = createGit(localPath);
+  try {
+    // NB: `--quiet` makes git exit 1 silently on an unborn HEAD, and simple-git
+    // does not throw on that — so we must validate the OUTPUT (a real sha), not
+    // rely on a thrown error. An unborn HEAD yields empty/whitespace output.
+    const out = (await git.raw(['rev-parse', '--verify', 'HEAD^{commit}'])).trim();
+    return /^[0-9a-f]{7,40}$/.test(out);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Stage the given pathspecs and commit them on the current branch of the repo at
+ * localPath. Best-effort helper for single-repo init: it seeds the business repo
+ * with a base commit carrying the committed .teamai/ knowledge skeleton so later
+ * knowledge PRs (which branch off HEAD) have something to branch from.
+ *
+ * Returns true if a commit was created, false if there was nothing to commit.
+ * Does NOT push — the user pushes their business repo on their own cadence.
+ */
+export async function commitPaths(
+  localPath: string,
+  message: string,
+  files: string[],
+): Promise<boolean> {
+  const git = createGit(localPath);
+  const existing = files.filter((f) => fs.existsSync(path.join(localPath, f)));
+  if (existing.length === 0) return false;
+  // Add each path individually and tolerate `git add` failing on an
+  // explicitly-gitignored path (it errors "Use -f if you really want to add
+  // them"). Callers should not pass ignored paths, but a stray one must not
+  // abort the whole commit. `--` guards against paths that look like options.
+  let added = 0;
+  for (const f of existing) {
+    try {
+      await git.add(['--', f]);
+      added++;
+    } catch {
+      // ignored/unaddable path — skip it
+    }
+  }
+  if (added === 0) return false;
+  const status = await git.status();
+  if (status.staged.length === 0) return false;
+  await git.commit(message);
+  return true;
+}
+
 export async function pullRepo(localPath: string): Promise<string> {
   const git = createGit(localPath);
   const result = await git.pull();
@@ -258,7 +328,7 @@ export async function pushRepoBranch(
   if (status.staged.length === 0) {
     const defaultBranch = await getDefaultBranch(localPath);
     log.debug(`Nothing to commit, switching back to ${defaultBranch}`);
-    await git.checkout(defaultBranch);
+    await switchToDefaultBranch(git, defaultBranch);
     await git.deleteLocalBranch(branchName, true);
     return false;
   }
@@ -268,7 +338,7 @@ export async function pushRepoBranch(
   if (isMetadataOnlyDiff(diffOutput)) {
     const defaultBranch = await getDefaultBranch(localPath);
     log.debug(`Only metadata/timestamp changes detected, switching back to ${defaultBranch}`);
-    await git.checkout(defaultBranch);
+    await switchToDefaultBranch(git, defaultBranch);
     await git.deleteLocalBranch(branchName, true);
     return false;
   }
@@ -281,13 +351,41 @@ export async function pushRepoBranch(
 }
 
 /**
+ * Switch a repo/worktree back to its default branch, tolerating the case where
+ * that branch is already checked out in another worktree.
+ *
+ * In single-repo mode, teamai stages knowledge PRs in a disposable worktree while
+ * the user's active tree holds the same default branch (e.g. `main`). Git refuses
+ * `checkout main` in a second worktree ("'main' is already used by worktree ...").
+ * That's harmless here: the worktree is about to be destroyed, and in a normal
+ * clone a skipped switch self-heals via resetToCleanMaster on the next run. So we
+ * swallow that specific conflict rather than letting it abort the whole operation.
+ */
+async function switchToDefaultBranch(git: SimpleGit, defaultBranch: string): Promise<void> {
+  try {
+    await git.checkout(defaultBranch);
+  } catch (e) {
+    const msg = (e as Error).message ?? '';
+    if (/already (used|checked out) by worktree|is already checked out/i.test(msg)) {
+      log.debug(`Skipping switch to ${defaultBranch}: already checked out in another worktree`);
+      return;
+    }
+    throw e;
+  }
+}
+
+/**
  * Switch the repo back to its default branch (main/master).
  * Used after pushRepoBranch + createPullRequest.
+ *
+ * Best-effort with respect to the "already used by worktree" conflict (see
+ * switchToDefaultBranch): a self-mode knowledge worktree shares the default branch
+ * with the user's active tree and is disposable, so failing to switch is a no-op.
  */
 export async function checkoutMaster(localPath: string): Promise<void> {
   const git = createGit(localPath);
   const defaultBranch = await getDefaultBranch(localPath);
-  await git.checkout(defaultBranch);
+  await switchToDefaultBranch(git, defaultBranch);
 }
 
 /**

--- a/src/utils/reports-branch.ts
+++ b/src/utils/reports-branch.ts
@@ -1,0 +1,368 @@
+/**
+ * Single-repo mode: manage the `teamai-reports` orphan branch via an isolated
+ * git worktree under <business-repo>/.teamai/reports-wt.
+ *
+ * Why an orphan branch + dedicated worktree?
+ *  - In single-repo mode the business repo IS the team repo. High-frequency,
+ *    noisy report data (members/sessions/votes/stats) must NOT pollute main.
+ *    The orphan branch has an independent history, so main stays clean.
+ *  - Report writes involve `git reset --hard` / `rebase --hard`. Running those
+ *    on the user's active working tree would destroy their uncommitted business
+ *    code. A separate worktree confines every destructive git op to the orphan
+ *    branch checkout — the active tree is never touched.
+ *
+ * Concurrency: the branch is shared by the whole team, but each member only ever
+ * writes their own `<user>.yaml`, so files never collide. Pushes race at the git
+ * layer (non-fast-forward); we resolve with fetch + rebase + retry.
+ */
+import path from 'node:path';
+import fse from 'fs-extra';
+import { createGit, isGitRepo, getDefaultBranch, hasCommits } from './git.js';
+import { acquireLock, releaseLock } from '../update.js';
+import { ensureDir, writeFile, pathExists } from './fs.js';
+import { log } from './logger.js';
+import {
+  REPORTS_BRANCH,
+  REPORTS_WORKTREE_DIRNAME,
+  REPORTS_LOCK_FILENAME,
+  KNOWLEDGE_WORKTREE_DIRNAME,
+  getReportsDir,
+  type LocalConfig,
+} from '../types.js';
+
+/**
+ * Thrown when a knowledge worktree is requested but the business repo has no
+ * commits yet (unborn HEAD). Callers catch this to print an actionable hint
+ * instead of crashing on a raw GitError.
+ */
+export class EmptyRepoError extends Error {
+  constructor(public readonly repoRoot: string) {
+    super(
+      `The repository at ${repoRoot} has no commits yet, so teamai cannot open a knowledge PR. ` +
+      `Make an initial commit and push it first (e.g. \`git add -A && git commit -m "init" && git push -u origin HEAD\`), then retry.`,
+    );
+    this.name = 'EmptyRepoError';
+  }
+}
+
+/** Resolve the business repo git root for a self-mode config. */
+function businessRoot(localConfig: LocalConfig): string {
+  return localConfig.repo.businessRepoRoot ?? path.dirname(localConfig.repo.localPath);
+}
+
+/** Path to the reports worktree directory (<repo>/.teamai/reports-wt). */
+function reportsWorktreePath(localConfig: LocalConfig): string {
+  return path.join(localConfig.repo.localPath, REPORTS_WORKTREE_DIRNAME);
+}
+
+/** Whether the remote already has the reports branch. */
+async function remoteBranchExists(repoRoot: string): Promise<boolean> {
+  const git = createGit(repoRoot);
+  try {
+    const res = await git.listRemote(['--heads', 'origin', REPORTS_BRANCH]);
+    return typeof res === 'string' && res.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Ensure a git worktree checked out on the `teamai-reports` orphan branch exists
+ * at <repo>/.teamai/reports-wt. Idempotent. Returns the worktree absolute path.
+ *
+ * Cold-start cases handled:
+ *  - worktree already present  → return it (optionally refreshed by caller).
+ *  - remote branch exists      → worktree add --track -b from origin/teamai-reports.
+ *  - remote branch absent      → create the orphan branch locally, then first-push.
+ */
+export async function ensureReportsWorktree(localConfig: LocalConfig): Promise<string> {
+  const wt = reportsWorktreePath(localConfig);
+  const repoRoot = businessRoot(localConfig);
+
+  // Already a valid worktree — nothing to do.
+  if (await isGitRepo(wt)) {
+    return wt;
+  }
+
+  // Path exists but is not a git worktree (stale/partial) — clear it so we can recreate.
+  if (await pathExists(wt)) {
+    await fse.remove(wt);
+  }
+
+  await ensureDir(path.dirname(wt));
+  const git = createGit(repoRoot);
+
+  // Prune any dangling worktree registration left from a previous removal.
+  try {
+    await git.raw(['worktree', 'prune']);
+  } catch {
+    // best effort
+  }
+
+  if (await remoteBranchExists(repoRoot)) {
+    // Remote branch exists: fetch and check it out into the worktree.
+    try {
+      await git.fetch(['origin', REPORTS_BRANCH]);
+    } catch {
+      // fetch may fail offline; worktree add can still work if we have it locally
+    }
+    // If a local branch of the same name exists, add tracking it; otherwise create tracking branch.
+    const branches = await git.branchLocal();
+    if (branches.all.includes(REPORTS_BRANCH)) {
+      await git.raw(['worktree', 'add', wt, REPORTS_BRANCH]);
+    } else {
+      await git.raw(['worktree', 'add', wt, '--track', '-b', REPORTS_BRANCH, `origin/${REPORTS_BRANCH}`]);
+    }
+  } else {
+    // Remote branch absent: create the orphan branch in the worktree.
+    await createOrphanWorktree(repoRoot, wt);
+    await writeWorktreeGitignore(wt);
+    const wtGit = createGit(wt);
+    await wtGit.add(['.gitignore']);
+    await wtGit.commit('[teamai] Initialize reports branch');
+    try {
+      await wtGit.push(['-u', 'origin', REPORTS_BRANCH]);
+    } catch (e) {
+      log.debug(`[reports] initial push skipped: ${(e as Error).message}`);
+    }
+  }
+
+  return wt;
+}
+
+/**
+ * Create an orphan-branch worktree. Uses the modern `--orphan` flag (git 2.42+)
+ * and falls back to the detach + `checkout --orphan` dance for older git.
+ */
+async function createOrphanWorktree(repoRoot: string, wt: string): Promise<void> {
+  const git = createGit(repoRoot);
+  try {
+    // git 2.42+: create a worktree on a fresh orphan branch directly.
+    // The branch name must be given via -b; a positional after <path> is treated
+    // as a commit-ish and errors ("--orphan and commit-ish cannot be used together").
+    await git.raw(['worktree', 'add', '--orphan', '-b', REPORTS_BRANCH, wt]);
+    // The --orphan worktree may inherit the index/files from HEAD in some git
+    // versions; clear tracked entries so the branch starts empty.
+    const wtGit = createGit(wt);
+    try {
+      await wtGit.raw(['rm', '-rf', '--cached', '.']);
+    } catch {
+      // nothing staged — fine
+    }
+    await clearWorktreeFiles(wt);
+  } catch {
+    // Older git (<2.42): detach a worktree at HEAD, then orphan-checkout inside it.
+    await git.raw(['worktree', 'add', '--detach', wt, 'HEAD']);
+    const wtGit = createGit(wt);
+    await wtGit.raw(['checkout', '--orphan', REPORTS_BRANCH]);
+    try {
+      await wtGit.raw(['rm', '-rf', '--cached', '.']);
+    } catch {
+      // nothing staged
+    }
+    await clearWorktreeFiles(wt);
+  }
+}
+
+/** Remove all files (except .git) from a freshly-created orphan worktree. */
+async function clearWorktreeFiles(wt: string): Promise<void> {
+  const entries = await fse.readdir(wt);
+  await Promise.all(
+    entries
+      .filter((e) => e !== '.git')
+      .map((e) => fse.remove(path.join(wt, e))),
+  );
+}
+
+/** Write a .gitignore inside the reports worktree to prevent nested-worktree recursion. */
+async function writeWorktreeGitignore(wt: string): Promise<void> {
+  const content = [
+    '# teamai reports branch — machine-local artifacts should never be tracked here',
+    `${REPORTS_WORKTREE_DIRNAME}/`,
+    'knowledge-wt/',
+    '',
+  ].join('\n');
+  await writeFile(path.join(wt, '.gitignore'), content);
+}
+
+const MAX_PUSH_RETRIES = 5;
+
+/**
+ * Commit the given files (relative to the reports worktree) to the reports orphan
+ * branch and push, retrying with fetch + rebase on non-fast-forward races.
+ *
+ * Callers write their files into getReportsDir(localConfig)/<...> (which is the
+ * worktree) BEFORE calling this. Best-effort: logs and returns false on failure
+ * rather than throwing, matching the existing pushRepoDirectly contract.
+ *
+ * @returns true if something was committed & pushed, false if nothing to do or on failure.
+ */
+export async function commitAndPushReports(
+  localConfig: LocalConfig,
+  message: string,
+  files: string[],
+): Promise<boolean> {
+  const lockPath = path.join(localConfig.repo.localPath, REPORTS_LOCK_FILENAME);
+  const locked = await acquireLock(lockPath);
+  if (!locked) {
+    log.debug('[reports] another reports write is in progress; skipping');
+    return false;
+  }
+
+  try {
+    const wt = await ensureReportsWorktree(localConfig);
+    const git = createGit(wt);
+
+    await git.add(files);
+    const status = await git.status();
+    if (status.staged.length === 0) {
+      log.debug('[reports] nothing to commit');
+      return false;
+    }
+
+    await git.commit(message);
+
+    // Push with fetch+rebase retry. Each member only writes <user>.yaml, so
+    // rebase conflicts are effectively impossible; retries handle the pure
+    // non-fast-forward race.
+    for (let attempt = 1; attempt <= MAX_PUSH_RETRIES; attempt++) {
+      try {
+        await git.push(['origin', REPORTS_BRANCH]);
+        return true;
+      } catch (pushErr) {
+        if (attempt === MAX_PUSH_RETRIES) {
+          log.debug(`[reports] push failed after ${attempt} attempts: ${(pushErr as Error).message}`);
+          return false;
+        }
+        try {
+          await git.fetch(['origin', REPORTS_BRANCH]);
+          await git.rebase([`origin/${REPORTS_BRANCH}`]);
+        } catch (rebaseErr) {
+          log.debug(`[reports] rebase failed, retrying: ${(rebaseErr as Error).message}`);
+          // Abort a half-finished rebase so the next attempt starts clean.
+          try {
+            await git.rebase(['--abort']);
+          } catch {
+            // no rebase in progress
+          }
+        }
+      }
+    }
+    return false;
+  } catch (e) {
+    log.debug(`[reports] commitAndPushReports failed (non-blocking): ${(e as Error).message}`);
+    return false;
+  } finally {
+    await releaseLock(lockPath);
+  }
+}
+
+/**
+ * Best-effort refresh of the reports worktree from origin so reader commands
+ * (digest/members/stats) see other members' latest data. Safe: only touches the
+ * orphan-branch worktree, never the active tree.
+ */
+export async function refreshReportsWorktree(localConfig: LocalConfig): Promise<void> {
+  try {
+    const wt = await ensureReportsWorktree(localConfig);
+    const git = createGit(wt);
+    await git.fetch(['origin', REPORTS_BRANCH]);
+    await git.raw(['reset', '--hard', `origin/${REPORTS_BRANCH}`]);
+  } catch (e) {
+    log.debug(`[reports] refresh skipped: ${(e as Error).message}`);
+  }
+}
+
+/**
+ * Ensure the reports directory exists and return it. For self mode this creates
+ * the worktree first; for other modes it just returns localPath (reports live
+ * alongside knowledge).
+ */
+export async function ensureReportsDir(localConfig: LocalConfig): Promise<string> {
+  if (localConfig.repo.kind === 'self') {
+    return ensureReportsWorktree(localConfig);
+  }
+  return getReportsDir(localConfig);
+}
+
+/**
+ * Run `fn` against a disposable knowledge worktree for single-repo mode.
+ *
+ * Knowledge PRs (skills/rules/docs/learnings → main) must never run `checkout -b`
+ * / `reset --hard` on the user's active working tree. This checks out a fresh,
+ * detached worktree at origin/<default> under .teamai/knowledge-wt, passes fn a
+ * clone of localConfig whose repo.localPath points at <wt>/.teamai (so all the
+ * existing push/remove/roles machinery operates on the worktree), then removes
+ * the worktree afterward. The user's active branch and working tree are untouched.
+ *
+ * @returns whatever fn returns.
+ */
+export async function withKnowledgeWorktree<T>(
+  localConfig: LocalConfig,
+  fn: (worktreeConfig: LocalConfig) => Promise<T>,
+): Promise<T> {
+  const repoRoot = businessRoot(localConfig);
+  const wt = path.join(localConfig.repo.localPath, KNOWLEDGE_WORKTREE_DIRNAME);
+  const git = createGit(repoRoot);
+
+  // A knowledge worktree must branch off a base commit. A freshly `git init`'d
+  // business repo (unborn HEAD) has none — `worktree add` would fail with an
+  // opaque "invalid reference: HEAD". Fail early with an actionable message that
+  // callers surface, instead of letting a raw GitError crash the CLI.
+  if (!(await hasCommits(repoRoot))) {
+    throw new EmptyRepoError(repoRoot);
+  }
+
+  // Clean any stale worktree from a previous interrupted run.
+  if (await pathExists(wt)) {
+    try {
+      await git.raw(['worktree', 'remove', '--force', wt]);
+    } catch {
+      await fse.remove(wt);
+    }
+  }
+  try {
+    await git.raw(['worktree', 'prune']);
+  } catch {
+    // best effort
+  }
+
+  // Fetch the latest default branch so the PR is based on current main.
+  const defaultBranch = await getDefaultBranch(repoRoot);
+  try {
+    await git.fetch(['origin', defaultBranch]);
+  } catch {
+    // offline / no remote — fall back to local default branch state
+  }
+
+  // Detached worktree at origin/<default>; pushRepoBranch will create the feature
+  // branch inside the worktree, so the active repo never switches branches.
+  let base = `origin/${defaultBranch}`;
+  try {
+    await git.raw(['worktree', 'add', '--detach', wt, base]);
+  } catch {
+    // origin/<default> may not exist locally (fresh repo); fall back to HEAD.
+    base = 'HEAD';
+    await git.raw(['worktree', 'add', '--detach', wt, base]);
+  }
+
+  const worktreeConfig: LocalConfig = {
+    ...localConfig,
+    repo: {
+      ...localConfig.repo,
+      localPath: path.join(wt, '.teamai'),
+      businessRepoRoot: wt,
+    },
+  };
+
+  try {
+    return await fn(worktreeConfig);
+  } finally {
+    try {
+      await git.raw(['worktree', 'remove', '--force', wt]);
+    } catch {
+      await fse.remove(wt);
+      try { await git.raw(['worktree', 'prune']); } catch { /* best effort */ }
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds **single-repo mode**: `teamai init .` (or `--self`) makes the current git repo double as the team repo, so a plain `git clone` carries the whole team setup — addressing #198's "clone = initialized" goal without needing a separate team repo. Existing standalone team-repo (git) and HTTP modes are unchanged; all self-mode logic is gated behind `repo.kind === 'self'`.

## How it works

**Data splits across branches:**

| Data | Where | Travels with `git clone`? |
|------|-------|---------------------------|
| Knowledge: `skills/` `rules/` `docs/` `learnings/` `agents/` `hooks/` `mcp/` `env/`, `teamai.yaml`, `.gitignore` | `.teamai/` on **main** | ✅ yes |
| Reports: `members/` `sessions/` `votes/` `stats/` | `teamai-reports` **orphan branch** (pushed to origin) | separate history |
| Machine-local: `config.yaml`, `token`, `state.json`, `env.local`, worktrees | `.teamai/` (gitignored) | ❌ per-machine |

**Clone = initialized:** teammates who clone a repo carrying `mode: self` in `.teamai/teamai.yaml` are auto-bootstrapped on their next teamai command / session (`detectProjectConfig` → `bootstrapSelfRepo` writes local config, injects hooks, registers the member) — no need to re-type repo/role.

**Safety invariant:** every git write teamai performs in self mode (knowledge PRs *and* the reports orphan branch) runs in an **isolated git worktree**, so the user's active working tree and current branch are never checked out, reset, or switched.

## Key pieces

- **types**: `repo.kind: 'self'` + `businessRepoRoot`; `TeamaiConfig.mode: 'self'` marker; `getKnowledgeDir`/`getReportsDir`/`getEnvBackupPath` helpers; reports/worktree/lock constants.
- **`utils/reports-branch.ts`** (new): orphan-branch worktree management (`ensureReportsWorktree`, `commitAndPushReports` with fetch+rebase retry) and `withKnowledgeWorktree` for knowledge PRs.
- **`init.ts` `initSelfRepo`**: no clone; seed `.teamai/` skeleton (incl. `agents/`, `hooks/`, `mcp/`); auto-commit the skeleton + selected tools' settings as the base commit; self-mode `.gitignore`.
- **`bootstrap.ts`** (new): non-interactive self-heal for cloned self-mode repos.
- **Report write-backs** (`team-push`/`save-session`/`votes`/`hook-handlers`) and **readers** (`members`/`digest`/`stats`/`pull`/`recall`) route to the reports worktree in self mode.
- **Knowledge writes** (`push`/`remove`/`roles`/`contribute`) run in an isolated knowledge worktree and open a PR; `EmptyRepoError` surfaces a clear hint instead of a raw `GitError` when the repo has no base commit.

## Follow-up commits in this PR

Beyond the initial single-repo mode, this PR carries refinements found while dogfooding the beta:

- **`fix(push)`: scan `.teamai/{skills,rules}` directly.** In self mode the knowledge dirs live in the user's own repo, so people naturally drop a skill straight into `.teamai/skills/` rather than an AI-tool dir. Push now also scans the active tree's `.teamai/{skills,rules}`, diffed against the knowledge worktree's `origin/<default>` checkout — genuine additions/edits surface, already-committed knowledge is skipped.

- **`feat(init)`: choose which AI tool dirs to create.** Previously init hardcoded `.claude/`. Now the tool set is user-driven via `enabledAgents`: `--agent <name>` (repeatable / comma-separated, non-variadic so it never swallows the `[repo]` positional), an interactive picker when omitted, or — non-interactively (no TTY / `--silent` / `--force` / clone-time bootstrap) — the tools already installed under `~/`. Also fixes a latent ordering bug: hooks are now injected **before** the skeleton commit, so each selected tool's settings file (`.claude/settings.json`, `.codex/hooks.json`, …) gets committed to main — the session-start hook teammates need for clone-time self-heal was previously skipped.

- **`feat(init)`: an "Auto" option in the tool picker.** The picker leads with an **Auto** option that lists the tools already installed on the machine and is the Enter default — "set up whatever I already use" in one keypress, while showing exactly what it resolves to.

- **`feat(push)`: env + agents direct-drop, and docs/hooks/mcp surfaced.** Extends "drop it in `.teamai/` and push" beyond skills/rules:
  - **env**: `.teamai/env/env.yaml` is now committed to main (removed from the self-mode `.gitignore`) so team env vars travel on clone. `env.yaml` holds plaintext key/value pairs, so docs/tips warn to keep real secrets out.
  - **agents**: canonical files placed directly in `.teamai/agents/` (`<name>.yaml`, or legacy `.md`) are picked up as-is (no reverse/merge) and win over the tool-dir reverse-parse path on name conflicts; `pushItem` preserves the source extension instead of hardcoding `.md`.
  - **docs/hooks/mcp**: already work via direct-edit + normal git commit (their `scanLocalForPush` returns `[]`); init now seeds `.teamai/{agents,hooks,mcp}` and the final tip + docs explain both workflows.
  - **Pull-side crash fix**: distributing `env.yaml` meant every teammate's `teamai pull` wrote its `KEY=value` backup to `<teamaiHome>/env` — but in self mode that path is the committed `env/` **directory**, throwing `EISDIR`, which aborted the resource loop (agents never synced) and stalled the rev cache (recurred every session). New `getEnvBackupPath()` routes the backup to `env.local` in self mode; writer and reader both use it; `env.local` is gitignored.

- **`fix(self)`: self-heal an older `.teamai/.gitignore`.** Repos initialized before env-goes-to-main (≤ beta.4) carry a committed `.gitignore` with a bare `env` line that keeps `env.yaml` off main; new code didn't rewrite an existing gitignore, so they were stuck. `migrateSelfModeGitignore` (pure core + in-place applier) drops the stale `env` line (never `env.sh`/`env.local`/`env/`/comments), ensures `env.local`, and — since the file lives on main — rewrites only the active tree and logs a hint to commit rather than committing for the user. Runs on both pull and push; no-op when already current.

- **Docs**: README + usage-guide updated in both languages for all of the above.

## Test Plan

- [x] `npx tsc --noEmit` clean on all non-test source.
- [x] `npm run build` succeeds.
- [x] Full unit suite green: **154 files / 2015 tests**, including new coverage for single-repo mode, bootstrap, commit-paths, the `.teamai` push scan (skills/rules/env/agents), agent selection (`normalizeAgentList`, `detectHomeInstalledAgents`, `resolveSelfModeSelection`), the interactive Auto picker (mocked `askSelection`), the self-mode `env` pull `EISDIR` regression, and the old-gitignore migration. (The 9 failing `iwiki`/`import` tests some environments show are a local `vitest` version drift, not a code regression — green under the pinned `vitest@2.1.9` via `npm ci`.)
- [x] **Real-CLI end-to-end** (global install), on real GitHub repos:
  - `teamai init .` on an **empty** repo → base commit + `.teamai/` skeleton (incl. agents/hooks/mcp) + selected tools' settings committed; hooks injected; active branch stays on main, working tree untouched.
  - `teamai init . --agent claude,codex` **and** flag-first `teamai init --agent claude,codex .` → both create `.claude/` + `.codex/` with correct settings paths, both committed; `enabledAgents` correct, no stray `.` id.
  - non-interactive `teamai init .` → mirrors the tools installed under `~/`, no hang.
  - hand-place a skill / rule / `env/env.yaml` / `agents/*.yaml` directly under `.teamai/` → `teamai push` detects all of them and opens a PR from an isolated worktree (correct paths, `.yaml` preserved); re-push after merge is idempotent.
  - **Pull/consumer side**: teammate `git clone` of a repo with committed `.teamai/env/env.yaml` + `.teamai/agents/*` → `teamai pull` no longer crashes (EISDIR fixed), writes `env.local`, and continues past env to sync agents; self-heal + skill injection work; reports land on the `teamai-reports` orphan branch, never on main.
- [x] Reviewed by automated code-review passes. Two HIGH findings were fixed and re-verified end-to-end: variadic `--agent` swallowing the `[repo]` positional, and the self-mode `env` pull `EISDIR` crash.

A beta (`teamai-cli@beta`, currently `0.20.0-beta.6`) is published for dogfooding; `latest` is untouched.

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)

