### PR TITLE
fix(skills): resolve openclaw skill path for both user and project scope

### DIFF
--- a/src/resources/skills.ts
+++ b/src/resources/skills.ts
@@ -436,7 +436,7 @@ export class SkillsHandler extends ResourceHandler {
       if (!toolPath.skills) continue;
 
       let dest: string;
-      if (tool === 'openclaw' && localConfig.scope !== 'project') {
+      if (tool === 'openclaw') {
         const wsDir = await resolveOpenclawWorkspaceDir();
         if (!wsDir) {
           log.debug(`Skipping skill sync for openclaw: workspace dir not found`);
@@ -493,7 +493,7 @@ export class SkillsHandler extends ResourceHandler {
     for (const [tool, toolPath] of Object.entries(teamConfig.toolPaths)) {
       if (!toolPath.skills) continue;
       let skillDir: string;
-      if (tool === 'openclaw' && localConfig.scope !== 'project') {
+      if (tool === 'openclaw') {
         const wsDir = await resolveOpenclawWorkspaceDir();
         if (!wsDir) continue;
         skillDir = path.join(wsDir, 'skills', name);


### PR DESCRIPTION
## Summary
- Remove `&& localConfig.scope !== 'project'` gate from openclaw skill sync in `SkillsHandler.pullItem()` and `removeItem()`
- OpenClaw reads skills from `<workspace>/skills/` regardless of scope, so both user and project scope should resolve the workspace directory via `resolveOpenclawWorkspaceDir()`

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 1978 tests pass
- [ ] imate openclaw project scope: verify skill installed to `<workspace>/skills/`
- [ ] imate openclaw user scope: verify skill still installed to `<workspace>/skills/` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)