### PR TITLE
fix(search): remove body truncation and allow docs body-only matches

### DIFF
--- a/src/__tests__/search-index.test.ts
+++ b/src/__tests__/search-index.test.ts
@@ -478,13 +478,30 @@ Overview of the middleware layer.
     expect(results[0].entry.filename).toContain('k8s-oom');
   });
 
-  it('discards results with only body matches (no title/tag hit)', async () => {
+  it('discards results with only body matches for non-docs types', async () => {
     // "部署" appears in the body of api-timeout doc ("部署 SGLang 推理服务")
     // but NOT in any title or tag of the test docs.
-    // A body-only match should be filtered out.
+    // A body-only match should be filtered out for learnings type.
     const index = await loadIndex();
     const results = search('部署', index!);
     expect(results).toHaveLength(0);
+  });
+
+  it('allows body-only matches for docs type entries', async () => {
+    // Build a separate index with a docs-type entry that has a generic title
+    // and a domain-specific term only in the body.
+    const docsDir = path.join(tmpDir, 'docs');
+    fs.mkdirSync(docsDir, { recursive: true });
+    fs.writeFileSync(path.join(docsDir, 'dev-guide.md'), `# Dev Guide\n\nUse @supercache decorator for caching.\n`, 'utf-8');
+
+    await buildIndex({ learningsDir, docsDir });
+    const index = await loadIndex();
+
+    // "supercache" only appears in the body of a docs entry, not in title/tags.
+    // With the isDocsEntry relaxation, it should still be returned.
+    const results = search('supercache', index!);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].entry.title).toContain('dev guide');
   });
 
   it('returns results when query matches tag but not title', async () => {

--- a/src/utils/search-index.ts
+++ b/src/utils/search-index.ts
@@ -45,7 +45,6 @@ function getSearchIndexPath(): string {
 //      └─ return sorted results
 //
 
-const MAX_BODY_CHARS = 2000;
 const MAX_DOC_BYTES = 50 * 1024; // 50KB
 
 // \u2500\u2500\u2500 P1.4 Domain inference \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
@@ -261,14 +260,14 @@ export function parseLearningDoc(
           : undefined,
     };
 
-    const bodyExcerpt = body.slice(0, MAX_BODY_CHARS);
+    const bodyExcerpt = body;
     return { meta, bodyExcerpt };
   } catch {
     // Fallback: treat entire content as body, derive title from filename
     log.error(`Failed to parse frontmatter for ${filename}, using fallback`);
     return {
       meta: {},
-      bodyExcerpt: content.slice(0, MAX_BODY_CHARS),
+      bodyExcerpt: content,
     };
   }
 }
@@ -726,13 +725,13 @@ export function search(
     }
 
     // Require at least one title or tag match to filter out body-only noise.
-    // Codebase docs (from team-codebase/) lack tags, so allow body-only matches for them.
-    const isCodebaseDoc = entry.type === 'docs' && (entry.path ?? entry.filename ?? '').includes('team-codebase');
-    if (score > 0 && (hasTitleOrTagMatch || isCodebaseDoc)) {
+    // Docs (type === 'docs') often lack tags and have generic titles, so allow body-only
+    // matches for them — the IDF weighting naturally demotes low-relevance hits.
+    const isDocsEntry = entry.type === 'docs';
+    if (score > 0 && (hasTitleOrTagMatch || isDocsEntry)) {
       // Normalize the token-match sum by query length before adding absolute
       // bonuses, so cross-query scores share a scale (see lengthNorm above).
       score /= lengthNorm;
-
       // Vote bonus: +0.5 per vote, max 5 points (unchanged).
       score += Math.min(entry.votes * 0.5, 5);
 


### PR DESCRIPTION
## Summary

- Remove `MAX_BODY_CHARS` (2000) truncation that prevented domain-specific terms deep in docs from being indexed (e.g. `@supercache` at char offset 12848 in `dev-guide.md` was invisible to search)
- Broaden body-only match exemption from `team-codebase/` paths to all `type === 'docs'` entries — docs often lack frontmatter tags and have generic titles, so the title/tag-match filter was silently dropping them
- Add regression test for docs body-only search matches

### Root cause

In AI-Benchmark testing, `teamai recall` consistently failed to find HAI domain knowledge (supercache, deny_check, errappid handling patterns) stored in docs files. Two bugs compounded:

1. `MAX_BODY_CHARS = 2000` truncated 8/12 HAI docs, losing 74-92% of body content from the search index
2. Even with full body indexing, docs entries were filtered by `hasTitleOrTagMatch` — but HAI docs have no frontmatter tags and generic h1 titles like "HAI 开发指南", so domain terms only appear in the body

This forced the recall subagent to fall back to manual file exploration (35-73 tool calls, 1-3M tokens) to find knowledge that should have been a single CLI search hit.

### After this fix

`teamai recall "supercache inquire cache"` now returns `dev-guide.md` and `hai-api-framework.md` in the top 5 results, where previously they were invisible.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run` — 1824 tests passed (1 new)
- [x] New test: docs entry with body-only match is returned by `search()`
- [x] Existing test: learnings body-only matches are still filtered out

🤖 Generated with [Claude Code](https://claude.com/claude-code)