### PR TITLE
fix(search): deduplicate recall results by stable content identity

### DIFF
--- a/agents/teamai-recall.md
+++ b/agents/teamai-recall.md
@@ -208,9 +208,10 @@ Use judgement rather than counting, in both directions:
   discriminating term as a lead to verify by opening the file, not as a
   conclusion.
 - **Fewer than 5 results does not mean the corpus is thin.** Results are
-  deduplicated when title, date, author and content all match, so a learning
-  shared twice appears once. Body-
-  only matches are also dropped. Both are intentional.
+  deduplicated when type, domain, title, date, author, tags and content all
+  match, so a learning shared twice appears once — including when the two copies
+  have collected different vote counts. Body-only matches are also dropped. Both
+  are intentional.
 
 For each hit you keep, read the source file directly (use `Read`) and
 condense each into **one or two sentences**.

--- a/src/__tests__/search-index.test.ts
+++ b/src/__tests__/search-index.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { tokenize, wordSegments, buildIndex, loadIndex, search } from '../utils/search-index.js';
 import { computeIdfBaseline, isRelevantScore } from '../recall.js';
-import type { SearchIndex } from '../types.js';
+import type { SearchIndex, SearchIndexEntry } from '../types.js';
 
 // ─── Test helpers ──────────────────────────────────────────
 
@@ -507,6 +507,126 @@ Overview of the middleware layer.
     const index = await loadIndex();
     const results = search('docker k8s api', index!, 1);
     expect(results).toHaveLength(1);
+  });
+});
+
+// ─── search: duplicate collapsing ──────────────────────────
+
+describe('search deduplication', () => {
+  /**
+   * Two copies of one re-shared learning, overridable per case. Entries are
+   * synthetic because buildIndex() cannot express "same content, different vote
+   * count" without a votes fixture per case.
+   */
+  function makeEntry(overrides: Partial<SearchIndexEntry> = {}): SearchIndexEntry {
+    return {
+      filename: 'dup-aaa.md',
+      title: 'Duplicate Learning',
+      author: 'carol',
+      date: '2026-03-01',
+      tags: ['oom'],
+      tokens: ['title:dup', 'dup', 'tag:oom', 'oom'],
+      votes: 0,
+      type: 'learnings',
+      domain: 'technical',
+      ...overrides,
+    };
+  }
+
+  function makeIndex(entries: SearchIndexEntry[]): SearchIndex {
+    return { version: 6, entries } as unknown as SearchIndex;
+  }
+
+  it('collapses identical content whose vote counts produced different scores', () => {
+    // A re-shared learning accumulates votes independently of its twin, and the
+    // vote bonus is part of the score — so a key holding score let both survive.
+    const index = makeIndex([
+      makeEntry({ filename: 'dup-aaa.md', votes: 0 }),
+      makeEntry({ filename: 'dup-bbb.md', votes: 3 }),
+    ]);
+
+    const results = search('dup', index);
+    expect(results).toHaveLength(1);
+    // Sorting runs before collapsing, so the surviving copy is the higher-scoring one.
+    expect(results[0].entry.filename).toBe('dup-bbb.md');
+  });
+
+  it('does not merge different content that shares a token count', () => {
+    // Same metadata, same number of tokens, and the same score — the query hits
+    // the same title token in both. Only the body vocabulary differs, which a
+    // length-based key cannot see.
+    const index = makeIndex([
+      makeEntry({ filename: 'alpha.md', tokens: ['title:dup', 'dup', 'tag:oom', 'alpha'] }),
+      makeEntry({ filename: 'beta.md', tokens: ['title:dup', 'dup', 'tag:oom', 'beta'] }),
+    ]);
+
+    const results = search('dup', index);
+    expect(results.map((r) => r.entry.filename).sort()).toEqual(['alpha.md', 'beta.md']);
+  });
+
+  it('does not merge entries that differ only in tags', () => {
+    // Tags reach the key through the token set rather than as a field of their
+    // own, so tag tokens are what has to keep these apart.
+    const index = makeIndex([
+      makeEntry({ filename: 'oom.md', tags: ['oom'], tokens: ['title:dup', 'dup', 'tag:oom', 'oom'] }),
+      makeEntry({ filename: 'cpu.md', tags: ['cpu'], tokens: ['title:dup', 'dup', 'tag:cpu', 'cpu'] }),
+    ]);
+
+    const results = search('dup', index);
+    expect(results).toHaveLength(2);
+  });
+
+  it('does not merge entries that differ only in domain', () => {
+    // domain is authored in frontmatter and never reaches the token set, so it
+    // needs its own slot in the key: dropping score dropped the domain
+    // multiplier that used to keep these apart by accident.
+    const index = makeIndex([
+      makeEntry({ filename: 'support.md', domain: 'support' }),
+      makeEntry({ filename: 'neutral.md', domain: 'neutral' }),
+    ]);
+
+    const results = search('dup', index);
+    expect(results).toHaveLength(2);
+  });
+
+  it('collapses a re-share whose tokens came out in another order', () => {
+    // Tag order is hand-authored, so a re-share can list the same tags
+    // differently and shift the derived tokens with them. That must not read as
+    // different content.
+    const index = makeIndex([
+      makeEntry({
+        filename: 'dup-aaa.md',
+        tags: ['oom', 'k8s'],
+        tokens: ['title:dup', 'dup', 'tag:oom', 'oom', 'tag:k8s', 'k8s'],
+      }),
+      makeEntry({
+        filename: 'dup-bbb.md',
+        tags: ['k8s', 'oom'],
+        tokens: ['title:dup', 'dup', 'tag:k8s', 'k8s', 'tag:oom', 'oom'],
+      }),
+    ]);
+
+    const results = search('dup', index);
+    expect(results).toHaveLength(1);
+  });
+
+  it('does not let duplicates consume the result limit', () => {
+    // Three copies of one learning plus a distinct entry, asking for two
+    // results. The copies must collapse so the distinct entry still makes the cut.
+    const index = makeIndex([
+      makeEntry({ filename: 'dup-aaa.md', votes: 0 }),
+      makeEntry({ filename: 'dup-bbb.md', votes: 3 }),
+      makeEntry({ filename: 'dup-ccc.md', votes: 6 }),
+      makeEntry({
+        filename: 'other.md',
+        title: 'Other Learning',
+        tags: ['cpu'],
+        tokens: ['title:dup', 'dup', 'tag:cpu', 'cpu'],
+      }),
+    ]);
+
+    const results = search('dup', index, 2);
+    expect(results.map((r) => r.entry.title)).toEqual(['Duplicate Learning', 'Other Learning']);
   });
 });
 

--- a/src/utils/search-index.ts
+++ b/src/utils/search-index.ts
@@ -642,6 +642,32 @@ export interface SearchResult {
 }
 
 /**
+ * Identity key for collapsing duplicate search results: only fields a re-share
+ * copies verbatim, so two copies of one document match however each scored.
+ *
+ * `score` is excluded because it is per-query and carries the vote bonus, so
+ * copies drift apart as they collect votes independently. Token *content* is
+ * compared rather than `tokens.length`, which distinct entries routinely share.
+ *
+ * `tokens` is the entry's deduplicated token set (title + tags + body excerpt),
+ * so tags and body reach the key already normalized, and comparison is by
+ * vocabulary rather than prose. It is sorted because tag order follows
+ * hand-authored frontmatter, which a re-share may reorder. `domain` is listed
+ * separately: it comes from frontmatter, never reaches the token set, and until
+ * now was kept apart only by the domain multiplier inside `score`.
+ */
+function dedupKey(r: SearchResult): string {
+  return JSON.stringify([
+    r.entry.type,
+    r.entry.domain,
+    r.entry.title,
+    r.entry.date,
+    r.entry.author,
+    [...r.entry.tokens].sort(),
+  ]);
+}
+
+/**
  * Search the index with a query string.
  *
  * Scoring (P1.4 domain-weighted):
@@ -780,24 +806,16 @@ export function search(
 
   // Collapse duplicates before truncating. The same learning can be shared
   // twice, landing in the corpus as two files whose only difference is the
-  // random filename suffix; both score identically and would otherwise consume
-  // two of the `limit` slots, silently narrowing the result set.
+  // random filename suffix; both would otherwise consume two of the `limit`
+  // slots, silently narrowing the result set.
   //
-  // The key must not merge genuinely distinct entries that happen to share a
-  // title, so it covers the fields a re-share copies verbatim. Entries differing
-  // in tags or body differ in token count, and any scoring difference separates
-  // them too.
+  // Results are already sorted by score descending, so the surviving copy of a
+  // duplicate is its highest-scoring one. See dedupKey for what counts as the
+  // same content.
   const seen = new Set<string>();
   const deduped: SearchResult[] = [];
   for (const r of results) {
-    const key = [
-      r.entry.type,
-      r.entry.title,
-      r.entry.date,
-      r.entry.author,
-      r.entry.tokens.length,
-      r.score,
-    ].join(' ');
+    const key = dedupKey(r);
     if (seen.has(key)) continue;
     seen.add(key);
     deduped.push(r);


### PR DESCRIPTION
## Summary

`search()` deduplicates results by a key that includes `score` and `tokens.length`. Neither identifies a document, so results are collapsed in both directions: identical content survives deduplication, and distinct content is merged. This replaces the key with stable content identity.

The index schema and public CLI behavior are unchanged.

## Problem

The key was `[type, title, date, author, tokens.length, score]` (`src/utils/search-index.ts`).

**Identical content survives deduplication.** `score` carries the vote bonus (`score += Math.min(entry.votes * 0.5, 5)`), so two copies of one re-shared learning drift apart as they collect votes independently. The comment above the block assumed the opposite — "both score identically" — which holds only until either copy is voted on. Both copies then consume a `limit` slot, and since Recall returns at most 5 results, the duplicate crowds out independent information.

**Distinct content is merged.** `tokens.length` counts tokens without comparing them, so two entries sharing type, title, date, author, token count and score are collapsed and one is silently dropped.

Reproduced end-to-end with the real CLI (fixture: one learning shared twice with different vote counts, plus one distinct learning):

```
# before — the duplicate takes two of three slots
[1/3] Redis connection timeout under load  Score: 11.8  → redis-timeout-2026-03-01-bbb.md
[2/3] Redis connection timeout under load  Score: 9.7   → redis-timeout-2026-03-01-aaa.md
[3/3] Redis pool sizing guide              Score: 4.2   → redis-pool-2026-03-02-ccc.md

# after — the duplicate collapses to its highest-scoring copy
[1/2] Redis connection timeout under load  Score: 11.8  → redis-timeout-2026-03-01-bbb.md
[2/2] Redis pool sizing guide              Score: 4.2   → redis-pool-2026-03-02-ccc.md
```

## Change

Key on the fields a re-share copies verbatim: `type`, `domain`, `title`, `date`, `author` and the full token set. Notes on the choices:

- **`score` is dropped** — it is per-query and vote-dependent, not an identity.
- **Token content replaces token count.** `tokens` is the entry's deduplicated token set (title + tags + body excerpt), so this compares vocabulary rather than prose. Two documents built from exactly the same terms are still treated as the same content; that is a deliberate limit of keying on the index rather than the source file.
- **Tags are covered by the token set, not listed separately.** They enter `tokens` as `tag:<token>` at index time, already lowercased. Adding raw `tags` alongside would be redundant and would also re-introduce a miss: a copy that capitalizes a tag differently (`API` vs `api`) has an identical token set but different raw tags, and would stop deduplicating.
- **`tokens` is sorted** because tag order follows hand-authored frontmatter, which a re-share may reorder.
- **`domain` is listed separately.** It is authored in frontmatter, never reaches the token set, and was previously kept apart only by the domain multiplier inside `score`. Without it `search-domain-weighting.test.ts` regresses — two entries differing only in domain get merged. Caught by the existing suite.
- Sorting stays before deduplication, so the surviving copy of a duplicate is its highest-scoring one.

## Open question for maintainers

`date` is kept in the key, which is the conservative choice (it preserves current behavior and cannot over-merge). But it means a learning re-shared on a **different day** still returns twice, and that may be the more common re-share in practice. If `date` is metadata rather than content identity, dropping it would catch that case — happy to change it either way.

## Test plan

Every item below was executed.

- [x] `npx vitest run src/__tests__/search-index.test.ts` — 52/52 pass. Six new cases in a `search deduplication` suite; four of them fail on `main` before the fix (vote-driven duplicates, same-token-count distinct content, tags-only difference, duplicates consuming the limit). The other two guard the merge directions this key must not take (domain, token order).
- [x] `npx vitest run src/__tests__/search-domain-weighting.test.ts src/__tests__/search-index-multi.test.ts src/__tests__/recall-check.test.ts src/__tests__/recall-format.test.ts` — no new failures.
- [x] `npm test` — 1927 passed / 57 failed, against a `main` baseline of 1921 passed / 57 failed on the same machine. Identical failure set; the pre-existing failures are Windows path-separator assertions (e.g. `expected 'common/coding-style.md' to be 'common\coding-style.md'`), unrelated to this change.
- [x] `npm run typecheck` — clean.
- [x] `npm run build` — clean.
- [x] Real CLI end-to-end: `teamai recall "redis timeout"` against a fixture team repo, before/after output shown above.

## Docs

`agents/teamai-recall.md` described deduplication as matching on "title, date, author and content". That was aspirational — content was never compared. Updated to state the actual fields and to note that copies with different vote counts now collapse. No other doc describes this behavior (grepped for `dedup|去重|duplicate`), and this file has no `.zh-CN` counterpart.

## Non-goals

- No ranking-formula changes.
- No Recall trigger changes.
- No index schema migration. An index-time `contentHash` is the natural follow-up if key construction ever shows up in a profile; it is not needed here, since the loop breaks at `limit` and so builds a bounded number of keys per query.
- No change to the cross-source merge in `recall.ts`, which re-sorts learnings and codebase-graph hits together. This PR fixes deduplication inside `search()` only.
