### PR TITLE
feat(git): support generic private repository hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ npm install -g teamai-cli
 
 ### Team admin / solo user
 
-Create a shared-experience repo on your git host (GitHub, TGit, or CNB), **grant write access to team members**, then have them run `teamai init https://github.com/yourorg/yourrepo`.
+Create a shared-experience repo on your git host (GitHub, TGit, CNB, or a self-hosted Git service), **grant write access to team members**, then have them run `teamai init https://github.com/yourorg/yourrepo`.
 
 > Solo use needs no separate repo setup: `teamai init` checks the target repo and creates it automatically if it doesn't exist.
+
+> Self-hosted GitLab/Gitea-style services use your HTTPS credential helper or SSH key. Create the repository first; merge requests are created manually for now. See [Git Provider docs](docs/providers.md).
 
 > **No team repo yet?** Start from a template pre-loaded with production-ready skills, rules, and review agents. Browse the [teamai-hub](https://github.com/teamai-hub) org, click **Use this template**, then `teamai init` against your new repo.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,9 +30,11 @@ npm install -g teamai-cli
 
 ### 团队管理员 / 个人使用者
 
-在 Git 托管平台（GitHub、TGit 或 CNB）创建共享经验仓库，**授予团队成员写权限**，然后让他们运行 `teamai init https://github.com/yourorg/yourrepo`。
+在 Git 托管平台（GitHub、TGit、CNB 或自建 Git 服务）创建共享经验仓库，**授予团队成员写权限**，然后让他们运行 `teamai init https://github.com/yourorg/yourrepo`。
 
 > 个人使用无需单独建仓：`teamai init` 会检查目标仓库，不存在时自动创建。
+
+> 自建 GitLab/Gitea 等服务支持 HTTPS Credential Helper 或 SSH Key；需预先创建仓库，MR 暂时手动创建。详见 [Git Provider 说明](docs/providers.md)。
 
 > **还没有团队仓库？** 可以从内置了成套 skills、rules、review agents 的模板起步。浏览 [teamai-hub](https://github.com/teamai-hub) org，点 **Use this template** 生成自己的仓库，再对它执行 `teamai init`。
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,12 +1,13 @@
 # Git Provider 说明
 
-TeamAI CLI 通过 provider 抽象层支持多个 git 托管平台。当前实现了三个：
+TeamAI CLI 通过 provider 抽象层支持多个 Git 托管平台。当前实现了四个：
 
 | Provider | Host            | 认证方式                            | 建议场景              |
 |----------|-----------------|--------------------------------------|----------------------|
 | `github` | github.com      | `gh` CLI 或 `GITHUB_TOKEN` 环境变量  | 开源项目、外部用户    |
 | `tgit`   | git.woa.com     | `gf` CLI（自动下载）+ `~/.netrc`     | 腾讯内部团队          |
 | `cnb`    | cnb.cool        | `cnb login` 或 `CNB_TOKEN` 环境变量  | CNB（云原生构建）用户 |
+| `git`    | 任意 Git host   | 系统 Git Credential Helper 或 SSH Key | 自建 GitLab/Gitea 等 |
 
 ## Provider 自动检测
 
@@ -20,9 +21,28 @@ https://git.woa.com/team/repo(.git)     → tgit
 git@git.woa.com:team/repo.git           → tgit
 https://cnb.cool/org/repo(.git)         → cnb
 git@cnb.cool:org/repo.git               → cnb
+https://git.example.com/group/repo.git  → git
+git@git.example.com:group/repo.git      → git
 ```
 
 provider 选择会写入 team 仓库的 `teamai.yaml` 的 `provider` 字段，后续 `push` / `pull` 都按这个值来。
+
+## 通用 Git Provider（自建/私有仓库）
+
+不在已知 host 列表中的完整 HTTPS 或 SSH URL 会自动选择 `git` provider。例如：
+
+```bash
+teamai init https://code.qschou.com/Enterprise/arb-workflow-kit.git --scope user
+# 或使用 SSH
+teamai init git@code.qschou.com:Enterprise/arb-workflow-kit.git --scope user
+```
+
+通用 provider 不读取或保存平台 Token，而是让系统 `git` 处理认证：
+
+- HTTPS：预先配置 Git Credential Helper；不要把用户名、密码或 Token 写进 URL。
+- SSH：预先配置 SSH Key，并确保 `ssh-agent` 能访问私钥。
+
+clone、pull、push 均可正常使用。平台 API 操作（自动建仓、自动创建 MR/PR）无法跨不同服务统一实现，因此暂不支持；`teamai push` 会先推送分支，再提示用户到对应平台手动创建 MR。
 
 ## GitHub Provider
 
@@ -141,7 +161,7 @@ CNB Provider 不设默认 email 域（同 GitHub）。
 
 ## 手动指定 Provider
 
-除了 URL 自动检测，也可以在 team 仓库的 `teamai.yaml` 中显式写 `provider: github`、`provider: tgit` 或 `provider: cnb` 强制切换。一个典型的 `teamai.yaml`：
+除了 URL 自动检测，也可以在 team 仓库的 `teamai.yaml` 中显式写 `provider: github`、`provider: tgit`、`provider: cnb` 或 `provider: git` 强制切换。一个典型的 `teamai.yaml`：
 
 ```yaml
 team: my-team
@@ -156,7 +176,7 @@ reviewers:
 
 ## 新增 Provider
 
-Provider 是一个 TypeScript 接口（见 [`src/providers/types.ts`](../src/providers/types.ts)），新增 GitLab / Bitbucket / Gitea 等只需要：
+Provider 是一个 TypeScript 接口（见 [`src/providers/types.ts`](../src/providers/types.ts)），新增带平台 API 能力的 GitLab / Bitbucket / Gitea provider 只需要：
 
 1. 新建 `src/providers/<name>/` 目录
 2. 实现 `GitProvider` 接口：`parseRepoInput` / `authenticate` / `cloneRepo` / `createRepo` / `createPullRequest` / `getDefaultEmailDomain`

--- a/src/__tests__/generic-git-provider.test.ts
+++ b/src/__tests__/generic-git-provider.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+
+vi.mock('node:child_process', () => ({
+  spawnSync: vi.fn(),
+}));
+
+import { spawnSync } from 'node:child_process';
+import { GenericGitProvider } from '../providers/git/index.js';
+import { parseGenericGitRepoInput } from '../providers/git/repo-url.js';
+import { detectProvider, getProvider } from '../providers/registry.js';
+
+const mockedSpawnSync = spawnSync as Mock;
+
+describe('generic Git provider detection', () => {
+  it('detects arbitrary HTTPS and SSH hosts', () => {
+    expect(detectProvider('https://code.qschou.com/Enterprise/arb-workflow-kit.git')).toBe('git');
+    expect(detectProvider('git@code.qschou.com:Enterprise/arb-workflow-kit.git')).toBe('git');
+    expect(detectProvider('ssh://git@code.qschou.com/Enterprise/arb-workflow-kit.git')).toBe('git');
+  });
+
+  it('keeps known hosts on their dedicated providers', () => {
+    expect(detectProvider('https://github.com/org/repo.git')).toBe('github');
+    expect(detectProvider('git@git.woa.com:org/repo.git')).toBe('tgit');
+    expect(detectProvider('https://cnb.cool/org/repo.git')).toBe('cnb');
+  });
+
+  it('returns a registered generic provider', () => {
+    expect(getProvider('git')).toBeInstanceOf(GenericGitProvider);
+  });
+});
+
+describe('parseGenericGitRepoInput', () => {
+  it('parses nested HTTPS namespaces and preserves the host', () => {
+    expect(parseGenericGitRepoInput(
+      'https://code.qschou.com/Enterprise/platform/arb-workflow-kit.git',
+    )).toEqual({
+      owner: 'Enterprise/platform',
+      repo: 'arb-workflow-kit',
+      httpsUrl: 'https://code.qschou.com/Enterprise/platform/arb-workflow-kit.git',
+      projectId: encodeURIComponent('Enterprise/platform/arb-workflow-kit'),
+    });
+  });
+
+  it('parses scp-style and ssh:// URLs', () => {
+    const scp = parseGenericGitRepoInput(
+      'git@code.qschou.com:Enterprise/arb-workflow-kit.git',
+    );
+    expect(scp.owner).toBe('Enterprise');
+    expect(scp.repo).toBe('arb-workflow-kit');
+    expect(scp.httpsUrl).toBe('git@code.qschou.com:Enterprise/arb-workflow-kit.git');
+
+    const ssh = parseGenericGitRepoInput(
+      'ssh://git@code.qschou.com:2222/Enterprise/arb-workflow-kit',
+    );
+    expect(ssh.httpsUrl).toBe(
+      'ssh://git@code.qschou.com:2222/Enterprise/arb-workflow-kit.git',
+    );
+  });
+
+  it('rejects bare names and embedded HTTPS credentials', () => {
+    expect(() => parseGenericGitRepoInput('Enterprise/arb-workflow-kit')).toThrow(
+      /Invalid Git repo URL/,
+    );
+    expect(() => parseGenericGitRepoInput(
+      'https://oauth2:secret@code.qschou.com/Enterprise/arb-workflow-kit.git',
+    )).toThrow(/Do not embed credentials/);
+  });
+});
+
+describe('GenericGitProvider transport', () => {
+  beforeEach(() => {
+    mockedSpawnSync.mockReset();
+  });
+
+  it('clones the exact parsed remote through system git', () => {
+    mockedSpawnSync.mockReturnValue({ status: 0, stdout: '', stderr: '' });
+    const provider = new GenericGitProvider();
+    provider.parseRepoInput('git@code.qschou.com:Enterprise/arb-workflow-kit.git');
+
+    provider.cloneRepo('Enterprise/arb-workflow-kit', '/tmp/team-repo');
+
+    expect(mockedSpawnSync).toHaveBeenCalledWith(
+      'git',
+      ['clone', 'git@code.qschou.com:Enterprise/arb-workflow-kit.git', '/tmp/team-repo'],
+      expect.objectContaining({ timeout: 120_000 }),
+    );
+  });
+
+  it('surfaces clone failures', () => {
+    mockedSpawnSync.mockReturnValue({
+      status: 128,
+      stdout: '',
+      stderr: 'fatal: Authentication failed',
+    });
+    const provider = new GenericGitProvider();
+    provider.parseRepoInput('https://code.qschou.com/Enterprise/arb-workflow-kit.git');
+
+    expect(() => provider.cloneRepo('Enterprise/arb-workflow-kit', '/tmp/team-repo'))
+      .toThrow(/git clone failed: fatal: Authentication failed/);
+  });
+
+  it('reports unsupported host API operations explicitly', async () => {
+    const provider = new GenericGitProvider();
+    await expect(provider.createRepo()).rejects.toThrow(/not supported/);
+    await expect(provider.createPullRequest({
+      repo: 'Enterprise/arb-workflow-kit',
+      source: 'feature',
+      target: 'main',
+      title: 'test',
+    })).rejects.toThrow(/not supported/);
+  });
+});

--- a/src/__tests__/generic-git-provider.test.ts
+++ b/src/__tests__/generic-git-provider.test.ts
@@ -5,7 +5,7 @@ vi.mock('node:child_process', () => ({
 }));
 
 import { spawnSync } from 'node:child_process';
-import { GenericGitProvider } from '../providers/git/index.js';
+import { GenericGitProvider, normalizeGitIdentity } from '../providers/git/index.js';
 import { parseGenericGitRepoInput } from '../providers/git/repo-url.js';
 import { detectProvider, getProvider } from '../providers/registry.js';
 
@@ -14,6 +14,7 @@ const mockedSpawnSync = spawnSync as Mock;
 describe('generic Git provider detection', () => {
   it('detects arbitrary HTTPS and SSH hosts', () => {
     expect(detectProvider('https://code.qschou.com/Enterprise/arb-workflow-kit.git')).toBe('git');
+    expect(detectProvider('HTTPS://code.qschou.com/Enterprise/arb-workflow-kit.git')).toBe('git');
     expect(detectProvider('git@code.qschou.com:Enterprise/arb-workflow-kit.git')).toBe('git');
     expect(detectProvider('ssh://git@code.qschou.com/Enterprise/arb-workflow-kit.git')).toBe('git');
   });
@@ -65,6 +66,32 @@ describe('parseGenericGitRepoInput', () => {
       'https://oauth2:secret@code.qschou.com/Enterprise/arb-workflow-kit.git',
     )).toThrow(/Do not embed credentials/);
   });
+
+  it('rejects insecure HTTP and does not echo query-string secrets', () => {
+    expect(() => parseGenericGitRepoInput(
+      'http://code.qschou.com/Enterprise/arb-workflow-kit.git',
+    )).toThrow(/plain HTTP is not supported/);
+
+    let message = '';
+    try {
+      parseGenericGitRepoInput(
+        'https://code.qschou.com/Enterprise/arb-workflow-kit.git?token=secret-value',
+      );
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).toMatch(/query strings and fragments are not supported/);
+    expect(message).not.toContain('secret-value');
+  });
+});
+
+describe('generic Git identity', () => {
+  it('normalizes display names and path-like values into safe member ids', () => {
+    expect(normalizeGitIdentity('Jane Doe')).toBe('Jane-Doe');
+    expect(normalizeGitIdentity('../../outside')).toBe('outside');
+    expect(normalizeGitIdentity('CON')).toBe('user-CON');
+    expect(normalizeGitIdentity('中文用户')).toBeNull();
+  });
 });
 
 describe('GenericGitProvider transport', () => {
@@ -83,9 +110,43 @@ describe('GenericGitProvider transport', () => {
 
     expect(mockedSpawnSync).toHaveBeenCalledWith(
       'git',
-      ['clone', 'git@code.qschou.com:Enterprise/arb-workflow-kit.git', '/tmp/team-repo'],
+      ['clone', '--', 'git@code.qschou.com:Enterprise/arb-workflow-kit.git', '/tmp/team-repo'],
       expect.objectContaining({ timeout: 120_000 }),
     );
+  });
+
+  it('checks that git is installed before transport operations', async () => {
+    mockedSpawnSync.mockReturnValue({ status: 0, stdout: 'git version 2.50.0\n', stderr: '' });
+
+    await expect(new GenericGitProvider().ensureInstalled()).resolves.toBeUndefined();
+    expect(mockedSpawnSync).toHaveBeenCalledWith(
+      'git',
+      ['--version'],
+      expect.objectContaining({ timeout: 10_000 }),
+    );
+  });
+
+  it('reports a clear error when git is unavailable', async () => {
+    mockedSpawnSync.mockReturnValue({
+      status: null,
+      stdout: '',
+      stderr: '',
+      error: new Error('spawn git ENOENT'),
+    });
+
+    await expect(new GenericGitProvider().ensureInstalled()).rejects.toThrow(
+      /git is required.*PATH/,
+    );
+  });
+
+  it('uses a safe normalized identity for member files and branch names', async () => {
+    mockedSpawnSync.mockReturnValue({
+      status: 0,
+      stdout: '../../outside\n',
+      stderr: '',
+    });
+
+    await expect(new GenericGitProvider().authenticate()).resolves.toBe('outside');
   });
 
   it('surfaces clone failures', () => {

--- a/src/__tests__/generic-git-provider.test.ts
+++ b/src/__tests__/generic-git-provider.test.ts
@@ -72,12 +72,14 @@ describe('GenericGitProvider transport', () => {
     mockedSpawnSync.mockReset();
   });
 
-  it('clones the exact parsed remote through system git', () => {
+  it('clones a full remote URL without requiring parseRepoInput first', () => {
     mockedSpawnSync.mockReturnValue({ status: 0, stdout: '', stderr: '' });
     const provider = new GenericGitProvider();
-    provider.parseRepoInput('git@code.qschou.com:Enterprise/arb-workflow-kit.git');
 
-    provider.cloneRepo('Enterprise/arb-workflow-kit', '/tmp/team-repo');
+    provider.cloneRepo(
+      'git@code.qschou.com:Enterprise/arb-workflow-kit.git',
+      '/tmp/team-repo',
+    );
 
     expect(mockedSpawnSync).toHaveBeenCalledWith(
       'git',
@@ -93,10 +95,28 @@ describe('GenericGitProvider transport', () => {
       stderr: 'fatal: Authentication failed',
     });
     const provider = new GenericGitProvider();
-    provider.parseRepoInput('https://code.qschou.com/Enterprise/arb-workflow-kit.git');
 
-    expect(() => provider.cloneRepo('Enterprise/arb-workflow-kit', '/tmp/team-repo'))
+    expect(() => provider.cloneRepo(
+      'https://code.qschou.com/Enterprise/arb-workflow-kit.git',
+      '/tmp/team-repo',
+    ))
       .toThrow(/git clone failed: fatal: Authentication failed/);
+  });
+
+  it('uses the shared URL sanitizer for clone errors', () => {
+    mockedSpawnSync.mockReturnValue({
+      status: 128,
+      stdout: '',
+      stderr: 'fatal: https://oauth2:secret@code.qschou.com/Enterprise/repo.git',
+    });
+    const provider = new GenericGitProvider();
+
+    expect(() => provider.cloneRepo(
+      'https://code.qschou.com/Enterprise/repo.git',
+      '/tmp/team-repo',
+    )).toThrow(
+      'git clone failed: fatal: https://***@code.qschou.com/Enterprise/repo.git',
+    );
   });
 
   it('reports unsupported host API operations explicitly', async () => {

--- a/src/__tests__/github-provider.test.ts
+++ b/src/__tests__/github-provider.test.ts
@@ -105,8 +105,8 @@ describe('detectProvider', () => {
     expect(detectProvider('org/repo')).toBe('github');
   });
 
-  it('defaults unknown hosts to github', () => {
-    expect(detectProvider('https://gitlab.com/org/repo')).toBe('github');
+  it('uses generic git for unknown hosts', () => {
+    expect(detectProvider('https://gitlab.com/org/repo')).toBe('git');
   });
 });
 

--- a/src/__tests__/home.test.ts
+++ b/src/__tests__/home.test.ts
@@ -1,0 +1,70 @@
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { getUserHome } from '../utils/home.js';
+import { getTeamaiHome, resolveBaseDir, type LocalConfig } from '../types.js';
+
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
+
+function restoreEnv(name: 'HOME' | 'USERPROFILE', value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+afterEach(() => {
+  restoreEnv('HOME', originalHome);
+  restoreEnv('USERPROFILE', originalUserProfile);
+});
+
+describe('getUserHome', () => {
+  it('prefers HOME when it is available', () => {
+    process.env.HOME = '/home/alice';
+    process.env.USERPROFILE = 'C:\\Users\\alice';
+
+    expect(getUserHome()).toBe('/home/alice');
+  });
+
+  it('falls back to USERPROFILE when HOME is unavailable', () => {
+    delete process.env.HOME;
+    process.env.USERPROFILE = 'C:\\Users\\alice';
+
+    expect(getUserHome()).toBe('C:\\Users\\alice');
+    expect(getTeamaiHome('user')).toBe(path.join('C:\\Users\\alice', '.teamai'));
+
+    const config: LocalConfig = {
+      repo: {
+        localPath: 'C:\\Users\\alice\\.teamai\\team-repo',
+        remote: 'git@example.com:team/repo.git',
+      },
+      username: 'alice',
+      scope: 'user',
+      additionalRoles: [],
+    };
+    expect(resolveBaseDir(config)).toBe('C:\\Users\\alice');
+  });
+
+  it('initializes exported user paths from USERPROFILE when HOME is unavailable', async () => {
+    delete process.env.HOME;
+    process.env.USERPROFILE = 'C:\\Users\\alice';
+    vi.resetModules();
+
+    const paths = await import('../types.js');
+
+    expect(paths.TEAMAI_HOME).toBe(path.join('C:\\Users\\alice', '.teamai'));
+    expect(paths.TEAMAI_CONFIG_PATH).toBe(
+      path.join('C:\\Users\\alice', '.teamai', 'config.yaml'),
+    );
+    expect(paths.TEAMAI_SOURCES_DIR).toBe(
+      path.join('C:\\Users\\alice', '.teamai', 'sources'),
+    );
+  });
+
+  it('falls back to os.homedir when neither environment variable is available', () => {
+    delete process.env.HOME;
+    delete process.env.USERPROFILE;
+
+    expect(getUserHome()).toBe(os.homedir());
+  });
+});

--- a/src/__tests__/provider-fallback.test.ts
+++ b/src/__tests__/provider-fallback.test.ts
@@ -112,9 +112,9 @@ describe('detectProvider with package-name fallback', () => {
     expect(detectProvider('HyperAI/teamai')).toBe('tgit');
   });
 
-  it('unknown host → tgit when installed from internal tnpm', () => {
+  it('unknown full URL → generic git even when installed from internal tnpm', () => {
     setPackageName('@tencent/teamai-cli');
-    expect(detectProvider('https://gitlab.com/org/repo')).toBe('tgit');
+    expect(detectProvider('https://gitlab.com/org/repo')).toBe('git');
   });
 
   it('explicit github.com URL still resolves to github on tnpm build', () => {

--- a/src/__tests__/source.test.ts
+++ b/src/__tests__/source.test.ts
@@ -27,7 +27,7 @@ vi.mock('../utils/git.js', () => ({
   pullRepo: vi.fn().mockResolvedValue('already up to date'),
 }));
 
-import { getAllSourceSkillNames, pullSources } from '../source.js';
+import { deriveSourceName, getAllSourceSkillNames, pullSources } from '../source.js';
 import type { TeamaiConfig, LocalConfig, SourceInstallManifest } from '../types.js';
 
 describe('source', () => {
@@ -74,6 +74,14 @@ describe('source', () => {
     await fse.remove(tmpDir);
   });
 
+  describe('deriveSourceName', () => {
+    it('handles HTTPS, scp-style SSH, and ssh:// URLs with a port', () => {
+      expect(deriveSourceName('https://git.example.com/group/sub/repo.git')).toBe('group');
+      expect(deriveSourceName('git@git.example.com:group/sub/repo.git')).toBe('group');
+      expect(deriveSourceName('ssh://git@git.example.com:2222/group/sub/repo.git')).toBe('group');
+    });
+  });
+
   describe('getAllSourceSkillNames', () => {
     it('should return empty set when no sources exist', async () => {
       const names = await getAllSourceSkillNames();
@@ -111,6 +119,22 @@ describe('source', () => {
       expect(names.has('team-a-skill')).toBe(true);
       expect(names.has('team-b-skill')).toBe(true);
       expect(names.size).toBe(2);
+    });
+
+    it('falls back to USERPROFILE when HOME is unavailable', async () => {
+      vi.unstubAllEnvs();
+      vi.stubEnv('USERPROFILE', homeDir);
+      delete process.env.HOME;
+
+      const manifestDir = path.join(sourcesDir, 'windows-team');
+      await fse.ensureDir(manifestDir);
+      await fse.writeJson(path.join(manifestDir, 'installed.json'), {
+        lastPull: new Date().toISOString(),
+        installedSkills: ['windows-skill'],
+      } satisfies SourceInstallManifest);
+
+      const names = await getAllSourceSkillNames();
+      expect(names).toContain('windows-skill');
     });
   });
 

--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -52,6 +52,18 @@ describe('MemberConfigSchema', () => {
 });
 
 describe('TeamaiConfigSchema', () => {
+  it.each(['github', 'tgit', 'cnb', 'git'] as const)(
+    'accepts the %s provider',
+    (provider) => {
+      const result = TeamaiConfigSchema.parse({
+        team: 'test-team',
+        repo: 'https://example.com/test/repo.git',
+        provider,
+      });
+      expect(result.provider).toBe(provider);
+    },
+  );
+
   it('should include codebuddy in default toolPaths', () => {
     const result = TeamaiConfigSchema.parse({
       team: 'test-team',

--- a/src/clone.ts
+++ b/src/clone.ts
@@ -138,11 +138,11 @@ async function gitCmd(
  * 三层认证策略：
  *   1. forceSsh=true 或 url 是 SSH 形式 → 直接走 SSH
  *   2. github 且能拿到 token → HTTPS + x-access-token 注入
- *   3. tgit 走 ~/.netrc（git 自身处理）；github 无 token 则匿名 HTTPS
+ *   3. 其他 provider 交给 Git credential helper / ~/.netrc 处理；github 无 token 则匿名 HTTPS
  *
  * @param url        仓库 URL（https/ssh 任一）
  * @param localPath  目标目录（存在则先 rm 再 clone）
- * @param provider   'github' | 'tgit'
+ * @param provider   Provider name such as 'github', 'tgit', 'cnb', or 'git'
  * @param opts       克隆选项
  */
 export async function shallowClone(
@@ -202,10 +202,10 @@ export async function shallowClone(
             log.debug(`shallowClone: 无 TGit OAuth token，尝试匿名 HTTPS 克隆`);
         }
     } else {
-        // 其他 provider，依赖 ~/.netrc
+        // 其他 provider 依赖 Git 自身的 credential helper / ~/.netrc。
         cloneUrl = url.replace(/^http:\/\//, 'https://');
         cloneMethod = 'https-anonymous';
-        log.debug(`shallowClone: 使用 HTTPS (~/.netrc) 克隆 ${provider} 仓库`);
+        log.debug(`shallowClone: 使用 HTTPS (Git credential helper / ~/.netrc) 克隆 ${provider} 仓库`);
     }
 
     // 构建 clone 参数：若有 token 则通过 http.extraHeader 注入，避免 token 出现在 URL 中

--- a/src/clone.ts
+++ b/src/clone.ts
@@ -5,6 +5,7 @@ import fs from 'fs-extra';
 import { getGitHubToken } from './providers/github/gh-cli.js';
 import { tgitGitCloneUrl } from './providers/tgit/rest-auth.js';
 import { log } from './utils/logger.js';
+import { sanitizeGitUrl } from './utils/redact.js';
 
 // ─── Types ──────────────────────────────────────────────
 
@@ -56,9 +57,7 @@ function convertHttpToSsh(url: string): string {
  * @param msg  可能含有 token 的字符串
  * @returns    脱敏后的字符串
  */
-export function sanitizeGitUrl(msg: string): string {
-    return msg.replace(/https?:\/\/[^@\s]+@/g, 'https://***@');
-}
+export { sanitizeGitUrl };
 
 /**
  * 对日志/错误信息中的 token 进行脱敏。

--- a/src/import-repo.ts
+++ b/src/import-repo.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 
 import { generateCodebaseMd } from './codebase.js';
 import { extractCodebase } from './codebase-extract.js';
-import { detectProvider } from './providers/registry.js';
+import { detectProvider, getProvider } from './providers/registry.js';
 import { shallowClone, shallowFetch } from './clone.js';
 import {
     getRepoCacheDir,
@@ -202,21 +202,9 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
         throw new Error(`Unsupported repo URL: ${url}`);
     }
 
-    // Extract owner and repo name from url
-    // Supports https://github.com/owner/repo[.git] and git@github.com:owner/repo[.git]
-    let owner: string;
-    let repoName: string;
-    const httpsMatch = url.match(/https?:\/\/[^/]+\/([^/]+)\/([^/]+?)(?:\.git)?(?:\/.*)?$/);
-    const sshMatch = url.match(/git@[^:]+:([^/]+)\/([^/]+?)(?:\.git)?$/);
-    if (httpsMatch) {
-        owner = httpsMatch[1];
-        repoName = httpsMatch[2];
-    } else if (sshMatch) {
-        owner = sshMatch[1];
-        repoName = sshMatch[2];
-    } else {
-        throw new Error(`Unsupported repo URL: ${url}`);
-    }
+    const repoInfo = getProvider(providerName).parseRepoInput(url);
+    const owner = repoInfo.owner;
+    const repoName = repoInfo.repo;
 
     log.info(`Importing remote repo: ${owner}/${repoName} (provider: ${providerName})`);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ program
 
 program
   .command('init')
-  .description('Initialize teamai (configure TGit, clone repo, register member)')
+  .description('Initialize teamai (configure Git provider, clone repo, register member)')
   .argument('[repo]', 'Team repo (owner/repo or full URL)')
   .option('--repo <repo>', 'Team repo (alias of the positional argument)')
   .option('--http <url>', 'Git-free HTTP team repo (read-only consumer; only needs an API key)')

--- a/src/init.ts
+++ b/src/init.ts
@@ -1002,8 +1002,11 @@ export async function init(options: GlobalOptions & {
 
   if (!await pathExists(localPath)) {
     const cloneSpin = spinner('Cloning team repo...').start();
+    const cloneTarget = provider.name === 'git'
+      ? repoInfo.httpsUrl
+      : `${repoInfo.owner}/${repoInfo.repo}`;
     try {
-      provider.cloneRepo(`${repoInfo.owner}/${repoInfo.repo}`, localPath);
+      provider.cloneRepo(cloneTarget, localPath);
       cloneSpin.succeed('Team repo cloned');
     } catch (e) {
       if (e instanceof RepoNotFoundError) {
@@ -1033,7 +1036,7 @@ export async function init(options: GlobalOptions & {
         // Retry clone after creation
         const retryCloneSpin = spinner('Cloning newly created repo...').start();
         try {
-          provider.cloneRepo(`${repoInfo.owner}/${repoInfo.repo}`, localPath);
+          provider.cloneRepo(cloneTarget, localPath);
           retryCloneSpin.succeed('Team repo cloned');
         } catch (ce) {
           retryCloneSpin.fail(`Clone failed: ${(ce as Error).message}`);

--- a/src/init.ts
+++ b/src/init.ts
@@ -9,6 +9,7 @@ import { getProvider, detectProvider, RepoNotFoundError } from './providers/inde
 import { ensureDir, writeFile, pathExists, expandHome, readFileSafe, remove } from './utils/fs.js';
 import { log, spinner } from './utils/logger.js';
 import { TEAMAI_HOME, REPORTS_BRANCH, type GlobalOptions, type LocalConfig, type Scope, getTeamaiHome, getConfigPath } from './types.js';
+import { getUserHome } from './utils/home.js';
 import { describeRoles, loadRolesManifest } from './roles.js';
 import { askQuestion, askConfirmation, askSelection, closePrompt } from './utils/prompt.js';
 import {
@@ -198,7 +199,7 @@ function printScopeSummary(
   explicit: boolean,
 ): void {
   const configPath = getConfigPath(scope, projectRoot);
-  const baseDir = scope === 'project' ? (projectRoot ?? process.cwd()) : (process.env.HOME ?? '~');
+  const baseDir = scope === 'project' ? (projectRoot ?? process.cwd()) : getUserHome();
   log.info(`Scope: ${scope}${scope === 'project' ? ` (${projectRoot})` : ''}`);
   log.info(`  config    → ${configPath}`);
   log.info(`  resources → ${baseDir}/.claude/skills, ...`);
@@ -241,7 +242,7 @@ export async function initHttp(
     ({ scope, projectRoot, explicit, fallbackReason } = resolveInitScope(
       options.scope,
       process.cwd(),
-      process.env.HOME ?? '',
+      getUserHome(),
     ));
   } catch (e) {
     log.error((e as Error).message);
@@ -886,7 +887,7 @@ export async function init(options: GlobalOptions & {
     ({ scope, projectRoot, explicit, fallbackReason } = resolveInitScope(
       options.scope,
       process.cwd(),
-      process.env.HOME ?? '',
+      getUserHome(),
     ));
   } catch (e) {
     log.error((e as Error).message);

--- a/src/init.ts
+++ b/src/init.ts
@@ -468,16 +468,17 @@ export async function init(options: GlobalOptions & {
   // Step 2: Ensure provider tools are installed and authenticate
   await provider.ensureInstalled();
 
-  const authSpin = spinner('Checking authentication...').start();
+  const isGenericGit = provider.name === 'git';
+  const authSpin = spinner(isGenericGit ? 'Checking Git identity...' : 'Checking authentication...').start();
   let username: string;
   try {
     if (provider.isAuthenticated()) {
       username = await provider.authenticate();
-      authSpin.succeed(`Authenticated as ${username}`);
+      authSpin.succeed(isGenericGit ? `Using Git identity ${username}` : `Authenticated as ${username}`);
     } else {
-      authSpin.info('Not logged in — starting authentication');
+      authSpin.info(isGenericGit ? 'Resolving Git identity' : 'Not logged in — starting authentication');
       username = await provider.authenticate();
-      log.success(`Authenticated as ${username}`);
+      log.success(isGenericGit ? `Using Git identity ${username}` : `Authenticated as ${username}`);
     }
   } catch (e) {
     authSpin.fail(`Authentication failed: ${(e as Error).message}`);

--- a/src/providers/git/index.ts
+++ b/src/providers/git/index.ts
@@ -5,6 +5,25 @@ import type { GitProvider, PrCreateOptions, RepoInfo } from '../types.js';
 import { sanitizeGitUrl } from '../../utils/redact.js';
 import { parseGenericGitRepoInput } from './repo-url.js';
 
+const WINDOWS_RESERVED_NAME = /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/i;
+
+/** Convert a display-oriented Git/OS name into a safe member and branch identifier. */
+export function normalizeGitIdentity(value: string): string | null {
+  let normalized = value
+    .trim()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .replace(/^[._-]+|[._-]+$/g, '')
+    .replace(/-{2,}/g, '-')
+    .slice(0, 64)
+    .replace(/[._-]+$/g, '');
+
+  if (!normalized) return null;
+  if (WINDOWS_RESERVED_NAME.test(normalized)) normalized = `user-${normalized}`;
+  return normalized.slice(0, 64);
+}
+
 function gitIdentity(): string {
   const result = spawnSync('git', ['config', '--get', 'user.name'], {
     encoding: 'utf-8',
@@ -12,7 +31,18 @@ function gitIdentity(): string {
     timeout: 10_000,
   });
   const configured = result.status === 0 ? (result.stdout ?? '').trim() : '';
-  return configured || process.env.GIT_AUTHOR_NAME?.trim() || os.userInfo().username;
+  let osUsername = '';
+  try {
+    osUsername = os.userInfo().username;
+  } catch {
+    // Extremely restricted runtimes may not expose OS account information.
+  }
+
+  for (const candidate of [configured, process.env.GIT_AUTHOR_NAME ?? '', osUsername]) {
+    const safe = normalizeGitIdentity(candidate);
+    if (safe) return safe;
+  }
+  return 'git-user';
 }
 
 /**
@@ -52,10 +82,11 @@ export class GenericGitProvider implements GitProvider {
   cloneRepo(repo: string, localPath: string): void {
     const remoteUrl = parseGenericGitRepoInput(repo).httpsUrl;
 
-    const result = spawnSync('git', ['clone', remoteUrl, localPath], {
+    const result = spawnSync('git', ['clone', '--', remoteUrl, localPath], {
       encoding: 'utf-8',
       stdio: ['inherit', 'pipe', 'pipe'],
       timeout: 120_000,
+      maxBuffer: 10 * 1024 * 1024,
     });
     if (result.error || result.status !== 0) {
       const output = `${result.stderr ?? ''} ${result.stdout ?? ''}`.trim();

--- a/src/providers/git/index.ts
+++ b/src/providers/git/index.ts
@@ -2,11 +2,8 @@ import os from 'node:os';
 import { spawnSync } from 'node:child_process';
 
 import type { GitProvider, PrCreateOptions, RepoInfo } from '../types.js';
+import { sanitizeGitUrl } from '../../utils/redact.js';
 import { parseGenericGitRepoInput } from './repo-url.js';
-
-function redactCredentials(message: string): string {
-  return message.replace(/(https?:\/\/)[^/@\s]+@/gi, '$1***@');
-}
 
 function gitIdentity(): string {
   const result = spawnSync('git', ['config', '--get', 'user.name'], {
@@ -26,12 +23,9 @@ function gitIdentity(): string {
  */
 export class GenericGitProvider implements GitProvider {
   readonly name = 'git';
-  private remoteUrl: string | null = null;
 
   parseRepoInput(input: string): RepoInfo {
-    const repoInfo = parseGenericGitRepoInput(input);
-    this.remoteUrl = repoInfo.httpsUrl;
-    return repoInfo;
+    return parseGenericGitRepoInput(input);
   }
 
   isAuthenticated(): boolean {
@@ -55,12 +49,10 @@ export class GenericGitProvider implements GitProvider {
     }
   }
 
-  cloneRepo(_repo: string, localPath: string): void {
-    if (!this.remoteUrl) {
-      throw new Error('Generic Git clone requires parseRepoInput() before cloneRepo().');
-    }
+  cloneRepo(repo: string, localPath: string): void {
+    const remoteUrl = parseGenericGitRepoInput(repo).httpsUrl;
 
-    const result = spawnSync('git', ['clone', this.remoteUrl, localPath], {
+    const result = spawnSync('git', ['clone', remoteUrl, localPath], {
       encoding: 'utf-8',
       stdio: ['inherit', 'pipe', 'pipe'],
       timeout: 120_000,
@@ -68,7 +60,7 @@ export class GenericGitProvider implements GitProvider {
     if (result.error || result.status !== 0) {
       const output = `${result.stderr ?? ''} ${result.stdout ?? ''}`.trim();
       const detail = output || result.error?.message || `exit ${result.status ?? 1}`;
-      throw new Error(`git clone failed: ${redactCredentials(detail)}`);
+      throw new Error(`git clone failed: ${sanitizeGitUrl(detail)}`);
     }
   }
 

--- a/src/providers/git/index.ts
+++ b/src/providers/git/index.ts
@@ -1,0 +1,92 @@
+import os from 'node:os';
+import { spawnSync } from 'node:child_process';
+
+import type { GitProvider, PrCreateOptions, RepoInfo } from '../types.js';
+import { parseGenericGitRepoInput } from './repo-url.js';
+
+function redactCredentials(message: string): string {
+  return message.replace(/(https?:\/\/)[^/@\s]+@/gi, '$1***@');
+}
+
+function gitIdentity(): string {
+  const result = spawnSync('git', ['config', '--get', 'user.name'], {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 10_000,
+  });
+  const configured = result.status === 0 ? (result.stdout ?? '').trim() : '';
+  return configured || process.env.GIT_AUTHOR_NAME?.trim() || os.userInfo().username;
+}
+
+/**
+ * Transport-only provider for arbitrary Git hosts.
+ *
+ * Authentication is intentionally delegated to Git itself, so existing SSH
+ * agents and credential helpers work without TeamAI reading or storing tokens.
+ */
+export class GenericGitProvider implements GitProvider {
+  readonly name = 'git';
+  private remoteUrl: string | null = null;
+
+  parseRepoInput(input: string): RepoInfo {
+    const repoInfo = parseGenericGitRepoInput(input);
+    this.remoteUrl = repoInfo.httpsUrl;
+    return repoInfo;
+  }
+
+  isAuthenticated(): boolean {
+    // Generic hosts have no portable platform-level auth check. The clone,
+    // pull, or push operation is the authoritative credential validation.
+    return true;
+  }
+
+  async authenticate(): Promise<string> {
+    return gitIdentity();
+  }
+
+  async ensureInstalled(): Promise<void> {
+    const result = spawnSync('git', ['--version'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 10_000,
+    });
+    if (result.error || result.status !== 0) {
+      throw new Error('git is required for generic Git repositories but was not found on PATH.');
+    }
+  }
+
+  cloneRepo(_repo: string, localPath: string): void {
+    if (!this.remoteUrl) {
+      throw new Error('Generic Git clone requires parseRepoInput() before cloneRepo().');
+    }
+
+    const result = spawnSync('git', ['clone', this.remoteUrl, localPath], {
+      encoding: 'utf-8',
+      stdio: ['inherit', 'pipe', 'pipe'],
+      timeout: 120_000,
+    });
+    if (result.error || result.status !== 0) {
+      const output = `${result.stderr ?? ''} ${result.stdout ?? ''}`.trim();
+      const detail = output || result.error?.message || `exit ${result.status ?? 1}`;
+      throw new Error(`git clone failed: ${redactCredentials(detail)}`);
+    }
+  }
+
+  async createRepo(): Promise<void> {
+    throw new Error(
+      'Automatic repository creation is not supported for generic Git hosts. Create the repository first.',
+    );
+  }
+
+  async createPullRequest(_opts: PrCreateOptions): Promise<string> {
+    throw new Error(
+      'Automatic pull/merge request creation is not supported for generic Git hosts.',
+    );
+  }
+
+  getDefaultEmailDomain(): string | null {
+    return null;
+  }
+}
+
+export { parseGenericGitRepoInput } from './repo-url.js';

--- a/src/providers/git/repo-url.ts
+++ b/src/providers/git/repo-url.ts
@@ -1,0 +1,74 @@
+import type { RepoInfo } from '../types.js';
+
+const SUPPORTED_URL_HINT =
+  'expected https://host/group/repo.git, ssh://git@host/group/repo.git, or git@host:group/repo.git';
+
+function parsePath(input: string, rawPath: string): { owner: string; repo: string; fullPath: string } {
+  const cleanPath = rawPath
+    .replace(/^\/+/, '')
+    .replace(/\/+$/, '')
+    .replace(/\.git$/i, '')
+    .replace(/\/+$/, '');
+  const segments = cleanPath.split('/').filter(Boolean);
+
+  if (
+    segments.length < 2
+    || segments.some((segment) => segment === '.' || segment === '..' || /[\s\\]/.test(segment))
+  ) {
+    throw new Error(`Invalid Git repo URL: "${input}" (${SUPPORTED_URL_HINT})`);
+  }
+
+  const repo = segments[segments.length - 1];
+  const owner = segments.slice(0, -1).join('/');
+  return { owner, repo, fullPath: `${owner}/${repo}` };
+}
+
+function buildRepoInfo(owner: string, repo: string, remoteUrl: string): RepoInfo {
+  return {
+    owner,
+    repo,
+    // RepoInfo predates generic Git hosts. For this provider the field stores
+    // the canonical clone URL, which may use HTTPS or SSH.
+    httpsUrl: remoteUrl,
+    projectId: encodeURIComponent(`${owner}/${repo}`),
+  };
+}
+
+/** Parse a full HTTPS or SSH clone URL for an arbitrary Git host. */
+export function parseGenericGitRepoInput(input: string): RepoInfo {
+  const trimmed = input.trim();
+
+  if (/^https?:\/\//i.test(trimmed) || /^ssh:\/\//i.test(trimmed)) {
+    let parsed: URL;
+    try {
+      parsed = new URL(trimmed);
+    } catch {
+      throw new Error(`Invalid Git repo URL: "${trimmed}" (${SUPPORTED_URL_HINT})`);
+    }
+
+    const httpCredentials = /^https?:$/i.test(parsed.protocol) && (parsed.username || parsed.password);
+    if (!parsed.hostname || parsed.password || httpCredentials) {
+      throw new Error(
+        'Invalid Git repo URL. Do not embed credentials in the URL; '
+        + 'configure a Git credential helper or SSH key instead.',
+      );
+    }
+    if (parsed.search || parsed.hash) {
+      throw new Error(`Invalid Git repo URL: "${trimmed}" (${SUPPORTED_URL_HINT})`);
+    }
+
+    const { owner, repo, fullPath } = parsePath(trimmed, parsed.pathname);
+    const auth = parsed.username ? `${parsed.username}@` : '';
+    const remoteUrl = `${parsed.protocol}//${auth}${parsed.host}/${fullPath}.git`;
+    return buildRepoInfo(owner, repo, remoteUrl);
+  }
+
+  const scpMatch = trimmed.match(/^([^@\s]+)@([^:\s]+):(.+)$/);
+  if (scpMatch) {
+    const [, user, host, rawPath] = scpMatch;
+    const { owner, repo, fullPath } = parsePath(trimmed, rawPath);
+    return buildRepoInfo(owner, repo, `${user}@${host}:${fullPath}.git`);
+  }
+
+  throw new Error(`Invalid Git repo URL: "${trimmed}" (${SUPPORTED_URL_HINT})`);
+}

--- a/src/providers/git/repo-url.ts
+++ b/src/providers/git/repo-url.ts
@@ -3,7 +3,12 @@ import type { RepoInfo } from '../types.js';
 const SUPPORTED_URL_HINT =
   'expected https://host/group/repo.git, ssh://git@host/group/repo.git, or git@host:group/repo.git';
 
-function parsePath(input: string, rawPath: string): { owner: string; repo: string; fullPath: string } {
+function invalidRepoUrl(reason?: string): Error {
+  const detail = reason ? `: ${reason}` : '';
+  return new Error(`Invalid Git repo URL${detail} (${SUPPORTED_URL_HINT})`);
+}
+
+function parsePath(rawPath: string): { owner: string; repo: string; fullPath: string } {
   const cleanPath = rawPath
     .replace(/^\/+/, '')
     .replace(/\/+$/, '')
@@ -15,7 +20,7 @@ function parsePath(input: string, rawPath: string): { owner: string; repo: strin
     segments.length < 2
     || segments.some((segment) => segment === '.' || segment === '..' || /[\s\\]/.test(segment))
   ) {
-    throw new Error(`Invalid Git repo URL: "${input}" (${SUPPORTED_URL_HINT})`);
+    throw invalidRepoUrl('repository paths need an owner/group and a repository name');
   }
 
   const repo = segments[segments.length - 1];
@@ -38,12 +43,16 @@ function buildRepoInfo(owner: string, repo: string, remoteUrl: string): RepoInfo
 export function parseGenericGitRepoInput(input: string): RepoInfo {
   const trimmed = input.trim();
 
-  if (/^https?:\/\//i.test(trimmed) || /^ssh:\/\//i.test(trimmed)) {
+  if (/^http:\/\//i.test(trimmed)) {
+    throw invalidRepoUrl('plain HTTP is not supported; use HTTPS or SSH');
+  }
+
+  if (/^https:\/\//i.test(trimmed) || /^ssh:\/\//i.test(trimmed)) {
     let parsed: URL;
     try {
       parsed = new URL(trimmed);
     } catch {
-      throw new Error(`Invalid Git repo URL: "${trimmed}" (${SUPPORTED_URL_HINT})`);
+      throw invalidRepoUrl();
     }
 
     const httpCredentials = /^https?:$/i.test(parsed.protocol) && (parsed.username || parsed.password);
@@ -54,10 +63,10 @@ export function parseGenericGitRepoInput(input: string): RepoInfo {
       );
     }
     if (parsed.search || parsed.hash) {
-      throw new Error(`Invalid Git repo URL: "${trimmed}" (${SUPPORTED_URL_HINT})`);
+      throw invalidRepoUrl('query strings and fragments are not supported');
     }
 
-    const { owner, repo, fullPath } = parsePath(trimmed, parsed.pathname);
+    const { owner, repo, fullPath } = parsePath(parsed.pathname);
     const auth = parsed.username ? `${parsed.username}@` : '';
     const remoteUrl = `${parsed.protocol}//${auth}${parsed.host}/${fullPath}.git`;
     return buildRepoInfo(owner, repo, remoteUrl);
@@ -66,9 +75,9 @@ export function parseGenericGitRepoInput(input: string): RepoInfo {
   const scpMatch = trimmed.match(/^([^@\s]+)@([^:\s]+):(.+)$/);
   if (scpMatch) {
     const [, user, host, rawPath] = scpMatch;
-    const { owner, repo, fullPath } = parsePath(trimmed, rawPath);
+    const { owner, repo, fullPath } = parsePath(rawPath);
     return buildRepoInfo(owner, repo, `${user}@${host}:${fullPath}.git`);
   }
 
-  throw new Error(`Invalid Git repo URL: "${trimmed}" (${SUPPORTED_URL_HINT})`);
+  throw invalidRepoUrl();
 }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -3,3 +3,4 @@ export { RepoNotFoundError } from './types.js';
 export { getProvider, getProviderFromUrl, detectProvider } from './registry.js';
 export { TGitProvider } from './tgit/index.js';
 export { GitHubProvider } from './github/index.js';
+export { GenericGitProvider } from './git/index.js';

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -72,7 +72,7 @@ export function detectProvider(input: string): string {
   const trimmed = input.trim();
 
   // HTTPS URL: extract host
-  const httpsMatch = trimmed.match(/^https?:\/\/([^/]+)\//);
+  const httpsMatch = trimmed.match(/^https?:\/\/([^/]+)\//i);
   if (httpsMatch) {
     const host = httpsMatch[1].toLowerCase();
     return HOST_MAP[host] ?? 'git';

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -2,6 +2,7 @@ import type { GitProvider } from './types.js';
 import { TGitProvider } from './tgit/index.js';
 import { GitHubProvider } from './github/index.js';
 import { CNBProvider } from './cnb/index.js';
+import { GenericGitProvider } from './git/index.js';
 import { getCurrentPackageName } from '../package-info.js';
 
 // ─── Provider Detection ──────────────────────────────────
@@ -13,7 +14,7 @@ import { getCurrentPackageName } from '../package-info.js';
 //  https://git.woa.com/o/r         tgit
 //  git@git.woa.com:o/r.git         tgit
 //  owner/repo (bare)               <fallback — see getDefaultProvider>
-//  https://<unknown-host>/o/r      <fallback>
+//  https://<unknown-host>/o/r      git (transport-only generic provider)
 //
 // The fallback is based on which distribution channel the CLI was installed
 // from:
@@ -60,10 +61,10 @@ export function getDefaultProvider(): string {
 
 /**
  * Detect which git provider to use based on a repo URL or short format.
- * Returns provider name string ('github' | 'tgit').
+ * Returns a registered provider name ('github' | 'tgit' | 'cnb' | 'git').
  *
- * - Full URL (HTTPS or SSH): matched by host. Unknown hosts fall back to the
- *   distribution-based default (see {@link getDefaultProvider}).
+ * - Full URL (HTTPS or SSH): matched by host. Unknown hosts use the generic
+ *   Git transport provider.
  * - Bare `owner/repo`: uses the distribution-based default so `@tencent/`
  *   tnpm users get tgit automatically without having to type the full URL.
  */
@@ -74,14 +75,24 @@ export function detectProvider(input: string): string {
   const httpsMatch = trimmed.match(/^https?:\/\/([^/]+)\//);
   if (httpsMatch) {
     const host = httpsMatch[1].toLowerCase();
-    return HOST_MAP[host] ?? getDefaultProvider();
+    return HOST_MAP[host] ?? 'git';
+  }
+
+  // ssh:// URL: extract host through URL parsing.
+  if (/^ssh:\/\//i.test(trimmed)) {
+    try {
+      const host = new URL(trimmed).hostname.toLowerCase();
+      return HOST_MAP[host] ?? 'git';
+    } catch {
+      return 'git';
+    }
   }
 
   // SSH URL: extract host
-  const sshMatch = trimmed.match(/^git@([^:]+):/);
+  const sshMatch = trimmed.match(/^[^@\s]+@([^:\s]+):/);
   if (sshMatch) {
     const host = sshMatch[1].toLowerCase();
-    return HOST_MAP[host] ?? getDefaultProvider();
+    return HOST_MAP[host] ?? 'git';
   }
 
   // Bare owner/repo — use distribution-based default.
@@ -95,6 +106,7 @@ const PROVIDERS: Record<string, () => GitProvider> = {
   tgit: () => new TGitProvider(),
   github: () => new GitHubProvider(),
   cnb: () => new CNBProvider(),
+  git: () => new GenericGitProvider(),
 };
 
 /**

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -17,6 +17,7 @@
 export interface RepoInfo {
   owner: string;
   repo: string;
+  /** Canonical clone URL. The legacy name is retained; generic Git may return an SSH URL. */
   httpsUrl: string;
   /** URL-encoded owner/repo for API calls */
   projectId: string;
@@ -60,7 +61,7 @@ export interface OrgRepoInfo {
 }
 
 export interface GitProvider {
-  /** Provider identifier: 'github' | 'tgit' */
+  /** Registered provider identifier, e.g. 'github', 'tgit', 'cnb', or 'git'. */
   readonly name: string;
 
   // ─── URL parsing ──────────────────────────────────────

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -89,8 +89,9 @@ export interface GitProvider {
   // ─── Repository operations ────────────────────────────
 
   /**
-   * Clone a repo to localPath. Should embed credentials in
-   * the remote URL so subsequent git ops work without extra auth.
+   * Clone a repo to localPath. The resulting origin remote must remain usable
+   * for later pull/push operations via provider credentials, a Git credential
+   * helper, or SSH agent.
    */
   cloneRepo(repo: string, localPath: string): void;
 

--- a/src/source.ts
+++ b/src/source.ts
@@ -18,6 +18,8 @@ import {
 import { getHandler } from './resources/index.js';
 import { ResourceHandler } from './resources/base.js';
 import { BUILTIN_SKILL_NAMES } from './builtin-skills.js';
+import { getUserHome } from './utils/home.js';
+import { assertSafeResourceName } from './utils/path-safety.js';
 import type {
   TeamaiConfig,
   LocalConfig,
@@ -30,7 +32,8 @@ import { resolveBaseDir, SOURCE_PULL_TTL_MS } from './types.js';
 // ─── Source repo management ──────────────────────────────
 
 function getSourceDir(sourceName: string): string {
-  return path.join(process.env.HOME ?? '', '.teamai', 'sources', sourceName);
+  assertSafeResourceName(sourceName);
+  return path.join(getUserHome(), '.teamai', 'sources', sourceName);
 }
 
 function getSourceRepoDir(sourceName: string): string {
@@ -84,7 +87,8 @@ async function ensureSourceRepo(source: SourceConfig, force: boolean): Promise<s
     }
   }
 
-  // First time: clone via provider so private repos get an auth token
+  // First time: clone via the provider so its configured authentication path
+  // (token, credential helper, or SSH agent) is used.
   try {
     await ensureDir(path.dirname(repoDir));
     const cloneSpin = spinner(`[source:${source.name}] Cloning...`).start();
@@ -119,6 +123,12 @@ export async function sourceAdd(repoUrl: string, options: { name?: string } & Gl
   const name = options.name ?? deriveSourceName(repoUrl);
   if (!name) {
     log.error('Could not derive source name from URL. Use --name to specify one.');
+    return;
+  }
+  try {
+    assertSafeResourceName(name);
+  } catch (e) {
+    log.error(`Invalid source name "${name}": ${(e as Error).message}`);
     return;
   }
 
@@ -510,20 +520,27 @@ async function pullSingleSource(
  *   - "https://github.com/teamai/skills.git"  → "teamai"
  *   - "git@git.woa.com:platform/skills.git"   → "platform"
  */
-function deriveSourceName(repoUrl: string): string | null {
-  // SSH format: git@host:owner/repo.git (or git@host:group/sub/repo.git)
-  const sshMatch = repoUrl.match(/:([^/]+)\//);
-  if (sshMatch) return sshMatch[1];
+export function deriveSourceName(repoUrl: string): string | null {
+  const trimmed = repoUrl.trim();
+  let repoPath = '';
 
-  // HTTPS format: https://host/owner/repo(.git)?
-  const httpsMatch = repoUrl.match(/\/\/[^/]+\/([^/]+)\/[^/]+?(?:\.git)?\/?$/);
-  if (httpsMatch) return httpsMatch[1];
+  if (/^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(trimmed)) {
+    try {
+      repoPath = new URL(trimmed).pathname;
+    } catch {
+      return null;
+    }
+  } else {
+    const scpMatch = trimmed.match(/^[^@\s]+@[^:\s]+:(.+)$/);
+    repoPath = scpMatch?.[1] ?? trimmed;
+  }
 
-  // Fallback: penultimate segment of the URL, stripping .git
-  const parts = repoUrl.replace(/\.git$/, '').split('/');
-  if (parts.length >= 2) return parts[parts.length - 2];
-
-  return null;
+  const segments = repoPath
+    .replace(/^\/+|\/+$/g, '')
+    .replace(/\.git$/i, '')
+    .split('/')
+    .filter(Boolean);
+  return segments.length >= 2 ? segments[0] : null;
 }
 
 /**
@@ -622,7 +639,7 @@ async function cleanupSourceSkills(sourceName: string, teamConfig: TeamaiConfig,
  */
 export async function getAllSourceSkillNames(): Promise<Set<string>> {
   const names = new Set<string>();
-  const sourcesDir = path.join(process.env.HOME ?? '', '.teamai', 'sources');
+  const sourcesDir = path.join(getUserHome(), '.teamai', 'sources');
   if (!await pathExists(sourcesDir)) return names;
 
   const sourceDirs = await listDirs(sourcesDir);

--- a/src/source.ts
+++ b/src/source.ts
@@ -92,7 +92,10 @@ async function ensureSourceRepo(source: SourceConfig, force: boolean): Promise<s
     const providerName = detectProvider(source.repo);
     const provider = getProvider(providerName);
     const repoInfo = provider.parseRepoInput(source.repo);
-    provider.cloneRepo(`${repoInfo.owner}/${repoInfo.repo}`, repoDir);
+    const cloneTarget = provider.name === 'git'
+      ? repoInfo.httpsUrl
+      : `${repoInfo.owner}/${repoInfo.repo}`;
+    provider.cloneRepo(cloneTarget, repoDir);
 
     cloneSpin.succeed(`[source:${source.name}] Cloned`);
     return repoDir;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import path from 'node:path';
+import { getUserHome } from './utils/home.js';
 
 // ─── Tool path config ───────────────────────────────────
 
@@ -143,7 +144,7 @@ export interface SourceInstallManifest {
 /** TTL for source repo pull: don't re-pull within this duration (ms). */
 export const SOURCE_PULL_TTL_MS = 24 * 60 * 60 * 1000;
 
-export const TEAMAI_SOURCES_DIR = `${process.env.HOME}/.teamai/sources`;
+export const TEAMAI_SOURCES_DIR = path.join(getUserHome(), '.teamai', 'sources');
 
 export const TeamaiConfigSchema = z.object({
   team: z.string(),
@@ -419,11 +420,11 @@ export interface GlobalOptions {
 
 // ─── Constants ──────────────────────────────────────────
 
-export const TEAMAI_HOME = `${process.env.HOME}/.teamai`;
-export const TEAMAI_CONFIG_PATH = `${TEAMAI_HOME}/config.yaml`;
-export const TEAMAI_STATE_PATH = `${TEAMAI_HOME}/state.json`;
-export const TEAMAI_TOKEN_PATH = `${TEAMAI_HOME}/token`;
-export const TEAMAI_UPDATE_LOCK_PATH = `${TEAMAI_HOME}/.update-lock`;
+export const TEAMAI_HOME = path.join(getUserHome(), '.teamai');
+export const TEAMAI_CONFIG_PATH = path.join(TEAMAI_HOME, 'config.yaml');
+export const TEAMAI_STATE_PATH = path.join(TEAMAI_HOME, 'state.json');
+export const TEAMAI_TOKEN_PATH = path.join(TEAMAI_HOME, 'token');
+export const TEAMAI_UPDATE_LOCK_PATH = path.join(TEAMAI_HOME, '.update-lock');
 
 export const RESOURCE_TYPES: ResourceType[] = ['skills', 'rules', 'docs', 'env', 'agents', 'hooks', 'mcp'];
 
@@ -997,7 +998,7 @@ export type CultureFrontmatter = z.infer<typeof CultureFrontmatterSchema>;
 
 /**
  * Resolve the base directory for resource installation based on scope.
- * - user scope  → process.env.HOME (e.g. /Users/xxx)
+ * - user scope  → the platform user home directory (e.g. /Users/xxx)
  * - project scope → localConfig.projectRoot (e.g. /Users/xxx/my-project)
  */
 export function resolveBaseDir(localConfig: LocalConfig): string {
@@ -1010,7 +1011,7 @@ export function resolveBaseDir(localConfig: LocalConfig): string {
     }
     return localConfig.projectRoot;
   }
-  return process.env.HOME!;
+  return getUserHome();
 }
 
 /** True when `tool` is in localConfig.disabledAgents (excluded from teamai sync). */
@@ -1075,7 +1076,7 @@ export function getTeamaiHome(scope: Scope, projectRoot?: string): string {
     }
     return path.join(projectRoot, '.teamai');
   }
-  return path.join(process.env.HOME ?? '', '.teamai');
+  return path.join(getUserHome(), '.teamai');
 }
 
 /**
@@ -1121,7 +1122,7 @@ export function getManagedHooksPath(scope: Scope, projectRoot?: string): string 
  * Get the user-level pushignore path.
  */
 export function getPushignorePath(): string {
-  return path.join(process.env.HOME ?? '', '.teamai', 'pushignore');
+  return path.join(getUserHome(), '.teamai', 'pushignore');
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -149,8 +149,8 @@ export const TeamaiConfigSchema = z.object({
   team: z.string(),
   description: z.string().default(''),
   repo: z.string(),
-  /** Git hosting provider: 'tgit' | 'github'. Defaults to 'tgit' for backward compatibility. */
-  provider: z.enum(['tgit', 'github']).default('tgit'),
+  /** Git hosting provider. `git` is the transport-only fallback for arbitrary hosts. */
+  provider: z.enum(['tgit', 'github', 'cnb', 'git']).default('tgit'),
   /**
    * @deprecated Ignored by `teamai init` (issue #250). Local install scope is
    * decided only by CLI `--scope` / default. Kept optional for old teamai.yaml files.

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -2,6 +2,7 @@ import fse from 'fs-extra';
 import crypto from 'node:crypto';
 import path from 'node:path';
 import { log } from './logger.js';
+import { getUserHome } from './home.js';
 
 const IGNORED_NAMES = new Set([
   '__pycache__',
@@ -16,11 +17,11 @@ function isIgnored(name: string): boolean {
 }
 
 /**
- * Expand ~ to $HOME in paths
+ * Expand ~ to the platform user home directory in paths.
  */
 export function expandHome(p: string): string {
   if (p.startsWith('~/') || p === '~') {
-    return path.join(process.env.HOME ?? '', p.slice(1));
+    return path.join(getUserHome(), p.slice(1));
   }
   return p;
 }

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -7,8 +7,8 @@ import { log } from './logger.js';
 /**
  * Create a SimpleGit instance for a given base path.
  *
- * Authentication is handled by credentials embedded in the remote URL
- * (set during clone by the provider). No credential-helper injection needed.
+ * Authentication is handled by the provider's remote URL or by normal Git
+ * facilities such as credential helpers, SSH config, and SSH agents.
  */
 export function createGit(basePath?: string): SimpleGit {
   if (basePath) {

--- a/src/utils/home.ts
+++ b/src/utils/home.ts
@@ -1,0 +1,14 @@
+import os from 'node:os';
+
+/**
+ * Resolve the current user's home directory across supported platforms.
+ *
+ * `HOME` is normally present on Unix-like systems, while a regular Windows
+ * PowerShell session commonly exposes only `USERPROFILE`. `os.homedir()` is
+ * the final platform-aware fallback.
+ */
+export function getUserHome(): string {
+  return process.env.HOME?.trim()
+    || process.env.USERPROFILE?.trim()
+    || os.homedir();
+}

--- a/src/utils/redact.ts
+++ b/src/utils/redact.ts
@@ -32,6 +32,11 @@
 
 const PLACEHOLDER = (label: string): string => `<REDACTED:${label}>`;
 
+/** Mask credentials embedded in HTTP(S) Git URLs found in logs or errors. */
+export function sanitizeGitUrl(text: string): string {
+  return text.replace(/(https?:\/\/)[^/@\s]+@/gi, '$1***@');
+}
+
 /** Env var name fragments that mark a value as likely-secret. */
 const SECRET_KEY_HINTS = ['TOKEN', 'SECRET', 'KEY', 'PASSWORD', 'PASSWD', '_PAT', 'CREDENTIAL'];
 


### PR DESCRIPTION
## Summary

- add a transport-only `git` provider for unknown full HTTPS and SSH repository URLs
- preserve nested namespaces and delegate private-repository authentication to system Git credential helpers or SSH agents
- support clone, pull, and push while explicitly falling back to manual MR/PR creation for host-specific API operations
- extend provider configuration, remote import parsing, tests, and documentation

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing behavior to change)
- [ ] Documentation only
- [ ] Refactor / internal cleanup

## Test Plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes (1991 tests)
- [x] `npm run build` passes
- [x] Added/updated tests for provider detection, URL parsing, clone behavior, schema compatibility, and unsupported host API operations

## Related Issues

Closes #300

## Notes for Reviewers

Generic hosts intentionally do not attempt platform authentication, repository creation, or MR/PR APIs. Git remains the credential boundary, embedded HTTPS credentials are rejected, and branch push succeeds before the existing manual-PR fallback is shown.