### PR TITLE
feat(providers): add GitLab as a git provider (#303)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm install -g teamai-cli
 
 ### Team admin / solo user
 
-Create a shared-experience repo on your git host (GitHub, TGit, or CNB), **grant write access to team members**, then have them run `teamai init https://github.com/yourorg/yourrepo`.
+Create a shared-experience repo on your git host (GitHub, GitLab, TGit, or CNB), **grant write access to team members**, then have them run `teamai init https://github.com/yourorg/yourrepo`.
 
 > Solo use needs no separate repo setup: `teamai init` checks the target repo and creates it automatically if it doesn't exist.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,7 +30,7 @@ npm install -g teamai-cli
 
 ### 团队管理员 / 个人使用者
 
-在 Git 托管平台（GitHub、TGit 或 CNB）创建共享经验仓库，**授予团队成员写权限**，然后让他们运行 `teamai init https://github.com/yourorg/yourrepo`。
+在 Git 托管平台（GitHub、GitLab、TGit 或 CNB）创建共享经验仓库，**授予团队成员写权限**，然后让他们运行 `teamai init https://github.com/yourorg/yourrepo`。
 
 > 个人使用无需单独建仓：`teamai init` 会检查目标仓库，不存在时自动创建。
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,12 +1,13 @@
 # Git Provider 说明
 
-TeamAI CLI 通过 provider 抽象层支持多个 git 托管平台。当前实现了三个：
+TeamAI CLI 通过 provider 抽象层支持多个 git 托管平台。当前实现了四个：
 
-| Provider | Host            | 认证方式                            | 建议场景              |
-|----------|-----------------|--------------------------------------|----------------------|
-| `github` | github.com      | `gh` CLI 或 `GITHUB_TOKEN` 环境变量  | 开源项目、外部用户    |
-| `tgit`   | git.woa.com     | `gf` CLI（自动下载）+ `~/.netrc`     | 腾讯内部团队          |
-| `cnb`    | cnb.cool        | `cnb login` 或 `CNB_TOKEN` 环境变量  | CNB（云原生构建）用户 |
+| Provider | Host                        | 认证方式                                       | 建议场景              |
+|----------|-----------------------------|------------------------------------------------|----------------------|
+| `github` | github.com                  | `gh` CLI 或 `GITHUB_TOKEN` 环境变量            | 开源项目、外部用户    |
+| `tgit`   | git.woa.com                 | `gf` CLI（自动下载）+ `~/.netrc`               | 腾讯内部团队          |
+| `cnb`    | cnb.cool                    | `cnb login` 或 `CNB_TOKEN` 环境变量            | CNB（云原生构建）用户 |
+| `gitlab` | gitlab.com / 自托管 GitLab  | `GITLAB_TOKEN` 环境变量 或 `glab` CLI          | GitLab 用户 / 自托管  |
 
 ## Provider 自动检测
 
@@ -20,6 +21,9 @@ https://git.woa.com/team/repo(.git)     → tgit
 git@git.woa.com:team/repo.git           → tgit
 https://cnb.cool/org/repo(.git)         → cnb
 git@cnb.cool:org/repo.git               → cnb
+https://gitlab.com/org/repo(.git)       → gitlab
+git@gitlab.com:org/repo.git             → gitlab
+https://<TEAMAI_GITLAB_HOST>/g/repo     → gitlab（自托管，见下）
 ```
 
 provider 选择会写入 team 仓库的 `teamai.yaml` 的 `provider` 字段，后续 `push` / `pull` 都按这个值来。
@@ -139,9 +143,70 @@ CNB Provider 不设默认 email 域（同 GitHub）。
 
 内部/企业自托管实例（如内网镜像）可通过 `TEAMAI_CNB_HOST` 覆盖 git host，但这类部署还必须给 `cnb` CLI 设置 `CNB_API_ENDPOINT`（以及 `CNB_WEB_ENDPOINT`）指向对应 API——本封装不代管这些端点，且尚未实测，暂不作为受支持配置。
 
+## GitLab Provider（gitlab.com / 自托管）
+
+GitLab provider 直接对接 GitLab REST API v4（`/api/v4`），不依赖第三方 CLI，思路与 TGit（本质上也是 GitLab 系）一致。同时支持公有 **gitlab.com** 和企业自托管实例。
+
+### 认证
+
+两种方式：
+
+**方式 1：`GITLAB_TOKEN` 环境变量（headless / CI 推荐）**
+
+```bash
+export GITLAB_TOKEN=glpat-xxxxxxxx   # Personal Access Token，需要 "api" scope
+teamai init https://gitlab.com/yourorg/yourrepo
+```
+
+`GL_TOKEN` 作为别名也会被识别；在 GitLab CI 中，内置的 `CI_JOB_TOKEN` 会作为兜底自动生效（无需额外配置）。这类 token 通过 `PRIVATE-TOKEN` 头发送。
+
+**方式 2：`glab` CLI**
+
+安装 [`glab`](https://gitlab.com/gitlab-org/cli) 并运行 `glab auth login` 后，teamai 会通过 `glab auth token` 取得 OAuth token（以 `Authorization: Bearer` 发送）。
+
+> 认证时先尝试解析到的 scheme，遇到 401 会自动用另一种 scheme 重试一次，所以 PAT 与 OAuth token 都能用。
+
+### 自托管实例
+
+设置 `TEAMAI_GITLAB_HOST` 指向自托管 host（默认 `gitlab.com`）：
+
+```bash
+export TEAMAI_GITLAB_HOST=gitlab.mycorp.com
+export GITLAB_TOKEN=glpat-xxxxxxxx
+teamai init https://gitlab.mycorp.com/platform/team/repo
+```
+
+设置后，指向该 host 的 URL（HTTPS / SSH）会被识别为 `gitlab`，REST API base 也随之切到 `https://<host>/api/v4`。
+
+### 支持的操作
+
+| 操作          | 实现                                                                 |
+|---------------|----------------------------------------------------------------------|
+| clone         | `git clone https://oauth2:$TOKEN@<host>/...`（凭据内嵌进 remote URL） |
+| 创建仓库      | `POST /projects`（owner 非本人时先解析 `GET /namespaces/:owner`）     |
+| 创建 MR       | `POST /projects/:id/merge_requests`                                  |
+| 指定 reviewer | 通过 `GET /users?username=` 解析为 `reviewer_ids`                    |
+| 拉取 MR 详情  | `GET /projects/:id/merge_requests/:iid` + `/commits` + `/changes`    |
+| 列出 group 仓库 | `GET /groups/:id/projects?include_subgroups=true`                  |
+
+### CI MR-extract
+
+CI 场景下（`teamai import --from-mr <MR-URL>` 及知识回写）同样支持 GitLab：
+
+- 幂等评论通过 notes API（`POST/PUT /projects/:id/merge_requests/:iid/notes`）写入，用 marker 注释锚定。
+- reviewer 的拒绝信号读取 note 上的 award emoji：👎（`thumbsdown`）= reject，无则默认写入。
+
+### 多级命名空间
+
+与 TGit / CNB 类似，GitLab 支持 `group/subgroup/repo` 这种嵌套路径；projectId 用 `encodeURIComponent(owner/repo)` 编码。
+
+### 默认 email 域
+
+GitLab Provider 不设默认 email 域（同 GitHub，让用户全局 git 配置生效）。
+
 ## 手动指定 Provider
 
-除了 URL 自动检测，也可以在 team 仓库的 `teamai.yaml` 中显式写 `provider: github`、`provider: tgit` 或 `provider: cnb` 强制切换。一个典型的 `teamai.yaml`：
+除了 URL 自动检测，也可以在 team 仓库的 `teamai.yaml` 中显式写 `provider: github`、`provider: tgit`、`provider: cnb` 或 `provider: gitlab` 强制切换。一个典型的 `teamai.yaml`：
 
 ```yaml
 team: my-team
@@ -156,7 +221,7 @@ reviewers:
 
 ## 新增 Provider
 
-Provider 是一个 TypeScript 接口（见 [`src/providers/types.ts`](../src/providers/types.ts)），新增 GitLab / Bitbucket / Gitea 等只需要：
+Provider 是一个 TypeScript 接口（见 [`src/providers/types.ts`](../src/providers/types.ts)），新增 Bitbucket / Gitea 等只需要（可参考已实现的 `src/providers/gitlab/`）：
 
 1. 新建 `src/providers/<name>/` 目录
 2. 实现 `GitProvider` 接口：`parseRepoInput` / `authenticate` / `cloneRepo` / `createRepo` / `createPullRequest` / `getDefaultEmailDomain`

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -76,7 +76,7 @@ teamai --version
 
 > Only one admin needs to do this — other members can skip to [Member Onboarding](#member-onboarding).
 
-Create an empty repository on GitHub, TGit (Tencent's internal Git host), or CNB (cnb.cool) (suggested naming: `TeamAi-<team-name>`), or simply run `teamai init` — if the repo doesn't exist yet, you'll be prompted to create it automatically.
+Create an empty repository on GitHub, GitLab (gitlab.com or self-hosted), TGit (Tencent's internal Git host), or CNB (cnb.cool) (suggested naming: `TeamAi-<team-name>`), or simply run `teamai init` — if the repo doesn't exist yet, you'll be prompted to create it automatically.
 
 ### Project Scope (default)
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -74,7 +74,7 @@ teamai --version
 
 > 只需一位管理员完成，其他成员跳到[成员接入](#成员接入)。
 
-在 GitHub、TGit（腾讯工蜂）或 CNB（cnb.cool）上创建一个空仓库（命名建议：`TeamAi-<团队名>`），或者直接执行 `teamai init`，不存在时会提示自动创建。
+在 GitHub、GitLab（gitlab.com 或自托管）、TGit（腾讯工蜂）或 CNB（cnb.cool）上创建一个空仓库（命名建议：`TeamAi-<团队名>`），或者直接执行 `teamai init`，不存在时会提示自动创建。
 
 ### 项目级（Project Scope，默认）
 

--- a/src/__tests__/github-provider.test.ts
+++ b/src/__tests__/github-provider.test.ts
@@ -106,7 +106,12 @@ describe('detectProvider', () => {
   });
 
   it('defaults unknown hosts to github', () => {
-    expect(detectProvider('https://gitlab.com/org/repo')).toBe('github');
+    expect(detectProvider('https://git.example.com/org/repo')).toBe('github');
+  });
+
+  it('detects gitlab from gitlab.com URLs', () => {
+    expect(detectProvider('https://gitlab.com/org/repo')).toBe('gitlab');
+    expect(detectProvider('git@gitlab.com:org/repo.git')).toBe('gitlab');
   });
 });
 

--- a/src/__tests__/mr-comment.test.ts
+++ b/src/__tests__/mr-comment.test.ts
@@ -18,8 +18,18 @@ describe('parseMrUrl', () => {
     expect(result).toEqual({ provider: 'tgit', owner: 'group/sub', repo: 'project', number: '123' });
   });
 
+  it('解析 GitLab MR URL（带 /-/ 分隔符）', () => {
+    const result = parseMrUrl('https://gitlab.com/org/repo/-/merge_requests/1');
+    expect(result).toEqual({ provider: 'gitlab', owner: 'org', repo: 'repo', number: '1' });
+  });
+
+  it('解析 GitLab MR URL（多层 group）', () => {
+    const result = parseMrUrl('https://gitlab.com/group/sub/project/-/merge_requests/88');
+    expect(result).toEqual({ provider: 'gitlab', owner: 'group/sub', repo: 'project', number: '88' });
+  });
+
   it('不支持的 URL 抛出错误', () => {
-    expect(() => parseMrUrl('https://gitlab.com/org/repo/-/merge_requests/1')).toThrow('无法解析 MR URL');
+    expect(() => parseMrUrl('https://bitbucket.org/org/repo/pull-requests/1')).toThrow('无法解析 MR URL');
   });
 });
 

--- a/src/__tests__/mr-hint.test.ts
+++ b/src/__tests__/mr-hint.test.ts
@@ -28,13 +28,28 @@ describe('parseRemoteToRepo', () => {
     expect(result).toEqual({ provider: 'github', owner: 'myorg', repo: 'myrepo' });
   });
 
+  it('parses GitLab HTTPS URL', () => {
+    const result = parseRemoteToRepo('https://gitlab.com/owner/repo.git');
+    expect(result).toEqual({ provider: 'gitlab', owner: 'owner', repo: 'repo' });
+  });
+
+  it('parses GitLab HTTPS URL with group path', () => {
+    const result = parseRemoteToRepo('https://gitlab.com/group/subgroup/repo.git');
+    expect(result).toEqual({ provider: 'gitlab', owner: 'group/subgroup', repo: 'repo' });
+  });
+
+  it('parses GitLab SSH URL', () => {
+    const result = parseRemoteToRepo('git@gitlab.com:myorg/myrepo.git');
+    expect(result).toEqual({ provider: 'gitlab', owner: 'myorg', repo: 'myrepo' });
+  });
+
   it('parses URL without .git suffix', () => {
     const result = parseRemoteToRepo('https://git.woa.com/owner/repo');
     expect(result).toEqual({ provider: 'tgit', owner: 'owner', repo: 'repo' });
   });
 
   it('returns null for unrecognized URL', () => {
-    expect(parseRemoteToRepo('https://gitlab.com/owner/repo.git')).toBeNull();
+    expect(parseRemoteToRepo('https://bitbucket.org/owner/repo.git')).toBeNull();
     expect(parseRemoteToRepo('')).toBeNull();
     expect(parseRemoteToRepo('not-a-url')).toBeNull();
   });

--- a/src/__tests__/provider-fallback.test.ts
+++ b/src/__tests__/provider-fallback.test.ts
@@ -83,7 +83,7 @@ describe('getDefaultProvider (fallback)', () => {
 
   it('ignores unknown TEAMAI_DEFAULT_PROVIDER values', () => {
     setPackageName('teamai-cli');
-    process.env.TEAMAI_DEFAULT_PROVIDER = 'gitlab';
+    process.env.TEAMAI_DEFAULT_PROVIDER = 'bitbucket';
     // Falls through to package-name-based default (public npm → github).
     expect(getDefaultProvider()).toBe('github');
   });
@@ -114,7 +114,14 @@ describe('detectProvider with package-name fallback', () => {
 
   it('unknown host → tgit when installed from internal tnpm', () => {
     setPackageName('@tencent/teamai-cli');
-    expect(detectProvider('https://gitlab.com/org/repo')).toBe('tgit');
+    expect(detectProvider('https://git.example.com/org/repo')).toBe('tgit');
+  });
+
+  it('explicit gitlab.com URL resolves to gitlab regardless of build', () => {
+    setPackageName('@tencent/teamai-cli');
+    expect(detectProvider('https://gitlab.com/org/repo')).toBe('gitlab');
+    setPackageName('teamai-cli');
+    expect(detectProvider('git@gitlab.com:org/repo.git')).toBe('gitlab');
   });
 
   it('explicit github.com URL still resolves to github on tnpm build', () => {

--- a/src/ci/mr-comment.ts
+++ b/src/ci/mr-comment.ts
@@ -8,6 +8,7 @@
 
 import type { LearningDraft, CodebaseSuggestion } from '../types.js';
 import { tgitFetch } from '../providers/tgit/rest-auth.js';
+import { gitlabFetch, getGitLabHost } from '../providers/gitlab/rest-auth.js';
 import { log } from '../utils/logger.js';
 
 // ─── 常量 ────────────────────────────────────────────────
@@ -23,7 +24,7 @@ export interface CommentResult {
 }
 
 interface ParsedMrUrl {
-  provider: 'github' | 'tgit';
+  provider: 'github' | 'tgit' | 'gitlab';
   owner: string;
   repo: string;
   number: string;
@@ -48,7 +49,23 @@ export function parseMrUrl(url: string): ParsedMrUrl {
     return { provider: 'tgit', owner: tgitMatch[1], repo: tgitMatch[2], number: tgitMatch[3] };
   }
 
-  throw new Error(`无法解析 MR URL: ${url}，仅支持 GitHub 和 TGit`);
+  // GitLab: https://<host>/{group}/{project}/-/merge_requests/{iid}
+  // host 为 gitlab.com 或自托管 TEAMAI_GITLAB_HOST；group 可能含多级路径。
+  // GitLab 现代路径带 `/-/` 分隔符，同时兼容不带分隔符的旧格式。
+  const glHosts = ['gitlab.com', getGitLabHost()];
+  for (const host of glHosts) {
+    const hostRe = host.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const dashMatch = url.match(new RegExp(`${hostRe}/(.+?)/([^/]+)/-/merge_requests/(\\d+)`));
+    if (dashMatch) {
+      return { provider: 'gitlab', owner: dashMatch[1], repo: dashMatch[2], number: dashMatch[3] };
+    }
+    const plainMatch = url.match(new RegExp(`${hostRe}/(.+?)/([^/]+)/merge_requests/(\\d+)`));
+    if (plainMatch) {
+      return { provider: 'gitlab', owner: plainMatch[1], repo: plainMatch[2], number: plainMatch[3] };
+    }
+  }
+
+  throw new Error(`无法解析 MR URL: ${url}，仅支持 GitHub、TGit 和 GitLab`);
 }
 
 // ─── Comment 格式化 ──────────────────────────────────────
@@ -264,6 +281,72 @@ async function updateTGitComment(
   return { created: false };
 }
 
+// ─── GitLab Comment API ─────────────────────────────────
+//
+//  GitLab 的 notes API 直接使用 MR 的项目内 iid（无需像 TGit 那样先查全局
+//  id）。projectId 为 URL 编码后的 `group/repo` 全路径。
+
+async function gitlabRequest(path: string, method: string, body?: unknown): Promise<Response> {
+  return gitlabFetch(path, {
+    method,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+interface GitLabNote {
+  id: number;
+  body: string;
+}
+
+async function findGitLabComment(
+  projectId: string,
+  mrIid: string,
+  marker: string,
+): Promise<GitLabNote | null> {
+  const resp = await gitlabRequest(
+    `/projects/${projectId}/merge_requests/${mrIid}/notes?per_page=100`,
+    'GET',
+  );
+  if (!resp.ok) return null;
+  const notes = (await resp.json()) as GitLabNote[];
+  return notes.find((n) => n.body.includes(marker)) ?? null;
+}
+
+async function postGitLabComment(
+  projectId: string,
+  mrIid: string,
+  body: string,
+): Promise<CommentResult> {
+  const resp = await gitlabRequest(
+    `/projects/${projectId}/merge_requests/${mrIid}/notes`,
+    'POST',
+    { body },
+  );
+  if (!resp.ok) {
+    const errText = await resp.text();
+    throw new Error(`GitLab comment 创建失败 (${resp.status}): ${errText}`);
+  }
+  return { created: true };
+}
+
+async function updateGitLabComment(
+  projectId: string,
+  mrIid: string,
+  noteId: number,
+  body: string,
+): Promise<CommentResult> {
+  const resp = await gitlabRequest(
+    `/projects/${projectId}/merge_requests/${mrIid}/notes/${noteId}`,
+    'PUT',
+    { body },
+  );
+  if (!resp.ok) {
+    const errText = await resp.text();
+    throw new Error(`GitLab comment 更新失败 (${resp.status}): ${errText}`);
+  }
+  return { created: false };
+}
+
 // ─── Public API ─────────────────────────────────────────
 
 /**
@@ -311,6 +394,17 @@ export async function postOrUpdateMrComment(
     return postGitHubComment(parsed.owner, parsed.repo, parsed.number, body);
   }
 
+  if (parsed.provider === 'gitlab') {
+    // GitLab — Notes API 使用 MR 的项目内 iid
+    const glProjectId = encodeURIComponent(`${parsed.owner}/${parsed.repo}`);
+    const existing = await findGitLabComment(glProjectId, parsed.number, effectiveMarker);
+    if (existing) {
+      log.debug(`发现已有 note #${existing.id}，更新中...`);
+      return updateGitLabComment(glProjectId, parsed.number, existing.id, body);
+    }
+    return postGitLabComment(glProjectId, parsed.number, body);
+  }
+
   // TGit — Notes API 使用 MR 全局 id
   const projectId = encodeURIComponent(`${parsed.owner}/${parsed.repo}`);
   const mrGlobalId = await getMrGlobalId(projectId, parsed.number);
@@ -331,7 +425,7 @@ export function formatIndividualComment(
   type: 'learning' | 'suggestion',
   index: number,
   content: { title?: string; body?: string; section?: string; action?: string; preview?: string },
-  provider: 'github' | 'tgit',
+  provider: 'github' | 'tgit' | 'gitlab',
 ): string {
   const markerId = type === 'learning' ? 'learning' : `suggestion:${index}`;
   const marker = `<!-- teamai:ci-extract:${markerId} -->`;
@@ -359,7 +453,7 @@ export function formatIndividualComment(
   }
 
   lines.push('');
-  if (provider === 'github') {
+  if (provider === 'github' || provider === 'gitlab') {
     lines.push('> 💡 不写入此条？请对本条 comment 加 👎 reaction');
   } else {
     lines.push('> 💡 不写入此条？请对本条评论加 ☝️ emoji reaction');
@@ -429,6 +523,19 @@ export async function postIndividualComments(
         await updateGitHubComment(parsed.owner, parsed.repo, existing.id, item.body);
       } else {
         await postGitHubComment(parsed.owner, parsed.repo, parsed.number, item.body);
+      }
+      posted++;
+    }
+  } else if (parsed.provider === 'gitlab') {
+    // GitLab: 逐条发布为 MR note（notes API 直接用 iid）
+    const glProjectId = encodeURIComponent(`${parsed.owner}/${parsed.repo}`);
+    for (const item of items) {
+      const marker = `<!-- teamai:ci-extract:${item.markerId} -->`;
+      const existing = await findGitLabComment(glProjectId, parsed.number, marker);
+      if (existing) {
+        await updateGitLabComment(glProjectId, parsed.number, existing.id, item.body);
+      } else {
+        await postGitLabComment(glProjectId, parsed.number, item.body);
       }
       posted++;
     }

--- a/src/ci/read-rejections.ts
+++ b/src/ci/read-rejections.ts
@@ -8,6 +8,7 @@
 
 import { parseMrUrl } from './mr-comment.js';
 import { tgitFetch } from '../providers/tgit/rest-auth.js';
+import { gitlabFetch } from '../providers/gitlab/rest-auth.js';
 import { log } from '../utils/logger.js';
 
 const API_TIMEOUT_MS = 15_000;
@@ -152,6 +153,53 @@ async function readTGitRejections(owner: string, repo: string, mrIid: string): P
   return result;
 }
 
+// ─── GitLab ─────────────────────────────────────────────
+
+interface GitLabNote {
+  id: number;
+  body: string;
+}
+
+/** GitLab award emoji on a note (used field only) */
+interface GitLabAwardEmoji {
+  name: string; // e.g. "thumbsdown", "thumbsup"
+}
+
+async function readGitLabRejections(owner: string, repo: string, mrIid: string): Promise<RejectionResult> {
+  const result: RejectionResult = { rejectedIds: new Set(), approvedIds: new Set(), allIds: new Set() };
+
+  const projectId = encodeURIComponent(`${owner}/${repo}`);
+
+  // 读取所有 notes（GitLab notes API 直接用 iid）
+  const resp = await gitlabFetch(`/projects/${projectId}/merge_requests/${mrIid}/notes?per_page=100`);
+  if (!resp.ok) return result;
+  const notes = (await resp.json()) as GitLabNote[];
+
+  for (const note of notes) {
+    const markerId = extractMarkerId(note.body);
+    if (!markerId) continue;
+    result.allIds.add(markerId);
+
+    // GitLab: 读取该 note 的 award emoji，👎 (thumbsdown) = reject，无则默认 approve
+    const awardResp = await gitlabFetch(
+      `/projects/${projectId}/merge_requests/${mrIid}/notes/${note.id}/award_emoji`,
+    );
+    if (!awardResp.ok) {
+      result.approvedIds.add(markerId); // 读取失败默认 approve
+      continue;
+    }
+    const awards = (await awardResp.json()) as GitLabAwardEmoji[];
+    const hasThumbsDown = awards.some((a) => a.name === 'thumbsdown');
+    if (hasThumbsDown) {
+      result.rejectedIds.add(markerId);
+    } else {
+      result.approvedIds.add(markerId);
+    }
+  }
+
+  return result;
+}
+
 // ─── Public API ─────────────────────────────────────────
 
 /**
@@ -159,6 +207,7 @@ async function readTGitRejections(owner: string, repo: string, mrIid: string): P
  *
  * 返回被 reject 和 approve 的 marker id 集合。
  * - GitHub: 默认写入，👎 = reject
+ * - GitLab: 默认写入，👎 (thumbsdown award emoji) = reject
  * - TGit: 默认不写入，点"解决" = approve
  */
 export async function readRejections(mrUrl: string): Promise<RejectionResult> {
@@ -169,6 +218,11 @@ export async function readRejections(mrUrl: string): Promise<RejectionResult> {
     return readGitHubRejections(parsed.owner, parsed.repo, parsed.number);
   }
 
+  if (parsed.provider === 'gitlab') {
+    log.debug('读取 GitLab award emoji...');
+    return readGitLabRejections(parsed.owner, parsed.repo, parsed.number);
+  }
+
   log.debug('读取 TGit emoji reactions...');
   return readTGitRejections(parsed.owner, parsed.repo, parsed.number);
 }
@@ -176,10 +230,15 @@ export async function readRejections(mrUrl: string): Promise<RejectionResult> {
 /**
  * 根据 rejection 结果判断某条建议是否应该写入。
  *
- * 两个平台逻辑统一：默认写入，被 reject 的不写入。
+ * 平台逻辑统一：默认写入，被 reject 的不写入。
  * - GitHub: 👎 reaction = reject
+ * - GitLab: 👎 award emoji = reject
  * - TGit: ☝️ emoji (编号 8) = reject
  */
-export function shouldWrite(markerId: string, rejections: RejectionResult, _provider: 'github' | 'tgit'): boolean {
+export function shouldWrite(
+  markerId: string,
+  rejections: RejectionResult,
+  _provider: 'github' | 'tgit' | 'gitlab',
+): boolean {
   return !rejections.rejectedIds.has(markerId);
 }

--- a/src/import-mr.ts
+++ b/src/import-mr.ts
@@ -6,6 +6,8 @@ import matter from 'gray-matter';
 
 import { fetchGitHubPR } from './providers/github/mr-fetch.js';
 import { fetchTGitMR } from './providers/tgit/mr-fetch.js';
+import { fetchGitLabMR } from './providers/gitlab/mr-fetch.js';
+import { getGitLabHost } from './providers/gitlab/rest-auth.js';
 import type { MRData, LearningDraft } from './types.js';
 import { callClaude } from './utils/ai-client.js';
 import { extractKeywords, findSupersededLearnings } from './utils/dedup.js';
@@ -31,7 +33,14 @@ async function fetchMR(url: string): Promise<MRData> {
   if (url.includes('git.woa.com')) {
     return fetchTGitMR(url);
   }
-  throw new Error(`Unsupported MR URL: ${url}. Only GitHub and TGit are supported`);
+  // GitLab: match the /merge_requests/ path on gitlab.com or a self-hosted host.
+  if (
+    /\/-?\/?merge_requests\/\d+/.test(url) &&
+    (url.includes('gitlab.com') || url.includes(getGitLabHost()))
+  ) {
+    return fetchGitLabMR(url);
+  }
+  throw new Error(`Unsupported MR URL: ${url}. Only GitHub, TGit and GitLab are supported`);
 }
 
 /**

--- a/src/mr-hint.ts
+++ b/src/mr-hint.ts
@@ -3,6 +3,11 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { getTGitToken, tgitFetch } from './providers/tgit/rest-auth.js';
+import {
+  getGitLabHost,
+  gitlabFetch,
+  tryGetGitLabToken,
+} from './providers/gitlab/rest-auth.js';
 import { log } from './utils/logger.js';
 
 // ─── MR Hint data flow ──────────────────────────────────
@@ -139,17 +144,23 @@ export function getGitRemote(cwd: string): string | null {
 /** Parsed result from a git remote URL. */
 export interface RemoteRepo {
   /** Git provider. */
-  provider: 'tgit' | 'github';
+  provider: 'tgit' | 'github' | 'gitlab';
   /** Owner or group path (may contain '/'). */
   owner: string;
   /** Repository name (last path segment). */
   repo: string;
 }
 
+/** Escape a string for safe interpolation into a RegExp. */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /**
  * Parse a git remote URL into provider + owner/repo info.
  *
- * Supports HTTPS and SSH formats for git.woa.com (TGit) and github.com.
+ * Supports HTTPS and SSH formats for git.woa.com (TGit), github.com, and
+ * GitLab (gitlab.com plus any self-hosted host set via TEAMAI_GITLAB_HOST).
  *
  * @param remoteUrl  Full git remote URL
  * @returns          Parsed RemoteRepo, or null if unrecognized
@@ -179,6 +190,23 @@ export function parseRemoteToRepo(remoteUrl: string): RemoteRepo | null {
   const ghSsh = url.match(/^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?\/?$/);
   if (ghSsh) {
     return { provider: 'github', owner: ghSsh[1], repo: ghSsh[2] };
+  }
+
+  // GitLab: match gitlab.com and the configured self-hosted host. Groups may be
+  // multi-level, so the owner segment allows '/'.
+  const hosts = Array.from(new Set(['gitlab.com', getGitLabHost()]));
+  for (const host of hosts) {
+    const h = escapeRegExp(host);
+    // HTTPS: https://<host>/group[/sub]/repo.git
+    const glHttps = url.match(new RegExp(`^https?://[^@]*${h}/(.+)/([^/]+?)(?:\\.git)?/?$`));
+    if (glHttps) {
+      return { provider: 'gitlab', owner: glHttps[1], repo: glHttps[2] };
+    }
+    // SSH: git@<host>:group[/sub]/repo.git
+    const glSsh = url.match(new RegExp(`^git@${h}:(.+)/([^/]+?)(?:\\.git)?/?$`));
+    if (glSsh) {
+      return { provider: 'gitlab', owner: glSsh[1], repo: glSsh[2] };
+    }
   }
 
   return null;
@@ -242,6 +270,64 @@ async function listTGitMergedMRs(
       }));
   } catch (err) {
     log.debug(`mr-hint: TGit API error: ${(err as Error).message}`);
+    return [];
+  }
+}
+
+/** GitLab API MR object (subset of fields). */
+interface GitLabMR {
+  iid: number;
+  title: string;
+  web_url: string;
+  merged_at: string | null;
+}
+
+/**
+ * List recently merged MRs from the GitLab REST API.
+ *
+ * Calls: GET /projects/<encoded-path>/merge_requests?state=merged&...
+ * Uses the token resolved from the environment or `glab` CLI.
+ *
+ * @param owner   Owner or group path (may contain '/')
+ * @param repo    Repository name
+ * @param since   Include only MRs merged after this date
+ * @returns       Array of MRSummary, empty on any error
+ */
+async function listGitLabMergedMRs(
+  owner: string,
+  repo: string,
+  since: Date,
+): Promise<MRSummary[]> {
+  if (!tryGetGitLabToken()) {
+    log.debug('mr-hint: no GitLab token, skipping GitLab MR check');
+    return [];
+  }
+
+  const projectId = encodeURIComponent(`${owner}/${repo}`);
+  const apiPath =
+    `/projects/${projectId}/merge_requests` +
+    `?state=merged&order_by=updated_at&sort=desc&per_page=${MAX_MRS}`;
+
+  try {
+    const resp = await gitlabFetch(apiPath, {
+      signal: AbortSignal.timeout(8000),
+    });
+    if (!resp.ok) {
+      log.debug(`mr-hint: GitLab API returned ${resp.status}`);
+      return [];
+    }
+    const items = (await resp.json()) as GitLabMR[];
+    const sinceMs = since.getTime();
+    return items
+      .filter((mr) => mr.merged_at && new Date(mr.merged_at).getTime() >= sinceMs)
+      .map((mr) => ({
+        id: String(mr.iid),
+        title: mr.title,
+        url: mr.web_url,
+        mergedAt: mr.merged_at!,
+      }));
+  } catch (err) {
+    log.debug(`mr-hint: GitLab API error: ${(err as Error).message}`);
     return [];
   }
 }
@@ -445,6 +531,8 @@ export async function computeMrHintOutput(): Promise<string | null> {
 
   if (provider === 'tgit') {
     allMrs = await listTGitMergedMRs(owner, repo, since);
+  } else if (provider === 'gitlab') {
+    allMrs = await listGitLabMergedMRs(owner, repo, since);
   } else {
     allMrs = await listGitHubMergedMRs(owner, repo, since);
   }

--- a/src/providers/gitlab/gitlab-api.ts
+++ b/src/providers/gitlab/gitlab-api.ts
@@ -1,0 +1,244 @@
+import { spawnSync } from 'node:child_process';
+import { log } from '../../utils/logger.js';
+import {
+  getGitLabHost,
+  gitlabFetch,
+  tryGetGitLabToken,
+  gitlabGitCloneUrl,
+} from './rest-auth.js';
+import { parseGitLabRepoInput } from './repo-url.js';
+
+/** Error indicating the remote repo was not found on GitLab. */
+export class RepoNotFoundError extends Error {
+  constructor(repo: string) {
+    super(`Repo "${repo}" not found on GitLab.`);
+    this.name = 'RepoNotFoundError';
+  }
+}
+
+// ─── Authentication state ────────────────────────────────
+
+/** True when any usable GitLab credential (env token or glab CLI) is present. */
+export function gitlabIsAuthenticated(): boolean {
+  return tryGetGitLabToken() !== null;
+}
+
+interface GitLabUser {
+  username: string;
+}
+
+/**
+ * Query the authenticated user's username via `GET /user`.
+ * Returns null on failure (no token, network error, invalid token).
+ */
+export async function gitlabWhoami(): Promise<string | null> {
+  try {
+    const resp = await gitlabFetch('/user');
+    if (!resp.ok) return null;
+    const data = (await resp.json()) as GitLabUser;
+    return data.username ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Ensure the user is authenticated. GitLab auth here is token-based (no
+ * interactive OAuth flow of our own): the user exports GITLAB_TOKEN or logs in
+ * via `glab auth login` beforehand. Returns the authenticated username.
+ *
+ * @throws Error with setup guidance when no credential resolves.
+ */
+export async function ensureGitLabAuthenticated(): Promise<string> {
+  const username = await gitlabWhoami();
+  if (username) return username;
+
+  throw new Error(
+    'GitLab authentication unavailable.\n' +
+      '  Option 1: Export a Personal Access Token (needs "api" scope):\n' +
+      '    export GITLAB_TOKEN=glpat-xxxxxxxx\n' +
+      '  Option 2: Install the glab CLI and run `glab auth login` —\n' +
+      '    https://gitlab.com/gitlab-org/cli\n' +
+      (getGitLabHost() !== 'gitlab.com'
+        ? `  For your self-hosted instance, TEAMAI_GITLAB_HOST=${getGitLabHost()} is set.\n`
+        : '  For a self-hosted instance, set TEAMAI_GITLAB_HOST=gitlab.mycorp.com\n'),
+  );
+}
+
+// ─── Repo operations ─────────────────────────────────────
+
+/**
+ * Clone a GitLab repo using `git clone` with an embedded token so subsequent
+ * pull/push operations work without a separate credential helper.
+ * Throws RepoNotFoundError when the remote does not exist.
+ */
+export function gitlabRepoClone(repo: string, localPath: string): void {
+  const info = parseGitLabRepoInput(repo);
+  const cloneUrl = gitlabGitCloneUrl(info.httpsUrl) ?? info.httpsUrl;
+
+  const result = spawnSync('git', ['clone', cloneUrl, localPath], {
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: 120_000,
+  });
+
+  const allOutput = `${result.stderr ?? ''} ${result.stdout ?? ''}`;
+  if (
+    allOutput.includes('not found') ||
+    allOutput.includes('does not exist') ||
+    allOutput.includes('Repository not found') ||
+    allOutput.includes('404')
+  ) {
+    throw new RepoNotFoundError(repo);
+  }
+  if (result.status !== 0) {
+    // Never leak the token embedded in the clone URL into error output.
+    const sanitized = allOutput.replace(/oauth2:[^@]+@/g, 'oauth2:***@');
+    throw new Error(`git clone failed: ${sanitized.trim()}`);
+  }
+}
+
+interface GitLabNamespace {
+  id: number;
+  full_path: string;
+  kind: 'user' | 'group';
+}
+
+/**
+ * Resolve a namespace (user or group) full path to its numeric id, required by
+ * the project-creation API. Returns null when the namespace is not found or is
+ * the caller's own user namespace (in which case no namespace_id is needed).
+ */
+async function resolveNamespaceId(owner: string): Promise<number | null> {
+  const resp = await gitlabFetch(`/namespaces/${encodeURIComponent(owner)}`);
+  if (!resp.ok) return null;
+  const ns = (await resp.json()) as GitLabNamespace;
+  return ns.id ?? null;
+}
+
+/**
+ * Create a repo on GitLab via `POST /projects`.
+ *  - If `owner` is a group, the project is created under that group's namespace.
+ *  - If `owner` is the authenticated user, it is created under their namespace.
+ * Throws on failure.
+ */
+export async function gitlabCreateRepo(owner: string, repo: string): Promise<void> {
+  const body: Record<string, unknown> = {
+    name: repo,
+    path: repo,
+    visibility: 'private',
+  };
+
+  // When the owner is not the caller's own username, treat it as a namespace
+  // (group or another user) and resolve its id.
+  const login = await gitlabWhoami();
+  if (!login || login.toLowerCase() !== owner.toLowerCase()) {
+    const nsId = await resolveNamespaceId(owner);
+    if (nsId === null) {
+      throw new Error(
+        `Failed to create GitLab repo: namespace "${owner}" not found or not accessible.`,
+      );
+    }
+    body.namespace_id = nsId;
+  }
+
+  const resp = await gitlabFetch('/projects', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+
+  if (!resp.ok) {
+    const errBody = await resp.text().catch(() => '');
+    throw new Error(`Failed to create GitLab repo: ${resp.status} ${errBody}`);
+  }
+}
+
+// ─── Merge Request ───────────────────────────────────────
+
+export interface GitLabMrCreateOptions {
+  /** Repository in "owner/repo" (owner may be a nested group path) format */
+  repo: string;
+  /** Source branch name */
+  source: string;
+  /** Target branch name (e.g. 'master' or 'main') */
+  target: string;
+  /** MR title */
+  title: string;
+  /** MR description */
+  description?: string;
+  /** Reviewer usernames */
+  reviewers?: string[];
+}
+
+interface GitLabMrResponse {
+  web_url?: string;
+  iid?: number;
+}
+
+interface GitLabUserLookup {
+  id: number;
+  username: string;
+}
+
+/**
+ * Resolve reviewer usernames to numeric user ids. Unknown usernames are
+ * silently skipped — a bad reviewer name must not block MR creation.
+ */
+async function resolveReviewerIds(usernames: string[]): Promise<number[]> {
+  const ids: number[] = [];
+  for (const name of usernames) {
+    try {
+      const resp = await gitlabFetch(`/users?username=${encodeURIComponent(name)}`);
+      if (!resp.ok) continue;
+      const users = (await resp.json()) as GitLabUserLookup[];
+      const match = users.find((u) => u.username?.toLowerCase() === name.toLowerCase());
+      if (match) ids.push(match.id);
+    } catch {
+      // Non-fatal — skip this reviewer.
+    }
+  }
+  return ids;
+}
+
+/**
+ * Create a Merge Request via `POST /projects/:id/merge_requests`.
+ * Returns the MR web URL.
+ */
+export async function gitlabMrCreate(opts: GitLabMrCreateOptions): Promise<string> {
+  const info = parseGitLabRepoInput(opts.repo);
+  const projectId = info.projectId;
+
+  const body: Record<string, unknown> = {
+    source_branch: opts.source,
+    target_branch: opts.target,
+    title: opts.title,
+    description: opts.description ?? '',
+    remove_source_branch: true,
+  };
+
+  if (opts.reviewers && opts.reviewers.length > 0) {
+    const reviewerIds = await resolveReviewerIds(opts.reviewers);
+    if (reviewerIds.length > 0) {
+      body.reviewer_ids = reviewerIds;
+    }
+  }
+
+  const resp = await gitlabFetch(`/projects/${projectId}/merge_requests`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+
+  if (!resp.ok) {
+    const errBody = await resp.text().catch(() => '');
+    // A duplicate MR for the same source/target is not a hard failure — surface
+    // a helpful message but keep the wording aligned with other providers.
+    throw new Error(`Failed to create GitLab MR: ${resp.status} ${errBody}`);
+  }
+
+  const mr = (await resp.json()) as GitLabMrResponse;
+  if (!mr.web_url) {
+    throw new Error('GitLab MR created but response did not include web_url.');
+  }
+  log.debug(`GitLab MR created: ${mr.web_url}`);
+  return mr.web_url;
+}

--- a/src/providers/gitlab/gitlab-org.ts
+++ b/src/providers/gitlab/gitlab-org.ts
@@ -1,0 +1,118 @@
+import type { OrgRepoInfo } from '../types.js';
+import { getGitLabToken, gitlabAuthHeaders, gitlabApiBase } from './rest-auth.js';
+import { log } from '../../utils/logger.js';
+
+const DEFAULT_PER_PAGE = 100;
+const DEFAULT_MAX_REPOS = 200;
+// Cap the response body at 50 MB to guard against a hostile server OOMing us.
+const MAX_RESPONSE_BYTES = 50 * 1024 * 1024;
+
+interface GitLabProjectApiItem {
+  id: number;
+  name: string;
+  path_with_namespace: string;
+  description?: string | null;
+  http_url_to_repo: string;
+  default_branch?: string | null;
+  archived?: boolean;
+  last_activity_at?: string;
+  star_count?: number;
+}
+
+function mapItem(item: GitLabProjectApiItem): OrgRepoInfo {
+  return {
+    url: item.http_url_to_repo,
+    fullName: item.path_with_namespace,
+    name: item.name,
+    description: item.description ?? undefined,
+    primaryLanguage: undefined,
+    archived: item.archived ?? false,
+    stars: item.star_count,
+    pushedAt: item.last_activity_at,
+  };
+}
+
+/** Read a fetch response body with a hard size cap. */
+async function readCapped(resp: Response): Promise<string> {
+  const reader = resp.body?.getReader();
+  let received = 0;
+  const chunks: Uint8Array[] = [];
+  if (reader) {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      received += value.length;
+      if (received > MAX_RESPONSE_BYTES) {
+        await reader.cancel();
+        throw new Error(`GitLab API response exceeds ${MAX_RESPONSE_BYTES} bytes`);
+      }
+      chunks.push(value);
+    }
+  }
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+/**
+ * List all projects under a GitLab group (including subgroups).
+ *
+ * Uses `GET /groups/<encoded-path>/projects?include_subgroups=true`, paginating
+ * until a short page or the maxRepos cap is reached.
+ *
+ * @param group   group full path (e.g. "team-org" / "team/sub-group")
+ * @param opts.maxRepos  cap, default 200
+ * @throws Error
+ *   - missing token → from getGitLabToken()
+ *   - group not found / no access → `GitLab group <path> not found or no access`
+ *   - other HTTP error → `GitLab API HTTP <code>: <text>`
+ */
+export async function gitlabListOrgRepos(
+  group: string,
+  opts?: { maxRepos?: number },
+): Promise<OrgRepoInfo[]> {
+  const { token, scheme } = getGitLabToken();
+
+  const maxRepos = opts?.maxRepos ?? DEFAULT_MAX_REPOS;
+  const perPage = DEFAULT_PER_PAGE;
+  const encodedGroup = encodeURIComponent(group);
+  const apiBase = gitlabApiBase();
+
+  const headers = {
+    ...gitlabAuthHeaders(token, scheme),
+    Accept: 'application/json',
+  };
+
+  const collected: OrgRepoInfo[] = [];
+  let page = 1;
+
+  while (collected.length < maxRepos) {
+    const url =
+      `${apiBase}/groups/${encodedGroup}/projects` +
+      `?include_subgroups=true&per_page=${perPage}&page=${page}`;
+    const resp = await fetch(url, { headers, redirect: 'manual' });
+
+    if (resp.status >= 300 && resp.status < 400) {
+      throw new Error(`Unexpected redirect from GitLab API: ${resp.status}`);
+    }
+    if (resp.status === 404) {
+      throw new Error(`GitLab group ${group} not found or no access`);
+    }
+    if (!resp.ok) {
+      throw new Error(`GitLab API HTTP ${resp.status}: ${await resp.text().catch(() => '')}`);
+    }
+
+    const bodyText = await readCapped(resp);
+    const items = JSON.parse(bodyText) as GitLabProjectApiItem[];
+    if (!Array.isArray(items) || items.length === 0) break;
+
+    for (const item of items) {
+      collected.push(mapItem(item));
+      if (collected.length >= maxRepos) break;
+    }
+
+    if (items.length < perPage) break;
+    page++;
+  }
+
+  log.debug(`gitlabListOrgRepos: ${group} → ${collected.length} projects`);
+  return collected;
+}

--- a/src/providers/gitlab/index.ts
+++ b/src/providers/gitlab/index.ts
@@ -1,0 +1,88 @@
+import type { GitProvider, PrCreateOptions, RepoInfo, OrgRepoInfo } from '../types.js';
+import { RepoNotFoundError } from '../types.js';
+import type { MRData } from '../../types.js';
+import {
+  gitlabIsAuthenticated,
+  gitlabWhoami,
+  ensureGitLabAuthenticated,
+  gitlabRepoClone,
+  gitlabCreateRepo,
+  gitlabMrCreate,
+  RepoNotFoundError as GitLabRepoNotFoundError,
+} from './gitlab-api.js';
+import { gitlabListOrgRepos } from './gitlab-org.js';
+import { fetchGitLabMR } from './mr-fetch.js';
+import { parseGitLabRepoInput } from './repo-url.js';
+
+/**
+ * GitLab provider — supports gitlab.com and self-hosted instances (via the
+ * `TEAMAI_GITLAB_HOST` env var). Auth is token-based: a `GITLAB_TOKEN`
+ * Personal Access Token, or `glab auth login`. All API operations go through
+ * the GitLab v4 REST API.
+ */
+export class GitLabProvider implements GitProvider {
+  readonly name = 'gitlab';
+
+  parseRepoInput(input: string): RepoInfo {
+    return parseGitLabRepoInput(input);
+  }
+
+  isAuthenticated(): boolean {
+    return gitlabIsAuthenticated();
+  }
+
+  async authenticate(): Promise<string> {
+    if (this.isAuthenticated()) {
+      const username = await gitlabWhoami();
+      if (username) return username;
+    }
+    return ensureGitLabAuthenticated();
+  }
+
+  async ensureInstalled(): Promise<void> {
+    // GitLab uses plain git + the REST API; no external CLI is required.
+    // (glab is optional and only used to source a token when present.)
+  }
+
+  cloneRepo(repo: string, localPath: string): void {
+    try {
+      gitlabRepoClone(repo, localPath);
+    } catch (e) {
+      if (e instanceof GitLabRepoNotFoundError) {
+        throw new RepoNotFoundError(repo);
+      }
+      throw e;
+    }
+  }
+
+  async createRepo(owner: string, repo: string): Promise<void> {
+    await gitlabCreateRepo(owner, repo);
+  }
+
+  async createPullRequest(opts: PrCreateOptions): Promise<string> {
+    return gitlabMrCreate({
+      repo: opts.repo,
+      source: opts.source,
+      target: opts.target,
+      title: opts.title,
+      description: opts.description,
+      reviewers: opts.reviewers,
+    });
+  }
+
+  async fetchMergeRequest(url: string): Promise<MRData> {
+    return fetchGitLabMR(url);
+  }
+
+  getDefaultEmailDomain(): string | null {
+    return null;
+  }
+
+  async listOrgRepos(org: string, opts?: { maxRepos?: number }): Promise<OrgRepoInfo[]> {
+    return gitlabListOrgRepos(org, opts);
+  }
+}
+
+// Re-export commonly used items.
+export { gitlabIsAuthenticated } from './gitlab-api.js';
+export { getGitLabHost, tryGetGitLabToken } from './rest-auth.js';

--- a/src/providers/gitlab/mr-fetch.ts
+++ b/src/providers/gitlab/mr-fetch.ts
@@ -1,0 +1,118 @@
+import { type MRData } from '../../types.js';
+import { log } from '../../utils/logger.js';
+import { gitlabFetch } from './rest-auth.js';
+
+/** GitLab MR URL parse result */
+interface ParsedGitLabMR {
+  /** Project full path, e.g. `group/subgroup/repo` */
+  projectPath: string;
+  /** MR internal id (iid) */
+  mrIid: string;
+}
+
+/**
+ * Parse a GitLab MR URL into project full path + MR iid.
+ *
+ * Supported: `https://<host>/<group>/<repo>/-/merge_requests/<iid>`
+ * GitLab prefixes project sub-paths with `/-/`; older/short forms without the
+ * `/-/` separator are also accepted. The group portion may be nested.
+ * Throws on parse failure.
+ */
+export function parseGitLabMRUrl(url: string): ParsedGitLabMR {
+  // Modern GitLab: .../<path>/-/merge_requests/<iid>
+  const dashMatch = url.match(/^https?:\/\/[^/]+\/(.+?)\/-\/merge_requests\/(\d+)/);
+  if (dashMatch) {
+    return { projectPath: dashMatch[1], mrIid: dashMatch[2] };
+  }
+  // Fallback without the /-/ separator
+  const plainMatch = url.match(/^https?:\/\/[^/]+\/(.+?)\/merge_requests\/(\d+)/);
+  if (plainMatch) {
+    return { projectPath: plainMatch[1], mrIid: plainMatch[2] };
+  }
+  throw new Error(`Invalid GitLab MR URL: ${url}`);
+}
+
+/** GitLab REST API MR metadata (used fields only) */
+interface GitLabMR {
+  iid: number;
+  title: string;
+  description: string | null;
+  author: { username: string };
+  merged_at?: string | null;
+  updated_at?: string | null;
+}
+
+/** GitLab REST API commit item (used fields only) */
+interface GitLabCommit {
+  id: string;
+  title: string;
+}
+
+/** /changes payload */
+interface GitLabChangesResponse {
+  changes?: Array<{ diff: string }>;
+}
+
+/**
+ * Fetch full MR data via the GitLab REST API (`<host>/api/v4`).
+ *
+ *   1. GET /projects/{enc}/merge_requests/{iid}          → metadata
+ *   2. GET /projects/{enc}/merge_requests/{iid}/commits  → commit list
+ *   3. GET /projects/{enc}/merge_requests/{iid}/changes  → diff (best-effort)
+ *
+ * Auth and scheme fallback are handled by gitlabFetch.
+ *
+ * @param url - GitLab MR web URL, e.g. https://gitlab.com/group/repo/-/merge_requests/42
+ * @throws Error when the URL is malformed or the metadata call fails
+ */
+export async function fetchGitLabMR(url: string): Promise<MRData> {
+  const { projectPath, mrIid } = parseGitLabMRUrl(url);
+  const enc = encodeURIComponent(projectPath);
+  log.debug(`fetchGitLabMR: ${projectPath}!${mrIid}`);
+
+  // ── 1. metadata ────────────────────────────────────────
+  const resp = await gitlabFetch(`/projects/${enc}/merge_requests/${mrIid}`);
+  if (!resp.ok) {
+    throw new Error(`GitLab API error ${resp.status}: ${await resp.text().catch(() => '')}`);
+  }
+  const mr = (await resp.json()) as GitLabMR;
+
+  // ── 2. commits (best-effort) ───────────────────────────
+  let commits: Array<{ hash: string; message: string }> = [];
+  try {
+    const commitsResp = await gitlabFetch(
+      `/projects/${enc}/merge_requests/${mrIid}/commits?per_page=50`,
+    );
+    if (commitsResp.ok) {
+      const raw = (await commitsResp.json()) as GitLabCommit[];
+      commits = raw.map((c) => ({ hash: c.id, message: c.title }));
+    }
+  } catch (err) {
+    log.debug(`GitLab MR commits fetch failed: ${(err as Error).message}`);
+  }
+
+  // ── 3. diff (best-effort, truncated to 50KB) ───────────
+  let diff = '';
+  try {
+    const diffResp = await gitlabFetch(`/projects/${enc}/merge_requests/${mrIid}/changes`);
+    if (diffResp.ok) {
+      const diffData = (await diffResp.json()) as GitLabChangesResponse;
+      const fileDiffs = diffData.changes ?? [];
+      diff = fileDiffs.map((c) => c.diff).join('\n').slice(0, 50000);
+    } else {
+      log.debug(`GitLab MR diff fetch failed (${diffResp.status}); diff will be empty`);
+    }
+  } catch (err) {
+    log.debug(`GitLab MR diff fetch error; diff will be empty: ${(err as Error).message}`);
+  }
+
+  return {
+    title: mr.title,
+    description: mr.description ?? '',
+    author: mr.author?.username,
+    mergedAt: mr.merged_at ?? mr.updated_at ?? undefined,
+    commits,
+    diff,
+    url,
+  };
+}

--- a/src/providers/gitlab/repo-url.ts
+++ b/src/providers/gitlab/repo-url.ts
@@ -1,0 +1,70 @@
+import type { RepoInfo } from '../types.js';
+import { getGitLabHost } from './rest-auth.js';
+
+/**
+ * Escape a string for safe interpolation into a RegExp.
+ */
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Parse user input into a standardized RepoInfo structure for GitLab.
+ *
+ * Supports:
+ *   - Short format: `owner/repo` or `group/subgroup/repo`
+ *   - HTTPS URL:    `https://gitlab.com/owner/repo.git`
+ *   - SSH URL:      `git@gitlab.com:owner/repo.git`
+ *
+ * The host is gitlab.com by default, or the value of `TEAMAI_GITLAB_HOST` for a
+ * self-hosted instance. GitLab groups may be nested arbitrarily deep, so the
+ * owner portion may contain multiple path segments (e.g. `group/subgroup`).
+ */
+export function parseGitLabRepoInput(input: string): RepoInfo {
+  const trimmed = input.trim();
+  const host = getGitLabHost();
+  const hostRe = escapeRegExp(host);
+
+  // HTTPS URL — owner path may contain multiple segments
+  const httpsMatch = trimmed.match(
+    new RegExp(`^https?://${hostRe}/(.+)/([^/]+?)(?:\\.git)?/?$`),
+  );
+  if (httpsMatch) {
+    return buildRepoInfo(host, httpsMatch[1], httpsMatch[2]);
+  }
+
+  // SSH URL — owner path may contain multiple segments
+  const sshMatch = trimmed.match(
+    new RegExp(`^git@${hostRe}:(.+)/([^/]+?)(?:\\.git)?/?$`),
+  );
+  if (sshMatch) {
+    return buildRepoInfo(host, sshMatch[1], sshMatch[2]);
+  }
+
+  // Short format: owner/repo or group/subgroup/repo
+  const shortMatch = trimmed.match(
+    /^([A-Za-z0-9_.\-]+(?:\/[A-Za-z0-9_.\-]+)*)\/([A-Za-z0-9_.\-]+)$/,
+  );
+  if (shortMatch) {
+    return buildRepoInfo(host, shortMatch[1], shortMatch[2]);
+  }
+
+  throw new Error(
+    `Unrecognized GitLab repo format: "${trimmed}"\n` +
+      '  Supported formats:\n' +
+      '    owner/repo\n' +
+      '    group/subgroup/repo\n' +
+      `    https://${host}/owner/repo.git\n` +
+      `    git@${host}:owner/repo.git`,
+  );
+}
+
+function buildRepoInfo(host: string, owner: string, repo: string): RepoInfo {
+  return {
+    owner,
+    repo,
+    httpsUrl: `https://${host}/${owner}/${repo}.git`,
+    // GitLab addresses a project by the URL-encoded full path `group/repo`.
+    projectId: encodeURIComponent(`${owner}/${repo}`),
+  };
+}

--- a/src/providers/gitlab/rest-auth.ts
+++ b/src/providers/gitlab/rest-auth.ts
@@ -1,0 +1,176 @@
+import { execSync } from 'node:child_process';
+import { log } from '../../utils/logger.js';
+
+/**
+ * GitLab git host. Defaults to the public platform gitlab.com.
+ *
+ * `TEAMAI_GITLAB_HOST` overrides it for a self-hosted / enterprise GitLab
+ * instance (e.g. `gitlab.mycorp.com`). Read at call time (not module load) so
+ * tests and long-running processes pick up the current environment.
+ */
+export function getGitLabHost(): string {
+  return process.env.TEAMAI_GITLAB_HOST?.trim() || 'gitlab.com';
+}
+
+/** Base URL for the GitLab REST API (modern v4 API). */
+export function gitlabApiBase(): string {
+  return `https://${getGitLabHost()}/api/v4`;
+}
+
+/**
+ * Authentication scheme accepted by the GitLab REST API.
+ *
+ * - `private-token`: a Personal / Project Access Token via the `PRIVATE-TOKEN`
+ *   header. This is the common CI credential.
+ * - `bearer`: an OAuth2 access token via `Authorization: Bearer`.
+ */
+export type GitLabAuthScheme = 'private-token' | 'bearer';
+
+/**
+ * The auth scheme confirmed to work earlier this process. Once a request
+ * succeeds after a scheme fallback we cache it so later calls skip the miss.
+ */
+let cachedScheme: GitLabAuthScheme | null = null;
+
+/** Reset the cached auth scheme (test helper). */
+export function resetGitLabAuthCache(): void {
+  cachedScheme = null;
+}
+
+/**
+ * Read a GitLab token from the environment.
+ *
+ * `GITLAB_TOKEN` is the primary variable; `GL_TOKEN` and `CI_JOB_TOKEN`
+ * (GitLab CI's built-in job token) are accepted as fallbacks so pipelines work
+ * without extra configuration.
+ */
+export function getGitLabEnvToken(): string | null {
+  return (
+    process.env.GITLAB_TOKEN ??
+    process.env.GL_TOKEN ??
+    process.env.CI_JOB_TOKEN ??
+    null
+  );
+}
+
+/**
+ * Retrieve an OAuth token via the `glab` CLI, when installed and logged in.
+ * Returns null when glab is unavailable or holds no token.
+ */
+export function glabGetToken(): string | null {
+  try {
+    const out = execSync('glab auth token', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const token = out.trim();
+    return token || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve a GitLab credential and its matching auth scheme.
+ *
+ * An env token (`GITLAB_TOKEN` / `GL_TOKEN` / `CI_JOB_TOKEN`) is treated as a
+ * Personal/Project Access Token (`PRIVATE-TOKEN` header). Otherwise the token
+ * from `glab auth token` is used as an OAuth2 bearer token.
+ *
+ * @throws Error when no credential is available
+ */
+export function getGitLabToken(): { token: string; scheme: GitLabAuthScheme } {
+  const envToken = getGitLabEnvToken();
+  if (envToken && envToken.length > 0) {
+    return { token: envToken, scheme: 'private-token' };
+  }
+
+  const glabToken = glabGetToken();
+  if (glabToken) {
+    return { token: glabToken, scheme: 'bearer' };
+  }
+
+  throw new Error(
+    'No GitLab credentials found. Set the GITLAB_TOKEN environment variable ' +
+      '(a GitLab Personal Access Token with "api" scope) or run `glab auth login`.',
+  );
+}
+
+/**
+ * Like {@link getGitLabToken} but returns null instead of throwing when no
+ * credential is available.
+ */
+export function tryGetGitLabToken(): { token: string; scheme: GitLabAuthScheme } | null {
+  try {
+    return getGitLabToken();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build an authenticated GitLab clone/fetch URL, or null when no credential is
+ * available.
+ *
+ * GitLab accepts both PATs and OAuth tokens presented as in-URL basic-auth with
+ * the `oauth2` username (`https://oauth2:<token>@host/…`), so a single form
+ * works for either credential kind.
+ *
+ * @param httpsUrl - the base `https://<host>/…` clone URL (no credentials)
+ */
+export function gitlabGitCloneUrl(httpsUrl: string): string | null {
+  const cred = tryGetGitLabToken();
+  if (!cred) return null;
+  return httpsUrl.replace(/^https:\/\//, `https://oauth2:${cred.token}@`);
+}
+
+/** Build the authorization header for the given token and scheme. */
+export function gitlabAuthHeaders(token: string, scheme: GitLabAuthScheme): Record<string, string> {
+  if (scheme === 'bearer') {
+    return { Authorization: `Bearer ${token}` };
+  }
+  return { 'PRIVATE-TOKEN': token };
+}
+
+/**
+ * Fetch a path from the GitLab REST API with automatic auth-scheme handling.
+ *
+ * The token and its resolved scheme come from {@link getGitLabToken}, unless a
+ * working scheme was cached earlier this process. On a 401 the request is
+ * retried once with the opposite scheme; a success there caches the scheme.
+ *
+ * @param path - API path beginning with '/', appended to `<host>/api/v4`
+ * @param init - optional fetch init; its headers and signal are respected
+ * @returns the final Response (callers inspect status themselves)
+ * @throws Error when no GitLab credential is available
+ */
+export async function gitlabFetch(path: string, init?: RequestInit): Promise<Response> {
+  const { token, scheme: resolvedScheme } = getGitLabToken();
+  const scheme = cachedScheme ?? resolvedScheme;
+  const url = `${gitlabApiBase()}${path}`;
+
+  const callerHeaders = { ...(init?.headers as Record<string, string> | undefined) };
+  const baseHeaders: Record<string, string> = { 'Content-Type': 'application/json', ...callerHeaders };
+
+  const doFetch = (activeScheme: GitLabAuthScheme): Promise<Response> =>
+    fetch(url, {
+      ...init,
+      headers: { ...baseHeaders, ...gitlabAuthHeaders(token, activeScheme) },
+      signal: init?.signal ?? AbortSignal.timeout(15000),
+    });
+
+  const resp = await doFetch(scheme);
+  if (resp.status !== 401) {
+    return resp;
+  }
+
+  // Auth rejected — retry once with the opposite scheme.
+  const altScheme: GitLabAuthScheme = scheme === 'bearer' ? 'private-token' : 'bearer';
+  log.debug(`GitLab auth scheme "${scheme}" rejected (401); retrying with "${altScheme}"`);
+  const altResp = await doFetch(altScheme);
+  if (altResp.status !== 401) {
+    cachedScheme = altScheme;
+    return altResp;
+  }
+  return resp;
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -3,3 +3,4 @@ export { RepoNotFoundError } from './types.js';
 export { getProvider, getProviderFromUrl, detectProvider } from './registry.js';
 export { TGitProvider } from './tgit/index.js';
 export { GitHubProvider } from './github/index.js';
+export { GitLabProvider } from './gitlab/index.js';

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -2,6 +2,7 @@ import type { GitProvider } from './types.js';
 import { TGitProvider } from './tgit/index.js';
 import { GitHubProvider } from './github/index.js';
 import { CNBProvider } from './cnb/index.js';
+import { GitLabProvider } from './gitlab/index.js';
 import { getCurrentPackageName } from '../package-info.js';
 
 // ─── Provider Detection ──────────────────────────────────
@@ -30,10 +31,22 @@ const HOST_MAP: Record<string, string> = {
   'github.com': 'github',
   'git.woa.com': 'tgit',
   'cnb.cool': 'cnb',
+  'gitlab.com': 'gitlab',
 };
 
 /** Providers we are willing to accept as a default override. */
-const KNOWN_PROVIDERS = new Set(['github', 'tgit', 'cnb']);
+const KNOWN_PROVIDERS = new Set(['github', 'tgit', 'cnb', 'gitlab']);
+
+/**
+ * Resolve the configured self-hosted GitLab host, lowercased, or null when
+ * `TEAMAI_GITLAB_HOST` is unset. This lets `detectProvider` route an enterprise
+ * GitLab URL (e.g. `gitlab.mycorp.com`) to the gitlab provider without a static
+ * HOST_MAP entry — mirroring how CNB uses TEAMAI_CNB_HOST.
+ */
+function selfHostedGitLabHost(): string | null {
+  const host = process.env.TEAMAI_GITLAB_HOST?.trim().toLowerCase();
+  return host && host !== 'gitlab.com' ? host : null;
+}
 
 /**
  * Decide the fallback provider used when the input URL host is unknown or
@@ -70,10 +83,13 @@ export function getDefaultProvider(): string {
 export function detectProvider(input: string): string {
   const trimmed = input.trim();
 
+  const selfGitLab = selfHostedGitLabHost();
+
   // HTTPS URL: extract host
   const httpsMatch = trimmed.match(/^https?:\/\/([^/]+)\//);
   if (httpsMatch) {
     const host = httpsMatch[1].toLowerCase();
+    if (selfGitLab && host === selfGitLab) return 'gitlab';
     return HOST_MAP[host] ?? getDefaultProvider();
   }
 
@@ -81,6 +97,7 @@ export function detectProvider(input: string): string {
   const sshMatch = trimmed.match(/^git@([^:]+):/);
   if (sshMatch) {
     const host = sshMatch[1].toLowerCase();
+    if (selfGitLab && host === selfGitLab) return 'gitlab';
     return HOST_MAP[host] ?? getDefaultProvider();
   }
 
@@ -95,6 +112,7 @@ const PROVIDERS: Record<string, () => GitProvider> = {
   tgit: () => new TGitProvider(),
   github: () => new GitHubProvider(),
   cnb: () => new CNBProvider(),
+  gitlab: () => new GitLabProvider(),
 };
 
 /**


### PR DESCRIPTION
## What & why

Implements the **GitLab provider** half of #303: support GitLab (both public **gitlab.com** and **self-hosted** instances via `TEAMAI_GITLAB_HOST`) as a first-class git provider, on par with GitHub / TGit / CNB. Covers `teamai init` (token auth), `push` (branch + MR), `pull` (fetch/merge), and the CI MR-extract flow.

> OpenCode agent support (the other half of #303) is intentionally out of scope here and will follow as a separate PR.

## Implementation

- **New `src/providers/gitlab/`**
  - `rest-auth.ts` — token resolution (`GITLAB_TOKEN` / `GL_TOKEN` / `CI_JOB_TOKEN` as PAT, or `glab auth token` as OAuth), `gitlabFetch` with 401 auth-scheme fallback, in-URL `oauth2:<token>@` clone URL, `TEAMAI_GITLAB_HOST` support.
  - `repo-url.ts` — host-dynamic parsing of HTTPS/SSH/short forms + multi-level groups.
  - `gitlab-api.ts` — auth check, whoami, clone (token sanitized on error), create repo (resolves `namespace_id`), create MR (resolves `reviewer_ids`).
  - `mr-fetch.ts` — MR metadata + commits + `/changes` diff (best-effort, capped).
  - `gitlab-org.ts` — list group projects (paginated, `include_subgroups=true`).
  - `index.ts` — `GitLabProvider` class.
- **Registration/detection** (`registry.ts`): `gitlab` in `HOST_MAP` + `PROVIDERS`; `detectProvider` recognizes `gitlab.com` and the self-hosted host in both HTTPS and SSH branches.
- **Dispatch points wired for GitLab**: `import-mr` `fetchMR`; `ci/mr-comment` `parseMrUrl` + idempotent notes comment; `ci/read-rejections` (👎 `thumbsdown` award emoji = reject); `mr-hint` `parseRemoteToRepo` + `listGitLabMergedMRs`.
- **Docs**: `docs/providers.md` GitLab section + table/detection rules; README (EN + zh-CN) and usage-guide (EN + zh-CN) provider lists.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 2070 tests pass (incl. new GitLab parse/detection cases)
- [x] `npm run build` — success
- [x] Real CLI e2e: `teamai init` routes gitlab.com URL → GitLab provider with GitLab-specific auth guidance
- [x] Real CLI e2e: `TEAMAI_GITLAB_HOST` self-hosted detection (multi-level group path `platform/team/repo`)
- [x] Parsing e2e: HTTPS/SSH/short/self-hosted-multi-level/MR-URL all produce correct structured output
- [x] Verified the constructed REST endpoints return 200 against the live gitlab.com API

🤖 Generated with [Claude Code](https://claude.com/claude-code)