### PR TITLE
fix(git): reject scp-style embedded credentials and align clone timeout

### DIFF
--- a/src/__tests__/generic-git-provider.test.ts
+++ b/src/__tests__/generic-git-provider.test.ts
@@ -67,6 +67,18 @@ describe('parseGenericGitRepoInput', () => {
     )).toThrow(/Do not embed credentials/);
   });
 
+  it('rejects scp-style embedded credentials but keeps a real SSH login', () => {
+    // A colon in the user field is a credential (e.g. "oauth2:token"), not a login.
+    expect(() => parseGenericGitRepoInput(
+      'oauth2:secret@code.qschou.com:Enterprise/arb-workflow-kit.git',
+    )).toThrow(/Do not embed credentials/);
+
+    // A normal SSH user must still be accepted and preserved verbatim.
+    expect(parseGenericGitRepoInput(
+      'git@code.qschou.com:Enterprise/arb-workflow-kit.git',
+    ).httpsUrl).toBe('git@code.qschou.com:Enterprise/arb-workflow-kit.git');
+  });
+
   it('rejects insecure HTTP and does not echo query-string secrets', () => {
     expect(() => parseGenericGitRepoInput(
       'http://code.qschou.com/Enterprise/arb-workflow-kit.git',
@@ -111,7 +123,7 @@ describe('GenericGitProvider transport', () => {
     expect(mockedSpawnSync).toHaveBeenCalledWith(
       'git',
       ['clone', '--', 'git@code.qschou.com:Enterprise/arb-workflow-kit.git', '/tmp/team-repo'],
-      expect.objectContaining({ timeout: 120_000 }),
+      expect.objectContaining({ timeout: 180_000 }),
     );
   });
 

--- a/src/providers/git/index.ts
+++ b/src/providers/git/index.ts
@@ -85,7 +85,9 @@ export class GenericGitProvider implements GitProvider {
     const result = spawnSync('git', ['clone', '--', remoteUrl, localPath], {
       encoding: 'utf-8',
       stdio: ['inherit', 'pipe', 'pipe'],
-      timeout: 120_000,
+      // Match the 180s default used by the shallow-clone path in clone.ts:
+      // large self-hosted repos over slow/VPN links need the extra headroom.
+      timeout: 180_000,
       maxBuffer: 10 * 1024 * 1024,
     });
     if (result.error || result.status !== 0) {

--- a/src/providers/git/repo-url.ts
+++ b/src/providers/git/repo-url.ts
@@ -75,6 +75,14 @@ export function parseGenericGitRepoInput(input: string): RepoInfo {
   const scpMatch = trimmed.match(/^([^@\s]+)@([^:\s]+):(.+)$/);
   if (scpMatch) {
     const [, user, host, rawPath] = scpMatch;
+    // A colon in the SSH user field means embedded credentials
+    // (e.g. "oauth2:token@host:path"); a real SSH login never contains one.
+    if (user.includes(':')) {
+      throw new Error(
+        'Invalid Git repo URL. Do not embed credentials in the URL; '
+        + 'configure a Git credential helper or SSH key instead.',
+      );
+    }
     const { owner, repo, fullPath } = parsePath(rawPath);
     return buildRepoInfo(owner, repo, `${user}@${host}:${fullPath}.git`);
   }


### PR DESCRIPTION
## Summary

Two follow-up fixes for the generic Git provider added in #301, found in code review.

### 1. scp-style URLs leaked embedded credentials (security)

`parseGenericGitRepoInput` rejected embedded credentials on the HTTPS/`ssh://` path, but the scp-style branch (`user@host:group/repo.git`) returned the input verbatim. An input like `oauth2:token@code.qschou.com:Enterprise/repo.git` was preserved as-is and could be written back into `teamai.yaml` (`repo:`) / `localConfig.remote`, contradicting the no-credentials-in-URL guarantee that the HTTPS path and the redact util both promise.

A colon in the SSH user field is a credential (`oauth2:token`), never a real login, so we now reject it with the same message the HTTPS path uses. Normal `git@host:group/repo.git` logins are unaffected.

### 2. Clone timeout shorter than the shallow-clone path

`cloneRepo` hardcoded a 120s timeout, shorter than the 180s default used by the shallow-clone path in `clone.ts`. Large self-hosted repos over slow/VPN links could time out where the equivalent path would not. Aligned to 180s.

## Test Plan

- [x] `npx tsc --noEmit` — no new type errors in changed files
- [x] `npx vitest run src/__tests__/generic-git-provider.test.ts` — 16/16 pass (added a scp-credential case; updated the timeout assertion)
- [x] `npm run build` — success; confirmed `timeout: 18e4` (180000) compiled into the generic cloneRepo
- [x] Real CLI E2E: `node dist/index.js init "oauth2:secret@code.qschou.com:Enterprise/repo.git"` → rejected with `Do not embed credentials`
- [x] Real CLI E2E: `node dist/index.js init "git@code.qschou.com:..."` → not rejected for credentials (normal scp login preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)