### PR TITLE
fix(home): resolve user home via getUserHome everywhere for Windows

### DIFF
--- a/src/__tests__/home.test.ts
+++ b/src/__tests__/home.test.ts
@@ -1,5 +1,7 @@
+import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { getUserHome } from '../utils/home.js';
@@ -66,5 +68,59 @@ describe('getUserHome', () => {
     delete process.env.USERPROFILE;
 
     expect(getUserHome()).toBe(os.homedir());
+  });
+
+  it('falls back to os.tmpdir when even os.homedir is unresolvable', () => {
+    delete process.env.HOME;
+    delete process.env.USERPROFILE;
+    // os.homedir() is documented to return '' when the home cannot be resolved.
+    const spy = vi.spyOn(os, 'homedir').mockReturnValue('');
+
+    try {
+      const home = getUserHome();
+      expect(home).toBe(os.tmpdir());
+      expect(home).not.toBe('');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('resolves user-scope resource paths from USERPROFILE when HOME is unavailable', async () => {
+    delete process.env.HOME;
+    process.env.USERPROFILE = 'C:\\Users\\alice';
+
+    const { getApiKeyPath } = await import('../api-key.js');
+
+    expect(getApiKeyPath()).toBe(path.join('C:\\Users\\alice', '.teamai', 'apikey'));
+  });
+});
+
+describe('home directory lookups', () => {
+  it('never read process.env.HOME directly outside getUserHome', async () => {
+    const srcDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+    const offenders: string[] = [];
+
+    async function walk(dir: string): Promise<void> {
+      const entries = await fs.readdir(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          if (entry.name === '__tests__') continue;
+          await walk(full);
+        } else if (entry.isFile() && entry.name.endsWith('.ts')) {
+          const rel = path.relative(srcDir, full);
+          // utils/home.ts is the single sanctioned reader of the raw env var.
+          if (rel === path.join('utils', 'home.ts')) continue;
+          const content = await fs.readFile(full, 'utf-8');
+          if (content.includes('process.env.HOME')) offenders.push(rel);
+        }
+      }
+    }
+
+    await walk(srcDir);
+
+    // A bare process.env.HOME breaks Windows, where only USERPROFILE is set:
+    // `?? ''` silently degrades to a relative path and a non-null assertion crashes.
+    expect(offenders).toEqual([]);
   });
 });

--- a/src/agent-skills.ts
+++ b/src/agent-skills.ts
@@ -4,6 +4,7 @@ import { listDirs, pathExists, readFileSafe } from './utils/fs.js';
 import { detectInstalledAgents, type ResolvedAgent } from './known-agents.js';
 import { BUILTIN_SKILL_NAMES } from './builtin-skills.js';
 import type { LocalConfig, TeamaiConfig } from './types.js';
+import { getUserHome } from './utils/home.js';
 
 // ─── Local agent skill scanning ─────────────────────────
 //
@@ -54,7 +55,7 @@ export async function buildClassifyContext(localConfig: LocalConfig): Promise<Cl
 
   const sourceSkills = new Map<string, string>();
   try {
-    const sourcesDir = path.join(process.env.HOME ?? '', '.teamai', 'sources');
+    const sourcesDir = path.join(getUserHome(), '.teamai', 'sources');
     if (await pathExists(sourcesDir)) {
       const sourceNames = await listDirs(sourcesDir);
       for (const sourceName of sourceNames) {

--- a/src/api-key.ts
+++ b/src/api-key.ts
@@ -15,10 +15,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { ensureDir } from './utils/fs.js';
+import { getUserHome } from './utils/home.js';
 
 /** Absolute path to the local API key file. */
 export function getApiKeyPath(): string {
-  return path.join(process.env.HOME ?? '', '.teamai', 'apikey');
+  return path.join(getUserHome(), '.teamai', 'apikey');
 }
 
 /**

--- a/src/builtin-agents.ts
+++ b/src/builtin-agents.ts
@@ -5,6 +5,7 @@ import { log } from './utils/logger.js';
 import type { TeamaiConfig, LocalConfig } from './types.js';
 import { resolveBaseDir, isAgentDisabled } from './types.js';
 import { ResourceHandler } from './resources/base.js';
+import { getUserHome } from './utils/home.js';
 
 // ─── Built-in agents deployment ──────────────────────────
 //
@@ -75,7 +76,7 @@ export async function deployBuiltinAgents(
     .filter((f) => !(options?.skipRecall && f === 'teamai-recall.md'));
   if (agentFiles.length === 0) return 0;
 
-  const baseDir = localConfig ? resolveBaseDir(localConfig) : (process.env.HOME ?? '');
+  const baseDir = localConfig ? resolveBaseDir(localConfig) : getUserHome();
   let deployed = 0;
 
   for (const [tool, toolPath] of Object.entries(teamConfig.toolPaths)) {

--- a/src/builtin-hooks.ts
+++ b/src/builtin-hooks.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { TEAMAI_HOOK_DESCRIPTION_PREFIX } from './types.js';
 import type { HookDef } from './types.js';
+import { getUserHome } from './utils/home.js';
 
 // ─── Built-in (A) operational hooks as data ─────────────────
 //
@@ -89,7 +90,7 @@ function pickLatestVersion(versions: string[]): string | undefined {
  * using numeric semver comparison (avoids '9.0.0' > '10.11.0' lexicographic error).
  */
 function resolveWorkbuddyNode(): string | null {
-  const home = process.env.HOME ?? '';
+  const home = getUserHome();
   const versionsDir = path.join(home, WORKBUDDY_BUNDLED_NODE_DIR);
   try {
     const versions = fs.readdirSync(versionsDir).filter(d => !d.startsWith('.'));
@@ -106,7 +107,7 @@ function resolveWorkbuddyNode(): string | null {
  * ~/.codebuddy-server-<variant>/bin/stable-<version>/node (prefix may vary).
  */
 function resolveCodebuddyNode(): string | null {
-  const home = process.env.HOME ?? '';
+  const home = getUserHome();
   try {
     const entries = fs.readdirSync(home);
     for (const entry of entries) {
@@ -150,7 +151,7 @@ export function ensureTeamaiWrapper(): string | null {
   if (!entryScript) return null;
 
   const nodeBin = resolveWorkbuddyNode() ?? resolveCodebuddyNode() ?? process.argv[0];
-  const home = process.env.HOME ?? '';
+  const home = getUserHome();
   const binDir = path.join(home, TEAMAI_BIN_DIR);
   const wrapperPath = path.join(binDir, WRAPPER_NAME);
 

--- a/src/builtin-rules.ts
+++ b/src/builtin-rules.ts
@@ -5,6 +5,7 @@ import { ResourceHandler } from './resources/base.js';
 import type { TeamaiConfig, LocalConfig } from './types.js';
 import { resolveBaseDir, isAgentDisabled } from './types.js';
 import fs from 'node:fs/promises';
+import { getUserHome } from './utils/home.js';
 
 // ─── Built-in rules deployment ──────────────────────────
 //
@@ -48,7 +49,7 @@ export async function deployBuiltinRules(
     localConfig?: LocalConfig,
     options?: { skipRecall?: boolean },
 ): Promise<number> {
-    const baseDir = localConfig ? resolveBaseDir(localConfig) : (process.env.HOME ?? '');
+    const baseDir = localConfig ? resolveBaseDir(localConfig) : getUserHome();
     let deployed = 0;
 
     const builtinRules: Array<{ name: string; content: string }> = [

--- a/src/builtin-skills.ts
+++ b/src/builtin-skills.ts
@@ -8,6 +8,7 @@ import type { TeamaiConfig, LocalConfig } from './types.js';
 import { resolveBaseDir, isAgentDisabled } from './types.js';
 import { ResourceHandler } from './resources/base.js';
 import { ensureSkillFrontmatter } from './resources/skills.js';
+import { getUserHome } from './utils/home.js';
 
 // ─── Built-in skills deployment ──────────────────────────
 //
@@ -97,7 +98,7 @@ export async function deployBuiltinSkills(teamConfig: TeamaiConfig, localConfig?
 
   if (skillNames.length === 0) return 0;
 
-  const baseDir = localConfig ? resolveBaseDir(localConfig) : (process.env.HOME ?? '');
+  const baseDir = localConfig ? resolveBaseDir(localConfig) : getUserHome();
   let deployed = 0;
 
   for (const [tool, toolPath] of Object.entries(teamConfig.toolPaths)) {

--- a/src/contribute-check.ts
+++ b/src/contribute-check.ts
@@ -23,6 +23,7 @@ import {
   CONTRIBUTE_SKILL_BONUS,
   CONTRIBUTE_DIVERSITY_BONUS_MAX,
 } from './types.js';
+import { getUserHome } from './utils/home.js';
 
 // ─── Contribute check data flow (Stop hook) ────────────────
 //
@@ -117,7 +118,7 @@ function normalizePromptSummary(raw?: string): string | undefined {
 /** Get session state file path: ~/.teamai/sessions/{sanitized-sessionId}.json */
 function getSessionPath(sessionId: string): string {
   return path.join(
-    process.env.HOME ?? '',
+    getUserHome(),
     '.teamai',
     'sessions',
     `${sanitizeSessionId(sessionId)}.json`,

--- a/src/dashboard-collector.ts
+++ b/src/dashboard-collector.ts
@@ -29,6 +29,7 @@ import {
   type TokenUsage,
   type SessionMetrics,
 } from './types.js';
+import { getUserHome } from './utils/home.js';
 
 // ─── Event collection data flow ─────────────────────────
 //
@@ -514,7 +515,7 @@ export async function parseHookEvent(
 
 /** Get events path (evaluated at call time). */
 function getEventsPath(): string {
-  return path.join(process.env.HOME ?? '', '.teamai', 'dashboard', 'events.jsonl');
+  return path.join(getUserHome(), '.teamai', 'dashboard', 'events.jsonl');
 }
 
 /**

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -13,6 +13,7 @@ import {
   type DashboardEvent,
 } from './types.js';
 import { getDashboardHtml } from './dashboard-html.js';
+import { getUserHome } from './utils/home.js';
 
 // ─── Dashboard server architecture ──────────────────────
 //
@@ -35,7 +36,7 @@ type SSEClient = http.ServerResponse;
  */
 export async function startDashboard(port?: number): Promise<void> {
   const serverPort = port ?? DASHBOARD_DEFAULT_PORT;
-  const eventsPath = path.join(process.env.HOME ?? '', '.teamai', 'dashboard', 'events.jsonl');
+  const eventsPath = path.join(getUserHome(), '.teamai', 'dashboard', 'events.jsonl');
 
   // Ensure events directory exists
   await ensureDir(path.dirname(eventsPath));

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -10,6 +10,7 @@ import {
   type TeamaiConfig,
 } from './types.js';
 import { TEAMAI_HOOK_SUBCOMMANDS } from './hooks.js';
+import { getUserHome } from './utils/home.js';
 
 interface Check {
   name: string;
@@ -65,7 +66,7 @@ export async function doctor(options: GlobalOptions): Promise<void> {
   // Fall back to schema defaults if team config is unavailable
   const toolPaths = teamConfig?.toolPaths ?? TeamaiConfigSchema.shape.toolPaths.parse(undefined);
   const providerName = teamConfig?.provider ?? 'tgit';
-  const baseDir = localConfig ? resolveBaseDir(localConfig) : (process.env.HOME ?? '');
+  const baseDir = localConfig ? resolveBaseDir(localConfig) : getUserHome();
 
   const checks: Check[] = [];
 
@@ -144,7 +145,7 @@ export async function doctor(options: GlobalOptions): Promise<void> {
         const envYamlPath = path.join(localConfig.repo.localPath, 'env', 'env.yaml');
         if (!await pathExists(envYamlPath)) return true;
 
-        const home = process.env.HOME ?? '';
+        const home = getUserHome();
 
         const envShPath = path.join(home, '.teamai', 'env.sh');
         if (!await pathExists(envShPath)) return false;

--- a/src/hooks-cmd.ts
+++ b/src/hooks-cmd.ts
@@ -6,6 +6,7 @@ import { parseTeamHooks, resolveTeamHooks } from './resources/hooks.js';
 import { log } from './utils/logger.js';
 import type { GlobalOptions, LocalConfig } from './types.js';
 import { resolveBaseDir, getManagedHooksPath } from './types.js';
+import { getUserHome } from './utils/home.js';
 
 type HookListStatus = HookStatus | 'not configured';
 
@@ -38,14 +39,13 @@ function resolveHookScopeTargets(localConfig: LocalConfig): HookScopeTarget[] {
         }];
     }
     return [{
-        baseDir: process.env.HOME ?? '',
+        baseDir: getUserHome(),
         manifestPath: getManagedHooksPath('user'),
     }];
 }
 
 function formatDisplayPath(settingsPath: string): string {
-    const home = process.env.HOME;
-    if (!home) return settingsPath;
+    const home = getUserHome();
 
     if (settingsPath === home) return '~';
     if (settingsPath.startsWith(home + path.sep) || settingsPath.startsWith(home + '/')) {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -6,6 +6,7 @@ import type { HookDef, TeamaiConfig, LocalConfig } from './types.js';
 import { builtinHookDefs, applyBuiltinOverride, ensureWrapperIfShellAvailable, SHELL_DEPENDENT_TOOLS } from './builtin-hooks.js';
 import type { BuiltinHookOverride } from './builtin-hooks.js';
 import { resolveTeamHooks } from './resources/hooks.js';
+import { getUserHome } from './utils/home.js';
 
 /**
  * Lobster-family agents (OpenClaw engine) that use HOOK.md + handler.ts instead
@@ -726,7 +727,7 @@ export async function hasTeamaiHooks(
  * preventing creation of config dirs for tools the user hasn't installed.
  */
 export async function injectHooksToAllTools(toolPaths: Record<string, { settings?: string }>, baseDir?: string, filterAgents?: string[]): Promise<void> {
-  const resolvedBaseDir = baseDir ?? (process.env.HOME ?? '');
+  const resolvedBaseDir = baseDir ?? getUserHome();
   const tools = Object.keys(toolPaths).filter(t => !filterAgents || filterAgents.includes(t));
   let shellAvailable = true;
   if (tools.some(t => SHELL_DEPENDENT_TOOLS.has(t))) {

--- a/src/import-local.ts
+++ b/src/import-local.ts
@@ -7,6 +7,7 @@ import { listFilesRecursive, readFileSafe, writeFile, expandHome, ensureDir } fr
 import { log } from './utils/logger.js';
 import { assertSafePath, defaultAllowedRoots } from './utils/path-safety.js';
 import type { ClassifiedItem, ImportSession, ImportSessionItem } from './types.js';
+import { getUserHome } from './utils/home.js';
 
 // ─── 常量 ──────────────────────────────────────────────────
 
@@ -17,7 +18,7 @@ const MAX_FILE_SIZE_BYTES = 50 * 1024;
 const MAX_CONTENT_CHARS = 3000;
 
 /** import 会话文件默认路径。 */
-const DEFAULT_SESSION_PATH = `${process.env.HOME}/.teamai/import-session.json`;
+const DEFAULT_SESSION_PATH = path.join(getUserHome(), '.teamai', 'import-session.json');
 
 /** 并发调用 Claude 的最大数量。 */
 const AI_CONCURRENCY = 3;

--- a/src/import-mr.ts
+++ b/src/import-mr.ts
@@ -11,9 +11,10 @@ import type { MRData, LearningDraft } from './types.js';
 import { callClaude } from './utils/ai-client.js';
 import { extractKeywords, findSupersededLearnings } from './utils/dedup.js';
 import { log, spinner } from './utils/logger.js';
+import { getUserHome } from './utils/home.js';
 
 /** Default directory for storing learnings. */
-const DEFAULT_LEARNINGS_DIR = path.join(process.env.HOME ?? '/tmp', '.teamai', 'learnings');
+const DEFAULT_LEARNINGS_DIR = path.join(getUserHome(), '.teamai', 'learnings');
 
 /** Dedup similarity threshold. */
 const SUPERSEDE_THRESHOLD = 0.6;

--- a/src/known-agents.ts
+++ b/src/known-agents.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { pathExists, ensureDir } from './utils/fs.js';
 import { resolveBaseDir, isAgentDisabled } from './types.js';
 import type { LocalConfig, TeamaiConfig } from './types.js';
+import { getUserHome } from './utils/home.js';
 
 /**
  * Single-repo mode: the AI tools offered when `teamai init .` asks which tool
@@ -177,8 +178,7 @@ export async function seedSelfModeToolDirs(
 export async function detectHomeInstalledAgents(
   candidateIds: readonly string[] = SELF_MODE_AGENT_CHOICES,
 ): Promise<string[]> {
-  const home = process.env.HOME;
-  if (!home) return [];
+  const home = getUserHome();
 
   const found: string[] = [];
   for (const id of candidateIds) {

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -44,6 +44,7 @@ import {
   type Scope,
   type TeamaiConfig,
 } from './types.js';
+import { getUserHome } from './utils/home.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -215,7 +216,7 @@ interface LocalAgentContext {
 }
 
 function getTeamaiHomePath(): string {
-  return path.join(process.env.HOME ?? '', '.teamai');
+  return path.join(getUserHome(), '.teamai');
 }
 
 function getLocalAgentHome(): string {
@@ -278,7 +279,7 @@ export function resolveRoute(config: Pick<LocalAgentConfig, 'routes'>, name: Rou
  * Note: install_path only feeds the local hash — it never leaves the machine.
  */
 function resolveAgentInstallPath(agentType: string): string {
-  const home = process.env.HOME ?? '';
+  const home = getUserHome();
   const skillsRel = createLocalAgentTeamConfig('').toolPaths[agentType]?.skills;
   const rel = skillsRel ? path.dirname(skillsRel) : `.${agentType}`;
   return path.join(home, rel);
@@ -382,7 +383,7 @@ function resolveToolSettingsPath(config: LocalAgentConfig, tool: string): string
   if (!toolPath?.settings) {
     throw new Error(`unsupported tool: ${tool} (no settings path)`);
   }
-  return path.join(process.env.HOME ?? '', toolPath.settings);
+  return path.join(getUserHome(), toolPath.settings);
 }
 
 function getPluginStatePath(): string {
@@ -1229,7 +1230,7 @@ export async function buildReportPayload(
     return { skills, rules };
   };
 
-  const userScope = await scanScope(process.env.HOME ?? '');
+  const userScope = await scanScope(getUserHome());
 
   const userLevel: Record<string, unknown> = { group_id: config.userGroupId };
   if (userScope.skills.length > 0) userLevel.skills = userScope.skills;
@@ -1715,7 +1716,7 @@ async function syncClaudemd(
 
   const defaultBaseDir = localConfig.scope === 'project' && localConfig.projectRoot
     ? localConfig.projectRoot
-    : process.env.HOME ?? '';
+    : getUserHome();
 
   for (const [tool, toolPath] of Object.entries(teamConfig.toolPaths)) {
     if (!toolPath.claudemd) continue;
@@ -2286,7 +2287,7 @@ export async function initLocalAgentHttp(options: {
   }
 
   const teamConfig = createLocalAgentTeamConfig(endpoint);
-  await injectHooksToAllTools(teamConfig.toolPaths, process.env.HOME ?? '', options.filterAgents);
+  await injectHooksToAllTools(teamConfig.toolPaths, getUserHome(), options.filterAgents);
   log.success(`HTTP local agent initialized at ${getConfigPath()}`);
 }
 

--- a/src/mcp-cmd.ts
+++ b/src/mcp-cmd.ts
@@ -13,10 +13,11 @@ import type { GlobalOptions } from './types.js';
 import { managedMcpManifestPath } from './types.js';
 import { readJson } from './utils/fs.js';
 import type { ManagedMcpManifest } from './types.js';
+import { getUserHome } from './utils/home.js';
 
 function displayPath(p: string): string {
-  const home = process.env.HOME;
-  if (home && (p === home || p.startsWith(home + path.sep))) return `~${p.slice(home.length)}`;
+  const home = getUserHome();
+  if (p === home || p.startsWith(home + path.sep)) return `~${p.slice(home.length)}`;
   return p;
 }
 

--- a/src/mr-hint.ts
+++ b/src/mr-hint.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 
 import { getTGitToken, tgitFetch } from './providers/tgit/rest-auth.js';
 import { log } from './utils/logger.js';
+import { getUserHome } from './utils/home.js';
 
 // ─── MR Hint data flow ──────────────────────────────────
 //
@@ -71,7 +72,7 @@ function repoSlug(owner: string, repo: string): string {
  */
 function getCachePath(owner: string, repo: string): string {
   return path.join(
-    process.env.HOME ?? '',
+    getUserHome(),
     '.teamai',
     'sessions',
     `mr-hint-${repoSlug(owner, repo)}.json`,

--- a/src/openclaw-hooks.ts
+++ b/src/openclaw-hooks.ts
@@ -22,6 +22,7 @@
 import path from 'node:path';
 import { writeFile, ensureDir, pathExists, readFileSafe, remove } from './utils/fs.js';
 import { log } from './utils/logger.js';
+import { getUserHome } from './utils/home.js';
 
 /**
  * Resolve the hooks directory for an OpenClaw-family tool.
@@ -36,7 +37,7 @@ export function resolveOpenClawHooksDir(tool: string): string {
   if (tool === 'openclaw' && process.env.OPENCLAW_STATE_DIR) {
     return path.join(process.env.OPENCLAW_STATE_DIR, 'hooks');
   }
-  const home = process.env.HOME ?? '';
+  const home = getUserHome();
   return path.join(home, `.${tool}`, 'hooks');
 }
 
@@ -231,8 +232,7 @@ export async function resolveOpenclawWorkspaceDir(workspacePath?: string): Promi
       } catch (e) { log.debug(`openclaw: failed to parse openclaw.json: ${(e as Error).message}`); }
     }
   }
-  const home = process.env.HOME;
-  if (home) candidates.push(path.join(home, '.openclaw', 'workspace'));
+  candidates.push(path.join(getUserHome(), '.openclaw', 'workspace'));
   for (const candidate of candidates) {
     if (await pathExists(candidate)) {
       log.debug(`openclaw: resolved workspace dir to ${candidate}`);

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -27,6 +27,7 @@ import {
 } from './types.js';
 import type { CultureFrontmatter } from './types.js';
 import { loadRolesManifest, resolveRoleResourceNamespaces, type ResourceNamespaces } from './roles.js';
+import { getUserHome } from './utils/home.js';
 
 interface RolePullContext {
   activeNamespaces: ResourceNamespaces;
@@ -1109,7 +1110,7 @@ async function collectClaudemdFiles(
  * Reinjects with the current version's hook definitions.
  */
 async function autoMigrateHooksIfNeeded(): Promise<void> {
-  const home = process.env.HOME ?? '';
+  const home = getUserHome();
   // Quick check: read the primary settings file and see if it has hook-dispatch
   const primarySettings = path.join(home, '.claude', 'settings.json');
   if (!await pathExists(primarySettings)) return;

--- a/src/recall-quality.ts
+++ b/src/recall-quality.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import fs from 'node:fs';
 import type { SearchResult } from './utils/search-index.js';
+import { getUserHome } from './utils/home.js';
 
 // ─── Recall quality tracking ─────────────────────────────
 //
@@ -37,7 +38,7 @@ function sanitizeSessionId(sessionId: string): string {
 function getCachePath(sessionId: string): string {
     const safeName = sanitizeSessionId(sessionId);
     return path.join(
-        process.env.HOME ?? '',
+        getUserHome(),
         '.teamai',
         'sessions',
         `${safeName}-recall-cache.json`,

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -10,6 +10,7 @@ import { queryCodeKnowledge } from './code-knowledge-recall.js';
 import type { CodeKnowledgeResult, SourceAnchor } from './code-knowledge-recall.js';
 import { recordRecallQuality } from './recall-quality.js';
 import { deriveSessionId } from './utils/session-id.js';
+import { getUserHome } from './utils/home.js';
 
 /** Relevance threshold for codebase graph hits.
  *  These are log-compressed to a bounded [0,10] range (see `queryCodeKnowledge`
@@ -114,7 +115,7 @@ export function computeIdfBaseline(indexes: SearchIndex[]): number {
 
 /** Resolve votes dir dynamically (respects HOME changes in tests). */
 function getVotesLocalDir(): string {
-  return `${process.env.HOME ?? ''}/.teamai/votes`;
+  return path.join(getUserHome(), '.teamai', 'votes');
 }
 
 /** Search result with scope label for merged output. */

--- a/src/resources/base.ts
+++ b/src/resources/base.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import type { ResourceType, ResourceItem, ResourceDiff, TeamaiConfig, LocalConfig } from '../types.js';
 import { readFileSafe, writeFile, ensureDir, pathExists } from '../utils/fs.js';
+import { getUserHome } from '../utils/home.js';
 
 const TOMBSTONE_FILE = '.removed';
 
@@ -64,7 +65,7 @@ export abstract class ResourceHandler {
    * @param baseDir - Override base directory (defaults to HOME). Used for project scope.
    */
   static async isToolInstalled(toolPath: string, baseDir?: string): Promise<boolean> {
-    const base = baseDir ?? process.env.HOME ?? '';
+    const base = baseDir ?? getUserHome();
     const toolRoot = path.join(base, toolPath.split('/')[0]);
     return pathExists(toolRoot);
   }

--- a/src/resources/env.ts
+++ b/src/resources/env.ts
@@ -6,6 +6,7 @@ import type { ResourceItem, TeamaiConfig, LocalConfig } from '../types.js';
 import { TEAMAI_ENV_START, TEAMAI_ENV_END, getTeamaiHome, getEnvBackupPath, isSelfMode } from '../types.js';
 import { pathExists, readFileSafe, writeFile, ensureDir, fileContentEqual } from '../utils/fs.js';
 import { log } from '../utils/logger.js';
+import { getUserHome } from '../utils/home.js';
 
 // ─── Schema for env.yaml ────────────────────────────────
 
@@ -247,7 +248,7 @@ export class EnvHandler extends ResourceHandler {
    * Detect the user's shell profile path.
    */
   private detectShellProfile(): string {
-    const home = process.env.HOME ?? '';
+    const home = getUserHome();
     const shell = process.env.SHELL ?? '';
 
     if (shell.includes('zsh')) {

--- a/src/team-push.ts
+++ b/src/team-push.ts
@@ -9,6 +9,7 @@ import { writeFile, readFileSafe, ensureDir, pathExists, readJson, writeJson } f
 import { log } from './utils/logger.js';
 import type { UserStats, UserInterventionStats, SessionMetrics, TokenUsage, DashboardEvent, LocalConfig } from './types.js';
 import { VOTES_LOCAL_DIR, emptyTokenUsage, addTokenUsage } from './types.js';
+import { getUserHome } from './utils/home.js';
 
 /** Snapshot of already-reported per-session intervention counts (idempotency basis). */
 type ReportedInterventions = Record<string, { interrupt: number; toolReject: number; correction: number }>;
@@ -117,7 +118,7 @@ export function mergeStats(
 
 /** Path to the local reported-interventions snapshot (evaluated at call time for tests). */
 function getReportedInterventionsPath(): string {
-  return path.join(process.env.HOME ?? '', '.teamai', 'dashboard', 'reported-interventions.json');
+  return path.join(getUserHome(), '.teamai', 'dashboard', 'reported-interventions.json');
 }
 
 async function readReportedInterventions(): Promise<ReportedInterventions> {
@@ -188,7 +189,7 @@ function hasInterventionDelta(d: UserInterventionStats): boolean {
 
 /** Path to the local prompt/token reported snapshot (evaluated at call time for tests). */
 function getReportedPromptTokensPath(): string {
-  return path.join(process.env.HOME ?? '', '.teamai', 'dashboard', 'reported-prompt-tokens.json');
+  return path.join(getUserHome(), '.teamai', 'dashboard', 'reported-prompt-tokens.json');
 }
 
 async function readReportedPromptTokens(): Promise<ReportedPromptTokens> {

--- a/src/todowrite-hint.ts
+++ b/src/todowrite-hint.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import fs from 'node:fs';
 import { log } from './utils/logger.js';
 import { deriveSessionId } from './utils/session-id.js';
+import { getUserHome } from './utils/home.js';
 
 // ─── TodoWrite hint data flow ───────────────────────────
 //
@@ -38,7 +39,7 @@ interface HookInput {
  */
 export function getTodoWriteHintCachePath(sessionId: string): string {
   return path.join(
-    process.env.HOME ?? '',
+    getUserHome(),
     '.teamai',
     'sessions',
     `${sessionId}-todowrite-hint.json`,

--- a/src/uninstall.ts
+++ b/src/uninstall.ts
@@ -38,6 +38,7 @@ import {
 } from './utils/fs.js';
 import { log } from './utils/logger.js';
 import { askConfirmation } from './utils/prompt.js';
+import { getUserHome } from './utils/home.js';
 
 // ─── Types ─────────────────────────────────────────────
 
@@ -109,9 +110,8 @@ const CLAUDEMD_MARKER_PAIRS: Array<[string, string]> = [
   [TEAMAI_RECALL_RULES_START, TEAMAI_RECALL_RULES_END],
 ];
 
-function detectShellProfile(): string | null {
-  const home = process.env.HOME;
-  if (!home) return null;
+function detectShellProfile(): string {
+  const home = getUserHome();
   const shell = process.env.SHELL ?? '';
   if (shell.includes('zsh')) {
     return path.join(home, '.zshrc');
@@ -283,7 +283,7 @@ async function buildRemovalPlan(
 
   // Also include resources installed by local-agent (HTTP distribution)
   const localAgentManifestPath = path.join(
-    process.env.HOME ?? '', '.teamai', 'local-agent', 'manifest.json',
+    getUserHome(), '.teamai', 'local-agent', 'manifest.json',
   );
   if (await pathExists(localAgentManifestPath)) {
     try {
@@ -761,12 +761,7 @@ export async function uninstall(opts: UninstallOptions): Promise<void> {
       process.exitCode = 2;
       return;
     }
-    const homeDir = process.env.HOME;
-    if (!homeDir) {
-      log.error('无法确定用户主目录（HOME 环境变量未设置）');
-      return;
-    }
-    const home = path.join(homeDir, '.teamai');
+    const home = path.join(getUserHome(), '.teamai');
     if (!await pathExists(home)) {
       log.info('没有需要卸载的内容');
       return;

--- a/src/usage-tracker.ts
+++ b/src/usage-tracker.ts
@@ -7,15 +7,16 @@ import {
   type UsageEvent,
 } from './types.js';
 import { ensureDir, readJson, writeJson, pathExists } from './utils/fs.js';
+import { getUserHome } from './utils/home.js';
 
 /** Get the usage JSONL path (evaluated at call time to respect HOME changes in tests). */
 function getUsagePath(): string {
-  return path.join(process.env.HOME ?? '', '.teamai', 'usage.jsonl');
+  return path.join(getUserHome(), '.teamai', 'usage.jsonl');
 }
 
 /** Get the known-skills.json path (evaluated at call time to respect HOME changes in tests). */
 function getKnownSkillsPath(): string {
-  return path.join(process.env.HOME ?? '', '.teamai', 'known-skills.json');
+  return path.join(getUserHome(), '.teamai', 'known-skills.json');
 }
 
 // ─── Data flow ─────────────────────────────────────────
@@ -130,7 +131,7 @@ const SKILL_DIRS = [
  * Performance: Checks at most 12 directories (6 user + 6 project) with a single stat() each — sub-millisecond.
  */
 export async function skillExistsOnDisk(skillName: string): Promise<boolean> {
-  const home = process.env.HOME ?? '';
+  const home = getUserHome();
   // Check user-level directories
   for (const dir of SKILL_DIRS) {
     const skillMd = path.join(home, dir, skillName, 'SKILL.md');

--- a/src/utils/home.ts
+++ b/src/utils/home.ts
@@ -5,10 +5,15 @@ import os from 'node:os';
  *
  * `HOME` is normally present on Unix-like systems, while a regular Windows
  * PowerShell session commonly exposes only `USERPROFILE`. `os.homedir()` is
- * the final platform-aware fallback.
+ * the platform-aware fallback, and `os.tmpdir()` is a last resort: `os.homedir()`
+ * is documented to return `''` when the home cannot be resolved (e.g. a passwd-less
+ * uid or `env -i`), and callers join this onto `.teamai/...`, so an empty result
+ * would silently yield a cwd-relative path. Guaranteeing a non-empty absolute path
+ * keeps every derived path absolute.
  */
 export function getUserHome(): string {
   return process.env.HOME?.trim()
     || process.env.USERPROFILE?.trim()
-    || os.homedir();
+    || os.homedir()
+    || os.tmpdir();
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import chalk from 'chalk';
 import ora, { type Ora } from 'ora';
+import { getUserHome } from './home.js';
 
 let verboseEnabled = false;
 let silentMode = false;
@@ -32,7 +33,7 @@ let _writing = false;
 
 function getLogFilePath(): string {
   if (!_logFilePath) {
-    _logFilePath = path.join(process.env.HOME ?? '/tmp', '.teamai', 'debug.log');
+    _logFilePath = path.join(getUserHome(), '.teamai', 'debug.log');
   }
   return _logFilePath;
 }

--- a/src/utils/search-index.ts
+++ b/src/utils/search-index.ts
@@ -13,10 +13,11 @@ import {
   type VoteEntryV2,
   type KnowledgeType,
 } from '../types.js';
+import { getUserHome } from './home.js';
 
 /** Resolve search index path dynamically (respects HOME changes in tests). */
 function getSearchIndexPath(): string {
-  return `${process.env.HOME ?? ''}/.teamai/search-index.json`;
+  return path.join(getUserHome(), '.teamai', 'search-index.json');
 }
 
 // ─── Search index data flow ──────────────────────────


### PR DESCRIPTION
## Problem

Reported by @MyNameisPI on #301: on a normal Windows PowerShell session, `teamai init git@…` fails with

```
Local config saved to undefined/.teamai/config.yaml
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
```

Windows commonly exposes only `USERPROFILE`, not `HOME`. #301 added `getUserHome()` (`HOME` → `USERPROFILE` → `os.homedir()`) but only wired it into `types.ts`. Every other module still read a bare `process.env.HOME`, which on Windows is `undefined` — `?? ''` silently degrades to a relative path, and a non-null assertion crashes.

## Fix

- Route **every** remaining home lookup through `getUserHome()` (30 source files).
- `getUserHome()` now always returns a non-empty path, so drop the dead `if (!home)` guards it made unreachable, and remove a stale Chinese error string in `uninstall.ts` (violated the English-output rule).
- Fix `getVotesLocalDir()` to build its path with `path.join` instead of a hardcoded `/` separator (also Windows-incorrect).
- Add a **guard test** that fails if any source file outside `utils/home.ts` reads `process.env.HOME` directly, preventing regressions.
- Add a `USERPROFILE`-fallback regression test.

## Test Plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 2140 passed (159 files)
- [x] `npm run build` — success
- [x] Guard test confirms no bare `process.env.HOME` remains in production code
- [x] E2E: ran built CLI with `HOME` unset and only `USERPROFILE` set — `teamai doctor` runs and resolves `~/.teamai/...` correctly instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)