### PR TITLE
fix: prevent silent capability loss for users upgrading from old versions

### DIFF
--- a/src/__tests__/issue-82-84-94-regression.test.ts
+++ b/src/__tests__/issue-82-84-94-regression.test.ts
@@ -128,7 +128,7 @@ describe('loadGraphIndex schema validation (issue #84 bug5)', () => {
   it('returns null when file exists but nodes/edges are not arrays', async () => {
     const { writeFile, mkdir, rm } = await import('node:fs/promises');
     const { join } = await import('node:path');
-    const { loadGraphIndex } = await import('../wiki-engine/core/graph-index.schema.js');
+    const { loadGraphIndex, GRAPH_INDEX_SCHEMA_VERSION } = await import('../wiki-engine/core/graph-index.schema.js');
 
     const tmpRoot = `/tmp/graph-schema-test-${Date.now()}`;
     const indicesDir = join(tmpRoot, '.indices');
@@ -144,12 +144,35 @@ describe('loadGraphIndex schema validation (issue #84 bug5)', () => {
     const result2 = await loadGraphIndex(tmpRoot);
     expect(result2).toBeNull();
 
-    // Write a valid graph — should return it
-    await writeFile(join(indicesDir, 'graph-index.json'), JSON.stringify({ nodes: [], edges: [] }));
+    // Write a valid graph (current schema) — should return it
+    await writeFile(join(indicesDir, 'graph-index.json'),
+      JSON.stringify({
+        schemaVersion: GRAPH_INDEX_SCHEMA_VERSION, generatedAt: new Date().toISOString(), nodes: [], edges: [],
+      }));
     const result3 = await loadGraphIndex(tmpRoot);
     expect(result3).not.toBeNull();
     expect(result3!.nodes).toEqual([]);
     expect(result3!.edges).toEqual([]);
+
+    await rm(tmpRoot, { recursive: true });
+  });
+
+  it('returns null when schemaVersion does not match (legacy index triggers rebuild)', async () => {
+    const { writeFile, mkdir, rm } = await import('node:fs/promises');
+    const { join } = await import('node:path');
+    const { loadGraphIndex } = await import('../wiki-engine/core/graph-index.schema.js');
+
+    const tmpRoot = `/tmp/graph-schema-legacy-test-${Date.now()}`;
+    const indicesDir = join(tmpRoot, '.indices');
+    await mkdir(indicesDir, { recursive: true });
+
+    // Write a structurally valid graph but with a mismatched (legacy) schemaVersion
+    await writeFile(join(indicesDir, 'graph-index.json'),
+      JSON.stringify({
+        schemaVersion: 'team-wiki.graph-index.v0', generatedAt: new Date().toISOString(), nodes: [], edges: [],
+      }));
+    const result = await loadGraphIndex(tmpRoot);
+    expect(result).toBeNull();
 
     await rm(tmpRoot, { recursive: true });
   });

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -339,12 +339,48 @@ export async function loadLocalAgentConfig(): Promise<LocalAgentConfig | null> {
       workspaceBindings: fileConfig.workspaceBindings ?? {},
     };
     // Migrate: clear legacy group-based bindings (groupId without projectId)
+    const removedLegacyPaths: string[] = [];
     for (const [wsPath, binding] of Object.entries(config.workspaceBindings)) {
       if ('groupId' in binding && !('projectId' in (binding as Record<string, unknown>))) {
         delete config.workspaceBindings[wsPath];
+        removedLegacyPaths.push(wsPath);
+      }
+    }
+    if (removedLegacyPaths.length > 0) {
+      log.warn(
+        `Removed ${removedLegacyPaths.length} legacy group-based workspace binding(s); ` +
+          `you will be prompted to re-bind on the next session.`,
+      );
+      try {
+        await saveLocalAgentConfig(config);
+      } catch (e) {
+        log.debug(`local-agent: failed to persist binding cleanup: ${(e as Error).message}`);
       }
     }
     return config;
+  }
+
+  // Backfill: if config.json is missing but a legacy ~/.teamai/config.yaml has
+  // an HTTP team repo, auto-create config.json so v0.17.x upgraders keep capability.
+  const { loadLocalConfig } = await import('./config.js');
+  const { resolveApiKey } = await import('./api-key.js');
+  const legacy = await loadLocalConfig();
+  if (legacy?.repo?.kind === 'http' && legacy.repo.url) {
+    const endpoint = normalizeEndpoint(legacy.repo.url);
+    const token = resolveApiKey() ?? undefined;
+    const backfilled: LocalAgentConfig = {
+      endpoint,
+      token,
+      createdAt: new Date().toISOString(),
+      workspaceBindings: {},
+    };
+    try {
+      await saveLocalAgentConfig(backfilled);
+      log.debug('local-agent: backfilled config.json from legacy ~/.teamai/config.yaml (http repo)');
+    } catch (e) {
+      log.debug(`local-agent: backfill persist failed, using in-memory config: ${(e as Error).message}`);
+    }
+    return backfilled;
   }
 
   const envEndpoint =

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -157,14 +157,17 @@ async function loadOrBuildScopeIndex(
     const rulesDir = path.join(localConfig.repo.localPath, 'rules');
     const skillsDir = path.join(localConfig.repo.localPath, 'skills');
     const repoCodebaseDir = path.join(localConfig.repo.localPath, 'docs', 'team-codebase');
-    const codebaseDir = await pathExists(repoCodebaseDir) ? repoCodebaseDir : undefined;
+    const hasLegacyCodebase = await pathExists(repoCodebaseDir);
+    if (hasLegacyCodebase) {
+      log.warn(`Legacy 'docs/team-codebase' is no longer indexed. Migrate to 'teamwiki/' for code-knowledge recall.`);
+    }
     try {
       await buildIndex({
         learningsDir: effectiveLearningsDir ?? undefined,
         docsDir: await pathExists(docsDir) ? docsDir : undefined,
         rulesDir: await pathExists(rulesDir) ? rulesDir : undefined,
         skillsDir: await pathExists(skillsDir) ? skillsDir : undefined,
-        codebaseDir,
+        codebaseDir: undefined, // codebase now served by teamwiki/ graph engine
         votesDir: votesExist ? votesDir : undefined,
         indexPath,
       });

--- a/src/wiki-engine/core/graph-index.schema.ts
+++ b/src/wiki-engine/core/graph-index.schema.ts
@@ -356,6 +356,9 @@ export async function loadGraphIndex(wikiRoot: string): Promise<GraphIndex | nul
     if (!Array.isArray(parsed?.nodes) || !Array.isArray(parsed?.edges)) {
       return null;
     }
+    if (parsed.schemaVersion !== GRAPH_INDEX_SCHEMA_VERSION) {
+      return null;
+    }
     return parsed as GraphIndex;
   } catch {
     return null;


### PR DESCRIPTION
## Summary

A user on v0.20.0 reported the project-binding prompt never appearing. Root-cause investigation traced it to a class of **upgrade-migration defects**: a runtime capability depends on a file/field/structure that only a *newer* version's write path produces, but upgrading neither backfills it nor self-heals — so users who initialized on an old version are silently degraded after upgrade, with nothing in the logs.

This PR fixes the four instances of that class that exist on `main`:

| Area | Fix |
|---|---|
| **local-agent config backfill** | `loadLocalAgentConfig` now backfills a missing `~/.teamai/local-agent/config.json` from the legacy `~/.teamai/config.yaml` (http repo) + `~/.teamai/apikey`, and auto-provisions it. v0.17.x upgraders (who initialized before the local-agent module existed) regain the binding prompt + resource sync without re-running `init`. The write is guarded so a persist failure degrades to an in-memory config instead of throwing out of the hook path. |
| **binding cleanup** | The legacy `groupId`-only binding cleanup is now persisted once and warns the user once, instead of re-firing the warning on every hook load and never self-completing. |
| **recall / team-codebase** | The recall fallback rebuild stops indexing the retired `docs/team-codebase` (aligning with `pull.ts`, which already dropped it for the teamwiki graph engine) and warns users to migrate to `teamwiki/`. Previously the two index-build paths diverged, so old teams' codebase knowledge silently vanished from most recalls. |
| **graph-index version guard** | `loadGraphIndex` now rejects an index whose `schemaVersion` does not match `GRAPH_INDEX_SCHEMA_VERSION` (returns null → rebuild), mirroring the existing search-index `SEARCH_INDEX_VERSION` + `isLegacyIndex` self-heal. |

## Note on scope

Two further instances of the same defect class (a scope-asymmetric `gitOnly` hook filter, and self-mode bootstrap not triggering for pre-existing project configs) live only on the `beta/0.20.0-beta.8` branch, not on `main`, so they are **out of scope here** and should be addressed when that branch merges to `main`.

## Test Plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — success
- [x] `npx vitest run` — **1824 passed (146 files)**
- [x] Updated the issue #84 `loadGraphIndex` regression test for the new `schemaVersion` guard, plus a new case asserting a mismatched version returns null
- [x] E2E (isolated HOME): legacy `config.yaml` (kind=http) + `apikey` with no `local-agent/config.json` → `loadLocalAgentConfig()` returns the backfilled endpoint+token **and** auto-writes `config.json`; no false backfill when neither legacy config nor env endpoint is present
- [x] E2E (isolated HOME): real `recall()` over a repo containing `docs/team-codebase/` emits the migration warning and no longer indexes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)