### PR TITLE
fix(tgit): run gf auth commands from a neutral cwd

### DIFF
--- a/src/__tests__/gf-cli.test.ts
+++ b/src/__tests__/gf-cli.test.ts
@@ -41,9 +41,16 @@ vi.mock('node:fs', () => ({
   },
 }));
 
+import os from 'node:os';
 import { spawnSync } from 'node:child_process';
 import { execSync } from 'node:child_process';
-import { gfGetOAuthToken, gfMrCreate } from '../providers/tgit/gf-cli.js';
+import {
+  gfGetOAuthToken,
+  gfMrCreate,
+  gfAuthWhoami,
+  gfIsAuthenticated,
+  gfAuthLogin,
+} from '../providers/tgit/gf-cli.js';
 
 describe('gfGetOAuthToken', () => {
   beforeEach(() => {
@@ -217,5 +224,61 @@ describe('gfMrCreate', () => {
         title: 'test',
       }),
     ).toThrow('gf mr create failed: auth required');
+  });
+});
+
+describe('gf auth commands run from a neutral cwd', () => {
+  const mockSpawnSync = vi.mocked(spawnSync);
+  const mockExecSync = vi.mocked(execSync);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Make getGfPath() find gf in PATH
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd.includes('test -x')) throw new Error('not found');
+      if (cmd === 'which gf') return '/usr/bin/gf' as any;
+      throw new Error('unexpected');
+    });
+  });
+
+  // gf `auth` commands inspect the current git repo's origin remote and scope
+  // the auth check to that host. Running them from the repo cwd wrongly reports
+  // "not logged in" when origin is a non-git.woa.com mirror (e.g. GitHub). They
+  // must run from a neutral, non-git directory (os.tmpdir()) so the host-scoped
+  // credential is found regardless of where teamai was invoked.
+  it('gfAuthWhoami spawns with cwd = os.tmpdir()', () => {
+    mockSpawnSync.mockReturnValue({
+      stdout: '当前登录用户：jeffyxu',
+      stderr: '',
+      status: 0,
+    } as any);
+
+    expect(gfAuthWhoami()).toBe('jeffyxu');
+
+    const opts = mockSpawnSync.mock.calls[0][2] as { cwd?: string };
+    expect(opts.cwd).toBe(os.tmpdir());
+  });
+
+  it('gfIsAuthenticated spawns with cwd = os.tmpdir()', () => {
+    mockSpawnSync.mockReturnValue({
+      stdout: '当前登录用户：jeffyxu',
+      stderr: '',
+      status: 0,
+    } as any);
+
+    expect(gfIsAuthenticated()).toBe(true);
+
+    const opts = mockSpawnSync.mock.calls[0][2] as { cwd?: string };
+    expect(opts.cwd).toBe(os.tmpdir());
+  });
+
+  it('gfAuthLogin spawns with cwd = os.tmpdir() and inherited stdio', () => {
+    mockSpawnSync.mockReturnValue({ status: 0 } as any);
+
+    gfAuthLogin();
+
+    const opts = mockSpawnSync.mock.calls[0][2] as { cwd?: string; stdio?: string };
+    expect(opts.cwd).toBe(os.tmpdir());
+    expect(opts.stdio).toBe('inherit');
   });
 });

--- a/src/providers/tgit/gf-cli.ts
+++ b/src/providers/tgit/gf-cli.ts
@@ -172,11 +172,26 @@ export async function ensureGfInstalled(): Promise<void> {
 // ─── Authentication ──────────────────────────────────────
 
 /**
+ * A neutral working directory for `gf auth` commands.
+ *
+ * `gf auth whoami` / `gf auth login` inspect the *current* git repository's
+ * `origin` remote and scope the authentication check to that remote's host.
+ * When teamai runs inside a repo whose origin is not git.woa.com (e.g. a GitHub
+ * mirror), gf reports "not logged in" even though a valid git.woa.com token
+ * exists — so teamai wrongly re-triggers interactive login and fails.
+ *
+ * Running these commands from the system temp dir (which is not a git repo)
+ * removes the cwd dependency, so the host-scoped credential is found reliably
+ * regardless of where teamai was invoked.
+ */
+const AUTH_CWD = os.tmpdir();
+
+/**
  * Check if gf is authenticated. Returns true if `gf auth whoami` succeeds.
  */
 export function gfIsAuthenticated(): boolean {
   try {
-    const result = gfExec(['auth', 'whoami']);
+    const result = gfExec(['auth', 'whoami'], { cwd: AUTH_CWD });
     return result.status === 0 && result.stdout.includes('当前登录用户');
   } catch {
     return false;
@@ -189,7 +204,7 @@ export function gfIsAuthenticated(): boolean {
  */
 export function gfAuthWhoami(): string | null {
   try {
-    const result = gfExec(['auth', 'whoami']);
+    const result = gfExec(['auth', 'whoami'], { cwd: AUTH_CWD });
     if (result.status !== 0) return null;
 
     // Parse "当前登录用户：<username>" or similar
@@ -207,7 +222,7 @@ export function gfAuthWhoami(): string | null {
  */
 export function gfAuthLogin(): void {
   log.info('Starting gf authentication...');
-  const result = gfExec(['auth', 'login'], { inheritStdio: true });
+  const result = gfExec(['auth', 'login'], { inheritStdio: true, cwd: AUTH_CWD });
   if (result.status !== 0) {
     throw new Error('gf auth login failed. Please try again.');
   }


### PR DESCRIPTION
## Problem

`teamai init` fails with `gf auth login failed` when run **inside a git repository whose `origin` remote is not `git.woa.com`** (e.g. a GitHub mirror — including this very repo).

Root cause: `gf auth whoami` / `gf auth login` inspect the **current git repository's `origin` remote** and scope the authentication check to that remote's host. When teamai runs from a repo whose origin is `github.com`, gf reports "还未登录" (not logged in) even though a valid git.woa.com OAuth token exists. `ensureAuthenticated()` takes that at face value, re-triggers interactive login, and fails.

The token itself is valid — the check is just being run from the wrong place. Reproduced deterministically:

| cwd | `gf auth whoami` |
|---|---|
| a repo with `origin = git.woa.com/...` | ✅ 当前登录用户 |
| a repo with `origin = github.com/...` | ❌ 还未登录 |
| a non-git dir (`/tmp`) | ✅ 当前登录用户 |

## Fix

Run the three `gf auth` calls (`gfIsAuthenticated`, `gfAuthWhoami`, `gfAuthLogin`) from a neutral working directory (`os.tmpdir()`, which is not a git repo). Authentication is host-scoped (git.woa.com), so it must not depend on the cwd's local git remote.

## Test Plan

- [x] `npm run build` — success
- [x] `npx vitest run src/__tests__/gf-cli.test.ts` — 13 passed (added 3 tests asserting each auth call spawns with `cwd = os.tmpdir()`)
- [x] `npx tsc --noEmit` on changed files — no errors
- [x] **End-to-end**: ran the built CLI's `teamai init` from a temp repo whose `origin = github.com/Tencent/teamai-cli` (the failing condition) → `✔ Authenticated as jeffyxu`, no interactive login triggered, clone + config + hooks all completed.

> Note: 9 pre-existing failures in `iwiki-dual` / `iwiki-review-apply` / `import-repo-incremental` are unrelated (local vitest version drift) and reproduce on a pristine `main` checkout without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)