### PR TITLE
fix(deps): patch runtime security advisories (simple-git RCE, js-yaml DoS)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "gray-matter": "^4.0.3",
         "listr2": "^9.0.5",
         "ora": "^8.1.0",
-        "simple-git": "^3.27.0",
+        "simple-git": "^3.36.0",
         "smol-toml": "^1.3.1",
         "yaml": "^2.6.0",
         "zod": "^3.24.0"
@@ -990,16 +990,18 @@
       ]
     },
     "node_modules/@simple-git/args-pathspec": {
-      "version": "1.0.2",
-      "resolved": "https://mirrors.tencent.com/npm/@simple-git/args-pathspec/-/args-pathspec-1.0.2.tgz",
-      "integrity": "sha512-nEFVejViHUoL8wU8GTcwqrvqfUG40S5ts6S4fr1u1Ki5CklXlRDYThPVA/qurTmCYFGnaX3XpVUmICLHdvhLaA=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz",
+      "integrity": "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==",
+      "license": "MIT"
     },
     "node_modules/@simple-git/argv-parser": {
-      "version": "1.0.3",
-      "resolved": "https://mirrors.tencent.com/npm/@simple-git/argv-parser/-/argv-parser-1.0.3.tgz",
-      "integrity": "sha512-NMKv9sJcSN2VvnPT9Ja7eKfGy8Q8mMFLwPTCcuZMtv3+mYcLIZflg31S/tp2XCCyiY7YAx6cgBHQ0fwA2fWHpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz",
+      "integrity": "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==",
+      "license": "MIT",
       "dependencies": {
-        "@simple-git/args-pathspec": "^1.0.2"
+        "@simple-git/args-pathspec": "^1.0.3"
       }
     },
     "node_modules/@types/estree": {
@@ -2902,9 +2904,10 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://mirrors.tencent.com/npm/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -4199,14 +4202,15 @@
       }
     },
     "node_modules/simple-git": {
-      "version": "3.35.2",
-      "resolved": "https://mirrors.tencent.com/npm/simple-git/-/simple-git-3.35.2.tgz",
-      "integrity": "sha512-ZMjl06lzTm1EScxEGuM6+mEX+NQd14h/B3x0vWU+YOXAMF8sicyi1K4cjTfj5is+35ChJEHDl1EjypzYFWH2FA==",
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.36.0.tgz",
+      "integrity": "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==",
+      "license": "MIT",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "@simple-git/args-pathspec": "^1.0.2",
-        "@simple-git/argv-parser": "^1.0.3",
+        "@simple-git/args-pathspec": "^1.0.3",
+        "@simple-git/argv-parser": "^1.1.0",
         "debug": "^4.4.0"
       },
       "funding": {

--- a/package.json
+++ b/package.json
@@ -53,10 +53,13 @@
     "gray-matter": "^4.0.3",
     "listr2": "^9.0.5",
     "ora": "^8.1.0",
-    "simple-git": "^3.27.0",
+    "simple-git": "^3.36.0",
     "smol-toml": "^1.3.1",
     "yaml": "^2.6.0",
     "zod": "^3.24.0"
+  },
+  "overrides": {
+    "js-yaml": "^3.15.1"
   },
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",


### PR DESCRIPTION
## What

Patches the two **runtime-scope** dependencies flagged by Dependabot. Both ship in the published `teamai-cli` package, so they are the ones that actually reach users.

| Dependabot | Package | Scope | Change | Fixes |
|---|---|---|---|---|
| [#6](https://github.com/Tencent/teamai-cli/security/dependabot/6) high | `simple-git` (direct) | runtime | `^3.27.0` → `^3.36.0` (3.35.2 → 3.36.0) | Remote Code Execution |
| [#16](https://github.com/Tencent/teamai-cli/security/dependabot/16) high | `js-yaml` (via `gray-matter`) | runtime | pinned to `^3.15.1` via `overrides` (was 3.14.2) | Quadratic-CPU DoS via YAML merge-key chains |

`js-yaml` is pulled transitively by `gray-matter@4.0.3` (declared `^3.13.1`), so `3.15.1` stays within range — an `overrides` entry is enough, no fork or replacement needed.

## Scope

Deliberately **runtime-only**. The remaining open Dependabot alerts are all devDependency-scoped (vitest, postcss, vite, esbuild, brace-expansion, picomatch) — they belong to the build/test toolchain and do **not** ship in the published package. Those are better handled in a separate cleanup PR, and the vitest critical (#8) requires a 2.x→3.x major bump that needs its own regression pass.

## Test Plan

- [x] `npm audit --omit=dev` → **0 vulnerabilities** (production tree clean)
- [x] `npx tsc --noEmit` → passes
- [x] `npm run build` → success
- [x] `npx vitest run` → **2182 tests / 161 files pass**, no regressions
- [x] Real `simple-git@3.36.0` ops verified end-to-end: init / add / commit / log / status / branchLocal
- [x] Real `js-yaml@3.15.1` + `gray-matter` frontmatter parsing verified (anchors, aliases, nested maps)