### PR TITLE
ci: publish prereleases to their own dist-tag, never latest

### DIFF
--- a/.coding-ci.yaml
+++ b/.coding-ci.yaml
@@ -97,7 +97,10 @@ stages:
         - "echo \"//r.tnpm.oa.com/:_auth=$(echo -n \"${NPM_USERNAME}:${NPM_TOKEN}\" | base64)\" > .npmrc"
         - npm ci --ignore-scripts
         - npm run build
-        - npm publish --registry http://r.tnpm.oa.com
+        # Resolve the dist-tag from the version: a prerelease (e.g. 0.21.0-beta.0)
+        # publishes to its own channel (beta/rc/...), never to `latest` — the tag
+        # the CLI's auto-update check reads for @tencent/teamai-cli (src/update.ts).
+        - "PKG_VERSION=$(node -p \"require('./package.json').version\")\ncase \"$PKG_VERSION\" in\n  *-*)\n    PRE=\"${PKG_VERSION#*-}\"\n    DIST_TAG=\"${PRE%%.*}\"\n    case \"$DIST_TAG\" in\n      ''|*[!a-zA-Z]*) DIST_TAG=\"beta\" ;;\n    esac\n    ;;\n  *)\n    DIST_TAG=\"latest\"\n    ;;\nesac\necho \"Publishing $PKG_VERSION with dist-tag: $DIST_TAG\"\nnpm publish --registry http://r.tnpm.oa.com --tag \"$DIST_TAG\"\n"
         - rm -f .npmrc
 trigger:
   branches:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,36 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Resolve dist-tag
+        id: disttag
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          case "$PKG_VERSION" in
+            *-*)
+              # Prerelease (e.g. 0.21.0-beta.0). Derive the dist-tag from the
+              # first prerelease identifier (beta, rc, alpha, ...) so it lands
+              # on its own channel and NEVER on `latest` — the tag consumed by
+              # the CLI's auto-update check (src/update.ts).
+              PRE="${PKG_VERSION#*-}"
+              DIST_TAG="${PRE%%.*}"
+              # npm rejects dist-tags that look like a semver version, so fall
+              # back to `beta` when the identifier isn't a plain word.
+              case "$DIST_TAG" in
+                ''|*[!a-zA-Z]*) DIST_TAG="beta" ;;
+              esac
+              IS_PRERELEASE=true
+              ;;
+            *)
+              DIST_TAG="latest"
+              IS_PRERELEASE=false
+              ;;
+          esac
+          echo "Publishing $PKG_VERSION with dist-tag: $DIST_TAG (prerelease=$IS_PRERELEASE)"
+          echo "dist_tag=$DIST_TAG" >> "$GITHUB_OUTPUT"
+          echo "is_prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
+
       - name: Publish
-        run: npm publish --provenance --access public
+        run: npm publish --provenance --access public --tag "${{ steps.disttag.outputs.dist_tag }}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -56,3 +84,4 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+          prerelease: ${{ steps.disttag.outputs.is_prerelease == 'true' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,8 @@ git push origin main --tags
 
 CI stages: validate (lint + test) -> build -> e2e -> publish (tag builds only).
 
+Prerelease versions (`npm version prerelease --preid=beta` → `0.21.0-beta.0`) publish to a matching dist-tag (`beta`, `rc`, ...) instead of `latest`, so auto-update is unaffected.
+
 ## Git Conventions
 
 - **Default branch**: `main` (not `master`). All worktrees and PRs should be based on `origin/main`.


### PR DESCRIPTION
## Problem

Both release pipelines run `npm publish` with **no `--tag`**, so npm defaults to `latest` — regardless of whether the version has a prerelease suffix. That means pushing a `vX.Y.Z-beta.N` tag would publish the beta to the `latest` dist-tag, which is exactly the tag the CLI's auto-update check reads (`src/update.ts` → `npm view teamai-cli version`). Every user would be auto-updated to a beta.

- `.github/workflows/release.yml:51` — `npm publish --provenance --access public`
- `.coding-ci.yaml:100` — `npm publish --registry http://r.tnpm.oa.com`

## Fix

Derive the dist-tag from the version string in both pipelines:

- `0.21.0-beta.0` → `beta`, `0.22.0-rc.1` → `rc`, `1.0.0-alpha.3` → `alpha`
- plain `0.21.0` → `latest` (unchanged behavior for real releases)
- non-word / semver-looking prerelease identifiers fall back to `beta`

GitHub Releases for prereleases are now flagged `prerelease: true`. Documented the beta flow in `CLAUDE.md`.

This unblocks cutting `v0.21.0-beta.0` without polluting `latest` auto-update.

## Test Plan

- [x] `python3 -c 'yaml.safe_load(...)'` on both YAML files — parse OK
- [x] dist-tag derivation logic run against `0.21.0-beta.0` / `0.21.0` / `0.22.0-rc.1` / `1.0.0-alpha.3` — resolves to `beta` / `latest` / `rc` / `alpha` respectively
- [ ] Real end-to-end verification happens on the actual `v0.21.0-beta.0` tag push (CI-only change; cannot be exercised without a tag build)