### PR TITLE
docs(readme): add feature overview matrix, trim Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,7 @@ npm install -g teamai-cli
 
 ### Team admin / solo user
 
-Create a shared-experience repo on your git host (GitHub, TGit, CNB, or a self-hosted Git service), **grant write access to team members**, then have them run `teamai init https://github.com/yourorg/yourrepo`.
-
-> Solo use needs no separate repo setup: `teamai init` checks the target repo and creates it automatically if it doesn't exist.
+Create a shared-experience repo on your git host (GitHub, GitLab (incl. self-hosted), CNB, TGit, or any private/self-hosted Git service), **grant write access to team members**, then have them run `teamai init https://github.com/yourorg/yourrepo`.
 
 > Self-hosted GitLab/Gitea-style services use your HTTPS credential helper or SSH key. Create the repository first; merge requests are created manually for now. See [Git Provider docs](docs/providers.md).
 
@@ -47,11 +45,6 @@ teamai init https://github.com/yourorg/yourrepo
 
 # User-scope init (resources installed under ~/)
 teamai init https://github.com/yourorg/yourrepo --scope user
-
-# Optional layered setup: keep a project repo active while inheriting safe
-# resources and searchable knowledge from an initialized user-scope repo
-cd /path/to/my-project
-teamai init https://github.com/yourorg/project-repo --inherit-user-scope
 ```
 
 Once initialized, every AI session automatically pulls the latest skills / rules and other Harness updates published by admins — no manual sync needed.
@@ -66,15 +59,37 @@ teamai init .                        # interactive: pick which AI tools to set u
 teamai init . --agent claude,codex   # non-interactive: Claude Code + Codex
 ```
 
-- **Knowledge** (skills / rules / docs / learnings) is committed to your repo's **main branch** under `.teamai/`, so a plain `git clone` already carries the whole team setup.
-- **Reports** (member registrations, session summaries, votes, usage stats) go to a separate **`teamai-reports` orphan branch** — they never touch main.
-- **You choose which AI tools to set up.** `--agent claude,codex` (repeatable/comma-separated), an interactive picker when omitted, or — in non-interactive contexts — whichever tools you already use under `~/`. teamai creates each selected tool's dir, injects hooks, and commits its settings.
-- **Clone = initialized.** When a teammate clones the repo, the next `teamai` command (or AI session) auto-detects the `mode: self` marker in `.teamai/teamai.yaml` and finishes local setup automatically — no need to re-type repo/role.
-- All of teamai's git operations run in isolated worktrees, so your working tree and current branch are never touched.
-
-`teamai init .` commits `.teamai/` (skills, rules, docs, learnings, `teamai.yaml`, `.gitignore`) plus each selected tool's settings (e.g. `.claude/settings.json`, `.codex/hooks.json`) for you; just push main so teammates get auto-initialized on clone.
-
 > **Full usage guide:** [docs/usage-guide.md](docs/usage-guide.md) ([中文版](docs/usage-guide.zh-CN.md)) — covers everything from team creation to day-to-day use.
+
+## Overview
+
+<table>
+  <thead>
+    <tr>
+      <th rowspan="2">Agent</th>
+      <th colspan="7">Harness</th>
+      <th colspan="3">Knowledge Base</th>
+      <th colspan="3">Governance</th>
+    </tr>
+    <tr>
+      <th>skills</th><th>rules</th><th>docs</th><th>env</th><th>agents</th><th>hooks</th><th>mcp</th>
+      <th>learnings</th><th>codebase</th><th>teamwiki</th>
+      <th>usage</th><th>sessions</th><th>dashboard</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>Claude Code</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td></tr>
+    <tr><td>Codex</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td></tr>
+    <tr><td>Cursor</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td></tr>
+    <tr><td>CodeBuddy</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td></tr>
+    <tr><td>OpenCode</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">—</td><td align="center">—</td></tr>
+    <tr><td>WorkBuddy</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td></tr>
+    <tr><td>OpenClaw</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">—</td><td align="center">—</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">—</td><td align="center">—</td></tr>
+    <tr><td>Hermes</td><td align="center">✓</td><td align="center">—</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">—</td><td align="center">—</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">—</td><td align="center">—</td></tr>
+  </tbody>
+</table>
+
+**Git providers** — GitHub · GitLab (incl. self-hosted) · CNB · TGit · any private/self-hosted Git service.
 
 ## Harness Management & Distribution
 
@@ -180,21 +195,6 @@ Author: member-b | Score: 12.0 | Tags: deploy, config
 Matched: conflict | Missing: port
 ```
 
-A `Matched: … | Missing: …` line appears whenever a hit does not cover every
-query term (omitted when all terms matched). Recall returns its top matches by
-score without filtering on coverage: a hit missing all of your distinctive
-terms is topically adjacent, not an answer. Judging that is the caller's job —
-the score alone cannot express it. Entries matching on title, date, author and
-content are collapsed, so the same learning shared twice does not occupy two
-slots.
-
-**Coverage spans two parts:**
-
-- **Shared search index** (`search-index.json`): four categories — learnings (session experience), docs (team docs), rules (coding rules), and skills (each `SKILL.md`) — sourced from the corresponding team-repo directories, (re)built on `teamai pull` / `teamai contribute`.
-- **Codebase knowledge graph** (`teamwiki/`): produced by `teamai import`, queried live at search time.
-
-Ranking uses BM25 + graph-boost. When the current working directory contains a project-scope config, Recall searches that project; if the project enables `--inherit-user-scope`, it then searches user knowledge, tags each result with its origin, and lets an identical project entry override the user entry. Without a project config in the current directory, Recall searches the user scope. Active-scope hits are implicitly upvoted; inherited user hits remain read-only while the project is active.
-
 ### Codebase Knowledge Graph
 
 `teamai import` parses source repos into a structured graph under `teamwiki/`, enabling structurally-aware retrieval:
@@ -231,8 +231,6 @@ When a recall hit comes from a codebase page, the result includes a `Sources:` l
 | `teamai digest` | Generate weekly team usage digest |
 | `teamai doctor` | Diagnose configuration issues |
 | `teamai uninstall` | Remove all teamai resources and hooks |
-
-Global options: `--dry-run`, `--verbose`
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,9 +30,7 @@ npm install -g teamai-cli
 
 ### 团队管理员 / 个人使用者
 
-在 Git 托管平台（GitHub、TGit、CNB 或自建 Git 服务）创建共享经验仓库，**授予团队成员写权限**，然后让他们运行 `teamai init https://github.com/yourorg/yourrepo`。
-
-> 个人使用无需单独建仓：`teamai init` 会检查目标仓库，不存在时自动创建。
+在 Git 托管平台（GitHub、GitLab（含自建）、CNB、TGit，或任意私有/自建 Git 服务）创建共享经验仓库，**授予团队成员写权限**，然后让他们运行 `teamai init https://github.com/yourorg/yourrepo`。
 
 > 自建 GitLab/Gitea 等服务支持 HTTPS Credential Helper 或 SSH Key；需预先创建仓库，MR 暂时手动创建。详见 [Git Provider 说明](docs/providers.md)。
 
@@ -47,11 +45,6 @@ teamai init https://github.com/yourorg/yourrepo
 
 # 用户级初始化（资源安装到 ~/ 下）
 teamai init https://github.com/yourorg/yourrepo --scope user
-
-# 可选的分层模式：项目仓库保持为当前 scope，同时继承已初始化的
-# user scope 中的安全资源和可检索知识
-cd /path/to/my-project
-teamai init https://github.com/yourorg/project-repo --inherit-user-scope
 ```
 
 初始化完成后，每次开启 AI 会话时都会自动拉取管理员发布的 skills / rules 等 Harness 更新，无需手动同步。
@@ -66,15 +59,37 @@ teamai init .                        # 交互式：选择要启用哪些 AI 工�
 teamai init . --agent claude,codex   # 非交互:启用 Claude Code + Codex
 ```
 
-- **知识资产**（skills / rules / docs / learnings）提交到仓库 **main 分支**的 `.teamai/` 目录，因此一次普通 `git clone` 就带上了整套团队配置。
-- **上报数据**（成员注册、会话摘要、投票、使用统计）走独立的 **`teamai-reports` 孤儿分支** —— 永不污染 main。
-- **由你选择启用哪些 AI 工具。** `--agent claude,codex`（可重复/逗号分隔）,省略时弹交互选择框,非交互场景则按你本机 `~/` 下已装的工具来建。teamai 为每个所选工具建目录、注入 hooks、并提交其 settings。
-- **克隆即初始化。** 团队成员 clone 仓库后，下一条 `teamai` 命令（或 AI 会话）会自动识别 `.teamai/teamai.yaml` 里的 `mode: self` 标记并自动完成本机初始化 —— 无需手抄 repo/role 参数。
-- teamai 的所有 git 操作都在隔离的 worktree 中进行，绝不触碰你的工作区和当前分支。
-
-`teamai init .` 会帮你把 `.teamai/`（skills、rules、docs、learnings、`teamai.yaml`、`.gitignore`）以及每个所选工具的 settings（如 `.claude/settings.json`、`.codex/hooks.json`）提交好;推送 main 后团队成员 clone 即可自动初始化。
-
 > **完整使用指南**：[docs/usage-guide.zh-CN.md](docs/usage-guide.zh-CN.md)（[English](docs/usage-guide.md)）— 涵盖从团队创建到日常使用的全流程。
+
+## 功能概览
+
+<table>
+  <thead>
+    <tr>
+      <th rowspan="2">Agent</th>
+      <th colspan="7">Harness</th>
+      <th colspan="3">知识库</th>
+      <th colspan="3">治理</th>
+    </tr>
+    <tr>
+      <th>skills</th><th>rules</th><th>docs</th><th>env</th><th>agents</th><th>hooks</th><th>mcp</th>
+      <th>learnings</th><th>codebase</th><th>teamwiki</th>
+      <th>usage</th><th>sessions</th><th>dashboard</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>Claude Code</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td></tr>
+    <tr><td>Codex</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td></tr>
+    <tr><td>Cursor</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td></tr>
+    <tr><td>CodeBuddy</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td></tr>
+    <tr><td>OpenCode</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">—</td><td align="center">—</td></tr>
+    <tr><td>WorkBuddy</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td></tr>
+    <tr><td>OpenClaw</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">—</td><td align="center">—</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">—</td><td align="center">—</td></tr>
+    <tr><td>Hermes</td><td align="center">✓</td><td align="center">—</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">—</td><td align="center">—</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">—</td><td align="center">—</td></tr>
+  </tbody>
+</table>
+
+**Git 托管平台** —— GitHub · GitLab（含自建）· CNB · TGit · 任意私有/自建 Git 服务。
 
 ## Harness 管理和分发
 
@@ -180,18 +195,6 @@ Author: member-b | Score: 12.0 | Tags: deploy, config
 Matched: conflict | Missing: port
 ```
 
-当某条结果未覆盖全部查询词时，会输出 `Matched: … | Missing: …` 行（全部命中时省略）。
-recall 按分数返回 top 结果，**不会**按覆盖度过滤：若你的关键区分词全在 `Missing:` 里，
-说明这条只是主题相邻，并非答案。这个判断由调用方来做 —— 分数本身无法表达它。
-标题、日期、作者与内容均相同的条目会被合并，因此同一条 learning 被分享两次不会占用两个名额。
-
-**检索内容覆盖两部分**：
-
-- **共享检索索引**（`search-index.json`）：learnings（session 经验）、docs（团队文档）、rules（编码规则）、skills（各 `SKILL.md`）四类，源自团队仓库对应目录，在 `teamai pull` / `teamai contribute` 时构建重建。
-- **代码知识图谱**（`teamwiki/`）：由 `teamai import` 生成，检索时实时查询。
-
-排序采用 BM25 + 图谱增强。当前工作目录包含 project scope 配置时，Recall 先检索该项目；如果项目启用了 `--inherit-user-scope`，再检索 user 知识并标注结果来源，相同条目由 project 版本覆盖 user 版本。当前目录没有 project 配置时，Recall 检索 user scope。当前 scope 的命中会隐式投票，项目运行期间继承的 user 命中保持只读。
-
 ### 代码知识图谱
 
 `teamai import` 将源码仓库解析为 `teamwiki/` 下的结构化图谱，实现结构感知的检索：
@@ -228,8 +231,6 @@ teamai codebase --lint                      # 健康检查
 | `teamai digest` | 生成团队周报 |
 | `teamai doctor` | 诊断配置问题 |
 | `teamai uninstall` | 移除所有 teamai 资源和 hooks |
-
-全局选项：`--dry-run`、`--verbose`
 
 ## 许可证
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -76,7 +76,7 @@ teamai --version
 
 > Only one admin needs to do this — other members can skip to [Member Onboarding](#member-onboarding).
 
-Create an empty repository on GitHub, TGit (Tencent's internal Git host), or CNB (cnb.cool) (suggested naming: `TeamAi-<team-name>`), or simply run `teamai init` — if the repo doesn't exist yet, you'll be prompted to create it automatically.
+Create an empty repository on GitHub, GitLab (gitlab.com or a self-hosted instance), CNB (cnb.cool), TGit (Tencent's internal Git host), or any private/self-hosted Git service (suggested naming: `TeamAi-<team-name>`), or simply run `teamai init` — if the repo doesn't exist yet, you'll be prompted to create it automatically.
 
 ### Project Scope (default)
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -74,7 +74,7 @@ teamai --version
 
 > 只需一位管理员完成，其他成员跳到[成员接入](#成员接入)。
 
-在 GitHub、TGit（腾讯工蜂）或 CNB（cnb.cool）上创建一个空仓库（命名建议：`TeamAi-<团队名>`），或者直接执行 `teamai init`，不存在时会提示自动创建。
+在 GitHub、GitLab（gitlab.com 或自建实例）、CNB（cnb.cool）、TGit（腾讯工蜂），或任意私有/自建 Git 服务上创建一个空仓库（命名建议：`TeamAi-<团队名>`），或者直接执行 `teamai init`，不存在时会提示自动创建。
 
 ### 项目级（Project Scope，默认）
 


### PR DESCRIPTION
## What

Add a **Feature Overview** table to the README (both languages) and trim redundant Quick Start prose.

### Overview matrix
Agents (rows) × resources (columns), rendered as an HTML two-level header table grouping columns into three areas:

- **Harness** — skills · rules · docs · env · agents · hooks · mcp
- **Knowledge Base** — learnings · codebase · teamwiki
- **Governance** — usage · sessions · dashboard

Covers 8 agents (Claude Code, Codex, Cursor, CodeBuddy, OpenCode, WorkBuddy, OpenClaw, Hermes). ✓/— cells are sourced from `src/types.ts` `toolPaths` (per-tool support) and `src/builtin-hooks.ts` (governance = tools with dispatch hooks).

A **Git providers** line lists the supported hosts: GitHub · GitLab (incl. self-hosted) · CNB · TGit · any private/self-hosted service (from `src/providers/registry.ts`).

### Trims
- Single-repo mode: removed the 5 detail bullets and the trailing commit-summary sentence
- Removed the `--inherit-user-scope` layered-setup example and the solo-use note
- Removed the recall coverage/ranking detail paragraphs
- Removed the `Global options` line

### Docs sync
- `docs/usage-guide.{md,zh-CN.md}`: added GitLab + private/self-hosted to the repo-creation line and moved TGit later in provider lists
- README.md / README.zh-CN.md kept in sync

## Test Plan
- [x] Both README tables render with matching column counts (13 data cells/row, colspan 7+3+3)
- [x] No stray garbage characters or escaped pipes
- [x] Provider lists consistent across README + usage-guide (TGit last among named hosts)
- [x] Bilingual docs verified in sync

Docs-only change; no code affected.