### PR TITLE
feat(dsh): add DeepSeek Harness as a supported agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ teamai init . --agent claude,codex   # non-interactive: Claude Code + Codex
     <tr><td>WorkBuddy</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td></tr>
     <tr><td>OpenClaw</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">—</td><td align="center">—</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">—</td><td align="center">—</td></tr>
     <tr><td>Hermes</td><td align="center">✓</td><td align="center">—</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">—</td><td align="center">—</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">—</td><td align="center">—</td></tr>
+    <tr><td>DeepSeek Harness</td><td align="center">✓</td><td align="center">—</td><td align="center">✓</td><td align="center">—</td><td align="center">—</td><td align="center">—</td><td align="center">—</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">—</td><td align="center">—</td></tr>
   </tbody>
 </table>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -86,6 +86,7 @@ teamai init . --agent claude,codex   # 非交互:启用 Claude Code + Codex
     <tr><td>WorkBuddy</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td></tr>
     <tr><td>OpenClaw</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">—</td><td align="center">—</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">—</td><td align="center">—</td></tr>
     <tr><td>Hermes</td><td align="center">✓</td><td align="center">—</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">—</td><td align="center">—</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">—</td><td align="center">—</td></tr>
+    <tr><td>DeepSeek Harness</td><td align="center">✓</td><td align="center">—</td><td align="center">✓</td><td align="center">—</td><td align="center">—</td><td align="center">—</td><td align="center">—</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">—</td><td align="center">—</td></tr>
   </tbody>
 </table>
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -181,7 +181,7 @@ teamai init . --agent claude,codex   # non-interactive: set up Claude Code + Cod
 
 **Choosing which AI tools to set up.** Single-repo mode creates a per-tool directory in your repo (e.g. `.claude/`, `.codex/`) — it seeds the skills dir, injects the teamai hooks, and commits that tool's settings to main so teammates get them on clone. You control which tools:
 
-- **`--agent <name...>`** — explicit list, repeatable or comma-separated: `--agent claude`, `--agent claude,codex`, `--agent claude --agent cursor`. Supported ids: `claude`, `codex`, `cursor`, `codebuddy`, `workbuddy`.
+- **`--agent <name...>`** — explicit list, repeatable or comma-separated: `--agent claude`, `--agent claude,codex`, `--agent claude --agent cursor`. Supported ids: `claude`, `codex`, `cursor`, `codebuddy`, `workbuddy`, `dsh` (DeepSeek Harness).
 - **Interactive (no `--agent`, a terminal)** — teamai shows a multi-select. Option 1 is **Auto**, which lists the AI tools already installed on your machine (`~/.claude`, `~/.codex`, …) and is the Enter default; the remaining options are the individual tools. Auto and specific tools can be combined.
 - **Non-interactive (no `--agent`, no terminal — CI, hooks, clone-time bootstrap)** — teamai mirrors the tools you already use under your home dir (`~/.claude`, `~/.codex`, …). If none are found, it creates nothing (you still get the knowledge; run `teamai init .` later to pick tools).
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -179,7 +179,7 @@ teamai init . --agent claude,codex   # 非交互:启用 Claude Code + Codex
 
 **选择启用哪些 AI 工具。** 单仓模式会在你的仓库里为每个工具创建一个目录（如 `.claude/`、`.codex/`）—— 建好 skills 目录、注入 teamai hooks,并把该工具的 settings 提交到 main,让队友 clone 后即可获得。由你决定启用哪些工具:
 
-- **`--agent <name...>`** —— 显式列表,可重复或逗号分隔:`--agent claude`、`--agent claude,codex`、`--agent claude --agent cursor`。支持的 id:`claude`、`codex`、`cursor`、`codebuddy`、`workbuddy`。
+- **`--agent <name...>`** —— 显式列表,可重复或逗号分隔:`--agent claude`、`--agent claude,codex`、`--agent claude --agent cursor`。支持的 id:`claude`、`codex`、`cursor`、`codebuddy`、`workbuddy`、`dsh`(DeepSeek Harness)。
 - **交互式（无 `--agent`、有终端）** —— teamai 弹出多选列表。第 1 项是 **Auto**,会列出你本机已安装的 AI 工具（`~/.claude`、`~/.codex`……）并作为回车默认项;其余各项是具体工具。Auto 与具体工具可以组合勾选。
 - **非交互（无 `--agent`、无终端 —— CI、hook、clone 时自愈 bootstrap）** —— teamai 会按你本机 home 目录下已装的工具（`~/.claude`、`~/.codex`……）来建。若一个都没检测到,则什么都不建（你仍拿到知识,可稍后运行 `teamai init .` 再选工具）。
 

--- a/src/agent-version.ts
+++ b/src/agent-version.ts
@@ -108,7 +108,16 @@ const DETECTORS: Record<string, VersionDetector> = {
   workbuddy: detectWorkbuddyVersion,
   hermes: detectHermesVersion,
   openclaw: detectOpenclawVersion,
+  // DeepSeek Harness: `dsh --version` prints e.g. "0.1.1" (optionally with a
+  // leading "v" or trailing commit info). Extract leading semver-ish digits.
+  dsh: detectDshVersion,
 };
+
+async function detectDshVersion(): Promise<string> {
+  const raw = await execVersion('dsh');
+  const match = raw.match(/v?(\d+(?:\.\d+)*)/);
+  return match?.[1] ?? '';
+}
 
 /**
  * Detect the version of a given agent. Returns '' on failure.

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ program
   // comma-separated (`--agent a,b`, split later by normalizeAgentList) both work,
   // WITHOUT the greedy `<name...>` variadic that would swallow the `[repo]`
   // positional (e.g. `init --agent claude .` must keep `.` as the repo arg).
-  .option('--agent <name>', 'AI tools to set up (e.g. claude, codex, cursor, codebuddy, workbuddy). Repeatable or comma-separated. In single-repo mode, selects which tool dirs to create; omit for an interactive picker. Additive on repeated runs.', (val: string, acc: string[]) => acc.concat(val), [] as string[])
+  .option('--agent <name>', 'AI tools to set up (e.g. claude, codex, cursor, codebuddy, workbuddy, dsh). Repeatable or comma-separated. In single-repo mode, selects which tool dirs to create; omit for an interactive picker. Additive on repeated runs.', (val: string, acc: string[]) => acc.concat(val), [] as string[])
   .option('--force', 'Overwrite existing config without confirmation')
   .action(async (repoArg, cmdOpts) => {
     const globalOpts = program.opts() as GlobalOptions;

--- a/src/known-agents.ts
+++ b/src/known-agents.ts
@@ -105,6 +105,12 @@ export const KNOWN_AGENTS: KnownAgent[] = [
   { id: 'autoclaw', displayName: 'AutoClaw', category: 'lobster', skillsPath: '.openclaw-autoclaw/skills' },
   { id: 'workbuddy', displayName: 'WorkBuddy', category: 'lobster', skillsPath: '.workbuddy/skills' },
 
+  // DeepSeek Harness (dsh) — plugin-based agent harness. Its skill-filesystem
+  // provider scans user skill roots: ~/.dsh/skills (rank 400) and ~/.agents/skills
+  // (rank 500). We sync to ~/.dsh/skills so dsh keeps its own copy; the central
+  // `.agents` entry below covers the shared root as well.
+  { id: 'dsh', displayName: 'DeepSeek Harness', category: 'coding', skillsPath: '.dsh/skills' },
+
   // Central agent skills directory (codex / generic)
   { id: 'agents', displayName: 'Central (Agent Skills)', category: 'central', skillsPath: '.agents/skills' },
 ];

--- a/src/types.ts
+++ b/src/types.ts
@@ -209,6 +209,10 @@ export const TeamaiConfigSchema = z.object({
     codebuddy: { skills: '.codebuddy/skills', rules: '.codebuddy/rules', settings: '.codebuddy/settings.json', claudemd: '.codebuddy/CODEBUDDY.md', agents: '.codebuddy/agents', mcp: '.codebuddy/mcp.json', mcpProject: '.codebuddy/mcp.json' },
     openclaw: { skills: '.openclaw/skills', rules: '.openclaw/rules', claudemd: '.openclaw/workspace/AGENTS.md' },
     hermes: { skills: '.hermes/skills', claudemd: 'AGENTS.md' },
+    // DeepSeek Harness: skills synced to ~/.dsh/skills, which its skill-filesystem
+    // provider scans as user-dsh root (rank 400). dsh discovers both directory
+    // bundles (<name>/SKILL.md) and flat Markdown files there natively.
+    dsh: { skills: '.dsh/skills' },
     workbuddy: { skills: '.workbuddy/skills', rules: '.workbuddy/rules', settings: '.workbuddy/settings.json', claudemd: 'AGENTS.md', mcp: '.workbuddy/mcp.json', mcpProject: '.workbuddy/mcp.json' },
     // OpenCode reads project config from <root>/.opencode/ but user config from
     // ~/.config/opencode/ — a different prefix, hence userScope. Skills are also


### PR DESCRIPTION
## What

Adds **DeepSeek Harness (dsh)** as a first-class supported agent, alongside hermes/openclaw:

- `KNOWN_AGENTS`: `dsh` entry (coding category) — skills at `~/.dsh/skills`
- Default `toolPaths`: `dsh: { skills: '.dsh/skills' }` — no team config needed
- `agent-version` detection via `dsh --version`
- README / README.zh-CN feature matrix rows + usage-guide (EN/中文) agent-id lists, per the bilingual docs policy

## Why

dsh's `skill-filesystem` provider ([deepseek-harness packages/skill](https://github.com/deepseek-ai/DeepSeek-Harness/tree/main/packages/skill/skill-filesystem)) natively scans user skill roots: `~/.dsh/skills` (user-dsh, rank 400) and `~/.agents/skills` (rank 500), discovering both `<name>/SKILL.md` bundles and flat `.md` files. Syncing into `~/.dsh/skills` gives dsh sessions the team harness with zero dsh-side config — the standard integration pattern used for the other agents.

dsh also ships Claude Code / Codex hook bridges, but skills-sync is the stable, non-invasive surface; hooks/env/MCP can follow once the dsh-side config surface stabilizes.

## Verification (real CLI, end-to-end against a self-hosted GitLab 18.7)

```
$ npm run build                       # tsup, success
$ npx tsc --noEmit                    # clean
$ npx vitest run                      # 2183 passed; 2 pre-existing failures in builtin-agents.test.ts (fail on main too, unrelated)
$ node dist/index.js init root/teamai-harness --scope user --agent dsh   # dsh accepted as agent id
$ node dist/index.js pull             # → 'Synced 331 skills' → ~/.dsh/skills (331 dirs)
```

Removing the custom `toolPaths.dsh` from the team repo's teamai.yaml and re-pulling confirmed the **built-in default** drives the sync (team config no longer required for dsh).

Test plan checklist per CLAUDE.md — build ✅, real CLI e2e ✅, docs updated in both languages ✅.