### PR TITLE
test(providers/gitlab): add opt-in live smoke test against real GitLab

### DIFF
--- a/src/__tests__/e2e/gitlab-provider-live.test.ts
+++ b/src/__tests__/e2e/gitlab-provider-live.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { gitlabIsAuthenticated, gitlabWhoami } from '../../providers/gitlab/gitlab-api.js';
+
+/**
+ * Live, read-only smoke test for the GitLab provider against a real account
+ * (gitlab.com or a self-hosted instance via GITLAB_URL).
+ *
+ * Opt-in: skipped unless GITLAB_TOKEN is set, so normal CI (no GitLab secret)
+ * never runs it. Intentionally read-only — it does NOT create repos/MRs.
+ * The full mutating flow (init → clone → push → open-MR) was verified manually
+ * against `git.guazi-corp.com`; see the PR notes.
+ */
+const HAS_GITLAB = Boolean(process.env.GITLAB_TOKEN);
+
+describe('GitLab provider (live GitLab instance)', () => {
+  it.skipIf(!HAS_GITLAB)('authenticates via env token and resolves the account username', async () => {
+    expect(gitlabIsAuthenticated()).toBe(true);
+    const user = await gitlabWhoami();
+    expect(typeof user).toBe('string');
+    expect((user ?? '').length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to the GitLab provider already shipping in 0.21.0-beta.0. Adds an opt-in live smoke test under `src/__tests__/e2e/`, mirroring the existing `cnb-provider-live` pattern: skipped unless `GITLAB_TOKEN` is set, runs a read-only `GET /user` against the configured instance (gitlab.com by default, or self-hosted via `GITLAB_URL`).

The full mutating flow was verified manually against `git.guazi-corp.com` before opening this PR:
- `git clone` with the in-URL `oauth2:<token>@` basic-auth form
- `teamai push` MR creation (real `!2` created with `sha=e160899`, then closed)
- All via the same provider code paths shipped in 0.21.0-beta.0

## Why this PR

During the work for #303 we discovered the upstream provider already shipped (between our branch and the rebase), so the originally-planned PR became redundant. Rather than re-implement, this lands the only piece that wasn't already there — an automated live auth smoke test — so future contributors can opt-in to CI verification of their GitLab setup.

## Type of Change

- [ ] Bug fix
- [x] New feature (test only)
- [ ] Breaking change
- [ ] Documentation only
- [ ] Refactor / internal cleanup

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` passes (2185/2185)
- [x] `npx vitest run --config vitest.e2e.config.ts` passes (64 pass, 24 skip including the new test)
- [x] New e2e test: `it.skipIf(!HAS_GITLAB)` correctly skips without `GITLAB_TOKEN`; verified manually with a real `GITLAB_TOKEN` against git.guazi-corp.com

## Related Issues

Refs #303

## Notes for Reviewers

- 22-line addition; no production code touched.
- Follows the existing `cnb-provider-live` pattern exactly — reviewers familiar with that test will recognise the shape.
- The test file is excluded from the default `npx vitest run` (matches `cnb-provider-live`) so it cannot accidentally run in a CI environment without the secret.