### PR TITLE
fix(push): carry teamai.yaml config changes through push

### DIFF
--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -1008,7 +1008,7 @@ teamai source browse other-team
 teamai source remove other-team
 ```
 
-A subscription source's skills are automatically synced locally on `teamai pull`, coexisting with the team's own skills. Configuration is stored in the `sources` field of the local `config.yaml`.
+A subscription source's skills are automatically synced locally on `teamai pull`, coexisting with the team's own skills. The subscription itself is stored in the `sources` field of the team repo's `teamai.yaml` — so it is shared with the whole team, not just your machine. After `teamai source add`/`remove`, run `teamai push` to open a PR with the `teamai.yaml` change; once it merges, every teammate's `teamai pull` picks up the new source automatically.
 
 #### HTTP Source
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -1003,7 +1003,7 @@ teamai source browse other-team
 teamai source remove other-team
 ```
 
-订阅源的 skills 在 `teamai pull` 时自动同步到本地，与团队自有 skills 共存。配置存储在本地 `config.yaml` 的 `sources` 字段中。
+订阅源的 skills 在 `teamai pull` 时自动同步到本地，与团队自有 skills 共存。订阅本身存储在团队仓库 `teamai.yaml` 的 `sources` 字段中——因此是共享给整个团队的，而不只对你本机生效。执行 `teamai source add`/`remove` 后，运行 `teamai push` 会开一个包含 `teamai.yaml` 改动的 PR；合入后，每位成员的 `teamai pull` 都会自动获取到新的订阅源。
 
 #### HTTP 源
 

--- a/src/__tests__/push-team-config.test.ts
+++ b/src/__tests__/push-team-config.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { simpleGit } from 'simple-git';
+
+// Integration test for the "push carries teamai.yaml" fix.
+//
+// Regression: `teamai source add` writes sources/publicSkills into the team repo's
+// teamai.yaml WITHOUT committing, then tells the user to run `teamai push`. Before
+// the fix, push would (1) `git reset --hard` the working tree in resetToCleanMaster
+// and destroy that edit, and (2) never include teamai.yaml in the commit even if it
+// survived. This test drives the real push() against real local git repos (a bare
+// "remote" + a working clone), mocking only the provider's PR creation.
+
+const mockCreatePullRequest = vi.fn().mockResolvedValue('https://example.test/pr/1');
+const mockAutoDetectInit = vi.fn();
+const mockLoadStateForScope = vi.fn();
+const mockSaveStateForScope = vi.fn();
+
+vi.mock('../providers/index.js', () => ({
+  getProvider: () => ({
+    name: 'github',
+    parseRepoInput: (input: string) => ({ owner: 'acme', repo: 'team', httpsUrl: input }),
+    createPullRequest: (...args: unknown[]) => mockCreatePullRequest(...args),
+  }),
+}));
+
+vi.mock('../config.js', () => ({
+  autoDetectInit: (...args: unknown[]) => mockAutoDetectInit(...args),
+  loadStateForScope: (...args: unknown[]) => mockLoadStateForScope(...args),
+  saveStateForScope: (...args: unknown[]) => mockSaveStateForScope(...args),
+}));
+
+vi.mock('../read-only.js', () => ({ assertNotReadOnly: vi.fn() }));
+
+// Pre-push sync reads/writes tool dirs we don't care about here — no-op it.
+vi.mock('../utils/pre-push-sync.js', () => ({ syncTeamUpdatesToLocal: vi.fn() }));
+
+vi.mock('../utils/prompt.js', () => ({
+  askQuestion: vi.fn(() => Promise.resolve('')),
+  askConfirmation: vi.fn(() => Promise.resolve(true)),
+  askSelection: vi.fn((_p: string, n: number, all?: boolean) =>
+    Promise.resolve(all ? Array.from({ length: n }, (_x, i) => i) : null)),
+  parseSelection: vi.fn(),
+  closePrompt: vi.fn(),
+}));
+
+async function initTeamRepos(root: string): Promise<string> {
+  const remote = path.join(root, 'remote.git');
+  const seed = path.join(root, 'seed');
+  const teamRepo = path.join(root, 'team-repo');
+
+  await simpleGit().init(['--bare', remote]);
+
+  fs.mkdirSync(path.join(seed, 'skills', 'ns'), { recursive: true });
+  fs.writeFileSync(path.join(seed, 'teamai.yaml'), 'version: 1\npublicSkills: []\n');
+  const seedGit = simpleGit(seed);
+  await seedGit.init();
+  await seedGit.addConfig('user.email', 't@t.com');
+  await seedGit.addConfig('user.name', 't');
+  await seedGit.add('.');
+  await seedGit.commit('init');
+  await seedGit.branch(['-M', 'main']);
+  await seedGit.addRemote('origin', remote);
+  await seedGit.push(['-u', 'origin', 'main']);
+
+  await simpleGit().clone(remote, teamRepo);
+  const trGit = simpleGit(teamRepo);
+  await trGit.addConfig('user.email', 't@t.com');
+  await trGit.addConfig('user.name', 't');
+  return teamRepo;
+}
+
+/** Read teamai.yaml as committed on the branch that push created + pushed to remote. */
+async function committedYamlOnPushedBranch(teamRepo: string): Promise<string> {
+  const git = simpleGit(teamRepo);
+  const branches = await git.branch();
+  const pushBranch = branches.all.find((b) => b.startsWith('teamai/') || b.includes('push'))
+    ?? branches.current;
+  return (await git.show([`${pushBranch}:teamai.yaml`]));
+}
+
+describe('push carries teamai.yaml (source add regression)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-push-cfg-'));
+    vi.clearAllMocks();
+    mockCreatePullRequest.mockResolvedValue('https://example.test/pr/1');
+    mockLoadStateForScope.mockResolvedValue({
+      lastPush: null, pushedSkills: [], pushedRules: [], pushedEnvVars: [],
+    });
+    mockSaveStateForScope.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('config-only: source add edit survives reset and is pushed', async () => {
+    const teamRepo = await initTeamRepos(tmpDir);
+
+    // Simulate `teamai source add`: edit teamai.yaml in the working tree, no commit.
+    const yamlPath = path.join(teamRepo, 'teamai.yaml');
+    fs.writeFileSync(yamlPath, 'version: 1\npublicSkills: []\nsources:\n  - name: dev\n    repo: https://git.example/dev\n');
+
+    mockAutoDetectInit.mockResolvedValue({
+      localConfig: {
+        repo: { localPath: teamRepo, remote: path.join(tmpDir, 'remote.git'), kind: undefined },
+        username: 'alice',
+        scope: 'project',
+        projectRoot: teamRepo,
+      },
+      teamConfig: { repo: 'acme/team', toolPaths: {} },
+    });
+
+    const { push } = await import('../push.js');
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await push({ all: true });
+    logSpy.mockRestore();
+
+    // A PR was created for the config change...
+    expect(mockCreatePullRequest).toHaveBeenCalledTimes(1);
+    // ...and the pushed branch's teamai.yaml contains the source (survived reset --hard).
+    const pushed = await committedYamlOnPushedBranch(teamRepo);
+    expect(pushed).toContain('sources:');
+    expect(pushed).toContain('https://git.example/dev');
+  });
+
+  it('no changes at all: reports nothing to push, no PR', async () => {
+    const teamRepo = await initTeamRepos(tmpDir);
+
+    mockAutoDetectInit.mockResolvedValue({
+      localConfig: {
+        repo: { localPath: teamRepo, remote: path.join(tmpDir, 'remote.git'), kind: undefined },
+        username: 'alice',
+        scope: 'project',
+        projectRoot: teamRepo,
+      },
+      teamConfig: { repo: 'acme/team', toolPaths: {} },
+    });
+
+    const { push } = await import('../push.js');
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await push({ all: true });
+    logSpy.mockRestore();
+
+    expect(mockCreatePullRequest).not.toHaveBeenCalled();
+  });
+});

--- a/src/push.ts
+++ b/src/push.ts
@@ -3,7 +3,7 @@ import { autoDetectInit, loadStateForScope, saveStateForScope } from './config.j
 import { assertNotReadOnly } from './read-only.js';
 import {
   createGit, pullRepo, pushRepoBranch, checkoutMaster, generateBranchName,
-  resetToCleanMaster, isDedicatedRepoRoot, getDefaultBranch,
+  resetToCleanMaster, isDedicatedRepoRoot, getDefaultBranch, getFileContentAtRev,
 } from './utils/git.js';
 import { syncTeamUpdatesToLocal } from './utils/pre-push-sync.js';
 import { getProvider } from './providers/index.js';
@@ -14,7 +14,7 @@ import type { GlobalOptions, ResourceItem, ResourceType, LocalConfig, TeamaiConf
 import { assertSafePath, assertSafeResourceName, defaultAllowedRoots } from './utils/path-safety.js';
 import { loadRolesManifest, resolveRoleResourceNamespaces } from './roles.js';
 import { askQuestion, askSelection } from './utils/prompt.js';
-import { pathExists } from './utils/fs.js';
+import { pathExists, readFileSafe, writeFile } from './utils/fs.js';
 
 /**
  * Synthetic toolPaths key used only to make `teamai push` scan the active tree's
@@ -165,6 +165,12 @@ async function pushCore(
   // In self mode the worktree is already a fresh detached checkout of
   // origin/<default>, so resetToCleanMaster/pullRepo (which assume a normal
   // clone on a branch) are neither needed nor safe — skip them.
+  // Uncommitted teamai.yaml edits (e.g. from `teamai source add`, which writes the
+  // file but does not commit) live in the team repo working tree. resetToCleanMaster
+  // below does `git reset --hard`, which would silently destroy them. Capture the
+  // working-tree content before the reset and restore it after pull, so config edits
+  // survive and get committed alongside resources (see gitFiles construction below).
+  let pendingTeamConfig: string | null = null;
   if (!selfMode) {
     const pullSpin = spinner('Pulling latest changes...').start();
     try {
@@ -180,8 +186,20 @@ async function pushCore(
           + 'Run `teamai init` to re-clone the team repo before pushing.');
         return;
       }
+      const yamlPath = path.join(repoPath, 'teamai.yaml');
+      const workingContent = await readFileSafe(yamlPath);
+      if (workingContent !== null) {
+        const committed = await getFileContentAtRev(repoPath, 'HEAD', 'teamai.yaml');
+        if (committed === null || committed.toString() !== workingContent) {
+          pendingTeamConfig = workingContent;
+        }
+      }
       await resetToCleanMaster(git, repoPath);
       await pullRepo(repoPath);
+      if (pendingTeamConfig !== null) {
+        // Re-apply the user's config edits on top of the freshly pulled default branch.
+        await writeFile(yamlPath, pendingTeamConfig);
+      }
       pullSpin.succeed('Up to date');
     } catch (e) {
       pullSpin.warn(`Pull failed: ${(e as Error).message}`);
@@ -355,6 +373,13 @@ async function pushCore(
   }
 
   if (allItems.length === 0) {
+    // No resource changes, but the user may have edited teamai.yaml (sources /
+    // publicSkills) via `teamai source add`. Push that config change on its own
+    // rather than reporting "nothing to push".
+    if (pendingTeamConfig !== null) {
+      await pushTeamConfigOnly(localConfig, teamConfig, options);
+      return;
+    }
     log.info('No new or modified resources to push');
     return;
   }
@@ -524,7 +549,10 @@ async function pushCore(
       localConfig.repo.localPath,
       sweeperCandidates,
     );
-    const gitFiles = [...new Set([...pushedFiles, ...existingSweepers])];
+    // Include teamai.yaml when the user edited it (e.g. `teamai source add`), so
+    // sources / publicSkills changes ride along in the same PR as the resources.
+    const configFiles = pendingTeamConfig !== null ? ['teamai.yaml'] : [];
+    const gitFiles = [...new Set([...pushedFiles, ...existingSweepers, ...configFiles])];
     const branchName = generateBranchName(localConfig.username);
     const commitMsg = `[teamai] Push ${selectedItems.length} resource(s) from ${localConfig.username}`;
 
@@ -588,4 +616,59 @@ async function pushCore(
     }
   }
   await saveStateForScope(state, localConfig.scope, localConfig.projectRoot);
+}
+
+/**
+ * Push a teamai.yaml-only change (e.g. from `teamai source add`) to the team repo
+ * via a PR. Called when the user edited config but changed no resources, so the
+ * normal resource-push path would exit with "No new or modified resources".
+ *
+ * Precondition: the working-tree teamai.yaml already carries the user's edits
+ * (restored after pull in pushCore) and the repo is a dedicated git root.
+ */
+async function pushTeamConfigOnly(
+  localConfig: LocalConfig,
+  teamConfig: TeamaiConfig,
+  options: GlobalOptions,
+): Promise<void> {
+  console.log('');
+  console.log('Found team config change to push:');
+  console.log('  - teamai.yaml');
+  console.log('');
+
+  if (options.dryRun) {
+    log.info('Dry run — no changes made');
+    return;
+  }
+
+  const pushSpin = spinner('Pushing team config...').start();
+  const branchName = generateBranchName(localConfig.username);
+  const commitMsg = `[teamai] Update team config from ${localConfig.username}`;
+
+  try {
+    const hasChanges = await pushRepoBranch(
+      localConfig.repo.localPath,
+      commitMsg,
+      ['teamai.yaml'],
+      branchName,
+    );
+    if (!hasChanges) {
+      pushSpin.succeed('No changes to push (config already up to date)');
+      return;
+    }
+    pushSpin.succeed(`Pushed branch ${branchName}`);
+
+    await createPrWithFallback(
+      teamConfig,
+      localConfig,
+      branchName,
+      commitMsg,
+      'Updated team config (teamai.yaml)',
+    );
+
+    await checkoutMaster(localConfig.repo.localPath);
+  } catch (e) {
+    pushSpin.fail(`Push failed: ${(e as Error).message}`);
+    return;
+  }
 }


### PR DESCRIPTION
## Problem

`teamai source add` (and `source remove`) edits the team repo's `teamai.yaml` — writing the `sources` / `publicSkills` a team subscribes to — and then prints **"Run `teamai push` to share this change with your team."** But `teamai push` did not handle `teamai.yaml` at all, so that advice was broken in three compounding ways:

1. **Data loss.** `push` starts by calling `resetToCleanMaster`, whose `git reset --hard` sees the dirty `teamai.yaml` and **silently discards** the user's `source add` edit before anything is committed.
2. **Never committed.** The push commit file list (`gitFiles`) is a whitelist of resource dirs (`skills/`, `rules/`, `env/`, …). `teamai.yaml` is never in it, so even a surviving edit would be ignored.
3. **Config-only exits early.** If the user only edited `teamai.yaml` (no resource changes), `push` returns at `allItems.length === 0` with *"No new or modified resources to push"* — the change never leaves their machine.

Net effect: subscribing to another team's public skill repo could not actually be shared with the team, and the attempt could destroy the edit.

## Fix

All in `src/push.ts`, on the normal dedicated-repo path (not `self` mode):

- **Preserve the edit across reset** — capture the working-tree `teamai.yaml` before `resetToCleanMaster`, then re-write it on top of the freshly pulled default branch.
- **Commit it with resources** — add `teamai.yaml` to `gitFiles` when the user edited it, so config rides along in the same PR as any skills/rules.
- **Config-only push** — new `pushTeamConfigOnly()` handles the "only `teamai.yaml` changed" case so `source add`'s advice actually works.

The change is **provider-agnostic** — no github/gitlab/tgit special-casing. PR/MR creation goes through the existing `createPrWithFallback` → `getProvider(...).createPullRequest(...)` abstraction, so GitHub, GitLab, and TGit are all covered by the path that already ships skills.

Docs: also corrected `docs/usage-guide.md` / `.zh-CN.md`, which wrongly claimed subscriptions live in the local `config.yaml`. They live in the team repo's `teamai.yaml` and are shared via push.

## Test Plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [x] `npx vitest run` — full suite green (163 files / 2187 tests), zero regressions
- [x] **New real-git integration test** `src/__tests__/push-team-config.test.ts` — drives real `push()` against a local bare remote + clone (mocking only the provider PR call): a `source add`-style edit **survives the real `git reset --hard`** and lands on the pushed branch; a no-op push creates no PR.
- [x] **Real CLI end-to-end** against `git.woa.com` (throwaway `HOME`, isolated from real `~/.teamai`): `teamai init e2e-test-repo` → `teamai source add teamai-dev-repo` → `teamai push --all`. The pushed remote branch's `teamai.yaml` contained `sources: e2e-dev`; baseline `origin/master` had none. Test branch and the auto-created MR were cleaned up afterward.
