### PR TITLE
fix(agents): resolve built-in agents dir with fileURLToPath for Windows

### DIFF
--- a/src/builtin-agents.ts
+++ b/src/builtin-agents.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { ensureDir, pathExists, copyFile } from './utils/fs.js';
 import { log } from './utils/logger.js';
 import type { TeamaiConfig, LocalConfig } from './types.js';
@@ -36,7 +37,10 @@ export const BUILTIN_AGENT_NAMES = new Set<string>(['teamai-recall']);
  * package root, so we walk up to find `agents/`.
  */
 function getBuiltinAgentsDir(): string {
-  const distDir = path.dirname(new URL(import.meta.url).pathname);
+  // __dirname equivalent for ESM: import.meta.url → file path → parent.
+  // Use fileURLToPath (not URL.pathname) so Windows drive-letter paths
+  // resolve correctly — a raw `/C:/…` pathname is not resolvable by fs.
+  const distDir = path.dirname(fileURLToPath(import.meta.url));
   return path.join(distDir, '..', 'agents');
 }
 


### PR DESCRIPTION
## Summary

Refs #322 (intentionally not auto-closing) — on Windows, `teamai pull` silently skipped deploying built-in subagents (`teamai-recall`), so `teamai recall enable` would inject recall rules into `CLAUDE.md` pointing at a subagent that never got deployed.

Root cause: `getBuiltinAgentsDir()` used `new URL(import.meta.url).pathname`, which on Windows produces a leading-slash path like `/C:/.../dist` that `fs` cannot resolve. `pathExists(builtinDir)` then returned `false`, and `deployBuiltinAgents()` took the "dev environment without build step" early return.

Skills were unaffected because the sibling `getBuiltinSkillsDir()` in `src/builtin-skills.ts` already uses `fileURLToPath`. This PR makes `builtin-agents.ts` consistent with it.

## Change

```diff
-  const distDir = path.dirname(new URL(import.meta.url).pathname);
+  const distDir = path.dirname(fileURLToPath(import.meta.url));
```

Plus the `import { fileURLToPath } from 'node:url'` import.

## Test Plan

- [x] `npx tsc --noEmit` — passes
- [x] `npx vitest run` — full suite, 2187 tests pass (163 files)
- [x] `npx vitest run src/__tests__/builtin-agents.test.ts` — 5/5 pass; the `deploys built-in agent files to every installed tool` case actually deploys `teamai-recall.md` to `.claude/agents/` and `.codebuddy/agents/` and asserts the files land
- [x] `npm run build` — passes; verified the compiled `dist/index.js` emits `path.dirname(fileURLToPath(import.meta.url))` and that `../agents/teamai-recall.md` resolves from the `dist/` layout

> Note: the platform-specific `fileURLToPath` divergence can't be reproduced on macOS (the function is platform-aware), but the fix is byte-for-byte the pattern that already works for skills on Windows per the issue report.
