### PR TITLE
docs(readme): trim onboarding, drop Discord, add Distribution/Analytics tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,9 @@
 [![npm downloads](https://img.shields.io/npm/dm/teamai-cli.svg)](https://www.npmjs.com/package/teamai-cli)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-[![User Chat](https://img.shields.io/badge/User_Chat-Discord-5865F2?logo=discord&logoColor=white)](https://discord.gg/gervEZm58g)
-[![Developer Chat](https://img.shields.io/badge/Developer_Chat-Discord-5865F2?logo=discord&logoColor=white)](https://discord.gg/DeHHxPnfZF)
+Make every AI coding agent work by the best harness.
 
-Make every AI coding agent work by the same harness.
-
-Git-native management of skills, rules, and docs across Claude Code / Codex / CodeBuddy / WorkBuddy / OpenCode and more.
-
-For you or your whole team.
+Git-native management of skills, rules, MCP, env vars, knowledge base, and more — across Claude Code / Codex / CodeBuddy / WorkBuddy / OpenCode and more.
 
 ## Quick Start
 
@@ -30,34 +25,24 @@ npm install -g teamai-cli
 
 ### Team admin / solo user
 
-Create a shared-experience repo on your git host (GitHub, GitLab (incl. self-hosted), CNB, TGit, or any private/self-hosted Git service), **grant write access to team members**, then have them run `teamai init https://github.com/yourorg/yourrepo`.
-
-> Self-hosted GitLab/Gitea-style services use your HTTPS credential helper or SSH key. Create the repository first; merge requests are created manually for now. See [Git Provider docs](docs/providers.md).
+Create a shared-experience repo on your git host (GitHub, GitLab, CNB, TGit, or a private Git service), **grant write access to team members**, then run `teamai init https://github.com/yourorg/yourrepo`.
 
 > **No team repo yet?** Start from a template pre-loaded with production-ready skills, rules, and review agents. Browse the [teamai-hub](https://github.com/teamai-hub) org, click **Use this template**, then `teamai init` against your new repo.
 
 ### Team members
 
 ```bash
+# Choose one, depending on where you want resources installed
+
 # Project-scope init (default, resources installed under the project directory)
 cd /path/to/my-project
 teamai init https://github.com/yourorg/yourrepo
 
-# User-scope init (resources installed under ~/)
+# Or, user-scope init (resources installed under ~/)
 teamai init https://github.com/yourorg/yourrepo --scope user
 ```
 
 Once initialized, every AI session automatically pulls the latest skills / rules and other Harness updates published by admins — no manual sync needed.
-
-### Single-repo mode (the business repo *is* the team repo)
-
-No separate team repo. Run `teamai init .` inside an existing project and its own git repo becomes the team repo:
-
-```bash
-cd /path/to/my-project
-teamai init .                        # interactive: pick which AI tools to set up
-teamai init . --agent claude,codex   # non-interactive: Claude Code + Codex
-```
 
 > **Full usage guide:** [docs/usage-guide.md](docs/usage-guide.md) ([中文版](docs/usage-guide.zh-CN.md)) — covers everything from team creation to day-to-day use.
 
@@ -69,7 +54,7 @@ teamai init . --agent claude,codex   # non-interactive: Claude Code + Codex
       <th rowspan="2">Agent</th>
       <th colspan="7">Harness</th>
       <th colspan="3">Knowledge Base</th>
-      <th colspan="3">Governance</th>
+      <th colspan="3">Analytics</th>
     </tr>
     <tr>
       <th>skills</th><th>rules</th><th>docs</th><th>env</th><th>agents</th><th>hooks</th><th>mcp</th>
@@ -90,11 +75,31 @@ teamai init . --agent claude,codex   # non-interactive: Claude Code + Codex
   </tbody>
 </table>
 
-**Git providers** — GitHub · GitLab (incl. self-hosted) · CNB · TGit · any private/self-hosted Git service.
+**Git providers** — GitHub · GitLab · CNB · TGit · private Git service.
+
+### Distribution Controls
+
+Team-wide settings an admin configures once and delivers to every member on `teamai pull`:
+
+| Capability | Command | What it does |
+|------------|---------|--------------|
+| **Roles** | `teamai roles` | Define role → namespace mappings so each member syncs only the skills for their role. |
+| **Tags** | `teamai tags` | Tag skills / rules so members subscribe to just the tags they need. |
+| **Sources** | `teamai source` | Subscribe to additional skill repos — other teams' public repos, or shared/public repos within your own org; subscribed skills sync automatically on pull. |
+
+### Analytics
+
+Insight into how the team actually uses its AI tools:
+
+| Capability | Command | What it shows |
+|------------|---------|---------------|
+| **Usage** | `teamai digest` | Weekly team digest — token usage, conversation volume, and intervention rate. |
+| **Sessions** | `teamai session save` | Privacy-scrubbed per-session summaries (tool sequence, prompt turns, interventions) that feed the digest's Session Highlights. |
+| **Dashboard** | `teamai dashboard` | Web dashboard showing team members' live coding-session status, intervention count, and token usage. |
 
 ## Harness Management & Distribution
 
-TeamAI keeps skills, rules, docs, and hooks in a shared git repo and distributes them to every member's local AI tools through a "push → review & merge → pull" flow — with support for subscribing to other teams' Harness.
+TeamAI keeps skills, rules, docs, and hooks in a shared git repo and distributes them to every member's local AI tools through a "push → review & merge → pull" flow — with support for subscribing to other teams' or shared repos' Harness.
 
 ### How It Works
 
@@ -143,9 +148,9 @@ servers:
 teamai mcp list | inject | remove
 ```
 
-### Cross-team Skill Subscription
+### Skill Subscription Sources
 
-Subscribe to other teams' public skill repos:
+Subscribe to additional skill repos — other teams' public repos, or shared/public repos within your own org:
 
 ```bash
 teamai source add https://github.com/other-team/teamai-public.git --name other-team
@@ -225,8 +230,9 @@ When a recall hit comes from a codebase page, the result includes a `Sources:` l
 | `teamai ci extract-mr --url <url>` | CI: extract knowledge from MR, post comments, write after merge |
 | `teamai members` | List team members |
 | `teamai roles` | Manage team roles and namespaces |
+| `teamai tags` | Manage tag-based skill/rule filtering |
 | `teamai skill exclude add/remove/list` | Manage skills excluded from local sync ([usage guide](docs/usage-guide.md#excluding-skills-you-dont-need)) |
-| `teamai source` | Manage cross-team skill subscriptions |
+| `teamai source` | Manage skill subscription sources (other teams or your org's shared repos) |
 | `teamai remove <type> <name>` | Remove a resource and open MR |
 | `teamai session save` | Record a privacy-scrubbed session summary to a monthly log (`--push` feeds `digest`) |
 | `teamai digest` | Generate weekly team usage digest |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,14 +11,9 @@
 [![npm downloads](https://img.shields.io/npm/dm/teamai-cli.svg)](https://www.npmjs.com/package/teamai-cli)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-[![用户交流](https://img.shields.io/badge/用户交流-Discord-5865F2?logo=discord&logoColor=white)](https://discord.gg/gervEZm58g)
-[![开发者交流](https://img.shields.io/badge/开发者交流-Discord-5865F2?logo=discord&logoColor=white)](https://discord.gg/DeHHxPnfZF)
+面向 AI 智能体的团队 Harness 管理和分发工具。
 
-面向 AI 智能体的团队 Harness 分发工具。
-
-通过 Git 统一管理 skills、rules、docs，驾驭 Claude Code / Codex / CodeBuddy / WorkBuddy / OpenCode 等多种 AI 工具。
-
-一个人也能用，团队用更强。
+通过 Git 统一管理 skills、rules、mcp、环境变量、知识库等 Harness，驾驭 Claude Code / Codex / CodeBuddy / WorkBuddy / OpenCode 等多种 AI 工具。
 
 ## 快速开始
 
@@ -30,34 +25,24 @@ npm install -g teamai-cli
 
 ### 团队管理员 / 个人使用者
 
-在 Git 托管平台（GitHub、GitLab（含自建）、CNB、TGit，或任意私有/自建 Git 服务）创建共享经验仓库，**授予团队成员写权限**，然后让他们运行 `teamai init https://github.com/yourorg/yourrepo`。
-
-> 自建 GitLab/Gitea 等服务支持 HTTPS Credential Helper 或 SSH Key；需预先创建仓库，MR 暂时手动创建。详见 [Git Provider 说明](docs/providers.md)。
+在 Git 托管平台（GitHub、GitLab、CNB、TGit，或私有 Git 服务）创建共享经验仓库，**授予团队成员写权限**，然后运行 `teamai init https://github.com/yourorg/yourrepo`。
 
 > **还没有团队仓库？** 可以从内置了成套 skills、rules、review agents 的模板起步。浏览 [teamai-hub](https://github.com/teamai-hub) org，点 **Use this template** 生成自己的仓库，再对它执行 `teamai init`。
 
 ### 团队成员
 
 ```bash
+# 二选一：按你想要的安装范围选择其中一条
+
 # 项目级初始化（默认，资源安装到项目目录下）
 cd /path/to/my-project
 teamai init https://github.com/yourorg/yourrepo
 
-# 用户级初始化（资源安装到 ~/ 下）
+# 或者，用户级初始化（资源安装到 ~/ 下）
 teamai init https://github.com/yourorg/yourrepo --scope user
 ```
 
 初始化完成后，每次开启 AI 会话时都会自动拉取管理员发布的 skills / rules 等 Harness 更新，无需手动同步。
-
-### 单仓模式（业务仓即团队仓）
-
-无需单独的团队仓库。在已有项目里运行 `teamai init .`，让它自己的 git 仓库直接充当团队仓：
-
-```bash
-cd /path/to/my-project
-teamai init .                        # 交互式：选择要启用哪些 AI 工具
-teamai init . --agent claude,codex   # 非交互:启用 Claude Code + Codex
-```
 
 > **完整使用指南**：[docs/usage-guide.zh-CN.md](docs/usage-guide.zh-CN.md)（[English](docs/usage-guide.md)）— 涵盖从团队创建到日常使用的全流程。
 
@@ -69,7 +54,7 @@ teamai init . --agent claude,codex   # 非交互:启用 Claude Code + Codex
       <th rowspan="2">Agent</th>
       <th colspan="7">Harness</th>
       <th colspan="3">知识库</th>
-      <th colspan="3">治理</th>
+      <th colspan="3">使用分析</th>
     </tr>
     <tr>
       <th>skills</th><th>rules</th><th>docs</th><th>env</th><th>agents</th><th>hooks</th><th>mcp</th>
@@ -90,11 +75,31 @@ teamai init . --agent claude,codex   # 非交互:启用 Claude Code + Codex
   </tbody>
 </table>
 
-**Git 托管平台** —— GitHub · GitLab（含自建）· CNB · TGit · 任意私有/自建 Git 服务。
+**Git 托管平台** —— GitHub · GitLab · CNB · TGit · 私有 Git 服务。
+
+### 分发策略
+
+管理员一次配置、随 `teamai pull` 分发给每位成员的团队级设置：
+
+| 能力 | 命令 | 作用 |
+|------|------|------|
+| **角色（Roles）** | `teamai roles` | 定义「角色 → 命名空间」映射，让每位成员只同步与自身角色匹配的 skills。 |
+| **标签（Tags）** | `teamai tags` | 给 skills / rules 打标签，成员只订阅自己需要的标签。 |
+| **订阅源（Sources）** | `teamai source` | 订阅额外的 skill 仓库——其他团队的公开仓库，或本团队内的公共/共享仓库；已订阅的 skills 会在 pull 时自动同步。 |
+
+### 使用分析
+
+洞察团队实际如何使用 AI 工具：
+
+| 能力 | 命令 | 呈现内容 |
+|------|------|----------|
+| **用量（Usage）** | `teamai digest` | 团队周报——token 用量、会话量、干预率。 |
+| **会话（Sessions）** | `teamai session save` | 脱敏的单会话摘要（工具序列、对话轮次、干预次数），喂给周报的 Session Highlights。 |
+| **看板（Dashboard）** | `teamai dashboard` | Web 看板，实时展示成员的编码会话状态、干预次数和 token 用量。 |
 
 ## Harness 管理和分发
 
-TeamAI 把 skills、rules、docs、hooks 统一存放在共享 Git 仓库，通过「push → 评审合并 → pull」的流程分发到每位成员的本地 AI 工具，并支持订阅其他团队的 Harness。
+TeamAI 把 skills、rules、docs、hooks 统一存放在共享 Git 仓库，通过「push → 评审合并 → pull」的流程分发到每位成员的本地 AI 工具，并支持订阅其他团队或公共仓库的 Harness。
 
 ### 工作原理
 
@@ -143,9 +148,9 @@ servers:
 teamai mcp list | inject | remove
 ```
 
-### 跨团队 Skill 订阅
+### Skill 订阅源
 
-订阅其他团队的公开 skill 仓库：
+订阅额外的 skill 仓库——其他团队的公开仓库，或本团队内的公共/共享仓库：
 
 ```bash
 teamai source add https://github.com/other-team/teamai-public.git --name other-team
@@ -225,8 +230,9 @@ teamai codebase --lint                      # 健康检查
 | `teamai ci extract-mr --url <url>` | CI：从 MR 提取知识、发评论、合并后写入 |
 | `teamai members` | 查看团队成员 |
 | `teamai roles` | 管理团队角色和命名空间 |
+| `teamai tags` | 管理基于标签的 skill/rule 过滤 |
 | `teamai skill exclude add/remove/list` | 管理不参与本地同步的 skills（[使用指南](docs/usage-guide.zh-CN.md#排除个人不需要的-skill)） |
-| `teamai source` | 管理跨团队 skill 订阅 |
+| `teamai source` | 管理 skill 订阅源（其他团队或本团队公共仓库） |
 | `teamai remove <type> <name>` | 删除资源并创建 MR |
 | `teamai session save` | 将脱敏后的 session 摘要记录到月度日志（`--push` 可喂给 `digest`） |
 | `teamai digest` | 生成团队周报 |


### PR DESCRIPTION
## What

README cleanup pass on both `README.md` and `README.zh-CN.md` (kept in sync).

- **Drop Discord badges** — the two community chat badges pointed to channels no one joins.
- **Trim tagline & onboarding** — remove the "For you or your whole team." line and the single-repo-mode section; the tagline now lists the real Harness surface (skills / rules / MCP / env vars / knowledge base).
- **Clarify scope init** — project- vs user-scope `teamai init` are now explicitly a *choose-one* pair, not two sequential steps.
- **Overview group rename** — the third column group `Governance` → `Analytics`, since `usage / sessions / dashboard` are usage-analytics features, not governance.
- **Two new Overview tables** —
  - **Distribution Controls**: `roles` / `tags` / `sources` (admin-configured, delivered on pull).
  - **Analytics**: `usage` (`teamai digest`) / `sessions` (`teamai session save`) / `dashboard` (`teamai dashboard`), each with what it shows.
- **Widen Sources** — `teamai source` now covers both other teams' public repos *and* your org's own shared/public repos; the detailed section title and command-reference row are aligned to match.
- **Add missing `teamai tags`** to the command reference table.
- **Simplify Git provider list** wording.

## Test Plan

- [x] `npm run build` passes.
- [x] Docs-only change; no code paths touched (`git diff --stat` shows only the two README files).
- [x] EN/ZH heading structure verified 1:1; `cross-team` / 跨团队 wording fully removed; `teamai tags` present in both overview and command tables; Sources wording consistent across overview / detail section / command table.
- [x] Feature descriptions cross-checked against `docs/usage-guide.md` (digest / session save / dashboard).