### PR TITLE
test(e2e): match English uninstall output after #326

### DIFF
--- a/src/__tests__/e2e/e2e.test.ts
+++ b/src/__tests__/e2e/e2e.test.ts
@@ -580,7 +580,7 @@ describe('remote commands', () => {
       // Step 1: Uninstall everything
       const uninstallResult = await runCLI(['uninstall', '--force']);
       expect(uninstallResult.code).toBe(0);
-      expect(uninstallResult.output).toContain('卸载完成');
+      expect(uninstallResult.output).toContain('teamai uninstalled');
 
       // Step 2: Verify cleanup — config.yaml should not exist
       const teamaiHome = path.join(process.env.HOME ?? '', '.teamai');

--- a/src/__tests__/scope-isolation-e2e.test.ts
+++ b/src/__tests__/scope-isolation-e2e.test.ts
@@ -174,6 +174,6 @@ describe('scope isolation e2e (issue #73)', () => {
   it('uninstall --dry-run: states it is acting on the project scope', async () => {
     const res = await runCLI(['uninstall', '--dry-run', '--force'], { HOME: homeDir }, projectRoot);
     expect(res.code, res.output).toBe(0);
-    expect(res.output).toContain('正在卸载 project scope（项目级）');
+    expect(res.output).toContain('Uninstalling project scope');
   });
 });


### PR DESCRIPTION
## Summary

- `main` CI has been red since #326 ([run 32938621010](https://github.com/Tencent/teamai-cli/actions/runs/32938621010)). #326 translated `src/uninstall.ts` user-facing output to English, but two e2e assertions still expected the old Chinese strings.
- Updated both assertions to the English output. The English output is the intended behavior per the "CLI output must be English" rule, so only the stale assertions needed changing — no production code touched.
  - `src/__tests__/e2e/e2e.test.ts`: `'卸载完成'` -> `'teamai uninstalled'`
  - `src/__tests__/scope-isolation-e2e.test.ts`: `'正在卸载 project scope（项目级）'` -> `'Uninstalling project scope'`
- Confirmed these are the only two remaining Chinese assertions in the e2e suite.

### Why #326 went in green

Worth flagging separately: #326's PR-level `e2e` job never ran. It was queued behind the `e2e-fixture-repo` concurrency lock (`cancel-in-progress: false`) and was dropped when the PR merged. Its post-merge run on `main` was then cancelled by the workflow-level `cancel-in-progress: true` when the next commit landed. So the merge path can silently skip e2e entirely — that gap is not addressed here and probably deserves its own fix.

The published `0.21.0-beta.3` is unaffected: this was a stale test assertion, not a product bug.

## Test plan

All executed locally against a real build (`npm run build`), not just type check:

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 164 files / 2228 tests passed
- [x] `npx vitest run --config vitest.e2e.config.ts` — 11 files / 64 tests passed, 24 skipped (the remote-gated ones that need the CI fixture repo credentials)
- [x] `scope-isolation-e2e.test.ts > uninstall --dry-run: states it is acting on the project scope` — passes locally (does not need remote fixtures)
- [x] Verified `teamai uninstalled` is really emitted: ran the built CLI as `HOME=<sandbox> node dist/index.js uninstall --force` against a throwaway home, output ends with `✔ teamai uninstalled`. The valid-config path (`uninstall.ts:825`) prints the same string, as shown in the failing CI log.
- [ ] CI e2e job on this PR (needs the fixture repo, only runnable in CI)

Made with [Cursor](https://cursor.com)