### PR TITLE
fix(pull): preserve role isolation for tag subscriptions

### DIFF
--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -357,7 +357,7 @@ teamai status        # Current scope, last sync time, resource stats
 
 ### Role management
 
-Roles control which skills each member sees. Admins define roles via `manifest/roles.yaml`; once a member selects their role, `pull` only syncs skills from the matching namespace.
+Roles control which skills each member sees. Admins define roles via `manifest/roles.yaml`; once a member selects their role, `pull` syncs skills from the matching namespace. Active tag subscriptions may additionally sync explicitly matching skills from other namespaces, but untagged skills in inactive namespaces are not included.
 
 **Admin operations:**
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -355,7 +355,7 @@ teamai status        # 当前 scope、同步时间、资源统计
 
 ### 角色管理
 
-角色（Roles）控制每个成员看到哪些 skills。管理员通过 `manifest/roles.yaml` 定义角色，成员选择自己的角色后，pull 只同步对应 namespace 的 skills。
+角色（Roles）控制每个成员看到哪些 skills。管理员通过 `manifest/roles.yaml` 定义角色，成员选择自己的角色后，pull 会同步对应 namespace 的 skills。启用标签订阅后，还可以额外同步其他 namespace 中显式匹配标签的 skills，但不会包含非活跃 namespace 中未打标签的 skills。
 
 **管理员操作：**
 

--- a/src/__tests__/e2e/roles-tags-pull.test.ts
+++ b/src/__tests__/e2e/roles-tags-pull.test.ts
@@ -1,0 +1,146 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { execFileSync, spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const CLI = path.join(ROOT, 'dist', 'index.js');
+
+interface RunResult {
+  code: number | null;
+  output: string;
+}
+
+function runCLI(args: string[], homeDir: string, cwd: string): Promise<RunResult> {
+  return new Promise((resolve) => {
+    const child = spawn('node', [CLI, ...args], {
+      cwd,
+      env: { ...process.env, FORCE_COLOR: '0', HOME: homeDir },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let output = '';
+    child.stdout.on('data', (data: Buffer) => { output += data.toString(); });
+    child.stderr.on('data', (data: Buffer) => { output += data.toString(); });
+    child.on('close', (code) => resolve({ code, output }));
+  });
+}
+
+function git(args: string[], cwd: string): void {
+  execFileSync('git', args, {
+    cwd,
+    stdio: 'pipe',
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'TeamAI CI',
+      GIT_AUTHOR_EMAIL: 'ci@teamai.test',
+      GIT_COMMITTER_NAME: 'TeamAI CI',
+      GIT_COMMITTER_EMAIL: 'ci@teamai.test',
+    },
+  });
+}
+
+function writeSkill(repoPath: string, namespace: string, name: string): void {
+  const skillDir = path.join(repoPath, 'skills', namespace, name);
+  fs.mkdirSync(skillDir, { recursive: true });
+  fs.writeFileSync(path.join(skillDir, 'SKILL.md'), `# ${name}\n`);
+}
+
+describe('roles and tags pull integration', () => {
+  let sandbox: string;
+  let homeDir: string;
+  let projectRoot: string;
+
+  beforeAll(() => {
+    if (!fs.existsSync(CLI)) {
+      throw new Error(`CLI binary not found at ${CLI}. Run "npm run build" first.`);
+    }
+
+    sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-roles-tags-e2e-'));
+    homeDir = path.join(sandbox, 'home');
+    projectRoot = path.join(sandbox, 'project');
+    const remoteRepo = path.join(sandbox, 'remote');
+    const localRepo = path.join(projectRoot, '.teamai', 'team-repo');
+
+    fs.mkdirSync(homeDir, { recursive: true });
+    fs.mkdirSync(path.join(projectRoot, '.claude', 'skills'), { recursive: true });
+    fs.mkdirSync(path.join(remoteRepo, 'manifest'), { recursive: true });
+
+    fs.writeFileSync(path.join(remoteRepo, 'teamai.yaml'), [
+      'team: roles-tags-e2e',
+      `repo: ${remoteRepo}`,
+      'provider: tgit',
+      'toolPaths:',
+      '  claude:',
+      '    skills: .claude/skills',
+      '    rules: .claude/rules',
+      '',
+    ].join('\n'));
+    fs.writeFileSync(path.join(remoteRepo, 'manifest', 'roles.yaml'), [
+      'version: 1',
+      'roles:',
+      '  - id: backend',
+      '    resources:',
+      '      knowledge: [common, backend]',
+      '      skills: [backend]',
+      '  - id: frontend',
+      '    resources:',
+      '      knowledge: [common, frontend]',
+      '      skills: [frontend]',
+      '',
+    ].join('\n'));
+    fs.writeFileSync(path.join(remoteRepo, 'tags.yaml'), [
+      'skills:',
+      '  beta-tag-wanted: [wanted]',
+      '  beta-tag-other: [other]',
+      '',
+    ].join('\n'));
+    writeSkill(remoteRepo, 'backend', 'backend-only');
+    writeSkill(remoteRepo, 'frontend', 'beta-tag-wanted');
+    writeSkill(remoteRepo, 'frontend', 'beta-tag-other');
+    writeSkill(remoteRepo, 'frontend', 'frontend-only');
+
+    git(['init', '-q', '-b', 'main'], remoteRepo);
+    git(['add', '-A'], remoteRepo);
+    git(['commit', '-q', '-m', 'fixture'], remoteRepo);
+    git(['clone', '-q', remoteRepo, localRepo], sandbox);
+
+    fs.writeFileSync(path.join(projectRoot, '.teamai', 'config.yaml'), [
+      'repo:',
+      `  localPath: ${localRepo}`,
+      `  remote: ${remoteRepo}`,
+      'username: ci-user',
+      'updatePolicy: auto',
+      'scope: project',
+      `projectRoot: ${projectRoot}`,
+      '',
+    ].join('\n'));
+  });
+
+  afterAll(() => {
+    if (sandbox) fs.rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  it('syncs active-role skills and explicit cross-role tag matches only', async () => {
+    const roleResult = await runCLI(['roles', 'set', 'backend'], homeDir, projectRoot);
+    expect(roleResult.code, roleResult.output).toBe(0);
+
+    const tagResult = await runCLI(['tags', 'subscribe', 'wanted'], homeDir, projectRoot);
+    expect(tagResult.code, tagResult.output).toBe(0);
+
+    const pullResult = await runCLI(['pull', '--force'], homeDir, projectRoot);
+    expect(pullResult.code, pullResult.output).toBe(0);
+    expect(pullResult.output).toContain('backend-only');
+    expect(pullResult.output).toContain('beta-tag-wanted');
+    expect(pullResult.output).not.toContain('beta-tag-other');
+    expect(pullResult.output).not.toContain('frontend-only');
+
+    const skillsDir = path.join(projectRoot, '.claude', 'skills');
+    expect(fs.existsSync(path.join(skillsDir, 'backend-only', 'SKILL.md'))).toBe(true);
+    expect(fs.existsSync(path.join(skillsDir, 'beta-tag-wanted', 'SKILL.md'))).toBe(true);
+    expect(fs.existsSync(path.join(skillsDir, 'beta-tag-other'))).toBe(false);
+    expect(fs.existsSync(path.join(skillsDir, 'frontend-only'))).toBe(false);
+  });
+});

--- a/src/__tests__/pull-tombstone.test.ts
+++ b/src/__tests__/pull-tombstone.test.ts
@@ -236,6 +236,64 @@ describe('pull role-aware sync and cleanup', () => {
     expect(await fse.pathExists(path.join(homeDir, '.claude/skills', 'pm-skill', 'SKILL.md'))).toBe(false);
   });
 
+  it('only augments role-scoped skills with explicit tag matches', async () => {
+    await fse.ensureDir(path.join(repoPath, 'skills', 'hai', 'backend-only'));
+    await fse.writeFile(path.join(repoPath, 'skills', 'hai', 'backend-only', 'SKILL.md'), '# Backend');
+    await fse.ensureDir(path.join(repoPath, 'skills', 'pm', 'beta-tag-wanted'));
+    await fse.writeFile(path.join(repoPath, 'skills', 'pm', 'beta-tag-wanted', 'SKILL.md'), '# Wanted');
+    await fse.ensureDir(path.join(repoPath, 'skills', 'pm', 'beta-tag-other'));
+    await fse.writeFile(path.join(repoPath, 'skills', 'pm', 'beta-tag-other', 'SKILL.md'), '# Other');
+    await fse.ensureDir(path.join(repoPath, 'skills', 'pm', 'frontend-only'));
+    await fse.writeFile(path.join(repoPath, 'skills', 'pm', 'frontend-only', 'SKILL.md'), '# Frontend');
+    await fse.writeFile(path.join(repoPath, 'tags.yaml'), [
+      'skills:',
+      '  beta-tag-wanted: [wanted]',
+      '  beta-tag-other: [other]',
+      '',
+    ].join('\n'));
+
+    vi.mocked(loadLocalConfigForScope).mockResolvedValue({
+      repo: { localPath: repoPath, remote: 'https://git.woa.com/test/repo.git' },
+      username: 'testuser',
+      updatePolicy: 'auto',
+      primaryRole: 'hai',
+      additionalRoles: [],
+      resourceProfileVersion: 1,
+      scope: 'user',
+      subscribedTags: ['wanted'],
+    });
+    const { log } = await import('../utils/logger.js');
+    vi.mocked(log.dim).mockClear();
+
+    await pull({ force: true });
+
+    const detailOutput = vi.mocked(log.dim).mock.calls.flat().join('\n');
+    expect(detailOutput).toContain('backend-only');
+    expect(detailOutput).toContain('beta-tag-wanted');
+    expect(detailOutput).not.toContain('beta-tag-other');
+    expect(detailOutput).not.toContain('frontend-only');
+    expect(await fse.pathExists(path.join(homeDir, '.claude/skills', 'backend-only', 'SKILL.md'))).toBe(true);
+    expect(await fse.pathExists(path.join(homeDir, '.claude/skills', 'beta-tag-wanted', 'SKILL.md'))).toBe(true);
+    expect(await fse.pathExists(path.join(homeDir, '.claude/skills', 'beta-tag-other'))).toBe(false);
+    expect(await fse.pathExists(path.join(homeDir, '.claude/skills', 'frontend-only'))).toBe(false);
+  });
+
+  it('removes a cross-role tagged skill after its subscription is cleared', async () => {
+    await fse.ensureDir(path.join(repoPath, 'skills', 'pm', 'beta-tag-wanted'));
+    await fse.writeFile(path.join(repoPath, 'skills', 'pm', 'beta-tag-wanted', 'SKILL.md'), '# Wanted');
+    await fse.writeFile(path.join(repoPath, 'tags.yaml'), [
+      'skills:',
+      '  beta-tag-wanted: [wanted]',
+      '',
+    ].join('\n'));
+    await fse.ensureDir(path.join(homeDir, '.claude/skills', 'beta-tag-wanted'));
+    await fse.writeFile(path.join(homeDir, '.claude/skills', 'beta-tag-wanted', 'SKILL.md'), '# Previously synced');
+
+    await pull({ force: true });
+
+    expect(await fse.pathExists(path.join(homeDir, '.claude/skills', 'beta-tag-wanted'))).toBe(false);
+  });
+
   it('removes stale skills from namespaces that are no longer active', async () => {
     await fse.ensureDir(path.join(homeDir, '.claude/skills', 'pm-skill'));
     await fse.writeFile(path.join(homeDir, '.claude/skills', 'pm-skill', 'SKILL.md'), '# PM');

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -199,7 +199,7 @@ export async function scanRoleAwareSkills(localConfig: LocalConfig, namespaces: 
 export async function cleanupInactiveNamespaceSkills(
   teamConfig: TeamaiConfig,
   localConfig: LocalConfig,
-  activeSkillNames: Set<string>,
+  retainedSkillNames: Set<string>,
   inactiveSkillNames: Set<string>,
 ): Promise<void> {
   const baseDir = resolveBaseDir(localConfig);
@@ -213,7 +213,7 @@ export async function cleanupInactiveNamespaceSkills(
     const localSkillNames = await listDirs(path.join(baseDir, toolPath.skills));
     for (const skillName of localSkillNames) {
       if (BUILTIN_SKILL_NAMES.has(skillName)) continue;
-      if (activeSkillNames.has(skillName)) continue;
+      if (retainedSkillNames.has(skillName)) continue;
       if (!inactiveSkillNames.has(skillName)) continue;
 
       const localSkillDir = path.join(baseDir, toolPath.skills, skillName);
@@ -429,7 +429,11 @@ async function pullForScope(
       let tagIncluded: ResourceItem[] = [];
       if (hasActiveTagSubscriptions) {
         const tagResult = filterByTags(allTeamSkills, tagsConfig, subscribedTags, 'skills');
-        tagIncluded = tagResult.included;
+        const subscribedTagSet = new Set(subscribedTags);
+        tagIncluded = tagResult.included.filter((item) => {
+          const itemTags = tagsConfig.skills[item.name];
+          return itemTags?.some((tag) => subscribedTagSet.has(tag));
+        });
         skippedByTags = tagResult.skipped.length;
       }
 
@@ -554,7 +558,7 @@ async function pullForScope(
       await cleanupInactiveNamespaceSkills(
         freshConfig,
         localConfig,
-        roleContext.activeSkillNames,
+        desiredSkillNames ?? roleContext.activeSkillNames,
         roleContext.inactiveSkillNames,
       );
     }


### PR DESCRIPTION
## Summary
- restrict the tag augmentation channel to explicitly matching skills so inactive namespaces cannot leak untagged skills
- retain valid cross-role tag matches during inactive-namespace cleanup and remove them after unsubscribe
- add unit/integration coverage, a real CLI E2E fixture, and synchronized English/Chinese documentation

Closes #334

## Test plan
- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm test` (2230 tests)
- [x] `npm run test:e2e -- src/__tests__/e2e/roles-tags-pull.test.ts`
- [x] Real CLI flow: `roles set backend` → `tags subscribe wanted` → `pull --force`

Made with [Cursor](https://cursor.com)