### PR TITLE
fix(push): commit role-scoped skill changes

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -45,7 +45,7 @@ teamai init git@code.qschou.com:Enterprise/arb-workflow-kit.git --scope user
 - HTTPS：预先配置 Git Credential Helper；不要把用户名、密码或 Token 写进 URL。
 - SSH：预先配置 SSH Key，并确保 `ssh-agent` 能访问私钥。
 
-clone、pull、push 均可正常使用。平台 API 操作（自动建仓、自动创建 MR/PR）无法跨不同服务统一实现，因此暂不支持；`teamai push` 会先推送分支，再提示用户到对应平台手动创建 MR。
+clone、pull、push 均可正常使用。平台 API 操作（自动建仓、自动创建 MR/PR）无法跨不同服务统一实现，因此暂不支持；`teamai push` 会先推送分支，再提示用户到对应平台手动创建 MR，并以非零退出码表明自动 PR/MR 创建未完成。
 
 ## GitHub Provider
 

--- a/src/__tests__/git.test.ts
+++ b/src/__tests__/git.test.ts
@@ -14,6 +14,7 @@ const mockGit = {
   addConfig: vi.fn(),
   revparse: vi.fn().mockResolvedValue('main'),
   reset: vi.fn(),
+  clean: vi.fn(),
   merge: vi.fn(),
   diff: vi.fn().mockResolvedValue('+some real content change\n'),
 };
@@ -137,6 +138,8 @@ describe('pushRepoBranch', () => {
     expect(result).toBe(false);
     expect(mockGit.checkout).toHaveBeenCalledWith('master');
     expect(mockGit.deleteLocalBranch).toHaveBeenCalledWith('teamai/push/test/456', true);
+    expect(mockGit.reset).toHaveBeenCalledWith(['--hard', 'HEAD']);
+    expect(mockGit.clean).toHaveBeenCalledWith('f', ['-d']);
     expect(mockGit.commit).not.toHaveBeenCalled();
     expect(mockGit.push).not.toHaveBeenCalled();
   });
@@ -158,6 +161,8 @@ describe('pushRepoBranch', () => {
     expect(mockGit.diff).toHaveBeenCalledWith(['--cached', '--unified=0']);
     expect(mockGit.checkout).toHaveBeenCalledWith('master');
     expect(mockGit.deleteLocalBranch).toHaveBeenCalledWith('teamai/push/test/789', true);
+    expect(mockGit.reset).toHaveBeenCalledWith(['--hard', 'HEAD']);
+    expect(mockGit.clean).toHaveBeenCalledWith('f', ['-d']);
     expect(mockGit.commit).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/push-role-skill-e2e.test.ts
+++ b/src/__tests__/push-role-skill-e2e.test.ts
@@ -1,0 +1,331 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { execFileSync, spawn } from 'node:child_process';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..', '..');
+const CLI = path.join(ROOT, 'dist', 'index.js');
+
+const GIT_ENV = {
+  GIT_AUTHOR_NAME: 'TeamAI CI',
+  GIT_AUTHOR_EMAIL: 'ci@teamai.test',
+  GIT_COMMITTER_NAME: 'TeamAI CI',
+  GIT_COMMITTER_EMAIL: 'ci@teamai.test',
+};
+
+interface RunResult {
+  code: number | null;
+  output: string;
+}
+
+function git(args: string[], cwd: string): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, ...GIT_ENV },
+  }).trim();
+}
+
+function runCLI(
+  args: string[],
+  cwd: string,
+  home: string,
+  envOverrides: Record<string, string> = {},
+): Promise<RunResult> {
+  return new Promise((resolve) => {
+    const child = spawn('node', [CLI, ...args], {
+      cwd,
+      env: {
+        ...process.env,
+        ...GIT_ENV,
+        HOME: home,
+        FORCE_COLOR: '0',
+        ...envOverrides,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let output = '';
+    child.stdout.on('data', (data: Buffer) => { output += data.toString(); });
+    child.stderr.on('data', (data: Buffer) => { output += data.toString(); });
+    child.on('close', (code) => resolve({ code, output }));
+  });
+}
+
+interface PushFixture {
+  sandbox: string;
+  home: string;
+  projectRoot: string;
+  remote: string;
+}
+
+function makePushFixture(provider: 'github' | 'gitlab', repoUrl: string): PushFixture {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), `teamai-push-${provider}-e2e-`));
+  const home = path.join(sandbox, 'home');
+  const projectRoot = path.join(sandbox, 'project');
+  const seed = path.join(sandbox, 'seed');
+  const remote = path.join(sandbox, 'team.git');
+  const teamRepo = path.join(projectRoot, '.teamai', 'team-repo');
+
+  fs.mkdirSync(home, { recursive: true });
+  fs.mkdirSync(path.join(projectRoot, '.claude', 'skills'), { recursive: true });
+  fs.mkdirSync(path.join(seed, 'skills', 'backend', 'beta-proof'), { recursive: true });
+  fs.writeFileSync(
+    path.join(seed, 'teamai.yaml'),
+    [
+      `team: issue-331-${provider}`,
+      `repo: ${repoUrl}`,
+      `provider: ${provider}`,
+      'reviewers: []',
+      'toolPaths:',
+      '  claude:',
+      '    skills: .claude/skills',
+    ].join('\n'),
+  );
+  fs.writeFileSync(
+    path.join(seed, 'skills', 'backend', 'beta-proof', 'SKILL.md'),
+    '---\nname: beta-proof\ndescription: original\n---\n\n# Original\n',
+  );
+  git(['init', '-q', '-b', 'main'], seed);
+  git(['add', '-A'], seed);
+  git(['commit', '-q', '-m', 'seed'], seed);
+  git(['clone', '-q', '--bare', seed, remote], sandbox);
+  git(['clone', '-q', remote, teamRepo], projectRoot);
+  fs.writeFileSync(
+    path.join(projectRoot, '.teamai', 'config.yaml'),
+    [
+      'repo:',
+      `  localPath: ${teamRepo}`,
+      `  remote: ${remote}`,
+      `username: issue-331-${provider}`,
+      'updatePolicy: auto',
+      'primaryRole: backend',
+      'additionalRoles: []',
+      'scope: project',
+      `projectRoot: ${projectRoot}`,
+    ].join('\n'),
+  );
+
+  return { sandbox, home, projectRoot, remote };
+}
+
+async function pullModifyAndPush(
+  fixture: PushFixture,
+  envOverrides: Record<string, string> = {},
+): Promise<RunResult> {
+  const pullResult = await runCLI(
+    ['pull'],
+    fixture.projectRoot,
+    fixture.home,
+    envOverrides,
+  );
+  expect(pullResult.code, pullResult.output).toBe(0);
+
+  fs.writeFileSync(
+    path.join(fixture.projectRoot, '.claude', 'skills', 'beta-proof', 'SKILL.md'),
+    '---\nname: beta-proof\ndescription: modified\n---\n\n# Modified locally\n',
+  );
+  return runCLI(
+    ['push', '--skill', '.claude/skills/beta-proof', '--role', 'backend', '--all'],
+    fixture.projectRoot,
+    fixture.home,
+    envOverrides,
+  );
+}
+
+describe('role-scoped skill push e2e (issue #331)', () => {
+  let sandbox: string;
+  let home: string;
+  let projectRoot: string;
+  let remote: string;
+  let teamRepo: string;
+  let pushResult: RunResult;
+
+  beforeAll(async () => {
+    if (!fs.existsSync(CLI)) {
+      throw new Error(`CLI binary not found at ${CLI}. Run "npm run build" first.`);
+    }
+
+    sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-push-role-e2e-'));
+    home = path.join(sandbox, 'home');
+    projectRoot = path.join(sandbox, 'project');
+    const seed = path.join(sandbox, 'seed');
+    remote = path.join(sandbox, 'team.git');
+    teamRepo = path.join(projectRoot, '.teamai', 'team-repo');
+
+    fs.mkdirSync(home, { recursive: true });
+    fs.mkdirSync(path.join(projectRoot, '.claude', 'skills'), { recursive: true });
+    fs.mkdirSync(path.join(seed, 'skills', 'backend', 'beta-proof'), { recursive: true });
+    fs.writeFileSync(
+      path.join(seed, 'teamai.yaml'),
+      [
+        'team: issue-331',
+        'repo: https://git.example.test/team/issue-331.git',
+        'provider: git',
+        'reviewers: []',
+        'toolPaths:',
+        '  claude:',
+        '    skills: .claude/skills',
+      ].join('\n'),
+    );
+    fs.writeFileSync(
+      path.join(seed, 'skills', 'backend', 'beta-proof', 'SKILL.md'),
+      '---\nname: beta-proof\ndescription: original\n---\n\n# Original\n',
+    );
+    git(['init', '-q', '-b', 'main'], seed);
+    git(['add', '-A'], seed);
+    git(['commit', '-q', '-m', 'seed'], seed);
+    git(['clone', '-q', '--bare', seed, remote], sandbox);
+
+    fs.mkdirSync(projectRoot, { recursive: true });
+    git(['clone', '-q', remote, teamRepo], projectRoot);
+    fs.writeFileSync(
+      path.join(projectRoot, '.teamai', 'config.yaml'),
+      [
+        'repo:',
+        `  localPath: ${teamRepo}`,
+        `  remote: ${remote}`,
+        'username: issue-331-user',
+        'updatePolicy: auto',
+        'primaryRole: backend',
+        'additionalRoles: []',
+        'scope: project',
+        `projectRoot: ${projectRoot}`,
+      ].join('\n'),
+    );
+
+    const pullResult = await runCLI(['pull'], projectRoot, home);
+    expect(pullResult.code, pullResult.output).toBe(0);
+
+    fs.writeFileSync(
+      path.join(projectRoot, '.claude', 'skills', 'beta-proof', 'SKILL.md'),
+      '---\nname: beta-proof\ndescription: modified\n---\n\n# Modified locally\n',
+    );
+
+    pushResult = await runCLI(
+      ['push', '--skill', '.claude/skills/beta-proof', '--role', 'backend', '--all'],
+      projectRoot,
+      home,
+    );
+  }, 60_000);
+
+  afterAll(() => {
+    if (sandbox) fs.rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  it('commits and pushes the modified skill and contributor metadata', () => {
+    expect(pushResult.output).not.toContain('No changes to push');
+    expect(pushResult.output).toContain('Pushed branch teamai/push/issue-331-user/');
+
+    const branch = git(
+      ['for-each-ref', '--format=%(refname:short)', 'refs/heads/teamai/push/issue-331-user/'],
+      remote,
+    );
+    expect(branch).toMatch(/^teamai\/push\/issue-331-user\//);
+    expect(git(['show', `${branch}:skills/backend/beta-proof/SKILL.md`], remote))
+      .toContain('# Modified locally');
+    expect(git(['show', `${branch}:skills/backend/beta-proof/CONTRIBUTORS`], remote))
+      .toBe('issue-331-user');
+  });
+
+  it('returns the generic Git unsupported-PR failure', () => {
+    expect(pushResult.code, pushResult.output).not.toBe(0);
+    expect(pushResult.output)
+      .toContain('Automatic pull/merge request creation is not supported for generic Git hosts.');
+  });
+});
+
+describe('role-scoped skill provider PR creation e2e (issue #331)', () => {
+  it('commits, pushes, and creates a GitHub PR', async () => {
+    const fixture = makePushFixture('github', 'https://github.com/team/issue-331.git');
+    const binDir = path.join(fixture.sandbox, 'bin');
+    const ghLog = path.join(fixture.sandbox, 'gh.log');
+    fs.mkdirSync(binDir);
+    fs.writeFileSync(
+      path.join(binDir, 'gh'),
+      '#!/bin/sh\nprintf "%s\\n" "$*" > "$TEAMAI_FAKE_GH_LOG"\nprintf "%s\\n" "https://github.com/team/issue-331/pull/331"\n',
+      { mode: 0o755 },
+    );
+
+    try {
+      const result = await pullModifyAndPush(fixture, {
+        PATH: `${binDir}:${process.env.PATH ?? ''}`,
+        TEAMAI_FAKE_GH_LOG: ghLog,
+      });
+
+      expect(result.code, result.output).toBe(0);
+      expect(result.output).toContain('Pull Request created: https://github.com/team/issue-331/pull/331');
+      expect(fs.readFileSync(ghLog, 'utf8')).toContain('pr create -R team/issue-331');
+
+      const branch = git(
+        ['for-each-ref', '--format=%(refname:short)', 'refs/heads/teamai/push/issue-331-github/'],
+        fixture.remote,
+      );
+      expect(branch).toMatch(/^teamai\/push\/issue-331-github\//);
+      expect(git(['show', `${branch}:skills/backend/beta-proof/SKILL.md`], fixture.remote))
+        .toContain('# Modified locally');
+      expect(git(['show', `${branch}:skills/backend/beta-proof/CONTRIBUTORS`], fixture.remote))
+        .toBe('issue-331-github');
+    } finally {
+      fs.rmSync(fixture.sandbox, { recursive: true, force: true });
+    }
+  }, 60_000);
+
+  it('commits, pushes, and creates a GitLab MR', async () => {
+    const requestPaths: string[] = [];
+    let requestBody = '';
+    const server = http.createServer((request, response) => {
+      requestPaths.push(request.url ?? '');
+      request.on('data', (chunk: Buffer) => { requestBody += chunk.toString(); });
+      request.on('end', () => {
+        response.writeHead(201, { 'content-type': 'application/json' });
+        response.end(JSON.stringify({
+          iid: 331,
+          web_url: 'https://gitlab.example.test/team/issue-331/-/merge_requests/331',
+        }));
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      server.close();
+      throw new Error('Failed to start the fake GitLab API server.');
+    }
+    const gitlabUrl = `http://127.0.0.1:${address.port}`;
+    const fixture = makePushFixture('gitlab', `${gitlabUrl}/team/issue-331.git`);
+
+    try {
+      const result = await pullModifyAndPush(fixture, {
+        GITLAB_URL: gitlabUrl,
+        GITLAB_TOKEN: 'test-token',
+      });
+
+      expect(result.code, result.output).toBe(0);
+      expect(result.output)
+        .toContain('Pull Request created: https://gitlab.example.test/team/issue-331/-/merge_requests/331');
+      expect(requestPaths).toEqual(['/api/v4/projects/team%2Fissue-331/merge_requests']);
+      expect(JSON.parse(requestBody)).toMatchObject({
+        source_branch: expect.stringMatching(/^teamai\/push\/issue-331-gitlab\//),
+        target_branch: 'main',
+      });
+
+      const branch = git(
+        ['for-each-ref', '--format=%(refname:short)', 'refs/heads/teamai/push/issue-331-gitlab/'],
+        fixture.remote,
+      );
+      expect(branch).toMatch(/^teamai\/push\/issue-331-gitlab\//);
+      expect(git(['show', `${branch}:skills/backend/beta-proof/SKILL.md`], fixture.remote))
+        .toContain('# Modified locally');
+      expect(git(['show', `${branch}:skills/backend/beta-proof/CONTRIBUTORS`], fixture.remote))
+        .toBe('issue-331-gitlab');
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => error ? reject(error) : resolve());
+      });
+      fs.rmSync(fixture.sandbox, { recursive: true, force: true });
+    }
+  }, 60_000);
+});

--- a/src/__tests__/push-role.test.ts
+++ b/src/__tests__/push-role.test.ts
@@ -290,6 +290,90 @@ describe('push namespace routing', () => {
     expect(pushedItems[0].relativePath).toBe('skills/pm/skill-a');
   });
 
+  it('explicit --role flag also routes a modified skill to that namespace', async () => {
+    const pushedItems: Array<Record<string, unknown>> = [];
+    mockAutoDetectInit.mockResolvedValue({
+      localConfig: makeLocalConfig(),
+      teamConfig: makeTeamConfig(),
+    });
+    mockGetHandler.mockImplementation((type: string) => {
+      if (type === 'skills') {
+        return {
+          scanLocalForPush: vi.fn().mockResolvedValue([
+            {
+              name: 'skill-a',
+              type: 'skills',
+              sourcePath: '/tmp/skill-a',
+              relativePath: 'skills/skill-a',
+              status: 'modified',
+            },
+          ]),
+          pushItem: vi.fn().mockImplementation(async (item: Record<string, unknown>) => {
+            pushedItems.push(item);
+          }),
+        };
+      }
+      return { scanLocalForPush: vi.fn().mockResolvedValue([]), pushItem: vi.fn() };
+    });
+
+    await push({ all: true, role: 'backend' });
+
+    expect(pushedItems[0].namespace).toBe('backend');
+    expect(pushedItems[0].relativePath).toBe('skills/backend/skill-a');
+  });
+
+  it('rejects a path-traversal value passed to --role', async () => {
+    mockAutoDetectInit.mockResolvedValue({
+      localConfig: makeLocalConfig(),
+      teamConfig: makeTeamConfig(),
+    });
+    mockSkillHandler();
+    const originalExitCode = process.exitCode;
+
+    try {
+      await push({ all: true, role: '../outside' });
+
+      expect(mockPushRepoBranch).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(2);
+    } finally {
+      process.exitCode = originalExitCode;
+    }
+  });
+
+  it('rejects an unsafe scanned skill name before building the role path', async () => {
+    mockAutoDetectInit.mockResolvedValue({
+      localConfig: makeLocalConfig(),
+      teamConfig: makeTeamConfig(),
+    });
+    mockGetHandler.mockImplementation((type: string) => {
+      if (type === 'skills') {
+        return {
+          scanLocalForPush: vi.fn().mockResolvedValue([
+            {
+              name: '../outside',
+              type: 'skills',
+              sourcePath: '/tmp/outside',
+              relativePath: 'skills/outside',
+              status: 'modified',
+            },
+          ]),
+          pushItem: vi.fn(),
+        };
+      }
+      return { scanLocalForPush: vi.fn().mockResolvedValue([]), pushItem: vi.fn() };
+    });
+    const originalExitCode = process.exitCode;
+
+    try {
+      await push({ all: true, role: 'backend' });
+
+      expect(mockPushRepoBranch).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(2);
+    } finally {
+      process.exitCode = originalExitCode;
+    }
+  });
+
   it('rejects out-of-range namespace selection', async () => {
     mockAutoDetectInit.mockResolvedValue({
       localConfig: makeLocalConfig(),  // skills: [common, hai]

--- a/src/__tests__/push-team-config.test.ts
+++ b/src/__tests__/push-team-config.test.ts
@@ -128,6 +128,34 @@ describe('push carries teamai.yaml (source add regression)', () => {
     expect(pushed).toContain('https://git.example/dev');
   });
 
+  it('config-only: returns a non-zero exit code when PR creation fails', async () => {
+    const teamRepo = await initTeamRepos(tmpDir);
+    const yamlPath = path.join(teamRepo, 'teamai.yaml');
+    fs.writeFileSync(yamlPath, 'version: 1\npublicSkills:\n  - beta-proof\n');
+    mockCreatePullRequest.mockRejectedValue(new Error('PR API unavailable'));
+    mockAutoDetectInit.mockResolvedValue({
+      localConfig: {
+        repo: { localPath: teamRepo, remote: path.join(tmpDir, 'remote.git'), kind: undefined },
+        username: 'alice',
+        scope: 'project',
+        projectRoot: teamRepo,
+      },
+      teamConfig: { repo: 'acme/team', toolPaths: {} },
+    });
+    const originalExitCode = process.exitCode;
+
+    try {
+      const { push } = await import('../push.js');
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      await push({ all: true });
+      logSpy.mockRestore();
+
+      expect(process.exitCode).toBe(1);
+    } finally {
+      process.exitCode = originalExitCode;
+    }
+  });
+
   it('no changes at all: reports nothing to push, no PR', async () => {
     const teamRepo = await initTeamRepos(tmpDir);
 

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -655,6 +655,30 @@ scope: 'user',
     expect(content).toBe('testuser\n');
   });
 
+  it('uses relativePath as the push destination instead of re-deriving it from primaryRole', async () => {
+    localConfig.primaryRole = 'backend';
+    const localSkillDir = path.join(homeDir, '.claude/skills', 'my-skill');
+    await fse.ensureDir(localSkillDir);
+    await fse.writeFile(path.join(localSkillDir, 'SKILL.md'), '# My Skill');
+
+    const item = {
+      name: 'my-skill',
+      type: 'skills' as const,
+      sourcePath: localSkillDir,
+      relativePath: 'skills/my-skill',
+      status: 'modified' as const,
+    };
+
+    await handler.pushItem(item, teamConfig, localConfig);
+
+    expect(await fse.pathExists(
+      path.join(localConfig.repo.localPath, 'skills', 'my-skill', 'SKILL.md'),
+    )).toBe(true);
+    expect(await fse.pathExists(
+      path.join(localConfig.repo.localPath, 'skills', 'backend', 'my-skill'),
+    )).toBe(false);
+  });
+
   it('should NOT copy .git directory when skill source is a git repo', async () => {
     const localSkillDir = path.join(homeDir, '.claude/skills', 'git-skill');
     await fse.ensureDir(localSkillDir);

--- a/src/push.ts
+++ b/src/push.ts
@@ -141,6 +141,7 @@ export async function push(options: GlobalOptions & { all?: boolean; role?: stri
       } else {
         log.error(`Push failed: ${(e as Error).message}`);
       }
+      process.exitCode = 1;
     }
     return;
   }
@@ -184,6 +185,7 @@ async function pushCore(
         // message rather than silently doing nothing or damaging their repo.
         pullSpin.fail('Cannot push: team repo path is not a dedicated git root. '
           + 'Run `teamai init` to re-clone the team repo before pushing.');
+        process.exitCode = 1;
         return;
       }
       const yamlPath = path.join(repoPath, 'teamai.yaml');
@@ -370,6 +372,29 @@ async function pushCore(
     // Replace allItems with just this one skill
     allItems.length = 0;
     allItems.push(matchedItem);
+  }
+
+  // An explicit --role is a destination override for every selected skill,
+  // including modified skills. Keep relativePath aligned with pushItem's
+  // destination so git stages the files that were actually copied (#331).
+  if (options.role) {
+    try {
+      assertSafeResourceName(options.role);
+      for (const item of allItems) {
+        if (item.type === 'skills') {
+          assertSafeResourceName(item.name);
+        }
+      }
+    } catch (e) {
+      log.error(`Invalid skill role or name: ${(e as Error).message}`);
+      process.exitCode = 2;
+      return;
+    }
+    for (const item of allItems) {
+      if (item.type !== 'skills') continue;
+      item.namespace = options.role;
+      item.relativePath = `skills/${options.role}/${item.name}`;
+    }
   }
 
   if (allItems.length === 0) {
@@ -574,13 +599,16 @@ async function pushCore(
     pushSpin.succeed(`Pushed branch ${branchName}`);
 
     // Create PR/MR via provider
-    await createPrWithFallback(
+    const prUrl = await createPrWithFallback(
       teamConfig,
       localConfig,
       branchName,
       commitMsg,
       `Pushed ${selectedItems.length} resource(s):\n${selectedItems.map((i) => `- [${i.type}] ${i.name}`).join('\n')}`,
     );
+    if (!prUrl) {
+      process.exitCode = 1;
+    }
 
     // Switch back to master after PR creation
     await checkoutMaster(localConfig.repo.localPath);
@@ -598,6 +626,7 @@ async function pushCore(
         );
       }
     }
+    process.exitCode = 1;
     return;
   }
 
@@ -658,17 +687,21 @@ async function pushTeamConfigOnly(
     }
     pushSpin.succeed(`Pushed branch ${branchName}`);
 
-    await createPrWithFallback(
+    const prUrl = await createPrWithFallback(
       teamConfig,
       localConfig,
       branchName,
       commitMsg,
       'Updated team config (teamai.yaml)',
     );
+    if (!prUrl) {
+      process.exitCode = 1;
+    }
 
     await checkoutMaster(localConfig.repo.localPath);
   } catch (e) {
     pushSpin.fail(`Push failed: ${(e as Error).message}`);
+    process.exitCode = 1;
     return;
   }
 }

--- a/src/resources/skills.ts
+++ b/src/resources/skills.ts
@@ -7,6 +7,7 @@ import { log } from '../utils/logger.js';
 import { BUILTIN_SKILL_NAMES } from '../builtin-skills.js';
 import { resolveOpenclawWorkspaceDir } from '../openclaw-hooks.js';
 import { loadRolesManifest, resolveRoleResourceNamespaces } from '../roles.js';
+import { assertWithinRoot } from '../utils/path-safety.js';
 
 /** File name used to track who has contributed (pushed) a skill. */
 const CONTRIBUTORS_FILE = 'CONTRIBUTORS';
@@ -141,14 +142,6 @@ async function resolveSkillNamespaces(localConfig: LocalConfig): Promise<string[
     return [localConfig.primaryRole, ...(localConfig.additionalRoles ?? [])];
   }
 }
-
-function getSkillDestination(localConfig: LocalConfig, skillName: string, namespace?: string): string {
-  if (namespace) {
-    return path.join(localConfig.repo.localPath, 'skills', namespace, skillName);
-  }
-  return path.join(localConfig.repo.localPath, 'skills', skillName);
-}
-
 
 /**
  * Recursively scan a directory tree to find all subdirectories containing SKILL.md.
@@ -405,7 +398,13 @@ export class SkillsHandler extends ResourceHandler {
    * Copy a local skill to the team repo.
    */
   async pushItem(item: ResourceItem, _teamConfig: TeamaiConfig, localConfig: LocalConfig): Promise<void> {
-    const dest = getSkillDestination(localConfig, item.name, item.namespace ?? localConfig.primaryRole);
+    const skillsRoot = path.join(localConfig.repo.localPath, 'skills');
+    const dest = path.resolve(localConfig.repo.localPath, item.relativePath);
+    assertWithinRoot(
+      skillsRoot,
+      dest,
+      `Invalid skill destination outside team repo skills directory: ${item.relativePath}`,
+    );
     await copyDir(item.sourcePath, dest);
     log.debug(`Copied skill ${item.name} → team repo`);
 

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -371,6 +371,10 @@ export async function pushRepoBranch(
   await git.add(files);
   const status = await git.status();
   if (status.staged.length === 0) {
+    // checkout would otherwise carry unmatched copied files back to the
+    // default branch as unstaged/untracked changes (#331).
+    await git.reset(['--hard', 'HEAD']);
+    await git.clean('f', ['-d']);
     const defaultBranch = await getDefaultBranch(localPath);
     log.debug(`Nothing to commit, switching back to ${defaultBranch}`);
     await switchToDefaultBranch(git, defaultBranch);
@@ -381,6 +385,8 @@ export async function pushRepoBranch(
   // Second gate: skip if all staged changes are metadata-only (timestamps)
   const diffOutput = await git.diff(['--cached', '--unified=0']);
   if (isMetadataOnlyDiff(diffOutput)) {
+    await git.reset(['--hard', 'HEAD']);
+    await git.clean('f', ['-d']);
     const defaultBranch = await getDefaultBranch(localPath);
     log.debug(`Only metadata/timestamp changes detected, switching back to ${defaultBranch}`);
     await switchToDefaultBranch(git, defaultBranch);


### PR DESCRIPTION
## Summary
- keep role-scoped skill copy destinations aligned with the paths staged by Git
- clean no-change branches and return non-zero status when push or PR creation is incomplete
- add dist CLI E2E coverage for GitHub, GitLab, and generic Git providers

Closes #331

## Test plan
- [x] `npm test` (2233 tests)
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run test:e2e` (68 passed, 24 environment-gated skips)
- [x] code review and security review

Made with [Cursor](https://cursor.com)