### PR TITLE
fix(uninstall): remove managed agents and OpenClaw skills

### DIFF
--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -1073,7 +1073,7 @@ inheritUserScope: true         # optional; project scope only, defaults to false
 `teamai uninstall` intelligently cleans up all teamai-managed resources, **preserving anything you created yourself**.
 
 ```bash
-# Preview what will be removed (no actual changes)
+# Preview every managed path that will be removed (no actual changes)
 teamai uninstall --dry-run
 
 # Interactive confirmation
@@ -1089,14 +1089,15 @@ teamai uninstall --agent claude
 What gets removed:
 - teamai hooks in AI tool settings
 - The teamai rules block in CLAUDE.md (your own content is preserved)
-- Team-synced skills (your own skills are preserved)
+- Team-synced skills, including OpenClaw workspace skills (your own skills are preserved)
 - Team-synced rules
+- Team-synced custom agents and CLI built-in agents (your own agents are preserved)
 - The env block in your shell profile
 - The `~/.teamai/` directory
 
 ### Uninstall a single tool (`--agent <tool>`)
 
-`--agent <tool>` removes only that tool's teamai resources (hooks, CLAUDE.md block, skills, rules, built-in agents). The tool name is a key of `toolPaths` (e.g. `claude`, `codex`, `codebuddy`) and is matched case-insensitively. An unknown tool name aborts without deleting anything, lists the available tools, and exits with a non-zero status.
+`--agent <tool>` removes only that tool's teamai resources (hooks, CLAUDE.md block, skills, rules, team-synced custom agents, and built-in agents). The tool name is a key of `toolPaths` (e.g. `claude`, `codex`, `codebuddy`) and is matched case-insensitively. An unknown tool name aborts without deleting anything, lists the available tools, and exits with a non-zero status.
 
 Shared resources (the env block, docs directory, and `~/.teamai/`) are removed **only when the target itself has teamai resources AND is the last tool still using teamai** — otherwise they are kept for the remaining tools. (So targeting a tool that has no teamai resources of its own is a no-op and leaves shared resources in place, even if it happens to be the only tool.)
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -1068,7 +1068,7 @@ inheritUserScope: true         # 可选，仅 project scope，默认 false
 `teamai uninstall` 会智能清理所有 teamai 管理的资源，**保留用户自建内容**。
 
 ```bash
-# 预览将要移除的内容（不做实际变更）
+# 预览将要移除的每个受管路径（不做实际变更）
 teamai uninstall --dry-run
 
 # 交互式确认卸载
@@ -1084,14 +1084,15 @@ teamai uninstall --agent claude
 移除内容：
 - AI 工具 settings 中的 teamai hooks
 - CLAUDE.md 中的 teamai rules 块（保留用户自写内容）
-- 团队同步的 skills（保留用户自建 skills）
+- 团队同步的 skills，包括 OpenClaw workspace skills（保留用户自建 skills）
 - 团队同步的 rules
+- 团队同步的自定义 agents 和 CLI 内置 agents（保留用户自建 agents）
 - Shell profile 中的 env 块
 - `~/.teamai/` 目录
 
 ### 只卸载单个工具（`--agent <tool>`）
 
-`--agent <tool>` 只移除该工具的 teamai 资源（hooks、CLAUDE.md 块、skills、rules、内置 agents）。工具名即 `toolPaths` 的键（如 `claude`、`codex`、`codebuddy`），匹配大小写不敏感。传入未知工具名会直接报错并列出可用工具、不执行任何删除，并以非零状态码退出。
+`--agent <tool>` 只移除该工具的 teamai 资源（hooks、CLAUDE.md 块、skills、rules、团队同步的自定义 agents、内置 agents）。工具名即 `toolPaths` 的键（如 `claude`、`codex`、`codebuddy`），匹配大小写不敏感。传入未知工具名会直接报错并列出可用工具、不执行任何删除，并以非零状态码退出。
 
 跨工具共享资源（shell profile env 块、docs 目录、`~/.teamai/`）**仅当该工具自身存在 teamai 资源、且它是最后一个仍在使用 teamai 的工具时**才一并移除，否则会为其余工具保留。（因此，定向卸载一个自身没有任何 teamai 资源的工具是 no-op，即便它恰好是唯一的工具，也不会删除共享资源。）
 

--- a/src/__tests__/e2e/managed-resources-uninstall.test.ts
+++ b/src/__tests__/e2e/managed-resources-uninstall.test.ts
@@ -1,0 +1,188 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { execFileSync, spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const CLI = path.join(ROOT, 'dist', 'index.js');
+
+interface RunResult {
+  code: number | null;
+  output: string;
+}
+
+function runCLI(args: string[], env: Record<string, string>, cwd: string): Promise<RunResult> {
+  return new Promise((resolve) => {
+    const child = spawn('node', [CLI, ...args], {
+      env: { ...process.env, FORCE_COLOR: '0', ...env },
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd,
+    });
+    let output = '';
+    child.stdout.on('data', (data: Buffer) => { output += data.toString(); });
+    child.stderr.on('data', (data: Buffer) => { output += data.toString(); });
+    child.stdin.end();
+    child.on('close', (code) => resolve({ code, output }));
+  });
+}
+
+function git(args: string[], cwd: string): void {
+  execFileSync('git', args, { cwd, stdio: 'ignore' });
+}
+
+describe('managed agents and OpenClaw skills uninstall (dist CLI e2e)', () => {
+  let sandbox: string;
+  let projectRoot: string;
+  let teamaiHome: string;
+  let managedAgentPaths: string[];
+  let managedOpenclawSkill: string;
+  let userAgent: string;
+  let userOpenclawSkill: string;
+
+  beforeAll(() => {
+    if (!fs.existsSync(CLI)) {
+      throw new Error(`CLI binary not found at ${CLI}. Run "npm run build" first.`);
+    }
+
+    sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-managed-uninstall-e2e-'));
+    projectRoot = path.join(sandbox, 'project');
+    teamaiHome = path.join(projectRoot, '.teamai');
+    const seedRepo = path.join(sandbox, 'seed');
+    const remoteRepo = path.join(sandbox, 'team-origin.git');
+    const repoLocal = path.join(teamaiHome, 'team-repo');
+
+    fs.mkdirSync(projectRoot, { recursive: true });
+    fs.mkdirSync(seedRepo, { recursive: true });
+    git(['init', '--initial-branch=main'], seedRepo);
+    git(['config', 'user.email', 'e2e@example.com'], seedRepo);
+    git(['config', 'user.name', 'TeamAI E2E'], seedRepo);
+
+    fs.mkdirSync(path.join(seedRepo, 'agents'), { recursive: true });
+    fs.writeFileSync(
+      path.join(seedRepo, 'agents', 'beta-proof-agent.yaml'),
+      [
+        'name: beta-proof-agent',
+        'description: Proves managed agents are removed',
+        'instructions: Help the team',
+        'targets:',
+        '  - claude',
+        '  - codex',
+        '  - cursor',
+        '  - codebuddy',
+        '  - opencode',
+      ].join('\n'),
+    );
+    fs.mkdirSync(path.join(seedRepo, 'skills', 'beta-proof'), { recursive: true });
+    fs.writeFileSync(
+      path.join(seedRepo, 'skills', 'beta-proof', 'SKILL.md'),
+      '---\nname: beta-proof\ndescription: Managed test skill\n---\n',
+    );
+    fs.writeFileSync(
+      path.join(seedRepo, 'teamai.yaml'),
+      [
+        'team: managed-uninstall-e2e',
+        `repo: ${remoteRepo}`,
+        'provider: github',
+        'toolPaths:',
+        '  claude:',
+        '    agents: .claude/agents',
+        '  codex:',
+        '    agents: .codex/agents',
+        '  cursor:',
+        '    agents: .cursor/agents',
+        '  codebuddy:',
+        '    agents: .codebuddy/agents',
+        '  opencode:',
+        '    agents: .opencode/agents',
+        '  openclaw:',
+        '    skills: .openclaw/skills',
+      ].join('\n'),
+    );
+    git(['add', '.'], seedRepo);
+    git(['commit', '-m', 'seed managed resources'], seedRepo);
+    git(['init', '--bare', remoteRepo], sandbox);
+    git(['remote', 'add', 'origin', remoteRepo], seedRepo);
+    git(['push', '-u', 'origin', 'main'], seedRepo);
+
+    fs.mkdirSync(teamaiHome, { recursive: true });
+    git(['clone', '--branch', 'main', remoteRepo, repoLocal], sandbox);
+    fs.writeFileSync(
+      path.join(teamaiHome, 'config.yaml'),
+      [
+        'repo:',
+        `  localPath: ${repoLocal}`,
+        `  remote: ${remoteRepo}`,
+        'username: e2e-user',
+        'updatePolicy: skip',
+        'scope: project',
+        `projectRoot: ${projectRoot}`,
+      ].join('\n'),
+    );
+
+    for (const toolRoot of ['.claude', '.codex', '.cursor', '.codebuddy', '.opencode']) {
+      fs.mkdirSync(path.join(projectRoot, toolRoot), { recursive: true });
+    }
+    fs.mkdirSync(path.join(projectRoot, '.openclaw', 'workspace'), { recursive: true });
+
+    managedAgentPaths = [
+      path.join(projectRoot, '.claude', 'agents', 'beta-proof-agent.md'),
+      path.join(projectRoot, '.codex', 'agents', 'beta-proof-agent.toml'),
+      path.join(projectRoot, '.cursor', 'agents', 'beta-proof-agent.md'),
+      path.join(projectRoot, '.codebuddy', 'agents', 'beta-proof-agent.md'),
+      path.join(projectRoot, '.opencode', 'agents', 'beta-proof-agent.md'),
+    ];
+    managedOpenclawSkill = path.join(
+      projectRoot,
+      '.openclaw',
+      'workspace',
+      'skills',
+      'beta-proof',
+    );
+    userAgent = path.join(projectRoot, '.claude', 'agents', 'my-own-agent.md');
+    userOpenclawSkill = path.join(
+      projectRoot,
+      '.openclaw',
+      'workspace',
+      'skills',
+      'my-own-skill',
+    );
+    fs.mkdirSync(path.dirname(userAgent), { recursive: true });
+    fs.writeFileSync(userAgent, '# User-owned agent');
+    fs.mkdirSync(userOpenclawSkill, { recursive: true });
+    fs.writeFileSync(path.join(userOpenclawSkill, 'SKILL.md'), '# User-owned skill');
+  }, 30_000);
+
+  afterAll(() => {
+    if (sandbox) fs.rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  it('pulls managed resources, lists them in dry-run, and removes only managed artifacts', async () => {
+    const env = { HOME: projectRoot };
+
+    const pull = await runCLI(['pull', '--force'], env, projectRoot);
+    expect(pull.code, pull.output).toBe(0);
+    for (const agentPath of managedAgentPaths) {
+      expect(fs.existsSync(agentPath), `${agentPath}\n${pull.output}`).toBe(true);
+    }
+    expect(fs.existsSync(managedOpenclawSkill)).toBe(true);
+
+    const dryRun = await runCLI(['uninstall', '--dry-run', '--force'], env, projectRoot);
+    expect(dryRun.code, dryRun.output).toBe(0);
+    for (const agentPath of managedAgentPaths) {
+      expect(dryRun.output).toContain(agentPath);
+    }
+    expect(dryRun.output).toContain(managedOpenclawSkill);
+
+    const uninstall = await runCLI(['uninstall', '--force'], env, projectRoot);
+    expect(uninstall.code, uninstall.output).toBe(0);
+    for (const agentPath of managedAgentPaths) {
+      expect(fs.existsSync(agentPath), agentPath).toBe(false);
+    }
+    expect(fs.existsSync(managedOpenclawSkill)).toBe(false);
+    expect(fs.existsSync(userAgent)).toBe(true);
+    expect(fs.existsSync(userOpenclawSkill)).toBe(true);
+  }, 60_000);
+});

--- a/src/__tests__/uninstall.test.ts
+++ b/src/__tests__/uninstall.test.ts
@@ -436,6 +436,106 @@ describe('uninstall', () => {
     expect(claudeMd).toContain(TEAMAI_RULES_START);
   });
 
+  it('dry-run 和卸载覆盖自定义 agents 及 OpenClaw workspace skills，同时保留用户资源', async () => {
+    const { homeDir, repoPath } = await setupFixture(tmpDir);
+    vi.stubEnv('HOME', homeDir);
+    vi.stubEnv('SHELL', '/bin/zsh');
+
+    await fse.ensureDir(path.join(repoPath, 'agents'));
+    await fse.writeFile(
+      path.join(repoPath, 'agents', 'beta-proof-agent.yaml'),
+      'name: beta-proof-agent\ndescription: Team agent\ninstructions: Help the team\n',
+    );
+    await fse.ensureDir(path.join(repoPath, 'skills', 'former-role-skill'));
+    await fse.writeFile(
+      path.join(repoPath, 'skills', 'former-role-skill', 'SKILL.md'),
+      '# Former Role Skill',
+    );
+
+    const managedAgentPaths = [
+      path.join(homeDir, '.claude', 'agents', 'beta-proof-agent.md'),
+      path.join(homeDir, '.codex', 'agents', 'beta-proof-agent.toml'),
+      path.join(homeDir, '.cursor', 'agents', 'beta-proof-agent.md'),
+      path.join(homeDir, '.codebuddy', 'agents', 'beta-proof-agent.md'),
+      path.join(homeDir, '.opencode', 'agents', 'beta-proof-agent.md'),
+    ];
+    for (const agentPath of managedAgentPaths) {
+      await fse.ensureDir(path.dirname(agentPath));
+      await fse.writeFile(agentPath, '# Managed agent');
+    }
+
+    const userAgentPath = path.join(homeDir, '.claude', 'agents', 'my-own-agent.md');
+    await fse.writeFile(userAgentPath, '# User agent');
+    const nestedUserAgentPath = path.join(
+      homeDir,
+      '.claude',
+      'agents',
+      'user-group',
+      'beta-proof-agent.md',
+    );
+    await fse.ensureDir(path.dirname(nestedUserAgentPath));
+    await fse.writeFile(nestedUserAgentPath, '# User agent with a managed-looking basename');
+
+    const openclawManagedSkill = path.join(
+      homeDir,
+      '.openclaw',
+      'workspace',
+      'skills',
+      'former-role-skill',
+    );
+    const openclawUserSkill = path.join(
+      homeDir,
+      '.openclaw',
+      'workspace',
+      'skills',
+      'my-own-skill',
+    );
+    await fse.ensureDir(openclawManagedSkill);
+    await fse.writeFile(path.join(openclawManagedSkill, 'SKILL.md'), '# Managed skill');
+    await fse.ensureDir(openclawUserSkill);
+    await fse.writeFile(path.join(openclawUserSkill, 'SKILL.md'), '# User skill');
+
+    const teamConfig = makeTeamConfig({
+      toolPaths: {
+        claude: { skills: '.claude/skills', agents: '.claude/agents' },
+        codex: { skills: '.codex/skills', agents: '.codex/agents' },
+        cursor: { skills: '.cursor/skills', agents: '.cursor/agents' },
+        codebuddy: { skills: '.codebuddy/skills', agents: '.codebuddy/agents' },
+        opencode: { skills: '.opencode/skills', agents: '.opencode/agents' },
+        openclaw: { skills: '.openclaw/skills' },
+      },
+    });
+    mockAutoDetectInit.mockResolvedValue({
+      localConfig: makeLocalConfig(homeDir, repoPath),
+      teamConfig,
+    });
+
+    const lines: string[] = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      lines.push(args.map(String).join(' '));
+    });
+    await uninstall({ dryRun: true, force: true });
+    spy.mockRestore();
+
+    const summary = lines.join('\n');
+    for (const agentPath of managedAgentPaths) {
+      expect(summary).toContain(agentPath);
+      expect(await fse.pathExists(agentPath)).toBe(true);
+    }
+    expect(summary).toContain(openclawManagedSkill);
+    expect(await fse.pathExists(openclawManagedSkill)).toBe(true);
+
+    await uninstall({ force: true });
+
+    for (const agentPath of managedAgentPaths) {
+      expect(await fse.pathExists(agentPath)).toBe(false);
+    }
+    expect(await fse.pathExists(openclawManagedSkill)).toBe(false);
+    expect(await fse.pathExists(userAgentPath)).toBe(true);
+    expect(await fse.pathExists(nestedUserAgentPath)).toBe(true);
+    expect(await fse.pathExists(openclawUserSkill)).toBe(true);
+  });
+
   it('uninstall summary lists teamai-managed MCP servers', async () => {
     const { homeDir, repoPath, teamaiHome } = await setupFixture(tmpDir);
     vi.stubEnv('HOME', homeDir);

--- a/src/uninstall.ts
+++ b/src/uninstall.ts
@@ -1,7 +1,12 @@
 import path from 'node:path';
 import { autoDetectInit, saveLocalConfig, saveLocalConfigForScope } from './config.js';
 import { reconcileHooks, hasTeamaiHooks } from './hooks.js';
-import { removeOpenClawHooks, OPENCLAW_HOOK_DIR, resolveOpenClawHooksDir } from './openclaw-hooks.js';
+import {
+  removeOpenClawHooks,
+  OPENCLAW_HOOK_DIR,
+  resolveOpenClawHooksDir,
+  resolveOpenclawWorkspaceDir,
+} from './openclaw-hooks.js';
 import {
   TEAMAI_RULES_START,
   TEAMAI_RULES_END,
@@ -34,6 +39,7 @@ import {
   writeFile,
   remove,
   listDirs,
+  listFiles,
   listFilesRecursive,
   expandHome,
 } from './utils/fs.js';
@@ -168,6 +174,19 @@ async function collectTeamRuleNames(repoPath: string): Promise<Set<string>> {
   );
 }
 
+/** Collect custom agent names from canonical YAML and legacy Markdown files. */
+async function collectTeamAgentNames(repoPath: string): Promise<Set<string>> {
+  const teamAgentsDir = path.join(repoPath, 'agents');
+  if (!await pathExists(teamAgentsDir)) return new Set();
+
+  const files = await listFiles(teamAgentsDir);
+  return new Set(
+    files
+      .filter((file) => file.endsWith('.yaml') || file.endsWith('.md'))
+      .map((file) => path.basename(file).replace(/\.(yaml|md)$/, '')),
+  );
+}
+
 /** Detect hooks cleared to empty arrays — a residue of prior teamai installation. */
 function isEmptyHooksResidue(parsed: Record<string, unknown> | null): boolean {
   if (parsed == null || !('hooks' in parsed) || typeof parsed.hooks !== 'object' || parsed.hooks == null) return false;
@@ -200,6 +219,7 @@ async function discoverToolResources(
   baseDir: string,
   teamSkillNames: Set<string>,
   teamRuleNames: Set<string>,
+  teamAgentNames: Set<string>,
   managedHooksPath: string,
   scope: Scope,
 ): Promise<ToolResources> {
@@ -258,12 +278,18 @@ async function discoverToolResources(
 
   // (c) Skills — only those matching team repo
   if (toolPath.skills) {
-    const skillsDir = path.join(baseDir, toolPath.skills);
-    if (await pathExists(skillsDir)) {
-      const dirs = await listDirs(skillsDir);
-      for (const dir of dirs) {
-        if (teamSkillNames.has(dir)) {
-          res.skillDirs.push(path.join(skillsDir, dir));
+    const skillRoots = new Set([path.join(baseDir, toolPath.skills)]);
+    if (tool === 'openclaw') {
+      const workspaceDir = await resolveOpenclawWorkspaceDir();
+      if (workspaceDir) skillRoots.add(path.join(workspaceDir, 'skills'));
+    }
+    for (const skillsDir of skillRoots) {
+      if (await pathExists(skillsDir)) {
+        const dirs = await listDirs(skillsDir);
+        for (const dir of dirs) {
+          if (teamSkillNames.has(dir)) {
+            res.skillDirs.push(path.join(skillsDir, dir));
+          }
         }
       }
     }
@@ -285,16 +311,16 @@ async function discoverToolResources(
     }
   }
 
-  // (d2) Built-in agents — CLI-deployed subagents (e.g. teamai-recall).
-  // Not synced from the team repo, so match by BUILTIN_AGENT_NAMES.
+  // (d2) Team-synced custom agents plus CLI built-ins. Native output uses
+  // .md for most tools and .toml for Codex, so match installed files by stem.
   if (toolPath.agents) {
     const agentsDir = path.join(baseDir, toolPath.agents);
     if (await pathExists(agentsDir)) {
-      for (const name of BUILTIN_AGENT_NAMES) {
-        const agentFile = path.join(agentsDir, `${name}.md`);
-        if (await pathExists(agentFile)) {
-          res.agentFiles.push(agentFile);
-        }
+      for (const file of await listFiles(agentsDir)) {
+        if (!file.endsWith('.md') && !file.endsWith('.toml')) continue;
+        const name = path.basename(file).replace(/\.(md|toml)$/, '');
+        if (!teamAgentNames.has(name) && !BUILTIN_AGENT_NAMES.has(name)) continue;
+        res.agentFiles.push(path.join(agentsDir, file));
       }
     }
   }
@@ -320,6 +346,7 @@ async function buildRemovalPlan(
   for (const name of BUILTIN_SKILL_NAMES) teamSkillNames.add(name);
   const teamRuleNames = await collectTeamRuleNames(repoPath);
   for (const name of BUILTIN_RULE_NAMES) teamRuleNames.add(name);
+  const teamAgentNames = await collectTeamAgentNames(repoPath);
 
   // Also include resources installed by local-agent (HTTP distribution)
   const localAgentManifestPath = path.join(
@@ -344,7 +371,16 @@ async function buildRemovalPlan(
   for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
     perTool.set(
       tool,
-      await discoverToolResources(tool, toolPath, baseDir, teamSkillNames, teamRuleNames, managedHooksPath, localConfig.scope),
+      await discoverToolResources(
+        tool,
+        toolPath,
+        baseDir,
+        teamSkillNames,
+        teamRuleNames,
+        teamAgentNames,
+        managedHooksPath,
+        localConfig.scope,
+      ),
     );
   }
 
@@ -507,7 +543,10 @@ function printSummary(plan: RemovalPlan, agentFilter?: string): void {
   }
 
   if (plan.skillDirs.length > 0) {
-    console.log(`   Skills (${plan.skillDirs.length} directories)`);
+    console.log(`   Skills (${plan.skillDirs.length} directories):`);
+    for (const skillDir of plan.skillDirs) {
+      console.log(`     ${skillDir}`);
+    }
     console.log('');
   }
 
@@ -517,7 +556,10 @@ function printSummary(plan: RemovalPlan, agentFilter?: string): void {
   }
 
   if (plan.agentFiles.length > 0) {
-    console.log(`   Agents (${plan.agentFiles.length} files)`);
+    console.log(`   Agents (${plan.agentFiles.length} files):`);
+    for (const agentFile of plan.agentFiles) {
+      console.log(`     ${agentFile}`);
+    }
     console.log('');
   }
 


### PR DESCRIPTION
## Summary
- remove team-managed custom agents across Claude, Codex, Cursor, CodeBuddy, and OpenCode during uninstall
- discover and remove managed skills from the actual OpenClaw workspace while preserving user-owned resources
- list concrete skill and agent paths in dry-run output and add unit/dist-CLI regression coverage
- update the English and Chinese uninstall documentation

## Test plan
- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm test` (2236 passed)
- [x] `npm run test:e2e` (70 passed, 24 skipped)
- [x] Dist CLI E2E pulls custom agents and OpenClaw skills, checks dry-run paths, uninstalls, and verifies user files remain

Closes #333

Made with [Cursor](https://cursor.com)