### PR TITLE
fix(source): preserve pending config during pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ All notable changes to this project will be documented in this file. See [standa
   - `teamai skill` 或 `teamai skill list`：等价 `teamai list skills --source all`
   - `teamai skill show <name>`：查看单个 skill 的来源标签、命名空间、贡献者、`tags.yaml` 中的 tags、已安装的 agent 列表，以及 frontmatter 中的描述（最多 160 字符）。不渲染完整 SKILL.md 正文
 
+### 🐛 修复
+
+- **项目级 source 配置持久化**（#335）：`teamai pull` 自动上报 usage 时不再丢弃 `source add`/`remove` 尚未提交的 `teamai.yaml` 改动，后续 pull 可正常部署订阅 skills 并写入安装清单
+
 ## [0.14.2] (2026-04-16)
 
 ### 🐛 修复

--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ teamai source browse other-team    # browse available skills
 teamai source remove other-team
 ```
 
-Subscribed skills sync automatically on `teamai pull`.
+The add/remove change takes effect locally right away, and subscribed skills sync on the next
+`teamai pull`. Run `teamai push` when you want to share the `teamai.yaml` change with teammates.
 
 ## Knowledge Base
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -159,7 +159,8 @@ teamai source browse other-team    # 浏览可用 skills
 teamai source remove other-team
 ```
 
-订阅的 skills 在 `teamai pull` 时自动同步。
+添加/移除会立即在本机生效，订阅的 skills 会在下一次 `teamai pull` 时同步。需要将
+`teamai.yaml` 的改动分享给团队成员时，再运行 `teamai push`。
 
 ## 知识库
 

--- a/docs/ci-e2e-setup.md
+++ b/docs/ci-e2e-setup.md
@@ -78,7 +78,7 @@ GitHub repo → **Settings → Secrets and variables → Actions → Variables �
 | `roles set + pull` | 切换角色后 skill 集变化 |
 | `init <repo> --force`（默认 project scope） | 全新 init（沙盒 cwd + 隔离 HOME） |
 
-不要 token 的部分：`--version` / `--help` / `tags --help` / `members --help` / `uninstall --help` / 源码 sanity check —— PR from forks 也能跑。
+不要 token 的部分：`--version` / `--help` / `tags --help` / `members --help` / `uninstall --help` / 源码 sanity check，以及 `source-project-scope-e2e.test.ts` 使用本地真实 Git 仓覆盖的 source add → list → browse → pull/deploy → remove/cleanup 生命周期——PR from forks 也能跑。
 
 ---
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -1009,7 +1009,7 @@ teamai source browse other-team
 teamai source remove other-team
 ```
 
-A subscription source's skills are automatically synced locally on `teamai pull`, coexisting with the team's own skills. The subscription itself is stored in the `sources` field of the team repo's `teamai.yaml` — so it is shared with the whole team, not just your machine. After `teamai source add`/`remove`, run `teamai push` to open a PR with the `teamai.yaml` change; once it merges, every teammate's `teamai pull` picks up the new source automatically.
+A subscription source's skills are automatically synced locally on `teamai pull`, coexisting with the team's own skills. `teamai source add`/`remove` updates the active scope's team repo immediately, so local `list`, `browse`, and `pull` commands use the change before it is committed. The subscription itself is stored in the `sources` field of that repo's `teamai.yaml`. Run `teamai push` to open a PR with the config change; once it merges, every teammate's `teamai pull` picks up the new source automatically.
 
 #### HTTP Source
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -1004,7 +1004,7 @@ teamai source browse other-team
 teamai source remove other-team
 ```
 
-订阅源的 skills 在 `teamai pull` 时自动同步到本地，与团队自有 skills 共存。订阅本身存储在团队仓库 `teamai.yaml` 的 `sources` 字段中——因此是共享给整个团队的，而不只对你本机生效。执行 `teamai source add`/`remove` 后，运行 `teamai push` 会开一个包含 `teamai.yaml` 改动的 PR；合入后，每位成员的 `teamai pull` 都会自动获取到新的订阅源。
+订阅源的 skills 在 `teamai pull` 时自动同步到本地，与团队自有 skills 共存。`teamai source add`/`remove` 会立即更新当前 scope 的团队仓，因此改动尚未提交时，本机的 `list`、`browse` 和 `pull` 也会使用它。订阅配置存储在该仓库 `teamai.yaml` 的 `sources` 字段中。运行 `teamai push` 会开一个包含配置改动的 PR；合入后，每位成员的 `teamai pull` 都会自动获取到新的订阅源。
 
 #### HTTP 源
 

--- a/src/__tests__/self-mode-no-business-reset.test.ts
+++ b/src/__tests__/self-mode-no-business-reset.test.ts
@@ -71,21 +71,29 @@ describe('E2E self-mode: business repo working tree is never reset', () => {
     expect(content).toContain('MY UNCOMMITTED WORK');
   });
 
-  it('git mode: a real dedicated cache clone IS still reset (no regression)', async () => {
+  it('git mode: resets cache garbage but preserves an uncommitted teamai.yaml edit', async () => {
     // A dedicated cache clone: repoPath IS the git top level.
     // Use 'main' as default branch so resetToCleanMaster's fallback checkout matches.
     const cacheRoot = path.join(tmp, 'cache');
     await makeRepo(cacheRoot, 'main');
     const git = simpleGit(cacheRoot);
 
-    // Simulate stale dirty state in the cache.
+    fs.writeFileSync(path.join(cacheRoot, 'teamai.yaml'), 'team: original\n');
+    await git.add('teamai.yaml');
+    await git.commit('add team config');
+
+    // Simulate both disposable cache garbage and a pending source add.
     fs.writeFileSync(path.join(cacheRoot, 'app.js'), 'garbage\n');
+    fs.writeFileSync(
+      path.join(cacheRoot, 'teamai.yaml'),
+      'team: original\nsources:\n  - name: beta-source\n    repo: https://source.test/root/beta-source.git\n',
+    );
 
     await reportUsageToTeam(cacheRoot, 'me', { skipTruncate: true });
 
-    // reset --hard should have discarded the dirty change in the cache clone.
-    const content = fs.readFileSync(path.join(cacheRoot, 'app.js'), 'utf-8');
-    expect(content).toBe('console.log(1)\n');
+    expect(fs.readFileSync(path.join(cacheRoot, 'app.js'), 'utf-8')).toBe('console.log(1)\n');
+    expect(fs.readFileSync(path.join(cacheRoot, 'teamai.yaml'), 'utf-8'))
+      .toContain('name: beta-source');
   });
 
   it('project scope (git kind): business repo is NOT reset when team-repo dir lacks its own .git', async () => {

--- a/src/__tests__/source-project-scope-e2e.test.ts
+++ b/src/__tests__/source-project-scope-e2e.test.ts
@@ -1,0 +1,205 @@
+import { execFileSync, spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import YAML from 'yaml';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..', '..');
+const CLI = path.join(ROOT, 'dist', 'index.js');
+
+const GIT_ENV = {
+  GIT_AUTHOR_NAME: 'TeamAI CI',
+  GIT_AUTHOR_EMAIL: 'ci@teamai.test',
+  GIT_COMMITTER_NAME: 'TeamAI CI',
+  GIT_COMMITTER_EMAIL: 'ci@teamai.test',
+};
+
+interface RunResult {
+  code: number | null;
+  output: string;
+}
+
+function git(args: string[], cwd: string): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, ...GIT_ENV },
+  }).trim();
+}
+
+function runCLI(
+  args: string[],
+  cwd: string,
+  home: string,
+  envOverrides: Record<string, string> = {},
+): Promise<RunResult> {
+  return new Promise((resolve) => {
+    const child = spawn('node', [CLI, ...args], {
+      cwd,
+      env: {
+        ...process.env,
+        ...GIT_ENV,
+        HOME: home,
+        FORCE_COLOR: '0',
+        ...envOverrides,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let output = '';
+    child.stdout.on('data', (data: Buffer) => { output += data.toString(); });
+    child.stderr.on('data', (data: Buffer) => { output += data.toString(); });
+    child.on('close', (code) => resolve({ code, output }));
+  });
+}
+
+describe('project-scope source lifecycle e2e (issue #335)', () => {
+  it('persists, deploys, and removes a source through the dist CLI', async () => {
+    if (!fs.existsSync(CLI)) {
+      throw new Error(`CLI binary not found at ${CLI}. Run "npm run build" first.`);
+    }
+
+    const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-source-project-e2e-'));
+    try {
+      const home = path.join(sandbox, 'home');
+      const projectRoot = path.join(sandbox, 'project');
+      const teamSeed = path.join(sandbox, 'team-seed');
+      const teamRemote = path.join(sandbox, 'team.git');
+      const teamRepo = path.join(projectRoot, '.teamai', 'team-repo');
+      const sourceSeed = path.join(sandbox, 'source-seed');
+      const sourceRemote = path.join(sandbox, 'beta-source.git');
+      const sourceUrl = 'https://source.test/root/beta-source.git';
+
+      fs.mkdirSync(home, { recursive: true });
+      fs.mkdirSync(path.join(projectRoot, '.claude', 'skills'), { recursive: true });
+      fs.mkdirSync(teamSeed, { recursive: true });
+      fs.writeFileSync(
+        path.join(teamSeed, 'teamai.yaml'),
+        [
+          'team: issue-335-consumer',
+          `repo: ${teamRemote}`,
+          'provider: git',
+          'reviewers: []',
+          'toolPaths:',
+          '  claude:',
+          '    skills: .claude/skills',
+        ].join('\n'),
+      );
+      git(['init', '-q', '-b', 'main'], teamSeed);
+      git(['add', '-A'], teamSeed);
+      git(['commit', '-q', '-m', 'seed consumer team'], teamSeed);
+      git(['clone', '-q', '--bare', teamSeed, teamRemote], sandbox);
+      git(['clone', '-q', teamRemote, teamRepo], projectRoot);
+
+      fs.writeFileSync(
+        path.join(projectRoot, '.teamai', 'config.yaml'),
+        [
+          'repo:',
+          `  localPath: ${teamRepo}`,
+          `  remote: ${teamRemote}`,
+          'username: issue-335-user',
+          'updatePolicy: auto',
+          'scope: project',
+          `projectRoot: ${projectRoot}`,
+        ].join('\n'),
+      );
+
+      fs.mkdirSync(path.join(sourceSeed, 'skills', 'external-beta-skill'), { recursive: true });
+      fs.writeFileSync(
+        path.join(sourceSeed, 'teamai.yaml'),
+        [
+          'team: beta-source',
+          `repo: ${sourceUrl}`,
+          'provider: git',
+          'reviewers: []',
+          'publicSkills:',
+          '  - external-beta-skill',
+        ].join('\n'),
+      );
+      fs.writeFileSync(
+        path.join(sourceSeed, 'skills', 'external-beta-skill', 'SKILL.md'),
+        [
+          '---',
+          'name: external-beta-skill',
+          'description: Source lifecycle E2E fixture',
+          '---',
+          '',
+          '# External beta skill',
+        ].join('\n'),
+      );
+      git(['init', '-q', '-b', 'main'], sourceSeed);
+      git(['add', '-A'], sourceSeed);
+      git(['commit', '-q', '-m', 'seed source team'], sourceSeed);
+      git(['clone', '-q', '--bare', sourceSeed, sourceRemote], sandbox);
+
+      const sourceGitEnv = {
+        GIT_CONFIG_COUNT: '2',
+        GIT_CONFIG_KEY_0: `url.file://${sourceRemote}.insteadOf`,
+        GIT_CONFIG_VALUE_0: sourceUrl,
+        GIT_CONFIG_KEY_1: 'protocol.file.allow',
+        GIT_CONFIG_VALUE_1: 'always',
+      };
+
+      const addResult = await runCLI(
+        ['source', 'add', sourceUrl, '--name', 'beta-source'],
+        projectRoot,
+        home,
+        sourceGitEnv,
+      );
+      expect(addResult.code, addResult.output).toBe(0);
+      expect(addResult.output).toContain('Added source "beta-source"');
+
+      const teamYamlPath = path.join(teamRepo, 'teamai.yaml');
+      expect(YAML.parse(fs.readFileSync(teamYamlPath, 'utf8')).sources).toEqual([
+        { name: 'beta-source', repo: sourceUrl },
+      ]);
+
+      const listResult = await runCLI(['source', 'list'], projectRoot, home, sourceGitEnv);
+      expect(listResult.code, listResult.output).toBe(0);
+      expect(listResult.output).toContain('beta-source (synced)');
+
+      const browseResult = await runCLI(
+        ['source', 'browse', 'beta-source'],
+        projectRoot,
+        home,
+        sourceGitEnv,
+      );
+      expect(browseResult.code, browseResult.output).toBe(0);
+      expect(browseResult.output).toContain('external-beta-skill');
+
+      const pullResult = await runCLI(['pull', '--force'], projectRoot, home, sourceGitEnv);
+      expect(pullResult.code, pullResult.output).toBe(0);
+      expect(YAML.parse(fs.readFileSync(teamYamlPath, 'utf8')).sources).toEqual([
+        { name: 'beta-source', repo: sourceUrl },
+      ]);
+      expect(
+        fs.readFileSync(
+          path.join(projectRoot, '.claude', 'skills', 'external-beta-skill', 'SKILL.md'),
+          'utf8',
+        ),
+      ).toContain('# External beta skill');
+
+      const manifestPath = path.join(home, '.teamai', 'sources', 'beta-source', 'installed.json');
+      expect(JSON.parse(fs.readFileSync(manifestPath, 'utf8')).installedSkills)
+        .toEqual(['external-beta-skill']);
+
+      const removeResult = await runCLI(
+        ['source', 'remove', 'beta-source'],
+        projectRoot,
+        home,
+        sourceGitEnv,
+      );
+      expect(removeResult.code, removeResult.output).toBe(0);
+      expect(removeResult.output).toContain('Removed source "beta-source"');
+      expect(YAML.parse(fs.readFileSync(teamYamlPath, 'utf8')).sources).toEqual([]);
+      expect(fs.existsSync(path.dirname(manifestPath))).toBe(false);
+      expect(
+        fs.existsSync(path.join(projectRoot, '.claude', 'skills', 'external-beta-skill')),
+      ).toBe(false);
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  }, 60_000);
+});

--- a/src/team-push.ts
+++ b/src/team-push.ts
@@ -3,7 +3,14 @@ import path from 'node:path';
 import { readUsageEvents, truncateUsageAfterReport } from './usage-tracker.js';
 import { aggregateUsage } from './stats.js';
 import { readEvents, aggregateSessionMetrics } from './dashboard-collector.js';
-import { createGit, pushRepoDirectly, pullRepo, resetToCleanMaster, isDedicatedRepoRoot } from './utils/git.js';
+import {
+  createGit,
+  pushRepoDirectly,
+  pullRepo,
+  resetToCleanMaster,
+  isDedicatedRepoRoot,
+  getFileContentAtRev,
+} from './utils/git.js';
 import { withTimeout } from './utils/async.js';
 import { writeFile, readFileSafe, ensureDir, pathExists, readJson, writeJson } from './utils/fs.js';
 import { log } from './utils/logger.js';
@@ -364,8 +371,28 @@ export async function reportUsageToTeam(
         log.debug(`Skipping report: ${repoPath} is not a dedicated team-repo root (safety guard)`);
         return;
       }
-      await resetToCleanMaster(git, repoPath);
-      await pullRepo(repoPath);
+      const yamlPath = path.join(repoPath, 'teamai.yaml');
+      const workingContent = await readFileSafe(yamlPath);
+      const committedContent = workingContent === null
+        ? null
+        : await getFileContentAtRev(repoPath, 'HEAD', 'teamai.yaml');
+      const pendingTeamConfig = workingContent !== null
+        && (committedContent === null || committedContent.toString() !== workingContent)
+        ? workingContent
+        : null;
+
+      try {
+        await resetToCleanMaster(git, repoPath);
+        await pullRepo(repoPath);
+      } finally {
+        // `source add` and `source remove` intentionally leave teamai.yaml
+        // uncommitted until `teamai push`. Auto-report must not discard those edits.
+        // Keep the complete local version, matching pushCore: it remains an explicit
+        // working-tree diff for review instead of being silently committed here.
+        if (pendingTeamConfig !== null) {
+          await writeFile(yamlPath, pendingTeamConfig);
+        }
+      }
     }
 
     // Process usage and/or intervention/prompt/token stats if anything is new to report.


### PR DESCRIPTION
## Summary
- preserve uncommitted `teamai.yaml` source changes across usage-report cleanup
- add a project-scope dist CLI E2E covering add, list, browse, pull/deploy, and remove/cleanup with real Git repositories
- document the local-versus-shared source lifecycle in both English and Chinese

Fixes #335

## Test plan
- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm test` (164 files, 2235 tests)
- [x] `npx vitest run --config vitest.e2e.config.ts src/__tests__/source-project-scope-e2e.test.ts`

Made with [Cursor](https://cursor.com)