### PR TITLE
fix(pull): sync newly available agent targets

### DIFF
--- a/src/__tests__/e2e/project-agent-cold-start.test.ts
+++ b/src/__tests__/e2e/project-agent-cold-start.test.ts
@@ -138,14 +138,22 @@ describe('project-scope sequential agent cold start (#342)', () => {
     if (sandbox) fs.rmSync(sandbox, { recursive: true, force: true });
   });
 
-  it('syncs a newly available agent at the same revision, then retains the fast-path', async () => {
+  it('tracks the exact target set across sequential and recreated agent roots', async () => {
+    for (const agentRoot of ['.claude', '.cursor', '.codex', '.codebuddy']) {
+      fs.rmSync(path.join(projectRoot, agentRoot), { recursive: true, force: true });
+    }
+    fs.rmSync(path.join(projectRoot, '.teamai', 'state.json'), { force: true });
     fs.mkdirSync(path.join(projectRoot, '.claude'), { recursive: true });
+    fs.mkdirSync(path.join(projectRoot, '.codebuddy'), { recursive: true });
 
     const firstPull = await runCLI(['pull'], { HOME: homeDir }, projectRoot);
     expect(firstPull.code, firstPull.output).toBe(0);
     expect(fs.existsSync(path.join(projectRoot, '.claude', 'skills', 'team-skill', 'SKILL.md'))).toBe(true);
     expect(fs.existsSync(path.join(projectRoot, '.claude', 'rules', 'team-rule.md'))).toBe(true);
     expect(fs.existsSync(path.join(projectRoot, '.claude', 'agents', 'team-helper.md'))).toBe(true);
+    expect(JSON.parse(
+      fs.readFileSync(path.join(projectRoot, '.teamai', 'state.json'), 'utf8'),
+    ).lastPullTargets).toEqual(['claude']);
 
     fs.mkdirSync(path.join(projectRoot, '.cursor'), { recursive: true });
 
@@ -155,12 +163,35 @@ describe('project-scope sequential agent cold start (#342)', () => {
     expect(fs.existsSync(path.join(projectRoot, '.cursor', 'skills', 'team-skill', 'SKILL.md'))).toBe(true);
     expect(fs.existsSync(path.join(projectRoot, '.cursor', 'rules', 'team-rule.md'))).toBe(true);
     expect(fs.existsSync(path.join(projectRoot, '.cursor', 'agents', 'team-helper.md'))).toBe(true);
+    expect(JSON.parse(
+      fs.readFileSync(path.join(projectRoot, '.teamai', 'state.json'), 'utf8'),
+    ).lastPullTargets).toEqual(['claude', 'cursor']);
 
     const thirdPull = await runCLI(['pull'], { HOME: homeDir }, projectRoot);
     expect(thirdPull.code, thirdPull.output).toBe(0);
     expect(thirdPull.output).toContain('Already synced');
 
+    fs.rmSync(path.join(projectRoot, '.cursor'), { recursive: true, force: true });
+    const fourthPull = await runCLI(['pull'], { HOME: homeDir }, projectRoot);
+    expect(fourthPull.code, fourthPull.output).toBe(0);
+    expect(fourthPull.output).not.toContain('Already synced');
+    expect(JSON.parse(
+      fs.readFileSync(path.join(projectRoot, '.teamai', 'state.json'), 'utf8'),
+    ).lastPullTargets).toEqual(['claude']);
+
+    fs.mkdirSync(path.join(projectRoot, '.cursor'), { recursive: true });
+    const fifthPull = await runCLI(['pull'], { HOME: homeDir }, projectRoot);
+    expect(fifthPull.code, fifthPull.output).toBe(0);
+    expect(fifthPull.output).not.toContain('Already synced');
+    expect(fs.existsSync(path.join(projectRoot, '.cursor', 'skills', 'team-skill', 'SKILL.md'))).toBe(true);
+    expect(JSON.parse(
+      fs.readFileSync(path.join(projectRoot, '.teamai', 'state.json'), 'utf8'),
+    ).lastPullTargets).toEqual(['claude', 'cursor']);
+
     expect(fs.existsSync(path.join(projectRoot, '.codex'))).toBe(false);
-    expect(fs.existsSync(path.join(projectRoot, '.codebuddy'))).toBe(false);
+    expect(fs.existsSync(path.join(projectRoot, '.codebuddy'))).toBe(true);
+    expect(fs.existsSync(path.join(projectRoot, '.codebuddy', 'skills'))).toBe(false);
+    expect(fs.existsSync(path.join(projectRoot, '.codebuddy', 'rules'))).toBe(false);
+    expect(fs.existsSync(path.join(projectRoot, '.codebuddy', 'agents'))).toBe(false);
   }, 30_000);
 });

--- a/src/__tests__/e2e/project-agent-cold-start.test.ts
+++ b/src/__tests__/e2e/project-agent-cold-start.test.ts
@@ -1,0 +1,166 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { execFileSync, spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const CLI = path.join(ROOT, 'dist', 'index.js');
+
+const GIT_ENV = {
+  GIT_AUTHOR_NAME: 'TeamAI CI',
+  GIT_AUTHOR_EMAIL: 'ci@teamai.test',
+  GIT_COMMITTER_NAME: 'TeamAI CI',
+  GIT_COMMITTER_EMAIL: 'ci@teamai.test',
+};
+
+interface RunResult {
+  code: number | null;
+  output: string;
+}
+
+function runCLI(args: string[], env: Record<string, string>, cwd: string): Promise<RunResult> {
+  return new Promise((resolve) => {
+    const child = spawn('node', [CLI, ...args], {
+      env: { ...process.env, FORCE_COLOR: '0', ...env },
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd,
+    });
+    let output = '';
+    child.stdout.on('data', (data: Buffer) => { output += data.toString(); });
+    child.stderr.on('data', (data: Buffer) => { output += data.toString(); });
+    child.stdin.end();
+    child.on('close', (code) => resolve({ code, output }));
+  });
+}
+
+function git(args: string[], cwd: string): void {
+  execFileSync('git', args, {
+    cwd,
+    stdio: 'pipe',
+    env: { ...process.env, ...GIT_ENV },
+  });
+}
+
+describe('project-scope sequential agent cold start (#342)', () => {
+  let sandbox: string;
+  let homeDir: string;
+  let projectRoot: string;
+
+  beforeAll(() => {
+    if (!fs.existsSync(CLI)) {
+      throw new Error(`CLI binary not found at ${CLI}. Run "npm run build" first.`);
+    }
+
+    sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-issue342-e2e-'));
+    homeDir = path.join(sandbox, 'home');
+    projectRoot = path.join(sandbox, 'project');
+    const remote = path.join(sandbox, 'team-remote');
+    const localRepo = path.join(projectRoot, '.teamai', 'team-repo');
+
+    fs.mkdirSync(homeDir, { recursive: true });
+    fs.mkdirSync(remote, { recursive: true });
+    fs.mkdirSync(path.join(remote, 'skills', 'team-skill'), { recursive: true });
+    fs.mkdirSync(path.join(remote, 'rules'), { recursive: true });
+    fs.mkdirSync(path.join(remote, 'agents'), { recursive: true });
+
+    fs.writeFileSync(
+      path.join(remote, 'teamai.yaml'),
+      [
+        'team: issue-342-e2e',
+        'repo: https://example.com/team.git',
+        'provider: tgit',
+        'toolPaths:',
+        '  claude:',
+        '    skills: .claude/skills',
+        '    rules: .claude/rules',
+        '    agents: .claude/agents',
+        '  cursor:',
+        '    skills: .cursor/skills',
+        '    rules: .cursor/rules',
+        '    agents: .cursor/agents',
+        '  codex:',
+        '    skills: .codex/skills',
+        '    rules: .codex/rules',
+        '    agents: .codex/agents',
+        '  codebuddy:',
+        '    skills: .codebuddy/skills',
+        '    rules: .codebuddy/rules',
+        '    agents: .codebuddy/agents',
+      ].join('\n'),
+    );
+    fs.writeFileSync(
+      path.join(remote, 'skills', 'team-skill', 'SKILL.md'),
+      '---\nname: team-skill\ndescription: Team skill fixture\n---\n\n# Team skill\n',
+    );
+    fs.writeFileSync(path.join(remote, 'rules', 'team-rule.md'), '# Team rule\n');
+    fs.writeFileSync(
+      path.join(remote, 'agents', 'team-helper.yaml'),
+      [
+        'name: team-helper',
+        'description: Team helper fixture',
+        'targets:',
+        '  - claude',
+        '  - cursor',
+        'instructions: |',
+        '  Help with team tasks.',
+      ].join('\n'),
+    );
+
+    git(['init', '-q'], remote);
+    git(['add', '-A'], remote);
+    git(['commit', '-q', '-m', 'fixture'], remote);
+
+    fs.mkdirSync(projectRoot, { recursive: true });
+    git(['clone', '-q', remote, localRepo], sandbox);
+    fs.writeFileSync(
+      path.join(projectRoot, '.teamai', 'config.yaml'),
+      [
+        'repo:',
+        `  localPath: ${localRepo}`,
+        `  remote: ${remote}`,
+        'username: ci-project',
+        'updatePolicy: auto',
+        'scope: project',
+        `projectRoot: ${projectRoot}`,
+        'enabledAgents:',
+        '  - claude',
+        '  - cursor',
+        'disabledAgents:',
+        '  - codebuddy',
+      ].join('\n'),
+    );
+  });
+
+  afterAll(() => {
+    if (sandbox) fs.rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  it('syncs a newly available agent at the same revision, then retains the fast-path', async () => {
+    fs.mkdirSync(path.join(projectRoot, '.claude'), { recursive: true });
+
+    const firstPull = await runCLI(['pull'], { HOME: homeDir }, projectRoot);
+    expect(firstPull.code, firstPull.output).toBe(0);
+    expect(fs.existsSync(path.join(projectRoot, '.claude', 'skills', 'team-skill', 'SKILL.md'))).toBe(true);
+    expect(fs.existsSync(path.join(projectRoot, '.claude', 'rules', 'team-rule.md'))).toBe(true);
+    expect(fs.existsSync(path.join(projectRoot, '.claude', 'agents', 'team-helper.md'))).toBe(true);
+
+    fs.mkdirSync(path.join(projectRoot, '.cursor'), { recursive: true });
+
+    const secondPull = await runCLI(['pull'], { HOME: homeDir }, projectRoot);
+    expect(secondPull.code, secondPull.output).toBe(0);
+    expect(secondPull.output).not.toContain('Already synced');
+    expect(fs.existsSync(path.join(projectRoot, '.cursor', 'skills', 'team-skill', 'SKILL.md'))).toBe(true);
+    expect(fs.existsSync(path.join(projectRoot, '.cursor', 'rules', 'team-rule.md'))).toBe(true);
+    expect(fs.existsSync(path.join(projectRoot, '.cursor', 'agents', 'team-helper.md'))).toBe(true);
+
+    const thirdPull = await runCLI(['pull'], { HOME: homeDir }, projectRoot);
+    expect(thirdPull.code, thirdPull.output).toBe(0);
+    expect(thirdPull.output).toContain('Already synced');
+
+    expect(fs.existsSync(path.join(projectRoot, '.codex'))).toBe(false);
+    expect(fs.existsSync(path.join(projectRoot, '.codebuddy'))).toBe(false);
+  }, 30_000);
+});

--- a/src/__tests__/pull-skip-sync.test.ts
+++ b/src/__tests__/pull-skip-sync.test.ts
@@ -137,6 +137,7 @@ describe('pull skip-sync when repo HEAD unchanged', () => {
     vi.mocked(loadStateForScope).mockResolvedValue({
       lastPull: '2026-04-01',
       lastPullRev: 'abc1234',
+      lastPullTargets: ['claude'],
       lastPush: null,
       pushedRules: [],
       pushedSkills: [],
@@ -152,6 +153,28 @@ describe('pull skip-sync when repo HEAD unchanged', () => {
     );
     // State should NOT be re-saved (no sync happened)
     expect(saveStateForScope).not.toHaveBeenCalled();
+  });
+
+  it('should sync once when a matching legacy state has no target marker', async () => {
+    vi.mocked(getHeadRev).mockResolvedValue('abc1234');
+    vi.mocked(loadStateForScope).mockResolvedValue({
+      lastPull: '2026-04-01',
+      lastPullRev: 'abc1234',
+      lastPush: null,
+      pushedRules: [],
+      pushedSkills: [],
+      pushedEnvVars: [],
+      lastUpdateCheck: null,
+      availableUpdate: null,
+    });
+
+    await pull({});
+
+    expect(log.success).not.toHaveBeenCalledWith(
+      expect.stringContaining('Already synced'),
+    );
+    expect(saveStateForScope).toHaveBeenCalled();
+    expect(vi.mocked(saveStateForScope).mock.calls[0][0].lastPullTargets).toEqual(['claude']);
   });
 
   it('should do full sync when HEAD rev differs from lastPullRev', async () => {
@@ -340,6 +363,7 @@ describe('pull skip-sync refreshes CLAUDE.md recall block (CLI upgrade)', () => 
     vi.mocked(loadStateForScope).mockResolvedValue({
       lastPull: '2026-04-01',
       lastPullRev: 'abc1234', // matches HEAD → triggers "Already synced" fast-path
+      lastPullTargets: ['claude'],
       lastPush: null,
       pushedRules: [],
       pushedSkills: [],

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -292,6 +292,37 @@ function logSyncDetail(
 }
 
 /**
+ * Return the installed tool targets that can receive team-owned resources.
+ *
+ * The revision cache is shared by a scope, while tool roots can appear later
+ * (for example, when Cursor creates `.cursor/` on its first launch). Persisting
+ * this set alongside the revision prevents a pull for one tool from suppressing
+ * the first resource sync for another.
+ */
+async function getInstalledResourceTargets(
+  teamConfig: TeamaiConfig,
+  localConfig: LocalConfig,
+): Promise<string[]> {
+  const baseDir = resolveBaseDir(localConfig);
+  const targets: string[] = [];
+
+  for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
+    if (isAgentDisabled(localConfig, tool)) continue;
+
+    const resourcePaths = [toolPath.skills, toolPath.rules, toolPath.agents]
+      .filter((resourcePath): resourcePath is string => !!resourcePath);
+    for (const resourcePath of resourcePaths) {
+      if (await ResourceHandler.isToolInstalled(resourcePath, baseDir)) {
+        targets.push(tool);
+        break;
+      }
+    }
+  }
+
+  return targets.sort();
+}
+
+/**
  * Pull resources for a single scope. This is the core sync logic extracted
  * from the original pull() function to support both user and project scope.
  */
@@ -305,6 +336,9 @@ async function pullForScope(
 ): Promise<void> {
   const scopeLabel = localConfig.scope;
   const revisionField = policy.revisionField ?? 'lastPullRev';
+  const targetsField = revisionField === 'lastPullRev'
+    ? 'lastPullTargets' as const
+    : 'lastInheritedPullTargets' as const;
   const teamConfig = await loadTeamConfig(localConfig.repo.localPath);
   if (!teamConfig) {
     log.warn(`[${scopeLabel}] Team config (teamai.yaml) not found. Skipping.`);
@@ -329,25 +363,36 @@ async function pullForScope(
   }
 
   // Step 1b: Skip sync if the repo version hasn't changed since last pull
+  let currentTargets: string[] | null = null;
   if (!options.force && !options.dryRun) {
     try {
       const state = await loadStateForScope(localConfig.scope, localConfig.projectRoot);
       if (currentRev && state[revisionField] && state[revisionField] === currentRev) {
-        log.success(`[${scopeLabel}] Already synced at ${currentRev}, skipping`);
-        // 即使 repo 未变化，仍部署 CLI 内置资源（确保 CLI 升级后新版本 agent/rules 生效）
-        if (!options.dryRun) {
-          const cfg = await loadTeamConfig(localConfig.repo.localPath);
-          if (cfg) {
-            const skipRecall = !isRecallEnabled(localConfig, cfg);
-            try { const { deployBuiltinAgents } = await import('./builtin-agents.js'); await deployBuiltinAgents(cfg, localConfig, { skipRecall }); } catch {}
-            try { const { deployBuiltinRules } = await import('./builtin-rules.js'); await deployBuiltinRules(cfg, localConfig, { skipRecall }); } catch {}
-            try { const { deployBuiltinSkills } = await import('./builtin-skills.js'); await deployBuiltinSkills(cfg, localConfig, { reportingOnly, skipRecall }); } catch {}
-            // Also refresh the CLAUDE.md recall block so a CLI upgrade that ships
-            // a new block reaches CLAUDE.md even when the repo HEAD is unchanged.
-            await injectRecallBlockIntoTools(cfg, localConfig, scopeLabel);
+        currentTargets = await getInstalledResourceTargets(teamConfig, localConfig);
+        const syncedTargets = new Set(state[targetsField] ?? []);
+        const unsyncedTargets = currentTargets.filter((target) => !syncedTargets.has(target));
+
+        if (unsyncedTargets.length === 0) {
+          log.success(`[${scopeLabel}] Already synced at ${currentRev}, skipping`);
+          // 即使 repo 未变化，仍部署 CLI 内置资源（确保 CLI 升级后新版本 agent/rules 生效）
+          if (!options.dryRun) {
+            const cfg = await loadTeamConfig(localConfig.repo.localPath);
+            if (cfg) {
+              const skipRecall = !isRecallEnabled(localConfig, cfg);
+              try { const { deployBuiltinAgents } = await import('./builtin-agents.js'); await deployBuiltinAgents(cfg, localConfig, { skipRecall }); } catch {}
+              try { const { deployBuiltinRules } = await import('./builtin-rules.js'); await deployBuiltinRules(cfg, localConfig, { skipRecall }); } catch {}
+              try { const { deployBuiltinSkills } = await import('./builtin-skills.js'); await deployBuiltinSkills(cfg, localConfig, { reportingOnly, skipRecall }); } catch {}
+              // Also refresh the CLAUDE.md recall block so a CLI upgrade that ships
+              // a new block reaches CLAUDE.md even when the repo HEAD is unchanged.
+              await injectRecallBlockIntoTools(cfg, localConfig, scopeLabel);
+            }
           }
+          return;
         }
-        return;
+
+        log.debug(
+          `[${scopeLabel}] Repo unchanged; syncing newly available target(s): ${unsyncedTargets.join(', ')}`,
+        );
       }
     } catch {
       // If rev check fails, proceed with full sync
@@ -815,6 +860,8 @@ async function pullForScope(
         state[revisionField] = null;
       }
     }
+    state[targetsField] = currentTargets
+      ?? await getInstalledResourceTargets(freshConfig, localConfig);
     await saveStateForScope(state, localConfig.scope, localConfig.projectRoot);
   }
 

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -369,10 +369,13 @@ async function pullForScope(
       const state = await loadStateForScope(localConfig.scope, localConfig.projectRoot);
       if (currentRev && state[revisionField] && state[revisionField] === currentRev) {
         currentTargets = await getInstalledResourceTargets(teamConfig, localConfig);
-        const syncedTargets = new Set(state[targetsField] ?? []);
-        const unsyncedTargets = currentTargets.filter((target) => !syncedTargets.has(target));
+        const previousTargets = state[targetsField];
+        const syncedTargets = new Set(previousTargets ?? []);
+        const targetSetMatches = previousTargets !== undefined
+          && previousTargets.length === currentTargets.length
+          && currentTargets.every((target) => syncedTargets.has(target));
 
-        if (unsyncedTargets.length === 0) {
+        if (targetSetMatches) {
           log.success(`[${scopeLabel}] Already synced at ${currentRev}, skipping`);
           // 即使 repo 未变化，仍部署 CLI 内置资源（确保 CLI 升级后新版本 agent/rules 生效）
           if (!options.dryRun) {
@@ -390,9 +393,7 @@ async function pullForScope(
           return;
         }
 
-        log.debug(
-          `[${scopeLabel}] Repo unchanged; syncing newly available target(s): ${unsyncedTargets.join(', ')}`,
-        );
+        log.debug(`[${scopeLabel}] Repo unchanged; resource target set changed, syncing`);
       }
     } catch {
       // If rev check fails, proceed with full sync

--- a/src/types.ts
+++ b/src/types.ts
@@ -304,8 +304,12 @@ export const StateSchema = z.object({
   lastPull: z.string().nullable().default(null),
   /** Git commit hash (short) of the team repo at the time of last successful pull. */
   lastPullRev: z.string().nullable().default(null),
+  /** Installed, enabled tool targets that completed the last full pull. */
+  lastPullTargets: z.array(z.string()).optional(),
   /** Git commit hash synchronized through the safe user-resource inheritance channel. */
   lastInheritedPullRev: z.string().nullable().optional(),
+  /** Tool targets that completed the last inherited user-resource pull. */
+  lastInheritedPullTargets: z.array(z.string()).optional(),
   pushedRules: z.array(z.string()).default([]),
   pushedSkills: z.array(z.string()).default([]),
   pushedEnvVars: z.array(z.string()).default([]),


### PR DESCRIPTION
## Summary
- track installed resource targets alongside each pull revision
- bypass the same-revision fast-path when a newly available Agent target has not received team resources
- add real CLI coverage for sequential Claude/Cursor cold starts while preserving fast-path and uninstalled/disabled target behavior

Closes #342

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` (165 files, 2252 tests)
- [x] `npm run build`
- [x] `npm run test:e2e` (16 files passed, 72 tests passed; 2 live-test files skipped)
- [x] Real dist CLI regression: Claude first pull, Cursor same-revision pull, then unchanged fast-path pull

Made with [Cursor](https://cursor.com)