### PR TITLE
fix(opencode): 修复启用召回后生成无效代理配置

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: OpenCode recall E2E
+        run: npx vitest run --config vitest.e2e.config.ts src/__tests__/e2e/opencode-recall.test.ts
+
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### 🐛 修复
 
+- **OpenCode recall agent 配置修复**（#332）：内置 subagent 现在与团队 subagent 一样按目标工具渲染原生格式，避免启用 recall 后把 Claude 的 `name`/`tools` frontmatter 原样写入 OpenCode 并阻止其启动；不支持的目标格式会跳过并输出可操作警告
 - **项目级 source 配置持久化**（#335）：`teamai pull` 自动上报 usage 时不再丢弃 `source add`/`remove` 尚未提交的 `teamai.yaml` 改动，后续 pull 可正常部署订阅 skills 并写入安装清单
 
 ## [0.14.2] (2026-04-16)

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@types/fs-extra": "^11.0.4",
         "@types/node": "^20.17.0",
         "@vitest/coverage-v8": "^2.1.9",
+        "opencode-ai": "1.18.23",
         "standard-version": "^9.5.0",
         "tsup": "^8.3.0",
         "typescript": "^5.7.0",
@@ -3553,6 +3554,196 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/opencode-ai": {
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/opencode-ai/-/opencode-ai-1.18.23.tgz",
+      "integrity": "sha512-3NkT0XINL7d0HYkTyGV1SPChHXhvRgKqNaTgKRTGb0TXUWszXA7MW/y3zMZw29y1AQuUDAzRvVYmQ9KGRQhroA==",
+      "cpu": [
+        "arm64",
+        "x64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "bin": {
+        "opencode": "bin/opencode.exe"
+      },
+      "optionalDependencies": {
+        "opencode-darwin-arm64": "1.18.23",
+        "opencode-darwin-x64": "1.18.23",
+        "opencode-darwin-x64-baseline": "1.18.23",
+        "opencode-linux-arm64": "1.18.23",
+        "opencode-linux-arm64-musl": "1.18.23",
+        "opencode-linux-x64": "1.18.23",
+        "opencode-linux-x64-baseline": "1.18.23",
+        "opencode-linux-x64-baseline-musl": "1.18.23",
+        "opencode-linux-x64-musl": "1.18.23",
+        "opencode-windows-arm64": "1.18.23",
+        "opencode-windows-x64": "1.18.23",
+        "opencode-windows-x64-baseline": "1.18.23"
+      }
+    },
+    "node_modules/opencode-darwin-arm64": {
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-arm64/-/opencode-darwin-arm64-1.18.23.tgz",
+      "integrity": "sha512-QP9PjwpHtZoLVXw2WvUmPZecz7mWbQkT4t3K36B//fCaDG+zWa+SsztIeaW5azujNwwtUemLA5icE/zINng48Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/opencode-darwin-x64": {
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-x64/-/opencode-darwin-x64-1.18.23.tgz",
+      "integrity": "sha512-R9nWP3edz/0FnEfwmuxtiWBB7bS4NtZCyCffJyiMlrbwdDC+bIXYrWxWXVrzaP1mJujs6g2MAwTCUSx/qpBhDw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/opencode-darwin-x64-baseline": {
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-x64-baseline/-/opencode-darwin-x64-baseline-1.18.23.tgz",
+      "integrity": "sha512-QGx6I/nFYur7qJ/Nx2L3fC4XYQt44cyDsm7p8twNA+cdjGX3ndnPbMdAl5ikdZyAfSMUGYK8VWY2JMxv0rmfjw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/opencode-linux-arm64": {
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/opencode-linux-arm64/-/opencode-linux-arm64-1.18.23.tgz",
+      "integrity": "sha512-g1zDFhuE9FOYwjSGderlu69wfd4GQzS0xsDiIY11QUciuBmM6DrHqLvmhlLFsUVHYVnCPY1YeN1pq5ewE3x72Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-arm64-musl": {
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/opencode-linux-arm64-musl/-/opencode-linux-arm64-musl-1.18.23.tgz",
+      "integrity": "sha512-VyDkzUJfJgkx9h9RhazTW9xeTgSXBmVFPblsbPGBW9tR612f6gjQxfOfu4cpHnQHK1qjuW9ClzLKHWqv3EcJTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64": {
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64/-/opencode-linux-x64-1.18.23.tgz",
+      "integrity": "sha512-5x9d1Cm/YtqzR6lAlNbgVprTQ3R3hx7qGTWCzm5l5u6lBNkhYTrhy2s8k25dxKKuxqZ9Kngqz9JYWvSVHy2Lmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64-baseline": {
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline/-/opencode-linux-x64-baseline-1.18.23.tgz",
+      "integrity": "sha512-yUhBOXfTQour2JCdAkwD3DDqSnyxB0grefwdPqEhYmJHIkYxfJIIzyy6V//pyouvkE0XMouFtiuZXw8S6Wo0iQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64-baseline-musl": {
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline-musl/-/opencode-linux-x64-baseline-musl-1.18.23.tgz",
+      "integrity": "sha512-c1DPxauhzAurlIBhJBr/rokDpc65l084T4qTl36gDDT9Xzc/Nk5Q5yMDaPm1DDI3WeHKDt11MDlxT5AjQW5gtw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64-musl": {
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-musl/-/opencode-linux-x64-musl-1.18.23.tgz",
+      "integrity": "sha512-t/5mlnTBZKdZpqKHwdwxlWqGakntauvMSmXtyJc17M7XJRmZaaGHtNSaSefbbYFIL4agoQCXTvIkhhyxOvr7zQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-windows-arm64": {
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/opencode-windows-arm64/-/opencode-windows-arm64-1.18.23.tgz",
+      "integrity": "sha512-QtJQcLU0yPz6on3jjks3f/EHgZuIDFw7FvAKu3wsHhL09NYDh7GczfRXDPRHa3NgqnU8dkB8p9mhqgaPRPogoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/opencode-windows-x64": {
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/opencode-windows-x64/-/opencode-windows-x64-1.18.23.tgz",
+      "integrity": "sha512-mMaIITuXzkNfjdcYL8uZaZuMDjulFyH/UCq9bxblam2mUZf9uWisoi5J6CXFsS/mkN7CZfTAt6PttSp4n3PH4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/opencode-windows-x64-baseline": {
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/opencode-windows-x64-baseline/-/opencode-windows-x64-baseline-1.18.23.tgz",
+      "integrity": "sha512-AqXsTKaPcDx3rrid5bLUwJbQ/3vr9rJ6fvOStIznTzwrbOgP8wy5G4jCoIzu6KB/WxGx/d1MrV4cGaJ73qnjBA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/ora": {
       "version": "8.2.0",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^20.17.0",
     "@vitest/coverage-v8": "^2.1.9",
+    "opencode-ai": "1.18.23",
     "standard-version": "^9.5.0",
     "tsup": "^8.3.0",
     "typescript": "^5.7.0",

--- a/src/__tests__/builtin-agents.test.ts
+++ b/src/__tests__/builtin-agents.test.ts
@@ -17,6 +17,7 @@ vi.mock('../utils/logger.js', () => ({
 
 import { deployBuiltinAgents, BUILTIN_AGENT_NAMES } from '../builtin-agents.js';
 import type { TeamaiConfig, LocalConfig } from '../types.js';
+import { log } from '../utils/logger.js';
 
 function buildTeamConfig(toolPaths: TeamaiConfig['toolPaths']): TeamaiConfig {
   return {
@@ -42,6 +43,7 @@ describe('deployBuiltinAgents', () => {
   let localConfig: LocalConfig;
 
   beforeEach(async () => {
+    vi.clearAllMocks();
     tmpDir = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-builtin-agents-test-'));
     homeDir = path.join(tmpDir, 'home');
     // Per import.meta.url resolution in builtin-agents.ts, the built-in dir is
@@ -115,6 +117,46 @@ describe('deployBuiltinAgents', () => {
     const written = await fse.readFile(localPath, 'utf8');
     expect(written).not.toBe('# stale outdated copy');
     expect(written).toContain('teamai-recall');
+  });
+
+  it('renders the recall agent in OpenCode native format', async () => {
+    const recallSrc = path.join(builtinAgentsDir, 'teamai-recall.md');
+    if (!fs.existsSync(recallSrc)) return; // Same skip guard
+
+    await fse.ensureDir(path.join(homeDir, '.config', 'opencode', 'agents'));
+    const teamConfig = buildTeamConfig({
+      opencode: {
+        agents: '.opencode/agents',
+        userScope: { agents: '.config/opencode/agents' },
+      },
+    });
+
+    await deployBuiltinAgents(teamConfig, localConfig);
+
+    const written = await fse.readFile(
+      path.join(homeDir, '.config', 'opencode', 'agents', 'teamai-recall.md'),
+      'utf8',
+    );
+    expect(written).toContain('mode: subagent');
+    expect(written).not.toMatch(/^name:/m);
+    expect(written).not.toMatch(/^tools:/m);
+  });
+
+  it('skips targets without a native agent renderer and warns how to proceed', async () => {
+    await fse.ensureDir(path.join(homeDir, '.unknown-tool', 'agents'));
+    const teamConfig = buildTeamConfig({
+      'unknown-tool': { agents: '.unknown-tool/agents' },
+    });
+
+    const deployed = await deployBuiltinAgents(teamConfig, localConfig);
+
+    expect(deployed).toBe(0);
+    expect(await fse.pathExists(
+      path.join(homeDir, '.unknown-tool', 'agents', 'teamai-recall.md'),
+    )).toBe(false);
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining(
+      'unsupported agent format; disable this target or add a native renderer',
+    ));
   });
 
   it('returns 0 and does not throw when no tools are installed', async () => {

--- a/src/__tests__/e2e/opencode-recall.test.ts
+++ b/src/__tests__/e2e/opencode-recall.test.ts
@@ -1,0 +1,162 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { execFileSync, spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const TEAMAI_CLI = path.join(ROOT, 'dist', 'index.js');
+const OPENCODE_INSTALL = path.join(ROOT, 'node_modules', 'opencode-ai', 'postinstall.mjs');
+const OPENCODE_CLI = path.join(
+  ROOT,
+  'node_modules',
+  '.bin',
+  process.platform === 'win32' ? 'opencode.cmd' : 'opencode',
+);
+
+const GIT_ENV = {
+  GIT_AUTHOR_NAME: 'TeamAI CI',
+  GIT_AUTHOR_EMAIL: 'ci@teamai.test',
+  GIT_COMMITTER_NAME: 'TeamAI CI',
+  GIT_COMMITTER_EMAIL: 'ci@teamai.test',
+};
+
+interface RunResult {
+  code: number | null;
+  output: string;
+}
+
+function run(
+  command: string,
+  args: string[],
+  env: Record<string, string>,
+  cwd: string,
+): Promise<RunResult> {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      env: { ...process.env, FORCE_COLOR: '0', ...env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      cwd,
+    });
+    let output = '';
+    child.stdout.on('data', (data: Buffer) => { output += data.toString(); });
+    child.stderr.on('data', (data: Buffer) => { output += data.toString(); });
+    child.on('close', (code) => resolve({ code, output }));
+  });
+}
+
+function git(args: string[], cwd: string): void {
+  execFileSync('git', args, {
+    cwd,
+    stdio: 'pipe',
+    env: { ...process.env, ...GIT_ENV },
+  });
+}
+
+describe('OpenCode recall startup (#332)', () => {
+  let sandbox: string;
+  let homeDir: string;
+  let projectRoot: string;
+
+  beforeAll(() => {
+    if (!fs.existsSync(TEAMAI_CLI)) {
+      throw new Error(`TeamAI CLI not found at ${TEAMAI_CLI}. Run "npm run build" first.`);
+    }
+    execFileSync(process.execPath, [OPENCODE_INSTALL], { cwd: ROOT, stdio: 'pipe' });
+    if (!fs.existsSync(OPENCODE_CLI)) {
+      throw new Error(`OpenCode CLI not found at ${OPENCODE_CLI}. Run "npm ci" first.`);
+    }
+
+    sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-issue332-e2e-'));
+    homeDir = path.join(sandbox, 'home');
+    projectRoot = path.join(sandbox, 'project');
+    const remote = path.join(sandbox, 'team-remote');
+    const localRepo = path.join(projectRoot, '.teamai', 'team-repo');
+
+    fs.mkdirSync(homeDir, { recursive: true });
+    fs.mkdirSync(remote, { recursive: true });
+    fs.writeFileSync(
+      path.join(remote, 'teamai.yaml'),
+      [
+        'team: issue-332-e2e',
+        'description: OpenCode recall E2E fixture',
+        `repo: ${remote}`,
+        'provider: tgit',
+        'sharing:',
+        '  recall:',
+        '    enabled: true',
+        'toolPaths:',
+        '  opencode:',
+        '    skills: .opencode/skills',
+        '    rules: .opencode/rules',
+        '    agents: .opencode/agents',
+      ].join('\n'),
+    );
+
+    git(['init', '-q'], remote);
+    git(['add', '-A'], remote);
+    git(['commit', '-q', '-m', 'fixture'], remote);
+
+    fs.mkdirSync(projectRoot, { recursive: true });
+    git(['clone', '-q', remote, localRepo], sandbox);
+    fs.mkdirSync(path.join(projectRoot, '.opencode'), { recursive: true });
+    fs.writeFileSync(
+      path.join(projectRoot, '.teamai', 'config.yaml'),
+      [
+        'repo:',
+        `  localPath: ${localRepo}`,
+        `  remote: ${remote}`,
+        'username: ci-project',
+        'updatePolicy: auto',
+        'scope: project',
+        `projectRoot: ${projectRoot}`,
+        'enabledAgents:',
+        '  - opencode',
+      ].join('\n'),
+    );
+  });
+
+  afterAll(() => {
+    if (sandbox) fs.rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  it('rejects the old artifact, then starts with every generated agent', async () => {
+    const env = { HOME: homeDir };
+    const agentsDir = path.join(projectRoot, '.opencode', 'agents');
+
+    fs.mkdirSync(agentsDir, { recursive: true });
+    fs.copyFileSync(
+      path.join(ROOT, 'agents', 'teamai-recall.md'),
+      path.join(agentsDir, 'teamai-recall.md'),
+    );
+    const brokenStartup = await run(OPENCODE_CLI, ['debug', 'config', '--pure'], env, projectRoot);
+    expect(brokenStartup.code, brokenStartup.output).not.toBe(0);
+    expect(brokenStartup.output).toContain('tools');
+    fs.rmSync(path.join(agentsDir, 'teamai-recall.md'));
+
+    const enable = await run('node', [TEAMAI_CLI, 'recall', 'enable'], env, projectRoot);
+    expect(enable.code, enable.output).toBe(0);
+
+    const pull = await run('node', [TEAMAI_CLI, 'pull', '--force'], env, projectRoot);
+    expect(pull.code, pull.output).toBe(0);
+
+    const agentFiles = fs.readdirSync(agentsDir).filter((file) => file.endsWith('.md'));
+    expect(agentFiles).toContain('teamai-recall.md');
+
+    for (const file of agentFiles) {
+      const agentName = path.basename(file, '.md');
+      const validation = await run(
+        OPENCODE_CLI,
+        ['debug', 'agent', agentName, '--pure'],
+        env,
+        projectRoot,
+      );
+      expect(validation.code, `${file}:\n${validation.output}`).toBe(0);
+    }
+
+    const startup = await run(OPENCODE_CLI, ['debug', 'config', '--pure'], env, projectRoot);
+    expect(startup.code, startup.output).toBe(0);
+  }, 30_000);
+});

--- a/src/__tests__/recall-toggle.test.ts
+++ b/src/__tests__/recall-toggle.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import path from 'node:path';
+import os from 'node:os';
+import fse from 'fs-extra';
+
+const mockAutoDetectInit = vi.fn();
+const mockSaveLocalConfigForScope = vi.fn();
+
+vi.mock('../config.js', () => ({
+  autoDetectInit: (...args: unknown[]) => mockAutoDetectInit(...args),
+  saveLocalConfigForScope: (...args: unknown[]) => mockSaveLocalConfigForScope(...args),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  log: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    dim: vi.fn(),
+  },
+}));
+
+import { recallDisable, recallEnable } from '../recall-toggle.js';
+import type { LocalConfig, TeamaiConfig } from '../types.js';
+
+describe('recall toggle native agent cleanup', () => {
+  let tmpDir: string;
+  let homeDir: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    tmpDir = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-recall-toggle-'));
+    homeDir = path.join(tmpDir, 'home');
+    await fse.ensureDir(path.join(homeDir, '.codex', 'agents'));
+    vi.stubEnv('HOME', homeDir);
+
+    const localConfig: LocalConfig = {
+      repo: {
+        localPath: path.join(tmpDir, 'team-repo'),
+        remote: 'https://example.com/test/repo.git',
+      },
+      username: 'testuser',
+      updatePolicy: 'auto',
+      additionalRoles: [],
+      scope: 'user',
+    };
+    const teamConfig = {
+      team: 'test',
+      description: '',
+      repo: 'https://example.com/test/repo.git',
+      provider: 'tgit',
+      reviewers: [],
+      sharing: {
+        skills: {},
+        rules: { enforced: [] },
+        docs: { localDir: '' },
+        env: { injectShellProfile: true },
+      },
+      toolPaths: {
+        codex: { agents: '.codex/agents' },
+      },
+    } as TeamaiConfig;
+    mockAutoDetectInit.mockResolvedValue({ localConfig, teamConfig });
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await fse.remove(tmpDir);
+  });
+
+  it('enable then disable removes the Codex TOML recall agent without leaving an orphan', async () => {
+    const tomlAgent = path.join(homeDir, '.codex', 'agents', 'teamai-recall.toml');
+    const legacyMarkdownAgent = path.join(homeDir, '.codex', 'agents', 'teamai-recall.md');
+
+    await recallEnable({});
+    expect(await fse.pathExists(tomlAgent)).toBe(true);
+    await fse.writeFile(legacyMarkdownAgent, 'legacy recall agent');
+
+    await recallDisable({});
+    expect(await fse.pathExists(tomlAgent)).toBe(false);
+    expect(await fse.pathExists(legacyMarkdownAgent)).toBe(false);
+  });
+
+  it('disable preserves non-agent files that only share the recall stem', async () => {
+    const backup = path.join(homeDir, '.codex', 'agents', 'teamai-recall.backup');
+    await fse.writeFile(backup, 'user backup');
+
+    await recallDisable({});
+
+    expect(await fse.readFile(backup, 'utf8')).toBe('user backup');
+  });
+});

--- a/src/__tests__/uninstall.test.ts
+++ b/src/__tests__/uninstall.test.ts
@@ -670,7 +670,22 @@ describe('uninstall', () => {
     vi.stubEnv('HOME', homeDir);
     vi.stubEnv('SHELL', '/bin/zsh');
 
-    const teamConfig = makeTeamConfig();
+    const codexRecallAgent = path.join(homeDir, '.codex', 'agents', 'teamai-recall.toml');
+    await fse.ensureDir(path.dirname(codexRecallAgent));
+    await fse.writeFile(codexRecallAgent, 'developer_instructions = "Recall"\n');
+
+    const teamConfig = makeTeamConfig({
+      toolPaths: {
+        claude: {
+          skills: '.claude/skills',
+          rules: '.claude/rules',
+          settings: '.claude/settings.json',
+          claudemd: '.claude/CLAUDE.md',
+          agents: '.claude/agents',
+        },
+        codex: { agents: '.codex/agents' },
+      },
+    });
     const localConfig = makeLocalConfig(homeDir, repoPath);
     mockAutoDetectInit.mockResolvedValue({ localConfig, teamConfig });
 
@@ -679,6 +694,7 @@ describe('uninstall', () => {
     // Built-in recall agent + rule removed
     expect(await fse.pathExists(path.join(homeDir, '.claude', 'agents', 'teamai-recall.md'))).toBe(false);
     expect(await fse.pathExists(path.join(homeDir, '.claude', 'rules', 'teamai-recall.md'))).toBe(false);
+    expect(await fse.pathExists(codexRecallAgent)).toBe(false);
     // Built-in skills removed
     expect(await fse.pathExists(path.join(homeDir, '.claude', 'skills', 'teamai-share-learnings'))).toBe(false);
     expect(await fse.pathExists(path.join(homeDir, '.claude', 'skills', 'team-wiki-codebase'))).toBe(false);

--- a/src/builtin-agents.ts
+++ b/src/builtin-agents.ts
@@ -1,12 +1,14 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { ensureDir, pathExists, copyFile } from './utils/fs.js';
+import { ensureDir, pathExists, readFileSafe, writeFile } from './utils/fs.js';
 import { log } from './utils/logger.js';
 import type { TeamaiConfig, LocalConfig } from './types.js';
 import { resolveBaseDir, isAgentDisabled, scopedToolPaths } from './types.js';
 import { ResourceHandler } from './resources/base.js';
 import { getUserHome } from './utils/home.js';
+import { ALL_SUPPORTED_TOOLS, renderForTool, reverseFromClaude } from './resources/agent-format.js';
+import type { ToolName } from './resources/agent-format.js';
 
 // ─── Built-in agents deployment ──────────────────────────
 //
@@ -93,6 +95,13 @@ export async function deployBuiltinAgents(
       continue;
     }
     if (localConfig && isAgentDisabled(localConfig, tool)) continue;
+    if (!(ALL_SUPPORTED_TOOLS as string[]).includes(tool)) {
+      log.warn(
+        `Skipping built-in agent deployment for ${tool}: unsupported agent format; ` +
+        'disable this target or add a native renderer',
+      );
+      continue;
+    }
 
     const targetAgentsDir = path.join(baseDir, toolPath.agents);
     try {
@@ -104,9 +113,17 @@ export async function deployBuiltinAgents(
 
     for (const file of agentFiles) {
       const src = path.join(builtinDir, file);
-      const dest = path.join(targetAgentsDir, file);
       try {
-        await copyFile(src, dest);
+        const source = await readFileSafe(src);
+        const parsed = source
+          ? reverseFromClaude(src, source)
+          : { ok: false as const, reason: 'cannot read source file' };
+        if (!parsed.ok) {
+          throw new Error(`invalid built-in agent ${file}: ${parsed.reason}`);
+        }
+        const rendered = renderForTool(parsed.spec, tool as ToolName);
+        const dest = path.join(targetAgentsDir, `${path.basename(file, '.md')}${rendered.ext}`);
+        await writeFile(dest, rendered.content);
         deployed++;
       } catch (e) {
         log.warn(`Failed to deploy built-in agent ${file} to ${tool}: ${(e as Error).message}`);

--- a/src/recall-toggle.ts
+++ b/src/recall-toggle.ts
@@ -3,6 +3,11 @@ import { autoDetectInit, saveLocalConfigForScope } from './config.js';
 import { log } from './utils/logger.js';
 import { readFileSafe, writeFile, remove, pathExists } from './utils/fs.js';
 import { ResourceHandler } from './resources/base.js';
+import {
+  ALL_SUPPORTED_TOOLS,
+  agentFileExtensionForTool,
+  type ToolName,
+} from './resources/agent-format.js';
 import { RECALL_DEPENDENT_SKILLS } from './builtin-skills.js';
 import {
   resolveBaseDir,
@@ -30,10 +35,17 @@ async function removeRecallArtifacts(teamConfig: TeamaiConfig, localConfig: Loca
 
     // Remove recall agent file
     if (toolPath.agents) {
-      const agentFile = path.join(baseDir, toolPath.agents, 'teamai-recall.md');
-      if (await pathExists(agentFile)) {
-        await remove(agentFile);
-        log.debug(`Removed recall agent from ${tool}`);
+      const agentsDir = path.join(baseDir, toolPath.agents);
+      const extensions = new Set<string>(['.md']);
+      if ((ALL_SUPPORTED_TOOLS as string[]).includes(tool)) {
+        extensions.add(agentFileExtensionForTool(tool as ToolName));
+      }
+      for (const extension of extensions) {
+        const agentFile = path.join(agentsDir, `teamai-recall${extension}`);
+        if (await pathExists(agentFile)) {
+          await remove(agentFile);
+          log.debug(`Removed recall agent from ${tool}`);
+        }
       }
     }
 

--- a/src/resources/agent-format.ts
+++ b/src/resources/agent-format.ts
@@ -19,6 +19,19 @@ export const ALL_SUPPORTED_TOOLS: ToolName[] = [
   'opencode',
 ];
 
+export type AgentFileExtension = '.md' | '.toml';
+
+export function agentFileExtensionForTool(tool: ToolName): AgentFileExtension {
+  switch (tool) {
+    case 'codex':
+    case 'codex-internal':
+    case 'tcodex':
+      return '.toml';
+    default:
+      return '.md';
+  }
+}
+
 // ─── Intermediate format ─────────────────────────────────────────────────────
 
 /**
@@ -138,7 +151,10 @@ export interface RenderResult {
  * Output: YAML frontmatter (.md) with optional model/tools and tool_extras.claude fields.
  */
 export function renderForClaude(spec: AgentSpec): RenderResult {
-  return { ext: '.md', content: renderMarkdownAgent(spec, spec.tool_extras?.['claude']) };
+  return {
+    ext: agentFileExtensionForTool('claude'),
+    content: renderMarkdownAgent(spec, spec.tool_extras?.['claude']),
+  };
 }
 
 /**
@@ -146,7 +162,10 @@ export function renderForClaude(spec: AgentSpec): RenderResult {
  * Same format as Claude — YAML frontmatter + body.
  */
 export function renderForClaudeInternal(spec: AgentSpec): RenderResult {
-  return { ext: '.md', content: renderMarkdownAgent(spec, spec.tool_extras?.['claude-internal']) };
+  return {
+    ext: agentFileExtensionForTool('claude-internal'),
+    content: renderMarkdownAgent(spec, spec.tool_extras?.['claude-internal']),
+  };
 }
 
 /**
@@ -154,7 +173,10 @@ export function renderForClaudeInternal(spec: AgentSpec): RenderResult {
  * Same format as Claude, but merges tool_extras.codebuddy into frontmatter.
  */
 export function renderForCodebuddy(spec: AgentSpec): RenderResult {
-  return { ext: '.md', content: renderMarkdownAgent(spec, spec.tool_extras?.['codebuddy']) };
+  return {
+    ext: agentFileExtensionForTool('codebuddy'),
+    content: renderMarkdownAgent(spec, spec.tool_extras?.['codebuddy']),
+  };
 }
 
 /**
@@ -162,7 +184,10 @@ export function renderForCodebuddy(spec: AgentSpec): RenderResult {
  * Output: TOML with developer_instructions and flattened tool_extras.codex fields.
  */
 export function renderForCodex(spec: AgentSpec): RenderResult {
-  return { ext: '.toml', content: renderTomlAgent(spec, spec.tool_extras?.['codex']) };
+  return {
+    ext: agentFileExtensionForTool('codex'),
+    content: renderTomlAgent(spec, spec.tool_extras?.['codex']),
+  };
 }
 
 /**
@@ -170,7 +195,10 @@ export function renderForCodex(spec: AgentSpec): RenderResult {
  * Same format as Codex — TOML with developer_instructions.
  */
 export function renderForCodexInternal(spec: AgentSpec): RenderResult {
-  return { ext: '.toml', content: renderTomlAgent(spec, spec.tool_extras?.['codex-internal']) };
+  return {
+    ext: agentFileExtensionForTool('codex-internal'),
+    content: renderTomlAgent(spec, spec.tool_extras?.['codex-internal']),
+  };
 }
 
 /**
@@ -193,7 +221,7 @@ export function renderForCursor(spec: AgentSpec): RenderResult {
     }
   }
   const content = matter.stringify(spec.instructions, frontmatterData);
-  return { ext: '.md', content };
+  return { ext: agentFileExtensionForTool('cursor'), content };
 }
 
 /**
@@ -221,7 +249,7 @@ export function renderForOpencode(spec: AgentSpec): RenderResult {
     }
   }
   const content = matter.stringify(spec.instructions, frontmatterData);
-  return { ext: '.md', content };
+  return { ext: agentFileExtensionForTool('opencode'), content };
 }
 
 // ─── Internal render helpers ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

修复启用 recall 后，TeamAI 将 Claude 格式的内置代理配置直接复制到 OpenCode，导致 OpenCode 配置校验失败、无法启动的问题。

内置代理现在会复用现有的目标工具原生渲染流程。OpenCode 生成的代理配置使用 `mode: subagent`，不再包含 Claude 专用的 `name` 和字符串格式的 `tools` 字段。对于尚无原生渲染器的目标工具，将跳过部署并输出可操作的警告。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing behavior to change)
- [ ] Documentation only
- [ ] Refactor / internal cleanup

## Test Plan

- [x] `npx tsc --noEmit` 通过
- [x] `npx vitest run --coverage` 通过
- [x] 已增加或更新相关测试
- [x] `npm run build` 通过
- [x] 使用真实 OpenCode CLI 验证旧配置会因 `tools` 字段失败
- [x] 执行 `teamai recall enable` 和 `teamai pull --force`
- [x] 使用当前 OpenCode schema 逐个验证所有生成的 agent 文件
- [x] 验证 OpenCode 能正常加载最终配置并启动

本地验证结果：

- 165 个测试文件全部通过
- 2254 个测试全部通过
- `src/builtin-agents.ts` 语句覆盖率为 81.94%
- OpenCode E2E 使用固定版本 `1.18.23`

## Related Issues

Fixes #332

## Notes for Reviewers

内置 recall agent 仍以 Claude Markdown 格式作为唯一源文件，部署时通过现有的 `reverseFromClaude` 和 `renderForTool` 转换成不同工具的原生格式。

本次修改没有为 OpenCode 单独维护第二份模板，避免内置代理与普通团队代理的渲染逻辑继续分叉。

真实 OpenCode E2E 包含负向对照：先确认旧版原样复制的配置确实会被 OpenCode 拒绝，再验证修复后的生成文件和完整配置均能通过校验。