### PR TITLE
fix(hooks): seed project agent root on SessionStart before pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ teamai push → create branch + MR → reviewer approves + merges
               SessionStart hook → teamai pull → synced to local AI tools
 ```
 
-Members push changes via `teamai push`, which opens a Merge Request for review. Once merged, `teamai pull` (triggered automatically on session start via the SessionStart hook) syncs the latest resources locally. Skills sync to `~/.claude/skills/`, `~/.codex/skills/`, `~/.cursor/skills/`, `~/.codebuddy/skills/`, etc.
+Members push changes via `teamai push`, which opens a Merge Request for review. Once merged, `teamai pull` (triggered automatically on session start via the SessionStart hook) syncs the latest resources locally. Skills sync to `~/.claude/skills/`, `~/.codex/skills/`, `~/.cursor/skills/`, `~/.codebuddy/skills/`, etc. In a **project-scope** install, SessionStart first creates that tool's project root (e.g. `<project>/.claude`) if it is missing, then pulls into it — a bare `teamai pull` still will not invent agent directories.
 
 ### Team Hooks
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -109,7 +109,7 @@ teamai push → 创建分支 + MR → reviewer 审批合并
            SessionStart hook → teamai pull → 同步到本地 AI 工具
 ```
 
-成员通过 `teamai push` 提交变更并创建合并请求供审核。合并后，`teamai pull`（由 SessionStart hook 在会话启动时自动触发）将最新资源同步到本地。Skills 会同步到 `~/.claude/skills/`、`~/.codex/skills/`、`~/.cursor/skills/`、`~/.codebuddy/skills/` 等目录。
+成员通过 `teamai push` 提交变更并创建合并请求供审核。合并后，`teamai pull`（由 SessionStart hook 在会话启动时自动触发）将最新资源同步到本地。Skills 会同步到 `~/.claude/skills/`、`~/.codex/skills/`、`~/.cursor/skills/`、`~/.codebuddy/skills/` 等目录。在 **project scope** 安装下，SessionStart 会先为当前工具创建项目根目录（例如 `<project>/.claude`），再 pull 写入；单独执行 `teamai pull` 仍不会凭空创建 Agent 目录。
 
 ### 团队 Hooks
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -101,6 +101,8 @@ Resulting directory structure:
 └── src/
 ```
 
+`teamai init` writes `.teamai/` only. Per-agent project roots (`.claude/`, `.cursor/`, `.codebuddy/`, …) are created on **SessionStart** for the tool that just opened (`--tool claude` creates `.claude/`, then pull writes into it). A bare `teamai pull` still skips tools whose project root does not exist, so it never invents agent directories for tools you have not opened in this project.
+
 If the repo has role-based skills enabled (i.e. `manifest/roles.yaml` exists), `teamai init` will also interactively ask you to choose:
 
 - `primaryRole`: the target namespace for skill sync and push by default
@@ -289,7 +291,7 @@ teamai skill show hai-deploy-test   # View a single skill's source / contributor
 
 ### Auto-sync
 
-`teamai init` already injected Hooks into your AI tools. **`teamai pull` runs automatically every time you start an AI session** — no manual action needed.
+`teamai init` already injected Hooks into your AI tools. **`teamai pull` runs automatically every time you start an AI session** — no manual action needed. In project scope, that SessionStart hook first creates the current agent's project root (e.g. `<project>/.claude` when Claude Code opens the repo) if it is missing, then pulls.
 
 If you need to sync immediately, you can run it manually:
 
@@ -878,7 +880,7 @@ Hooks automatically injected by `teamai init`:
 
 | Hook Event | Action |
 |-----------|------|
-| `SessionStart` | Auto pull + report session start |
+| `SessionStart` | Seed the current agent's project root (project scope), then auto pull + report session start |
 | `PostToolUse` | Skill tracking + knowledge contribution detection + dashboard reporting |
 | `UserPromptSubmit` | Slash command tracking |
 | `Stop` | CLI update check + report session end |
@@ -1125,6 +1127,10 @@ In interactive mode, you'll be asked whether to overwrite — type `y` to confir
 ```bash
 teamai init --repo <group>/<repo> --force
 ```
+
+**Q: After `teamai init` in a project, there is no `.claude/` (or `.cursor/`, `.codebuddy/`) directory?**
+
+That is expected. `init` does not know which agent you will open. Open Claude Code / Cursor / CodeBuddy in the project: the SessionStart hook creates that tool's project root and then pulls. A bare `teamai pull` will not create missing agent roots.
 
 **Q: Hooks aren't firing automatically?**
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -99,6 +99,8 @@ teamai init <group>/TeamAi-<team>
 └── src/
 ```
 
+`teamai init` 只写入 `.teamai/`。各 Agent 的项目根目录（`.claude/`、`.cursor/`、`.codebuddy/` 等）会在 **SessionStart** 时按刚打开的工具创建（`--tool claude` 会建 `.claude/`，再 pull 写入）。单独执行 `teamai pull` 仍会跳过项目里还不存在根目录的工具，因此不会给尚未在本项目打开过的 Agent 凭空建目录。
+
 如果仓库启用了角色化 skills（存在 `manifest/roles.yaml`），`teamai init` 还会交互式要求你选择：
 
 - `primaryRole`：默认 skill 同步和推送的目标 namespace
@@ -287,7 +289,7 @@ teamai skill show hai-deploy-test   # 看单个 skill 的来源 / 贡献者 / �
 
 ### 自动同步
 
-`teamai init` 时已注入 Hooks 到你的 AI 工具中。**每次启动 AI 会话时会自动执行 `teamai pull`**，无需手动操作。
+`teamai init` 时已注入 Hooks 到你的 AI 工具中。**每次启动 AI 会话时会自动执行 `teamai pull`**，无需手动操作。在 project scope 下，该 SessionStart hook 会先为当前 Agent 创建项目根目录（例如用 Claude Code 打开仓库时创建 `<project>/.claude`），然后再 pull。
 
 如果需要立即同步，可以手动执行：
 
@@ -873,7 +875,7 @@ teamai session save --push --include-prompt  # 额外带上（脱敏后的）首
 
 | Hook 事件 | 操作 |
 |-----------|------|
-| `SessionStart` | 自动 pull + 上报会话启动 |
+| `SessionStart` | 先为当前 Agent 创建项目根目录（project scope），再自动 pull + 上报会话启动 |
 | `PostToolUse` | skill 追踪 + 知识贡献检测 + dashboard 上报 |
 | `UserPromptSubmit` | slash 命令追踪 |
 | `Stop` | CLI 更新检查 + 上报会话结束 |
@@ -1120,6 +1122,10 @@ teamai pull
 ```bash
 teamai init --repo <group>/<repo> --force
 ```
+
+**Q: 在项目里执行 `teamai init` 后没有 `.claude/`（或 `.cursor/`、`.codebuddy/`）目录？**
+
+这是预期行为。`init` 不知道你会打开哪个 Agent。在项目中打开 Claude Code / Cursor / CodeBuddy：SessionStart hook 会创建该工具的项目根目录并随后 pull。单独执行 `teamai pull` 不会为缺失的 Agent 根目录建目录。
 
 **Q: Hooks 没有自动触发？**
 

--- a/src/__tests__/e2e/project-agent-cold-start.test.ts
+++ b/src/__tests__/e2e/project-agent-cold-start.test.ts
@@ -21,7 +21,12 @@ interface RunResult {
   output: string;
 }
 
-function runCLI(args: string[], env: Record<string, string>, cwd: string): Promise<RunResult> {
+function runCLI(
+  args: string[],
+  env: Record<string, string>,
+  cwd: string,
+  stdin = '',
+): Promise<RunResult> {
   return new Promise((resolve) => {
     const child = spawn('node', [CLI, ...args], {
       env: { ...process.env, FORCE_COLOR: '0', ...env },
@@ -31,7 +36,7 @@ function runCLI(args: string[], env: Record<string, string>, cwd: string): Promi
     let output = '';
     child.stdout.on('data', (data: Buffer) => { output += data.toString(); });
     child.stderr.on('data', (data: Buffer) => { output += data.toString(); });
-    child.stdin.end();
+    child.stdin.end(stdin);
     child.on('close', (code) => resolve({ code, output }));
   });
 }
@@ -193,5 +198,71 @@ describe('project-scope sequential agent cold start (#342)', () => {
     expect(fs.existsSync(path.join(projectRoot, '.codebuddy', 'skills'))).toBe(false);
     expect(fs.existsSync(path.join(projectRoot, '.codebuddy', 'rules'))).toBe(false);
     expect(fs.existsSync(path.join(projectRoot, '.codebuddy', 'agents'))).toBe(false);
+  }, 30_000);
+
+  it('does not create missing agent roots on a bare pull', async () => {
+    for (const agentRoot of ['.claude', '.cursor', '.codex', '.codebuddy']) {
+      fs.rmSync(path.join(projectRoot, agentRoot), { recursive: true, force: true });
+    }
+    fs.rmSync(path.join(projectRoot, '.teamai', 'state.json'), { force: true });
+
+    const result = await runCLI(['pull'], { HOME: homeDir }, projectRoot);
+    expect(result.code, result.output).toBe(0);
+    expect(fs.existsSync(path.join(projectRoot, '.claude'))).toBe(false);
+    expect(fs.existsSync(path.join(projectRoot, '.cursor'))).toBe(false);
+  }, 30_000);
+
+  it('SessionStart --tool claude seeds .claude then pulls into it', async () => {
+    for (const agentRoot of ['.claude', '.cursor', '.codex', '.codebuddy']) {
+      fs.rmSync(path.join(projectRoot, agentRoot), { recursive: true, force: true });
+    }
+    fs.rmSync(path.join(projectRoot, '.teamai', 'state.json'), { force: true });
+
+    const result = await runCLI(
+      ['hook-dispatch', 'session-start', '--tool', 'claude', '--bg-only'],
+      { HOME: homeDir },
+      projectRoot,
+      JSON.stringify({ cwd: projectRoot }),
+    );
+    expect(result.code, result.output).toBe(0);
+    expect(fs.existsSync(path.join(projectRoot, '.claude', 'skills', 'team-skill', 'SKILL.md'))).toBe(true);
+    expect(fs.existsSync(path.join(projectRoot, '.cursor'))).toBe(false);
+    expect(JSON.parse(
+      fs.readFileSync(path.join(projectRoot, '.teamai', 'state.json'), 'utf8'),
+    ).lastPullTargets).toEqual(['claude']);
+  }, 30_000);
+
+  it('SessionStart --tool cursor seeds only .cursor, not .claude', async () => {
+    for (const agentRoot of ['.claude', '.cursor', '.codex', '.codebuddy']) {
+      fs.rmSync(path.join(projectRoot, agentRoot), { recursive: true, force: true });
+    }
+    fs.rmSync(path.join(projectRoot, '.teamai', 'state.json'), { force: true });
+
+    const result = await runCLI(
+      ['hook-dispatch', 'session-start', '--tool', 'cursor', '--bg-only'],
+      { HOME: homeDir },
+      projectRoot,
+      JSON.stringify({ cwd: projectRoot }),
+    );
+    expect(result.code, result.output).toBe(0);
+    expect(fs.existsSync(path.join(projectRoot, '.cursor', 'skills', 'team-skill', 'SKILL.md'))).toBe(true);
+    expect(fs.existsSync(path.join(projectRoot, '.claude'))).toBe(false);
+    expect(fs.existsSync(path.join(projectRoot, '.codebuddy'))).toBe(false);
+  }, 30_000);
+
+  it('SessionStart does not seed a disabled agent', async () => {
+    for (const agentRoot of ['.claude', '.cursor', '.codex', '.codebuddy']) {
+      fs.rmSync(path.join(projectRoot, agentRoot), { recursive: true, force: true });
+    }
+    fs.rmSync(path.join(projectRoot, '.teamai', 'state.json'), { force: true });
+
+    const result = await runCLI(
+      ['hook-dispatch', 'session-start', '--tool', 'codebuddy', '--bg-only'],
+      { HOME: homeDir },
+      projectRoot,
+      JSON.stringify({ cwd: projectRoot }),
+    );
+    expect(result.code, result.output).toBe(0);
+    expect(fs.existsSync(path.join(projectRoot, '.codebuddy'))).toBe(false);
   }, 30_000);
 });

--- a/src/__tests__/hook-handlers.test.ts
+++ b/src/__tests__/hook-handlers.test.ts
@@ -58,6 +58,11 @@ vi.mock('../local-agent.js', () => ({
   reportAndSyncFromHook: mockReportAndSyncFromHook,
 }));
 
+const mockSeedProjectAgentRoot = vi.fn().mockResolvedValue(undefined);
+vi.mock('../project-agent-root.js', () => ({
+  seedProjectAgentRoot: mockSeedProjectAgentRoot,
+}));
+
 import { buildHandlerRegistry, filterHandlersForConfig, type HandlerRegistration } from '../hook-handlers.js';
 import { createDispatcher } from '../hook-dispatch.js';
 
@@ -84,6 +89,21 @@ describe('hook-handlers registry', () => {
       .map((r) => r.handler.name);
     expect(sessionStartHandlers).toContain('pull');
     expect(sessionStartHandlers).toContain('dashboard-report');
+  });
+
+  it('session-start pull seeds the hook tool root before pulling', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'session-start' && r.handler.name === 'pull',
+    )!.handler;
+
+    await handler.execute({ cwd: '/tmp/some-project' }, 'claude');
+
+    expect(mockSeedProjectAgentRoot).toHaveBeenCalledWith('claude', '/tmp/some-project');
+    expect(mockPull).toHaveBeenCalledWith({ silent: true });
+    expect(mockSeedProjectAgentRoot.mock.invocationCallOrder[0]).toBeLessThan(
+      mockPull.mock.invocationCallOrder[0],
+    );
   });
 
   it('stop has update, contribute-check, and dashboard-report handlers', () => {

--- a/src/__tests__/project-agent-root.test.ts
+++ b/src/__tests__/project-agent-root.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import YAML from 'yaml';
+import { seedProjectAgentRoot } from '../project-agent-root.js';
+
+let tmpDir: string;
+
+function writeProjectConfig(opts: {
+  projectRoot?: string;
+  enabledAgents?: string[];
+  disabledAgents?: string[];
+  teamYaml?: string;
+}): string {
+  const projectRoot = opts.projectRoot ?? tmpDir;
+  const teamaiDir = path.join(projectRoot, '.teamai');
+  const repoPath = path.join(teamaiDir, 'team-repo');
+  fs.mkdirSync(repoPath, { recursive: true });
+  fs.writeFileSync(
+    path.join(teamaiDir, 'config.yaml'),
+    YAML.stringify({
+      repo: { localPath: repoPath, remote: 'https://example.com/team.git' },
+      username: 'ci',
+      scope: 'project',
+      projectRoot,
+      ...(opts.enabledAgents ? { enabledAgents: opts.enabledAgents } : {}),
+      ...(opts.disabledAgents ? { disabledAgents: opts.disabledAgents } : {}),
+    }),
+  );
+  if (opts.teamYaml !== undefined) {
+    fs.writeFileSync(path.join(repoPath, 'teamai.yaml'), opts.teamYaml);
+  }
+  return projectRoot;
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-seed-agent-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('seedProjectAgentRoot', () => {
+  it('creates the current tool root under a project-scope cwd', async () => {
+    const projectRoot = writeProjectConfig({});
+    expect(fs.existsSync(path.join(projectRoot, '.claude'))).toBe(false);
+
+    await seedProjectAgentRoot('claude', projectRoot);
+
+    expect(fs.existsSync(path.join(projectRoot, '.claude'))).toBe(true);
+    expect(fs.existsSync(path.join(projectRoot, '.cursor'))).toBe(false);
+    expect(fs.existsSync(path.join(projectRoot, '.codebuddy'))).toBe(false);
+  });
+
+  it('creates only the requested tool root (cursor, not claude)', async () => {
+    const projectRoot = writeProjectConfig({});
+    await seedProjectAgentRoot('cursor', projectRoot);
+    expect(fs.existsSync(path.join(projectRoot, '.cursor'))).toBe(true);
+    expect(fs.existsSync(path.join(projectRoot, '.claude'))).toBe(false);
+  });
+
+  it('creates .codebuddy when the hook tool is codebuddy', async () => {
+    const projectRoot = writeProjectConfig({});
+    await seedProjectAgentRoot('codebuddy', projectRoot);
+    expect(fs.existsSync(path.join(projectRoot, '.codebuddy'))).toBe(true);
+    expect(fs.existsSync(path.join(projectRoot, '.claude'))).toBe(false);
+  });
+
+  it('does nothing when cwd has no project-scope config', async () => {
+    await seedProjectAgentRoot('claude', tmpDir);
+    expect(fs.existsSync(path.join(tmpDir, '.claude'))).toBe(false);
+  });
+
+  it('does nothing for user-scope config in cwd', async () => {
+    const teamaiDir = path.join(tmpDir, '.teamai');
+    fs.mkdirSync(teamaiDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(teamaiDir, 'config.yaml'),
+      YAML.stringify({
+        repo: { localPath: teamaiDir, remote: 'https://example.com/team.git' },
+        username: 'ci',
+        scope: 'user',
+      }),
+    );
+    await seedProjectAgentRoot('claude', tmpDir);
+    expect(fs.existsSync(path.join(tmpDir, '.claude'))).toBe(false);
+  });
+
+  it('does not create a disabled agent root', async () => {
+    const projectRoot = writeProjectConfig({ disabledAgents: ['claude'] });
+    await seedProjectAgentRoot('claude', projectRoot);
+    expect(fs.existsSync(path.join(projectRoot, '.claude'))).toBe(false);
+  });
+
+  it('does not create a tool missing from enabledAgents', async () => {
+    const projectRoot = writeProjectConfig({ enabledAgents: ['cursor'] });
+    await seedProjectAgentRoot('claude', projectRoot);
+    expect(fs.existsSync(path.join(projectRoot, '.claude'))).toBe(false);
+    await seedProjectAgentRoot('cursor', projectRoot);
+    expect(fs.existsSync(path.join(projectRoot, '.cursor'))).toBe(true);
+  });
+
+  it('does not create an unknown tool root', async () => {
+    const projectRoot = writeProjectConfig({});
+    await seedProjectAgentRoot('not-a-tool', projectRoot);
+    expect(fs.readdirSync(projectRoot).filter((name) => name.startsWith('.'))).toEqual(['.teamai']);
+  });
+
+  it('is idempotent when the agent root already exists', async () => {
+    const projectRoot = writeProjectConfig({});
+    fs.mkdirSync(path.join(projectRoot, '.claude'));
+    await seedProjectAgentRoot('claude', projectRoot);
+    expect(fs.existsSync(path.join(projectRoot, '.claude'))).toBe(true);
+  });
+
+  it('uses teamai.yaml toolPaths when they override the default root', async () => {
+    const projectRoot = writeProjectConfig({
+      teamYaml: [
+        'team: t',
+        'repo: https://example.com/team.git',
+        'toolPaths:',
+        '  claude:',
+        '    skills: .claude-custom/skills',
+      ].join('\n'),
+    });
+    await seedProjectAgentRoot('claude', projectRoot);
+    expect(fs.existsSync(path.join(projectRoot, '.claude-custom'))).toBe(true);
+    expect(fs.existsSync(path.join(projectRoot, '.claude'))).toBe(false);
+  });
+});

--- a/src/hook-handlers.ts
+++ b/src/hook-handlers.ts
@@ -14,6 +14,7 @@ import path from 'node:path';
 import type { HookHandler } from './hook-dispatch.js';
 import type { LocalConfig } from './types.js';
 import { deriveSessionId } from './utils/session-id.js';
+import { log } from './utils/logger.js';
 import { normalizeToolName } from './utils/tool-names.js';
 
 // ─── Public types ───────────────────────────────────────
@@ -81,7 +82,14 @@ const LOCAL_AGENT_TIMEOUT_MS = 15_000;
 
 const pullHandler: HookHandler = {
   name: 'pull',
-  async execute(_stdin, _tool) {
+  async execute(stdin, tool) {
+    const cwd = typeof stdin.cwd === 'string' ? stdin.cwd : undefined;
+    try {
+      const { seedProjectAgentRoot } = await import('./project-agent-root.js');
+      await seedProjectAgentRoot(tool, cwd);
+    } catch (e) {
+      log.debug(`hook-dispatch: seedProjectAgentRoot failed: ${(e as Error).message}`);
+    }
     const { pull } = await import('./pull.js');
     await pull({ silent: true });
     return null;

--- a/src/project-agent-root.ts
+++ b/src/project-agent-root.ts
@@ -1,0 +1,66 @@
+import path from 'node:path';
+
+import { detectProjectConfig, loadTeamConfig } from './config.js';
+import { KNOWN_AGENTS } from './known-agents.js';
+import { toolInstallRoot } from './resources/base.js';
+import { isAgentDisabled, resolveBaseDir, scopedToolPaths } from './types.js';
+import { ensureDir } from './utils/fs.js';
+import { log } from './utils/logger.js';
+
+/**
+ * Relative agent-root paths we are willing to mkdir under projectRoot.
+ * Must stay relative, dotted (`.claude`, `.config/opencode`), and free of `..`.
+ */
+function isSafeRelativeRoot(root: string): boolean {
+  if (!root) return false;
+  const posix = root.replaceAll('\\', '/');
+  if (path.isAbsolute(root) || path.isAbsolute(posix)) return false;
+  if (posix === '~' || posix.startsWith('~/')) return false;
+  const segments = posix.split('/');
+  if (segments.some((segment) => !segment || segment === '.' || segment === '..')) return false;
+  return segments[0].startsWith('.');
+}
+
+function resolveSkillsPath(
+  tool: string,
+  teamConfig: Awaited<ReturnType<typeof loadTeamConfig>>,
+  localConfig: { scope?: 'project' | 'user' },
+): string | undefined {
+  if (teamConfig) {
+    const fromTeam = scopedToolPaths(teamConfig, localConfig)[tool]?.skills;
+    if (fromTeam) return fromTeam;
+  }
+  return KNOWN_AGENTS.find((agent) => agent.id === tool)?.skillsPath;
+}
+
+/**
+ * Project-scope SessionStart: create the *current* agent's install root under
+ * the project (e.g. `<project>/.claude`) so a subsequent `teamai pull` has
+ * somewhere to write. Bare `teamai pull` / `teamai init` still do not create
+ * agent roots — only the hook that knows which tool just opened does.
+ *
+ * No-ops when: not project scope, the tool is disabled / not in enabledAgents,
+ * the tool is unknown, or the resolved root would escape the project.
+ */
+export async function seedProjectAgentRoot(tool: string, cwd?: string): Promise<void> {
+  const id = tool.trim();
+  if (!id) return;
+
+  const projectConfig = await detectProjectConfig(cwd);
+  if (!projectConfig) return;
+
+  if (isAgentDisabled(projectConfig, id)) return;
+  const enabled = projectConfig.enabledAgents;
+  if (enabled && enabled.length > 0 && !enabled.includes(id)) return;
+
+  const teamConfig = await loadTeamConfig(projectConfig.repo.localPath);
+  const skillsPath = resolveSkillsPath(id, teamConfig, projectConfig);
+  if (!skillsPath) return;
+
+  const root = toolInstallRoot(skillsPath);
+  if (!isSafeRelativeRoot(root)) return;
+
+  const dest = path.join(resolveBaseDir(projectConfig), root);
+  await ensureDir(dest);
+  log.debug(`Seeded project agent root for ${id}: ${dest}`);
+}


### PR DESCRIPTION
## Summary
- In project scope, SessionStart with `--tool claude|cursor|codebuddy|…` now creates that agent's project root (`<project>/.claude`, etc.) before `teamai pull`, so the first open of Claude/Cursor/CodeBuddy actually syncs skills.
- Bare `teamai pull` / `teamai init` still do not invent agent directories. Disabled agents and tools missing from `enabledAgents` are not seeded.
- Completes the original project-scope cold-start workflow that #343 only covered for already-existing roots.

## Test plan
- [x] Unit: `seedProjectAgentRoot` creates only the requested tool root; no-ops for user scope, disabled agents, unknown tools, and `enabledAgents` misses
- [x] Unit: SessionStart pull handler calls seed before `pull({ silent: true })`
- [x] E2E: bare `teamai pull` does not create `.claude`
- [x] E2E: `hook-dispatch session-start --tool claude --bg-only` seeds `.claude` and writes the team skill; `--tool cursor` seeds only `.cursor`; disabled codebuddy is not created
- [x] Local: global CLI from this branch, open Claude in a project-scope repo (`hai`) — `.claude/` appears and pull targets are no longer empty


Made with [Cursor](https://cursor.com)