### PR TITLE
fix(openclaw): silence "no workspace dir" warning when OpenClaw not installed

### DIFF
--- a/src/openclaw-hooks.ts
+++ b/src/openclaw-hooks.ts
@@ -239,6 +239,10 @@ export async function resolveOpenclawWorkspaceDir(workspacePath?: string): Promi
       return candidate;
     }
   }
-  log.warn(`openclaw: no workspace dir found (tried: ${candidates.join(', ') || 'none'})`);
+  // A missing workspace dir is the normal case when OpenClaw is not installed;
+  // callers treat null as "skip openclaw" and log their own debug line, so keep
+  // this at debug level to avoid warning noise (one line per skill/file) on
+  // machines without OpenClaw.
+  log.debug(`openclaw: no workspace dir found (tried: ${candidates.join(', ') || 'none'})`);
   return null;
 }


### PR DESCRIPTION
## Problem

On a machine without OpenClaw installed, `teamai pull` prints a warning for every skill and every CLAUDE.md file it syncs:

```
⚠ openclaw: no workspace dir found (tried: /Users/.../.openclaw/workspace)
⚠ openclaw: no workspace dir found (tried: /Users/.../.openclaw/workspace)
... (repeated 19+ times)
```

`resolveOpenclawWorkspaceDir()` returns `null` when no workspace dir exists, then emits `log.warn`. But a missing workspace dir is simply the normal case when OpenClaw isn't installed — every caller (`skills.ts`, `local-agent.ts`, `uninstall.ts`) already treats `null` as "skip openclaw" and logs its own `debug` line. The `log.warn` is pure noise, and because it fires once per skill / per CLAUDE.md file, it floods the output.

## Fix

Downgrade the single `log.warn` in `resolveOpenclawWorkspaceDir()` to `log.debug`. No logic change; the diagnostic is still available in `~/.teamai/debug.log` for troubleshooting.

## Test Plan

- [x] `npx tsc --noEmit` — passes
- [x] `npm run build` — succeeds
- [x] `teamai pull` (via the freshly built dist, in a project without OpenClaw) — **0** openclaw warnings on the terminal (was 19+)
- [x] Confirmed the message is still written to `~/.teamai/debug.log` at DEBUG level, so observability is preserved