### PR TITLE
fix(doctor): resolve env.sh path via getTeamaiHome for project scope

### DIFF
--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -7,6 +7,7 @@ import {
   TeamaiConfigSchema,
   TEAMAI_ENV_START,
   resolveBaseDir,
+  getTeamaiHome,
   type TeamaiConfig,
 } from './types.js';
 import { TEAMAI_HOOK_SUBCOMMANDS } from './hooks.js';
@@ -147,7 +148,13 @@ export async function doctor(options: GlobalOptions): Promise<void> {
 
         const home = getUserHome();
 
-        const envShPath = path.join(home, '.teamai', 'env.sh');
+        // env.sh lives under teamaiHome, which is <projectRoot>/.teamai in
+        // project scope and ~/.teamai in user scope — mirror the path that
+        // `teamai pull` actually writes to, not a hardcoded user-home path.
+        const envShPath = path.join(
+          getTeamaiHome(localConfig.scope, localConfig.projectRoot),
+          'env.sh',
+        );
         if (!await pathExists(envShPath)) return false;
 
         const shell = process.env.SHELL ?? '';


### PR DESCRIPTION
## Problem

Running `teamai doctor` in **project scope** always reports the env-injection check as failed, even when env variables are correctly injected:

```
✖ Env variables injected in shell profile
  → Run `teamai pull` to inject env variables into shell profile
```

## Root Cause

The check in `src/doctor.ts` hardcodes the env.sh path to the user home:

```ts
const envShPath = path.join(home, '.teamai', 'env.sh');
if (!await pathExists(envShPath)) return false;
```

But `teamai pull` writes env.sh to `getTeamaiHome(scope, projectRoot)`, which is `<projectRoot>/.teamai/env.sh` in project scope (and the shell profile is injected to source *that* path). So `~/.teamai/env.sh` never exists in project scope and the check yields a false negative.

## Fix

Resolve the env.sh path with `getTeamaiHome(localConfig.scope, localConfig.projectRoot)` so the check mirrors exactly where pull writes. The shell-profile lookup (`.zshrc`/`.bashrc`) correctly stays under the user home.

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npx vitest run doctor` — 7/7 pass
- [x] Real CLI e2e in a project-scope repo: the check flips ✖ → ✔, full `teamai doctor` reports **All checks passed!**