### PR TITLE
fix(rules): write Cursor rules as .mdc with derived frontmatter

### DIFF
--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -950,6 +950,15 @@ team-repo/
 - **Hooks** are delivered as an OpenCode *plugin*, not a settings-file entry — OpenCode has no `hooks` array; it auto-loads JS/TS plugins from **both** `~/.config/opencode/plugin/` and `<project>/.opencode/plugin/`. A plugin present in both dirs is loaded twice and would dispatch every event twice, so teamai keeps exactly one copy: `teamai-hooks.ts` in the user dir, which covers every project. Any project-scope copy left by an earlier layout is deleted on the next sync. This matches the other tools, whose `settings.json` hooks also live in HOME and gate on the `cwd` handed to `hook-dispatch`. The plugin subscribes to OpenCode's own events and shelling out to the same `teamai hook-dispatch` entry point every other tool uses. The event mapping mirrors the Claude built-in set: `session.created` → session-start, `session.idle` → stop, `chat.message` → prompt-submit, `tool.execute.after` → post-tool-use. The plugin forwards the same STDIN payload other agents send (`cwd`, `tool_name`, `tool_input`, `prompt`), and maps OpenCode's lowercase tool ids (`skill`, `todowrite`) back to the PascalCase matchers the handler registry expects. OpenCode cannot inject a hook's stdout back into the session, so hooks run purely for their side effects (status report / sync / update). Note that OpenCode *awaits* its named hooks (`chat.message`, `tool.execute.after`), so those dispatches briefly wait on the `teamai` subprocess before the agent continues; the errors are always swallowed so a hook can never fail the session. Server-pushed agent hooks (`teamai-agent-<slug>.ts`) install into the same user plugin dir.
 - **MCP** servers live under the `mcp` key of the shared `opencode.json` (see the MCP section above).
 
+### Cursor
+
+Cursor project rules must live in `.cursor/rules/` as **`.mdc`** files with YAML frontmatter — a plain `.md` file there is silently ignored by Cursor. teamai therefore writes rules to Cursor as `<name>.mdc` (every other tool still gets a plain `.md`), deriving the frontmatter from the team rule:
+
+- A rule scoped with a `paths:` list becomes `globs: <comma-joined>` + `alwaysApply: false` (Cursor auto-attaches it when a matching file is in context).
+- A rule with no `paths` (a mandatory team rule) becomes `alwaysApply: true` (applied to every Cursor chat session).
+
+The markdown body is preserved verbatim; only the frontmatter is machine-derived, so a `pull` → `push` round-trip does not look like a content change. `push` reads back `.cursor/rules/*.mdc` too — editing a rule's body there and running `teamai push` sends just that body change upstream (the Cursor frontmatter is stripped). Stale-file cleanup and `remove` handle the `.mdc` extension as well.
+
 ### Miscellaneous
 
 ```bash

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -954,10 +954,17 @@ team-repo/
 
 Cursor project rules must live in `.cursor/rules/` as **`.mdc`** files with YAML frontmatter — a plain `.md` file there is silently ignored by Cursor. teamai therefore writes rules to Cursor as `<name>.mdc` (every other tool still gets a plain `.md`), deriving the frontmatter from the team rule:
 
-- A rule scoped with a `paths:` list becomes `globs: <comma-joined>` + `alwaysApply: false` (Cursor auto-attaches it when a matching file is in context).
+- A rule scoped with a `paths:` list becomes `globs: "<comma-joined>"` + `alwaysApply: false` (Cursor auto-attaches it when a matching file is in context). The value is quoted because a glob starting with `*` is not valid YAML unquoted.
 - A rule with no `paths` (a mandatory team rule) becomes `alwaysApply: true` (applied to every Cursor chat session).
 
-The markdown body is preserved verbatim; only the frontmatter is machine-derived, so a `pull` → `push` round-trip does not look like a content change. `push` reads back `.cursor/rules/*.mdc` too — editing a rule's body there and running `teamai push` sends just that body change upstream (the Cursor frontmatter is stripped). Stale-file cleanup and `remove` handle the `.mdc` extension as well.
+Only the markdown body crosses between the two formats; each side keeps its own frontmatter. On `pull` the Cursor frontmatter is machine-derived (the body is copied over with leading/trailing blank lines normalized), so a `pull` → `push` round-trip is not seen as a content change. On `push`, editing a rule's body in `.cursor/rules/*.mdc` and running `teamai push` sends **only that body** upstream — the team rule keeps its own `paths:` frontmatter, so the rule's scope is never silently lost.
+
+Two things are deliberately *not* pushed from Cursor's rules directory:
+
+- A `.mdc` file with no matching team rule. `.cursor/rules/` is also where Cursor's own *New Cursor Rule* command writes personal rules, so teamai never offers those as new team resources.
+- The CLI built-in rules, which are deployed (as `.mdc` for Cursor) rather than synced.
+
+Upgrading from an earlier version: `.cursor/rules/*.md` copies written by the old layout are inert — Cursor never read them — so `pull`, `remove`, and `uninstall` delete them alongside the `.mdc` file. A `.md` you put there yourself is left alone.
 
 ### Miscellaneous
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -945,6 +945,15 @@ team-repo/
 - **Hooks** 以 OpenCode *plugin* 形式交付，而非配置文件条目——OpenCode 没有 `hooks` 数组，它会**同时**加载 `~/.config/opencode/plugin/` 和 `<project>/.opencode/plugin/` 下的 JS/TS 插件。两个目录都有插件时会被加载两次，每个事件也就派发两次，因此 teamai 只保留一份：写在用户目录的 `teamai-hooks.ts`，覆盖所有项目；早期布局残留的项目级副本会在下次同步时被删除。这与其他工具一致——它们的 `settings.json` hooks 同样放在 HOME，靠传给 `hook-dispatch` 的 `cwd` 做作用域判断。插件订阅 OpenCode 自己的事件，并 shell 到其他所有工具共用的 `teamai hook-dispatch` 入口。事件映射对齐 Claude 内置集合：`session.created` → session-start、`session.idle` → stop、`chat.message` → prompt-submit、`tool.execute.after` → post-tool-use。插件会转发与其他工具一致的 STDIN 负载（`cwd`、`tool_name`、`tool_input`、`prompt`），并把 OpenCode 的小写工具 id（`skill`、`todowrite`）映射回 handler 注册表期望的 PascalCase matcher。OpenCode 无法把 hook 的 stdout 回注到会话，因此 hooks 只为副作用运行（状态上报 / 同步 / 更新）。注意 OpenCode 会 **await** 它的具名 hook（`chat.message`、`tool.execute.after`），所以这两个事件的派发会短暂等待 `teamai` 子进程后 agent 才继续；错误始终被吞掉，hook 永远不会让会话失败。服务端下发的 agent hook（`teamai-agent-<slug>.ts`）同样装在这个用户级 plugin 目录下。
 - **MCP** server 位于共享 `opencode.json` 的 `mcp` 键下（详见上文 MCP 章节）。
 
+### Cursor
+
+Cursor 的项目规则必须以 **`.mdc`** 文件形式放在 `.cursor/rules/` 下，且带 YAML frontmatter——放在那里的纯 `.md` 会被 Cursor 直接忽略。因此 teamai 向 Cursor 写规则时用 `<name>.mdc`（其他工具仍写纯 `.md`），并从团队规则派生 frontmatter：
+
+- 带 `paths:` 列表的规则会转成 `globs: <逗号拼接>` + `alwaysApply: false`（上下文中有匹配文件时 Cursor 自动附加该规则）。
+- 无 `paths` 的规则（团队强制规则）会转成 `alwaysApply: true`（每个 Cursor 会话都应用）。
+
+markdown 正文原样保留，只有 frontmatter 是机器派生的，因此 `pull` → `push` 往返不会被误判为内容变更。`push` 同样会读取 `.cursor/rules/*.mdc`——在那里改规则正文后执行 `teamai push`，只会把正文改动回流上游（Cursor 的 frontmatter 会被剥除）。stale 文件清理与 `remove` 也会处理 `.mdc` 扩展名。
+
 ### 其他
 
 ```bash

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -949,10 +949,17 @@ team-repo/
 
 Cursor 的项目规则必须以 **`.mdc`** 文件形式放在 `.cursor/rules/` 下，且带 YAML frontmatter——放在那里的纯 `.md` 会被 Cursor 直接忽略。因此 teamai 向 Cursor 写规则时用 `<name>.mdc`（其他工具仍写纯 `.md`），并从团队规则派生 frontmatter：
 
-- 带 `paths:` 列表的规则会转成 `globs: <逗号拼接>` + `alwaysApply: false`（上下文中有匹配文件时 Cursor 自动附加该规则）。
+- 带 `paths:` 列表的规则会转成 `globs: "<逗号拼接>"` + `alwaysApply: false`（上下文中有匹配文件时 Cursor 自动附加该规则）。值加引号是因为以 `*` 开头的 glob 不加引号时并非合法 YAML。
 - 无 `paths` 的规则（团队强制规则）会转成 `alwaysApply: true`（每个 Cursor 会话都应用）。
 
-markdown 正文原样保留，只有 frontmatter 是机器派生的，因此 `pull` → `push` 往返不会被误判为内容变更。`push` 同样会读取 `.cursor/rules/*.mdc`——在那里改规则正文后执行 `teamai push`，只会把正文改动回流上游（Cursor 的 frontmatter 会被剥除）。stale 文件清理与 `remove` 也会处理 `.mdc` 扩展名。
+两种格式之间只有 markdown 正文互通，各自的 frontmatter 归各自所有。`pull` 时 Cursor 的 frontmatter 由机器派生（正文原样拷贝，仅规范化首尾空行），因此 `pull` → `push` 往返不会被误判为内容变更。`push` 时，在 `.cursor/rules/*.mdc` 里改完正文再执行 `teamai push`，**只有正文**会回流上游——团队规则自己的 `paths:` frontmatter 会被保留，规则的作用域不会被悄悄丢掉。
+
+有两类文件刻意**不会**从 Cursor 规则目录推送：
+
+- 团队仓库中没有同名规则的 `.mdc`。`.cursor/rules/` 同时也是 Cursor 自带的 *New Cursor Rule* 命令写入个人规则的地方，teamai 不会把它们当作新的团队资源。
+- CLI 内置规则——它们是被下发的（对 Cursor 同样写成 `.mdc`），而非同步而来。
+
+从旧版本升级：旧布局写入的 `.cursor/rules/*.md` 是无效文件（Cursor 从未读取过它们），因此 `pull`、`remove`、`uninstall` 会连同 `.mdc` 一起删除。你自己放在那里的 `.md` 不受影响。
 
 ### 其他
 

--- a/src/__tests__/builtin-rules.test.ts
+++ b/src/__tests__/builtin-rules.test.ts
@@ -50,6 +50,35 @@ describe('builtin-rules', () => {
             expect(content).toContain('teamai recall');
         });
 
+        it('should deploy the recall rule to cursor as .mdc, not an ignored .md', async () => {
+            const cursorRulesDir = path.join(tmpDir, '.cursor', 'rules');
+            fs.mkdirSync(cursorRulesDir, { recursive: true });
+            // A copy left by the layout that predates `.mdc`.
+            fs.writeFileSync(path.join(cursorRulesDir, 'teamai-recall.md'), 'stale');
+
+            const teamConfig = {
+                toolPaths: {
+                    cursor: {
+                        skills: '.cursor/skills',
+                        rules: '.cursor/rules',
+                        settings: '.cursor/hooks.json',
+                    },
+                },
+            } as any;
+
+            const { deployBuiltinRules } = await import('../builtin-rules.js');
+            await deployBuiltinRules(teamConfig);
+
+            const mdc = path.join(cursorRulesDir, 'teamai-recall.mdc');
+            expect(fs.existsSync(mdc)).toBe(true);
+            // Cursor silently ignores a plain `.md` here, so it must not linger.
+            expect(fs.existsSync(path.join(cursorRulesDir, 'teamai-recall.md'))).toBe(false);
+            const content = fs.readFileSync(mdc, 'utf-8');
+            expect(content.startsWith('---\n')).toBe(true);
+            expect(content).toContain('alwaysApply: true');
+            expect(content).toContain('Team Knowledge Recall');
+        });
+
         it('should skip tool directories that do not exist (tool not installed)', async () => {
             // Arrange: only create one tool directory
             const claudeRulesDir = path.join(tmpDir, '.claude', 'rules');

--- a/src/__tests__/cursor-mdc.test.ts
+++ b/src/__tests__/cursor-mdc.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
+import matter from 'gray-matter';
 import {
   teamRuleToCursorMdc,
-  cursorMdcToTeamMd,
+  mergeCursorBodyIntoTeamMd,
   cursorMdcBodyEqualsTeamMd,
 } from '../resources/cursor-mdc.js';
 
@@ -15,7 +16,7 @@ paths:
 
 Use named exports.`;
     const mdc = teamRuleToCursorMdc(team);
-    expect(mdc).toContain('globs: **/*.ts, **/*.tsx');
+    expect(mdc).toContain('globs: "**/*.ts, **/*.tsx"');
     expect(mdc).toContain('alwaysApply: false');
     expect(mdc).toContain('Use named exports.');
   });
@@ -47,7 +48,7 @@ paths: "src/**/*.py, tests/**/*.py"
 
 Python rule.`;
     const mdc = teamRuleToCursorMdc(team);
-    expect(mdc).toContain('globs: src/**/*.py, tests/**/*.py');
+    expect(mdc).toContain('globs: "src/**/*.py, tests/**/*.py"');
     expect(mdc).toContain('alwaysApply: false');
   });
 
@@ -56,19 +57,81 @@ Python rule.`;
   });
 });
 
-describe('cursorMdcToTeamMd', () => {
-  it('strips Cursor frontmatter and keeps the body', () => {
-    const mdc = `---
+describe('teamRuleToCursorMdc — emitted frontmatter is valid YAML', () => {
+  it('quotes globs so a leading-star glob does not break the YAML parse', () => {
+    const team = `---
+paths:
+  - "**/*.ts"
+---
+
+Body.`;
+    const mdc = teamRuleToCursorMdc(team);
+    // Unquoted, `**/*.ts` is a YAML alias node and the whole block fails to
+    // parse — which would leave Cursor ignoring the rule all over again.
+    expect(() => matter(mdc)).not.toThrow();
+    expect(matter(mdc).data).toEqual({ globs: '**/*.ts', alwaysApply: false });
+  });
+
+  it('honours a team rule authored with an unquoted `globs:` value', () => {
+    const team = `---
 globs: **/*.ts
+---
+
+Body.`;
+    const mdc = teamRuleToCursorMdc(team);
+    expect(matter(mdc).data).toEqual({ globs: '**/*.ts', alwaysApply: false });
+  });
+});
+
+describe('mergeCursorBodyIntoTeamMd', () => {
+  it('keeps the team rule frontmatter and replaces only the body', () => {
+    const team = `---
+paths:
+  - "**/*.ts"
+---
+
+Original body.`;
+    const mdc = `---
+globs: "**/*.ts"
 alwaysApply: false
 ---
 
-The rule body.`;
-    expect(cursorMdcToTeamMd(mdc)).toBe('The rule body.\n');
+Edited body.`;
+    const merged = mergeCursorBodyIntoTeamMd(mdc, team);
+    expect(merged).toContain('paths:');
+    expect(merged).toContain('- "**/*.ts"');
+    expect(merged).toContain('Edited body.');
+    expect(merged).not.toContain('Original body.');
+    expect(merged).not.toContain('alwaysApply');
+    expect(merged).not.toContain('globs');
   });
 
-  it('handles content with no frontmatter', () => {
-    expect(cursorMdcToTeamMd('just a body')).toBe('just a body\n');
+  it('returns the team file untouched when the body did not change', () => {
+    const team = `---
+paths: ["**/*.ts"]
+---
+
+Same body.`;
+    const mdc = teamRuleToCursorMdc(team);
+    expect(mergeCursorBodyIntoTeamMd(mdc, team)).toBe(team);
+  });
+
+  it('writes body only for a rule that does not exist upstream yet', () => {
+    const mdc = `---
+alwaysApply: true
+---
+
+Brand new rule.`;
+    expect(mergeCursorBodyIntoTeamMd(mdc, null)).toBe('Brand new rule.\n');
+  });
+
+  it('handles a team rule that has no frontmatter', () => {
+    expect(mergeCursorBodyIntoTeamMd('just a body', 'old body')).toBe('just a body\n');
+  });
+
+  it('does not leak an empty `---/---` block into the body', () => {
+    const mdc = '---\n---\nThe rule body.';
+    expect(mergeCursorBodyIntoTeamMd(mdc, null)).toBe('The rule body.\n');
   });
 });
 

--- a/src/__tests__/cursor-mdc.test.ts
+++ b/src/__tests__/cursor-mdc.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import {
+  teamRuleToCursorMdc,
+  cursorMdcToTeamMd,
+  cursorMdcBodyEqualsTeamMd,
+} from '../resources/cursor-mdc.js';
+
+describe('teamRuleToCursorMdc', () => {
+  it('maps a team `paths:` array to Cursor `globs` with alwaysApply=false', () => {
+    const team = `---
+paths:
+  - "**/*.ts"
+  - "**/*.tsx"
+---
+
+Use named exports.`;
+    const mdc = teamRuleToCursorMdc(team);
+    expect(mdc).toContain('globs: **/*.ts, **/*.tsx');
+    expect(mdc).toContain('alwaysApply: false');
+    expect(mdc).toContain('Use named exports.');
+  });
+
+  it('treats a rule with no frontmatter as always-on (alwaysApply=true)', () => {
+    const team = 'Always follow the MR submission process.';
+    const mdc = teamRuleToCursorMdc(team);
+    expect(mdc).toContain('alwaysApply: true');
+    expect(mdc).not.toContain('globs:');
+    expect(mdc).toContain('Always follow the MR submission process.');
+  });
+
+  it('treats a rule with unrelated frontmatter (no paths) as always-on', () => {
+    const team = `---
+title: Some Rule
+---
+
+Body here.`;
+    const mdc = teamRuleToCursorMdc(team);
+    expect(mdc).toContain('alwaysApply: true');
+    expect(mdc).not.toContain('globs:');
+    expect(mdc).toContain('Body here.');
+  });
+
+  it('accepts a comma-separated string `paths`', () => {
+    const team = `---
+paths: "src/**/*.py, tests/**/*.py"
+---
+
+Python rule.`;
+    const mdc = teamRuleToCursorMdc(team);
+    expect(mdc).toContain('globs: src/**/*.py, tests/**/*.py');
+    expect(mdc).toContain('alwaysApply: false');
+  });
+
+  it('starts the output with a frontmatter block', () => {
+    expect(teamRuleToCursorMdc('body').startsWith('---\n')).toBe(true);
+  });
+});
+
+describe('cursorMdcToTeamMd', () => {
+  it('strips Cursor frontmatter and keeps the body', () => {
+    const mdc = `---
+globs: **/*.ts
+alwaysApply: false
+---
+
+The rule body.`;
+    expect(cursorMdcToTeamMd(mdc)).toBe('The rule body.\n');
+  });
+
+  it('handles content with no frontmatter', () => {
+    expect(cursorMdcToTeamMd('just a body')).toBe('just a body\n');
+  });
+});
+
+describe('cursorMdcBodyEqualsTeamMd — round-trip stability', () => {
+  it('a pulled .mdc compares equal to its source team .md (no spurious modified)', () => {
+    const team = `---
+paths:
+  - "**/*.ts"
+---
+
+Rule text that must not drift.`;
+    const mdc = teamRuleToCursorMdc(team);
+    expect(cursorMdcBodyEqualsTeamMd(mdc, team)).toBe(true);
+  });
+
+  it('a mandatory (no-frontmatter) team rule round-trips equal', () => {
+    const team = 'A mandatory rule with no frontmatter.';
+    const mdc = teamRuleToCursorMdc(team);
+    expect(cursorMdcBodyEqualsTeamMd(mdc, team)).toBe(true);
+  });
+
+  it('detects a genuine body edit as different', () => {
+    const team = `---
+paths: ["**/*.ts"]
+---
+
+Original body.`;
+    const editedMdc = `---
+globs: **/*.ts
+alwaysApply: false
+---
+
+Edited body.`;
+    expect(cursorMdcBodyEqualsTeamMd(editedMdc, team)).toBe(false);
+  });
+
+  it('ignores frontmatter-only differences', () => {
+    const team = `---
+paths: ["**/*.ts"]
+---
+
+Same body.`;
+    const differentFrontmatter = `---
+alwaysApply: true
+---
+
+Same body.`;
+    expect(cursorMdcBodyEqualsTeamMd(differentFrontmatter, team)).toBe(true);
+  });
+});

--- a/src/__tests__/pre-push-sync.test.ts
+++ b/src/__tests__/pre-push-sync.test.ts
@@ -261,6 +261,80 @@ describe('syncTeamUpdatesToLocal — rules', () => {
     expect(mockGetFileContentAtRev).not.toHaveBeenCalled();
   });
 
+  // Regression: Cursor rules moved to `.mdc`, and matching only `.md` here made
+  // pre-push sync skip them entirely — push then reported the stale local copy
+  // as "modified" and sent it upstream, reverting the teammate's update.
+  it('should sync a cursor .mdc rule when the team updated it and the user did not', async () => {
+    await fse.ensureDir(path.join(homeDir, '.cursor', 'rules'));
+    teamConfig.toolPaths.cursor = {
+      skills: '.cursor/skills',
+      rules: '.cursor/rules',
+      settings: '.cursor/hooks.json',
+    };
+
+    // Team repo has v2, scoped.
+    await fse.writeFile(
+      path.join(repoPath, 'rules', 'my-rule.md'),
+      '---\npaths:\n  - "**/*.ts"\n---\n\nv2 content',
+    );
+    // Local Cursor copy is still v1, in Cursor's derived-frontmatter form.
+    await fse.writeFile(
+      path.join(homeDir, '.cursor/rules', 'my-rule.mdc'),
+      '---\nglobs: "**/*.ts"\nalwaysApply: false\n---\n\nv1 content',
+    );
+    mockGetFileContentAtRev.mockResolvedValue(
+      Buffer.from('---\npaths:\n  - "**/*.ts"\n---\n\nv1 content'),
+    );
+
+    await syncTeamUpdatesToLocal(teamConfig, localConfig, 'abc1234');
+
+    const content = await fse.readFile(path.join(homeDir, '.cursor/rules', 'my-rule.mdc'), 'utf-8');
+    expect(content).toContain('v2 content');
+    // Refreshed in Cursor's format, not as a raw copy of the team `.md`.
+    expect(content).toContain('globs: "**/*.ts"');
+    expect(content).not.toContain('paths:');
+  });
+
+  it('should NOT sync a cursor .mdc rule the user edited', async () => {
+    await fse.ensureDir(path.join(homeDir, '.cursor', 'rules'));
+    teamConfig.toolPaths.cursor = {
+      skills: '.cursor/skills',
+      rules: '.cursor/rules',
+      settings: '.cursor/hooks.json',
+    };
+
+    await fse.writeFile(path.join(repoPath, 'rules', 'my-rule.md'), 'v2 content');
+    await fse.writeFile(
+      path.join(homeDir, '.cursor/rules', 'my-rule.mdc'),
+      '---\nalwaysApply: true\n---\n\nuser custom content',
+    );
+    mockGetFileContentAtRev.mockResolvedValue(Buffer.from('v1 content'));
+
+    await syncTeamUpdatesToLocal(teamConfig, localConfig, 'abc1234');
+
+    const content = await fse.readFile(path.join(homeDir, '.cursor/rules', 'my-rule.mdc'), 'utf-8');
+    expect(content).toContain('user custom content');
+  });
+
+  it('should treat a clean pull of a cursor rule as a no-op', async () => {
+    await fse.ensureDir(path.join(homeDir, '.cursor', 'rules'));
+    teamConfig.toolPaths.cursor = {
+      skills: '.cursor/skills',
+      rules: '.cursor/rules',
+      settings: '.cursor/hooks.json',
+    };
+
+    await fse.writeFile(path.join(repoPath, 'rules', 'my-rule.md'), 'same content');
+    const mdcPath = path.join(homeDir, '.cursor/rules', 'my-rule.mdc');
+    await fse.writeFile(mdcPath, '---\nalwaysApply: true\n---\n\nsame content\n');
+    const before = await fse.readFile(mdcPath, 'utf-8');
+
+    await syncTeamUpdatesToLocal(teamConfig, localConfig, 'abc1234');
+
+    expect(await fse.readFile(mdcPath, 'utf-8')).toBe(before);
+    expect(mockGetFileContentAtRev).not.toHaveBeenCalled();
+  });
+
   it('should skip sync when getFileContentAtRev returns null (rev invalid)', async () => {
     await fse.writeFile(path.join(repoPath, 'rules', 'my-rule.md'), 'v2');
     await fse.writeFile(path.join(homeDir, '.claude/rules', 'my-rule.md'), 'v1');

--- a/src/__tests__/rules.test.ts
+++ b/src/__tests__/rules.test.ts
@@ -723,7 +723,7 @@ describe('RulesHandler — Cursor .mdc handling', () => {
     expect(await fse.pathExists(mdcPath)).toBe(true);
     expect(await fse.pathExists(path.join(homeDir, '.cursor/rules/ts-style.md'))).toBe(false);
     const content = await fse.readFile(mdcPath, 'utf-8');
-    expect(content).toContain('globs: **/*.ts');
+    expect(content).toContain('globs: "**/*.ts"');
     expect(content).toContain('alwaysApply: false');
     // claude still gets a plain .md copy
     expect(await fse.pathExists(path.join(homeDir, '.claude/rules/ts-style.md'))).toBe(true);
@@ -754,7 +754,7 @@ describe('RulesHandler — Cursor .mdc handling', () => {
 
   it('pushItem strips cursor frontmatter when writing an .mdc back to team repo', async () => {
     const mdcPath = path.join(homeDir, '.cursor/rules/back.mdc');
-    await fse.writeFile(mdcPath, '---\nglobs: **/*.ts\nalwaysApply: false\n---\n\nBody to push.');
+    await fse.writeFile(mdcPath, '---\nglobs: "**/*.ts"\nalwaysApply: false\n---\n\nBody to push.');
 
     await handler.pushItem(
       { name: 'back', type: 'rules', sourcePath: mdcPath, relativePath: 'rules/back.md' },
@@ -765,6 +765,115 @@ describe('RulesHandler — Cursor .mdc handling', () => {
     const teamContent = await fse.readFile(path.join(repoPath, 'rules', 'back.md'), 'utf-8');
     expect(teamContent).toBe('Body to push.\n');
     expect(teamContent).not.toContain('globs');
+  });
+
+  it('pushItem preserves the team rule `paths:` frontmatter when pushing from cursor', async () => {
+    // The team rule is scoped; only its body may cross back from Cursor.
+    await fse.writeFile(
+      path.join(repoPath, 'rules', 'scoped.md'),
+      '---\npaths:\n  - "**/*.ts"\n---\n\nOriginal body.',
+    );
+    await handler.pullAllRules(teamConfig, localConfig);
+
+    const mdcPath = path.join(homeDir, '.cursor/rules/scoped.mdc');
+    await fse.writeFile(mdcPath, '---\nglobs: "**/*.ts"\nalwaysApply: false\n---\n\nEdited body.');
+
+    await handler.pushItem(
+      { name: 'scoped', type: 'rules', sourcePath: mdcPath, relativePath: 'rules/scoped.md' },
+      teamConfig,
+      localConfig,
+    );
+
+    const teamContent = await fse.readFile(path.join(repoPath, 'rules', 'scoped.md'), 'utf-8');
+    expect(teamContent).toContain('paths:');
+    expect(teamContent).toContain('- "**/*.ts"');
+    expect(teamContent).toContain('Edited body.');
+    expect(teamContent).not.toContain('Original body.');
+    // Cursor's own derived frontmatter must not leak upstream.
+    expect(teamContent).not.toContain('alwaysApply');
+
+    // And the scope survives the next pull.
+    await handler.pullAllRules(teamConfig, localConfig);
+    const mdc = await fse.readFile(mdcPath, 'utf-8');
+    expect(mdc).toContain('globs: "**/*.ts"');
+    expect(mdc).toContain('alwaysApply: false');
+  });
+
+  it('pushItem fails loudly instead of blanking the team rule on an unreadable source', async () => {
+    await fse.writeFile(path.join(repoPath, 'rules', 'keepme.md'), 'Precious team content.');
+    const missing = path.join(homeDir, '.cursor/rules/keepme.mdc');
+
+    await expect(
+      handler.pushItem(
+        { name: 'keepme', type: 'rules', sourcePath: missing, relativePath: 'rules/keepme.md' },
+        teamConfig,
+        localConfig,
+      ),
+    ).rejects.toThrow(/Cannot read rule source/);
+
+    const teamContent = await fse.readFile(path.join(repoPath, 'rules', 'keepme.md'), 'utf-8');
+    expect(teamContent).toBe('Precious team content.');
+  });
+
+  it('does not offer a user-authored cursor .mdc as a new team rule', async () => {
+    // `.cursor/rules/` is where Cursor's own "New Cursor Rule" writes personal
+    // rules — they must never be proposed as team resources.
+    await fse.writeFile(path.join(repoPath, 'rules', 'team.md'), 'Team rule.');
+    await handler.pullAllRules(teamConfig, localConfig);
+    await fse.writeFile(
+      path.join(homeDir, '.cursor/rules/my-personal-rule.mdc'),
+      '---\nalwaysApply: true\n---\n\nMy private notes.',
+    );
+
+    const items = await handler.scanLocalForPush(teamConfig, localConfig);
+    expect(items.find((i) => i.name === 'my-personal-rule')).toBeUndefined();
+  });
+
+  it('pull removes the legacy .md copy an older layout left in the cursor dir', async () => {
+    await fse.writeFile(path.join(repoPath, 'rules', 'legacy.md'), 'Legacy rule body.');
+    // Simulate the pre-.mdc layout.
+    await fse.writeFile(path.join(homeDir, '.cursor/rules/legacy.md'), 'Legacy rule body.');
+
+    await handler.pullAllRules(teamConfig, localConfig);
+
+    expect(await fse.pathExists(path.join(homeDir, '.cursor/rules/legacy.md'))).toBe(false);
+    expect(await fse.pathExists(path.join(homeDir, '.cursor/rules/legacy.mdc'))).toBe(true);
+  });
+
+  it('removeItem deletes a legacy .md cursor copy as well as the .mdc', async () => {
+    await fse.writeFile(path.join(repoPath, 'rules', 'both.md'), 'bye');
+    await handler.pullAllRules(teamConfig, localConfig);
+    // Re-create the legacy copy to prove `remove` sweeps both extensions.
+    await fse.writeFile(path.join(homeDir, '.cursor/rules/both.md'), 'bye');
+
+    await handler.removeItem('both', teamConfig, localConfig);
+
+    expect(await fse.pathExists(path.join(homeDir, '.cursor/rules/both.mdc'))).toBe(false);
+    expect(await fse.pathExists(path.join(homeDir, '.cursor/rules/both.md'))).toBe(false);
+  });
+
+  it('sweeps a legacy .md whose rule the team has since deleted', async () => {
+    await fse.writeFile(path.join(repoPath, 'rules', 'team.md'), 'Team rule.');
+    // `dropped` is no longer in the team repo, but its pre-.mdc copy lingers.
+    await fse.writeFile(path.join(homeDir, '.cursor/rules/dropped.md'), 'gone upstream');
+
+    await handler.pullAllRules(teamConfig, localConfig);
+
+    expect(await fse.pathExists(path.join(homeDir, '.cursor/rules/dropped.md'))).toBe(false);
+    expect(await fse.pathExists(path.join(homeDir, '.cursor/rules/team.mdc'))).toBe(true);
+  });
+
+  it('sweeps a legacy .md copy of the built-in recall rule from the cursor dir', async () => {
+    await fse.writeFile(path.join(repoPath, 'rules', 'team.md'), 'Team rule.');
+    // Built-ins now deploy to Cursor as `.mdc`, so the `.md` must not survive.
+    await fse.writeFile(path.join(homeDir, '.cursor/rules/teamai-recall.md'), '# Recall');
+    await fse.writeFile(path.join(homeDir, '.claude/rules/teamai-recall.md'), '# Recall');
+
+    await handler.pullAllRules(teamConfig, localConfig);
+
+    expect(await fse.pathExists(path.join(homeDir, '.cursor/rules/teamai-recall.md'))).toBe(false);
+    // The built-in copy in a `.md` tool's dir is still managed by the CLI.
+    expect(await fse.pathExists(path.join(homeDir, '.claude/rules/teamai-recall.md'))).toBe(true);
   });
 
   it('stale cleanup removes an orphaned cursor .mdc not in team repo', async () => {

--- a/src/__tests__/rules.test.ts
+++ b/src/__tests__/rules.test.ts
@@ -663,3 +663,130 @@ describe('RulesHandler.pullAllRules — OpenCode instructions activation', () =>
     expect(await fse.pathExists(ocConfig())).toBe(false);
   });
 });
+
+describe('RulesHandler — Cursor .mdc handling', () => {
+  let tmpDir: string;
+  let homeDir: string;
+  let repoPath: string;
+  let handler: RulesHandler;
+  let teamConfig: TeamaiConfig;
+  let localConfig: LocalConfig;
+
+  beforeEach(async () => {
+    tmpDir = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-rules-cursor-'));
+    homeDir = path.join(tmpDir, 'home');
+    repoPath = path.join(tmpDir, 'team-repo');
+    await fse.ensureDir(path.join(repoPath, 'rules'));
+    // Both tools installed so pull targets both dirs.
+    await fse.ensureDir(path.join(homeDir, '.claude', 'rules'));
+    await fse.ensureDir(path.join(homeDir, '.cursor', 'rules'));
+
+    vi.stubEnv('HOME', homeDir);
+    handler = new RulesHandler();
+
+    teamConfig = {
+      team: 'test',
+      description: '',
+      repo: 'https://git.woa.com/test/repo.git',
+      provider: 'tgit' as const,
+      reviewers: [],
+      sharing: { skills: {}, rules: { enforced: [] }, docs: { localDir: '' }, env: { injectShellProfile: true } },
+      toolPaths: {
+        claude: { skills: '.claude/skills', rules: '.claude/rules', settings: '.claude/settings.json', claudemd: '.claude/CLAUDE.md' },
+        cursor: { skills: '.cursor/skills', rules: '.cursor/rules', settings: '.cursor/hooks.json' },
+      },
+    };
+
+    localConfig = {
+      repo: { localPath: repoPath, remote: 'https://git.woa.com/test/repo.git' },
+      username: 'testuser',
+      updatePolicy: 'auto',
+      additionalRoles: [],
+      scope: 'user',
+    };
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await fse.remove(tmpDir);
+  });
+
+  it('pull writes .mdc (not .md) with derived frontmatter for cursor', async () => {
+    await fse.writeFile(
+      path.join(repoPath, 'rules', 'ts-style.md'),
+      '---\npaths:\n  - "**/*.ts"\n---\n\nUse named exports.',
+    );
+
+    await handler.pullAllRules(teamConfig, localConfig);
+
+    const mdcPath = path.join(homeDir, '.cursor/rules/ts-style.mdc');
+    expect(await fse.pathExists(mdcPath)).toBe(true);
+    expect(await fse.pathExists(path.join(homeDir, '.cursor/rules/ts-style.md'))).toBe(false);
+    const content = await fse.readFile(mdcPath, 'utf-8');
+    expect(content).toContain('globs: **/*.ts');
+    expect(content).toContain('alwaysApply: false');
+    // claude still gets a plain .md copy
+    expect(await fse.pathExists(path.join(homeDir, '.claude/rules/ts-style.md'))).toBe(true);
+  });
+
+  it('a clean pull does not make cursor rules look modified on push', async () => {
+    await fse.writeFile(path.join(repoPath, 'rules', 'enforced.md'), 'A mandatory rule.');
+    await handler.pullAllRules(teamConfig, localConfig);
+
+    const items = await handler.scanLocalForPush(teamConfig, localConfig);
+    expect(items.find((i) => i.name === 'enforced')).toBeUndefined();
+  });
+
+  it('detects a genuine edit to a cursor .mdc body as modified', async () => {
+    await fse.writeFile(path.join(repoPath, 'rules', 'edit-me.md'), 'Original body.');
+    await handler.pullAllRules(teamConfig, localConfig);
+
+    // User edits the body of the .mdc directly.
+    const mdcPath = path.join(homeDir, '.cursor/rules/edit-me.mdc');
+    await fse.writeFile(mdcPath, '---\nalwaysApply: true\n---\n\nEdited body.');
+
+    const items = await handler.scanLocalForPush(teamConfig, localConfig);
+    const item = items.find((i) => i.name === 'edit-me');
+    expect(item).toBeDefined();
+    expect(item!.status).toBe('modified');
+    expect(item!.sourcePath).toBe(mdcPath);
+  });
+
+  it('pushItem strips cursor frontmatter when writing an .mdc back to team repo', async () => {
+    const mdcPath = path.join(homeDir, '.cursor/rules/back.mdc');
+    await fse.writeFile(mdcPath, '---\nglobs: **/*.ts\nalwaysApply: false\n---\n\nBody to push.');
+
+    await handler.pushItem(
+      { name: 'back', type: 'rules', sourcePath: mdcPath, relativePath: 'rules/back.md' },
+      teamConfig,
+      localConfig,
+    );
+
+    const teamContent = await fse.readFile(path.join(repoPath, 'rules', 'back.md'), 'utf-8');
+    expect(teamContent).toBe('Body to push.\n');
+    expect(teamContent).not.toContain('globs');
+  });
+
+  it('stale cleanup removes an orphaned cursor .mdc not in team repo', async () => {
+    // Team has one rule; cursor dir has an extra orphan .mdc.
+    await fse.writeFile(path.join(repoPath, 'rules', 'keep.md'), 'keep me');
+    await fse.writeFile(
+      path.join(homeDir, '.cursor/rules/orphan.mdc'),
+      '---\nalwaysApply: true\n---\n\norphan',
+    );
+
+    await handler.pullAllRules(teamConfig, localConfig);
+
+    expect(await fse.pathExists(path.join(homeDir, '.cursor/rules/orphan.mdc'))).toBe(false);
+    expect(await fse.pathExists(path.join(homeDir, '.cursor/rules/keep.mdc'))).toBe(true);
+  });
+
+  it('removeItem deletes the cursor .mdc copy', async () => {
+    await fse.writeFile(path.join(repoPath, 'rules', 'gone.md'), 'bye');
+    await handler.pullAllRules(teamConfig, localConfig);
+    expect(await fse.pathExists(path.join(homeDir, '.cursor/rules/gone.mdc'))).toBe(true);
+
+    await handler.removeItem('gone', teamConfig, localConfig);
+    expect(await fse.pathExists(path.join(homeDir, '.cursor/rules/gone.mdc'))).toBe(false);
+  });
+});

--- a/src/__tests__/skip-uninstalled-tools.test.ts
+++ b/src/__tests__/skip-uninstalled-tools.test.ts
@@ -287,7 +287,9 @@ scope: 'user',
     await handler.pullItem(item, teamConfig, localConfig);
 
     expect(await fse.pathExists(path.join(homeDir, '.claude/rules/test-rule.md'))).toBe(true);
-    expect(await fse.pathExists(path.join(homeDir, '.cursor/rules/test-rule.md'))).toBe(true);
+    // Cursor rules must be written as `.mdc` (a plain `.md` there is ignored by Cursor).
+    expect(await fse.pathExists(path.join(homeDir, '.cursor/rules/test-rule.mdc'))).toBe(true);
+    expect(await fse.pathExists(path.join(homeDir, '.cursor/rules/test-rule.md'))).toBe(false);
   });
 });
 

--- a/src/__tests__/uninstall.test.ts
+++ b/src/__tests__/uninstall.test.ts
@@ -246,6 +246,48 @@ describe('uninstall', () => {
     expect(await fse.pathExists(teamaiHome)).toBe(false);
   });
 
+  // Regression: Cursor rules are `.mdc`; matching only `.md` left every team
+  // rule on disk after uninstall, still injected into each Cursor session.
+  it('removes cursor .mdc rules (and a legacy .md copy) on uninstall', async () => {
+    const { homeDir, repoPath, teamaiHome } = await setupFixture(tmpDir);
+    vi.stubEnv('HOME', homeDir);
+    vi.stubEnv('SHELL', '/bin/zsh');
+
+    const cursorRules = path.join(homeDir, '.cursor', 'rules');
+    await fse.ensureDir(cursorRules);
+    await fse.writeFile(path.join(cursorRules, 'team-rule.mdc'), '---\nalwaysApply: true\n---\n\n# Team Rule');
+    // Left behind by the layout that predates `.mdc`.
+    await fse.writeFile(path.join(cursorRules, 'team-rule.md'), '# Team Rule');
+    // A rule the user wrote themselves must survive.
+    await fse.writeFile(path.join(cursorRules, 'my-own-rule.mdc'), '---\nalwaysApply: true\n---\n\nmine');
+
+    const teamConfig = makeTeamConfig({
+      sharing: {
+        skills: {},
+        rules: { enforced: [] },
+        docs: { localDir: `${teamaiHome}/docs` },
+        env: { injectShellProfile: true },
+      },
+      toolPaths: {
+        claude: {
+          skills: '.claude/skills',
+          rules: '.claude/rules',
+          settings: '.claude/settings.json',
+          claudemd: '.claude/CLAUDE.md',
+          agents: '.claude/agents',
+        },
+        cursor: { skills: '.cursor/skills', rules: '.cursor/rules', settings: '.cursor/hooks.json' },
+      },
+    });
+    mockAutoDetectInit.mockResolvedValue({ localConfig: makeLocalConfig(homeDir, repoPath), teamConfig });
+
+    await uninstall({ force: true });
+
+    expect(await fse.pathExists(path.join(cursorRules, 'team-rule.mdc'))).toBe(false);
+    expect(await fse.pathExists(path.join(cursorRules, 'team-rule.md'))).toBe(false);
+    expect(await fse.pathExists(path.join(cursorRules, 'my-own-rule.mdc'))).toBe(true);
+  });
+
   // Regression: MCP cleanup used to run after ~/.teamai/ was deleted, so the
   // ownership manifest was already gone and removeAll became a no-op.
   it('卸载时移除 teamai 管理的 MCP server，并保留用户自建的', async () => {

--- a/src/builtin-rules.ts
+++ b/src/builtin-rules.ts
@@ -2,6 +2,8 @@ import path from 'node:path';
 import { ensureDir, writeFile, pathExists } from './utils/fs.js';
 import { log } from './utils/logger.js';
 import { ResourceHandler } from './resources/base.js';
+import { ruleFileExtensionForTool, usesCursorMdcRules } from './resources/rule-format.js';
+import { teamRuleToCursorMdc } from './resources/cursor-mdc.js';
 import type { TeamaiConfig, LocalConfig } from './types.js';
 import { resolveBaseDir, isAgentDisabled, scopedToolPaths } from './types.js';
 import fs from 'node:fs/promises';
@@ -72,21 +74,39 @@ export async function deployBuiltinRules(
         try {
             await ensureDir(rulesDir);
 
-            // Deploy current built-in rules
+            // Deploy current built-in rules. Cursor only reads `.cursor/rules/*.mdc`
+            // — a plain `.md` there is silently ignored — so its copy carries the
+            // `.mdc` extension and derived frontmatter, same as team rules.
+            const ext = ruleFileExtensionForTool(tool);
             for (const rule of builtinRules) {
-                const destFile = path.join(rulesDir, `${rule.name}.md`);
-                await writeFile(destFile, rule.content);
+                const destFile = path.join(rulesDir, `${rule.name}${ext}`);
+                const content = usesCursorMdcRules(tool)
+                    ? teamRuleToCursorMdc(rule.content)
+                    : rule.content;
+                await writeFile(destFile, content);
                 log.debug(`Deployed built-in rule ${rule.name} → ${tool}`);
+
+                // Drop the `.md` copy an older layout left in a Cursor rules dir.
+                if (ext !== '.md') {
+                    try {
+                        await fs.unlink(path.join(rulesDir, `${rule.name}.md`));
+                        log.debug(`Removed legacy .md built-in rule ${rule.name} from ${tool}`);
+                    } catch {
+                        // File doesn't exist — that's fine
+                    }
+                }
             }
 
-            // Clean up legacy rules no longer deployed
+            // Clean up legacy rules no longer deployed (both extensions)
             for (const legacyName of LEGACY_RULE_NAMES) {
-                const legacyFile = path.join(rulesDir, `${legacyName}.md`);
-                try {
-                    await fs.unlink(legacyFile);
-                    log.debug(`Removed legacy built-in rule ${legacyName} from ${tool}`);
-                } catch {
-                    // File doesn't exist — that's fine
+                for (const legacyExt of new Set<string>([ext, '.md'])) {
+                    const legacyFile = path.join(rulesDir, `${legacyName}${legacyExt}`);
+                    try {
+                        await fs.unlink(legacyFile);
+                        log.debug(`Removed legacy built-in rule ${legacyName} from ${tool}`);
+                    } catch {
+                        // File doesn't exist — that's fine
+                    }
                 }
             }
 

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -26,6 +26,7 @@ import { parseHookEvent } from './dashboard-collector.js';
 import { getAgentVersion } from './agent-version.js';
 import { getMachineId, deriveLocalAgentId } from './machine-id.js';
 import { EXCLUDED_RULE_NAMES } from './builtin-rules.js';
+import { ruleStemFromFilename } from './resources/rule-format.js';
 import { resolveTeamaiEntryScript } from './builtin-hooks.js';
 import { resolveOpenclawWorkspaceDir } from './openclaw-hooks.js';
 import { assertSafeResourceName } from './utils/path-safety.js';
@@ -1157,10 +1158,16 @@ async function scanRulesFromDisk(
   manifestSlugs: Set<string>,
 ): Promise<ReportedResource[]> {
   if (!(await pathExists(rulesDir))) return [];
-  const files = (await listFilesRecursive(rulesDir)).filter((f) => f.endsWith('.md'));
+  // Cursor stores rules as `.mdc`, every other tool as `.md`; match by stem so
+  // a Cursor agent still reports its installed rules.
+  const files = await listFilesRecursive(rulesDir);
   const results: ReportedResource[] = [];
+  const seen = new Set<string>();
   for (const file of files) {
-    const slug = file.replace(/\.md$/, '');
+    const slug = ruleStemFromFilename(file);
+    if (slug === null) continue;
+    if (seen.has(slug)) continue; // Same rule under both extensions
+    seen.add(slug);
     // Skip CLI built-in / legacy rules (e.g. teamai-recall) so they are not
     // reported as user-installed resources — mirrors the pull/uninstall filter.
     if (EXCLUDED_RULE_NAMES.has(path.basename(slug)) || EXCLUDED_RULE_NAMES.has(slug)) continue;

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -8,6 +8,7 @@ import { pathExists, remove, listFiles, listDirs, readFileSafe } from './utils/f
 import { injectClaudeMdSection } from './utils/claudemd.js';
 import { getHandler, RulesHandler, DocsHandler, EnvHandler } from './resources/index.js';
 import { ResourceHandler } from './resources/base.js';
+import { ruleFileExtensionForTool } from './resources/rule-format.js';
 import { loadTagsConfig, filterByTags } from './utils/tags.js';
 import { BUILTIN_SKILL_NAMES } from './builtin-skills.js';
 import type { GlobalOptions, ResourceType, ResourceItem, TeamaiConfig, LocalConfig, TagsConfig } from './types.js';
@@ -590,15 +591,20 @@ async function pullForScope(
         if (!await ResourceHandler.isToolInstalled(dir, baseDir)) continue;
         if (isAgentDisabled(localConfig, tool)) continue;
 
-        // Cursor stores rules as `.mdc`; use that extension so its copies of a
-        // tombstoned rule are cleaned up too.
-        const effectiveExt = type === 'rules' && tool === 'cursor' ? '.mdc' : ext;
+        // Rules carry a per-tool extension (Cursor uses `.mdc`), and Cursor dirs
+        // may still hold a `.md` copy from the layout that predates it, so a
+        // tombstoned rule is cleaned up under every extension it may wear.
+        const extensions = type === 'rules'
+          ? [...new Set([ruleFileExtensionForTool(tool), '.md'])]
+          : [ext];
 
         for (const name of tombstones) {
-          const localPath = path.join(baseDir, dir, effectiveExt ? `${name}${effectiveExt}` : name);
-          if (await pathExists(localPath)) {
-            await remove(localPath);
-            log.debug(`[${scopeLabel}] Cleaned up tombstoned ${type} ${name} from ${dir}`);
+          for (const extension of extensions) {
+            const localPath = path.join(baseDir, dir, extension ? `${name}${extension}` : name);
+            if (await pathExists(localPath)) {
+              await remove(localPath);
+              log.debug(`[${scopeLabel}] Cleaned up tombstoned ${type} ${name} from ${dir}`);
+            }
           }
         }
       }

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -590,8 +590,12 @@ async function pullForScope(
         if (!await ResourceHandler.isToolInstalled(dir, baseDir)) continue;
         if (isAgentDisabled(localConfig, tool)) continue;
 
+        // Cursor stores rules as `.mdc`; use that extension so its copies of a
+        // tombstoned rule are cleaned up too.
+        const effectiveExt = type === 'rules' && tool === 'cursor' ? '.mdc' : ext;
+
         for (const name of tombstones) {
-          const localPath = path.join(baseDir, dir, ext ? `${name}${ext}` : name);
+          const localPath = path.join(baseDir, dir, effectiveExt ? `${name}${effectiveExt}` : name);
           if (await pathExists(localPath)) {
             await remove(localPath);
             log.debug(`[${scopeLabel}] Cleaned up tombstoned ${type} ${name} from ${dir}`);

--- a/src/recall-toggle.ts
+++ b/src/recall-toggle.ts
@@ -8,6 +8,7 @@ import {
   agentFileExtensionForTool,
   type ToolName,
 } from './resources/agent-format.js';
+import { ruleFileExtensionForTool } from './resources/rule-format.js';
 import { RECALL_DEPENDENT_SKILLS } from './builtin-skills.js';
 import {
   resolveBaseDir,
@@ -26,10 +27,14 @@ async function removeRecallArtifacts(teamConfig: TeamaiConfig, localConfig: Loca
   for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
     // Remove recall rule file
     if (toolPath.rules) {
-      const ruleFile = path.join(baseDir, toolPath.rules, 'teamai-recall.md');
-      if (await pathExists(ruleFile)) {
-        await remove(ruleFile);
-        log.debug(`Removed recall rule from ${tool}`);
+      // Cursor's copy is `.mdc`; older layouts also left a `.md` there.
+      const extensions = new Set<string>([ruleFileExtensionForTool(tool), '.md']);
+      for (const extension of extensions) {
+        const ruleFile = path.join(baseDir, toolPath.rules, `teamai-recall${extension}`);
+        if (await pathExists(ruleFile)) {
+          await remove(ruleFile);
+          log.debug(`Removed recall rule from ${tool}`);
+        }
       }
     }
 

--- a/src/resources/cursor-mdc.ts
+++ b/src/resources/cursor-mdc.ts
@@ -1,0 +1,121 @@
+import matter from 'gray-matter';
+
+/**
+ * Cursor project rules must live in `.cursor/rules/*.mdc` with YAML frontmatter
+ * (`description` / `globs` / `alwaysApply`). A plain `.md` file placed there is
+ * silently ignored by Cursor because it has no recognizable frontmatter, so the
+ * team rules never enter a Cursor session.
+ *
+ * The team repo, in contrast, stores rules as `.md` with an optional, tool-neutral
+ * frontmatter (currently a `paths:` array used to scope a rule to file globs).
+ * This module converts between the two representations:
+ *
+ *   team `.md`  ──teamRuleToCursorMdc──▶  Cursor `.mdc`   (pull)
+ *   Cursor `.mdc`  ──cursorMdcToTeamMd──▶  team `.md`      (push)
+ *
+ * Mapping:
+ *   - team `paths: [glob, ...]`  → Cursor `globs: <comma-joined>` + `alwaysApply: false`
+ *   - no `paths` (a mandatory team rule) → Cursor `alwaysApply: true`
+ *     (Cursor applies such rules to every chat session; globs/description ignored)
+ *
+ * The markdown body is preserved verbatim in both directions. Only the frontmatter
+ * is machine-derived, which is what lets pull→push round-trip without spurious
+ * "modified" diffs (see cursorMdcBodyEqualsTeamMd).
+ */
+
+/** The Cursor frontmatter fields we emit. */
+interface CursorFrontmatter {
+  globs?: string;
+  alwaysApply: boolean;
+}
+
+/**
+ * Extract the markdown body of a rule file by textually removing a leading
+ * `---\n...\n---` frontmatter block. Deliberately does NOT parse YAML: the
+ * Cursor `globs` value we emit (a glob starting with a star) is valid to Cursor
+ * but not to a strict YAML parser, so parsing would fail and swallow the
+ * frontmatter into the body. Delimiter-based stripping round-trips regardless
+ * of YAML validity.
+ */
+function extractBody(raw: string): string {
+  const m = raw.match(/^﻿?---\r?\n[\s\S]*?\r?\n---\r?\n?/);
+  return m ? raw.slice(m[0].length) : raw;
+}
+
+/**
+ * Parse a team rule's frontmatter data with gray-matter. Team repo `.md` files
+ * are human-authored valid YAML, so this is safe here. Returns empty data on any
+ * parse failure.
+ */
+function parseFrontmatterData(raw: string): Record<string, unknown> {
+  try {
+    return matter(raw).data;
+  } catch {
+    return {};
+  }
+}
+
+/** Normalize a markdown body for comparison (ignore leading/trailing whitespace). */
+function normalizeBody(body: string): string {
+  return body.replace(/^\s+/, '').replace(/\s+$/, '');
+}
+
+/**
+ * Derive Cursor frontmatter from a team rule's frontmatter data.
+ *
+ * A team rule scoped with `paths:` becomes an auto-attached Cursor rule
+ * (`globs` + `alwaysApply: false`). A rule with no `paths` is treated as a
+ * mandatory team rule and made always-on (`alwaysApply: true`).
+ */
+function deriveCursorFrontmatter(data: Record<string, unknown>): CursorFrontmatter {
+  const rawPaths = data.paths ?? data.globs;
+  const patterns = Array.isArray(rawPaths)
+    ? rawPaths.map((p) => String(p).trim()).filter(Boolean)
+    : typeof rawPaths === 'string' && rawPaths.trim() !== ''
+      ? rawPaths.split(',').map((p) => p.trim()).filter(Boolean)
+      : [];
+
+  if (patterns.length > 0) {
+    return { globs: patterns.join(', '), alwaysApply: false };
+  }
+  return { alwaysApply: true };
+}
+
+/** Serialize Cursor frontmatter into a `.mdc` file string. */
+function renderCursorMdc(fm: CursorFrontmatter, body: string): string {
+  const lines = ['---'];
+  if (fm.globs !== undefined) lines.push(`globs: ${fm.globs}`);
+  lines.push(`alwaysApply: ${fm.alwaysApply}`);
+  lines.push('---');
+  return `${lines.join('\n')}\n\n${normalizeBody(body)}\n`;
+}
+
+/**
+ * Convert a team repo rule file (`.md`) into Cursor `.mdc` content.
+ */
+export function teamRuleToCursorMdc(rawTeamRule: string): string {
+  const data = parseFrontmatterData(rawTeamRule);
+  return renderCursorMdc(deriveCursorFrontmatter(data), extractBody(rawTeamRule));
+}
+
+/**
+ * Convert a Cursor `.mdc` file back into team repo `.md` content.
+ *
+ * The Cursor-specific frontmatter (globs/alwaysApply) is dropped; only the
+ * markdown body is written back to the team repo. This keeps the team repo as
+ * the tool-neutral source of truth — a user editing the body of a `.cursor`
+ * rule pushes just that body change upstream.
+ */
+export function cursorMdcToTeamMd(rawCursorMdc: string): string {
+  return `${normalizeBody(extractBody(rawCursorMdc))}\n`;
+}
+
+/**
+ * Compare the markdown body of a Cursor `.mdc` file against a team repo `.md`
+ * file, ignoring frontmatter on both sides. Used by push scanning so that a
+ * pull-then-push round-trip (which rewrites frontmatter) is not seen as a
+ * content modification.
+ */
+export function cursorMdcBodyEqualsTeamMd(rawCursorMdc: string, rawTeamRule: string): boolean {
+  return normalizeBody(extractBody(rawCursorMdc)) === normalizeBody(extractBody(rawTeamRule));
+}

--- a/src/resources/cursor-mdc.ts
+++ b/src/resources/cursor-mdc.ts
@@ -10,17 +10,20 @@ import matter from 'gray-matter';
  * frontmatter (currently a `paths:` array used to scope a rule to file globs).
  * This module converts between the two representations:
  *
- *   team `.md`  ──teamRuleToCursorMdc──▶  Cursor `.mdc`   (pull)
- *   Cursor `.mdc`  ──cursorMdcToTeamMd──▶  team `.md`      (push)
+ *   team `.md`  ──teamRuleToCursorMdc───────▶  Cursor `.mdc`   (pull)
+ *   Cursor `.mdc`  ──mergeCursorBodyIntoTeamMd──▶  team `.md`  (push)
  *
  * Mapping:
- *   - team `paths: [glob, ...]`  → Cursor `globs: <comma-joined>` + `alwaysApply: false`
+ *   - team `paths: [glob, ...]`  → Cursor `globs: "<comma-joined>"` + `alwaysApply: false`
  *   - no `paths` (a mandatory team rule) → Cursor `alwaysApply: true`
  *     (Cursor applies such rules to every chat session; globs/description ignored)
  *
- * The markdown body is preserved verbatim in both directions. Only the frontmatter
- * is machine-derived, which is what lets pull→push round-trip without spurious
- * "modified" diffs (see cursorMdcBodyEqualsTeamMd).
+ * The markdown body is the only thing that crosses in both directions; the
+ * frontmatter on each side stays owned by that side. On pull the Cursor
+ * frontmatter is machine-derived, and on push the team file keeps its own
+ * frontmatter and only its body is replaced. That is what lets a pull→push
+ * round-trip avoid both spurious "modified" diffs (see
+ * cursorMdcBodyEqualsTeamMd) and silent loss of the team rule's `paths:` scope.
  */
 
 /** The Cursor frontmatter fields we emit. */
@@ -30,26 +33,62 @@ interface CursorFrontmatter {
 }
 
 /**
- * Extract the markdown body of a rule file by textually removing a leading
- * `---\n...\n---` frontmatter block. Deliberately does NOT parse YAML: the
- * Cursor `globs` value we emit (a glob starting with a star) is valid to Cursor
- * but not to a strict YAML parser, so parsing would fail and swallow the
- * frontmatter into the body. Delimiter-based stripping round-trips regardless
- * of YAML validity.
+ * A leading `---\n...\n---` frontmatter block, with an optional BOM. The inner
+ * group is optional so an empty block (`---\n---`) matches too — otherwise its
+ * delimiters would leak into the body and get pushed to the team repo verbatim.
  */
+const FRONTMATTER_RE = /^﻿?---\r?\n(?:[\s\S]*?\r?\n)?---\r?\n?/;
+
+/**
+ * Split a rule file into its leading frontmatter block (empty string when there
+ * is none) and its body. Deliberately textual, NOT a YAML parse: the Cursor
+ * `globs` value is a glob, and a strict parse of a malformed one would fail and
+ * swallow the frontmatter into the body. Delimiter-based splitting round-trips
+ * regardless of YAML validity.
+ */
+function splitFrontmatter(raw: string): { block: string; body: string } {
+  const m = raw.match(FRONTMATTER_RE);
+  return m ? { block: m[0], body: raw.slice(m[0].length) } : { block: '', body: raw };
+}
+
+/** Extract the markdown body of a rule file, dropping any frontmatter block. */
 function extractBody(raw: string): string {
-  const m = raw.match(/^﻿?---\r?\n[\s\S]*?\r?\n---\r?\n?/);
-  return m ? raw.slice(m[0].length) : raw;
+  return splitFrontmatter(raw).body;
 }
 
 /**
- * Parse a team rule's frontmatter data with gray-matter. Team repo `.md` files
- * are human-authored valid YAML, so this is safe here. Returns empty data on any
- * parse failure.
+ * Quote scalars that YAML would read as an alias (`*`) or anchor (`&`) node.
+ * A glob is the common case: `globs: **\/*.ts` is not valid YAML, so a strict
+ * parse of an otherwise fine frontmatter block throws on it.
+ */
+function quoteYamlUnsafeScalars(block: string): string {
+  return block
+    .split(/\r?\n/)
+    .map((line) => {
+      const m = line.match(/^(\s*(?:-\s+|[A-Za-z0-9_.-]+:[ \t]+))([*&][^"']*)$/);
+      return m ? `${m[1]}"${m[2].trimEnd()}"` : line;
+    })
+    .join('\n');
+}
+
+/**
+ * Parse a team rule's frontmatter data with gray-matter, retrying once with
+ * alias-unsafe scalars quoted so a rule authored as `globs: **\/*.ts` is still
+ * honoured rather than silently falling back to always-on. Returns empty data
+ * when both attempts fail.
  */
 function parseFrontmatterData(raw: string): Record<string, unknown> {
   try {
     return matter(raw).data;
+  } catch {
+    // Invalid YAML — retry below with unsafe scalars quoted.
+  }
+
+  const { block } = splitFrontmatter(raw);
+  if (!block) return {};
+  const quoted = quoteYamlUnsafeScalars(block);
+  try {
+    return matter(quoted.endsWith('\n') ? quoted : `${quoted}\n`).data;
   } catch {
     return {};
   }
@@ -84,7 +123,10 @@ function deriveCursorFrontmatter(data: Record<string, unknown>): CursorFrontmatt
 /** Serialize Cursor frontmatter into a `.mdc` file string. */
 function renderCursorMdc(fm: CursorFrontmatter, body: string): string {
   const lines = ['---'];
-  if (fm.globs !== undefined) lines.push(`globs: ${fm.globs}`);
+  // Quoted deliberately: a glob starting with `*` is an alias node in YAML, so
+  // an unquoted value makes the whole block unparseable — which would put us
+  // back where we started, with Cursor ignoring the rule.
+  if (fm.globs !== undefined) lines.push(`globs: ${JSON.stringify(fm.globs)}`);
   lines.push(`alwaysApply: ${fm.alwaysApply}`);
   lines.push('---');
   return `${lines.join('\n')}\n\n${normalizeBody(body)}\n`;
@@ -99,15 +141,31 @@ export function teamRuleToCursorMdc(rawTeamRule: string): string {
 }
 
 /**
- * Convert a Cursor `.mdc` file back into team repo `.md` content.
+ * Write a Cursor `.mdc` file's markdown body back into the team repo `.md`,
+ * keeping the team file's own frontmatter.
  *
- * The Cursor-specific frontmatter (globs/alwaysApply) is dropped; only the
- * markdown body is written back to the team repo. This keeps the team repo as
- * the tool-neutral source of truth — a user editing the body of a `.cursor`
- * rule pushes just that body change upstream.
+ * Only the body crosses back: the Cursor-specific frontmatter (globs/alwaysApply)
+ * is machine-derived on pull and is dropped, while the team rule's tool-neutral
+ * frontmatter (`paths:`, …) is preserved from `existingTeamMd`. Dropping it
+ * instead would silently un-scope the rule for the whole team on the next pull.
+ *
+ * `existingTeamMd` is null for a rule that does not exist upstream yet, in which
+ * case the body alone becomes the new team file.
  */
-export function cursorMdcToTeamMd(rawCursorMdc: string): string {
-  return `${normalizeBody(extractBody(rawCursorMdc))}\n`;
+export function mergeCursorBodyIntoTeamMd(
+  rawCursorMdc: string,
+  existingTeamMd: string | null,
+): string {
+  const body = normalizeBody(extractBody(rawCursorMdc));
+  if (existingTeamMd === null) return `${body}\n`;
+
+  // Body unchanged — hand back the team file byte-for-byte so a no-op push
+  // never shows up as a diff.
+  if (normalizeBody(extractBody(existingTeamMd)) === body) return existingTeamMd;
+
+  const { block } = splitFrontmatter(existingTeamMd);
+  if (!block) return `${body}\n`;
+  return `${block.endsWith('\n') ? block : `${block}\n`}\n${body}\n`;
 }
 
 /**

--- a/src/resources/rule-format.ts
+++ b/src/resources/rule-format.ts
@@ -1,0 +1,51 @@
+/**
+ * Per-tool on-disk format for rule files.
+ *
+ * The team repo always stores rules as tool-neutral `<name>.md`. Most tools take
+ * a verbatim `.md` copy, but Cursor only reads `.cursor/rules/*.mdc` — a plain
+ * `.md` placed there is silently ignored — so its copies carry the `.mdc`
+ * extension and machine-derived frontmatter (see `./cursor-mdc.ts`).
+ *
+ * This module is the single place that decision lives, mirroring
+ * `agentFileExtensionForTool` in `./agent-format.ts`. Every site that writes,
+ * scans, or deletes files in a tool's rules directory must go through it, so a
+ * new per-tool extension never has to be re-discovered call site by call site.
+ */
+
+/** Extension teamai writes rules with for a given tool. */
+export function ruleFileExtensionForTool(tool: string): '.md' | '.mdc' {
+  return tool === 'cursor' ? '.mdc' : '.md';
+}
+
+/** True when the tool stores rules in Cursor's `.mdc` format. */
+export function usesCursorMdcRules(tool: string): boolean {
+  return tool === 'cursor';
+}
+
+/**
+ * Every extension a rule file may carry on disk, newest layout first.
+ *
+ * Writers use `ruleFileExtensionForTool`; scanners and deleters use this list so
+ * they also see copies left by an older teamai layout (e.g. `.cursor/rules/*.md`
+ * written before Cursor rules moved to `.mdc`).
+ */
+export const RULE_FILE_EXTENSIONS = ['.mdc', '.md'] as const;
+
+/**
+ * Extract a rule name stem from a filename, accepting either extension.
+ * Returns null for files that are not rule files.
+ */
+export function ruleStemFromFilename(filename: string): string | null {
+  if (filename.endsWith('.mdc')) return filename.slice(0, -'.mdc'.length);
+  if (filename.endsWith('.md')) return filename.slice(0, -'.md'.length);
+  return null;
+}
+
+/**
+ * True when `filename` is a copy left in a Cursor rules directory by an older
+ * teamai layout: Cursor never reads `.md` there, so such a file is inert
+ * leftover rather than an active rule.
+ */
+export function isLegacyCursorRuleFile(tool: string, filename: string): boolean {
+  return usesCursorMdcRules(tool) && filename.endsWith('.md');
+}

--- a/src/resources/rules.ts
+++ b/src/resources/rules.ts
@@ -5,6 +5,16 @@ import { listFilesRecursive, pathExists, copyFile, ensureDir, remove, fileConten
 import { log } from '../utils/logger.js';
 import { TEAMAI_RULES_START, TEAMAI_RULES_END, resolveBaseDir, isAgentDisabled, scopedToolPaths } from '../types.js';
 import { EXCLUDED_RULE_NAMES } from '../builtin-rules.js';
+import { teamRuleToCursorMdc, cursorMdcToTeamMd, cursorMdcBodyEqualsTeamMd } from './cursor-mdc.js';
+
+/**
+ * Cursor stores project rules as `.cursor/rules/*.mdc` and ignores plain `.md`
+ * files there (they lack the frontmatter Cursor requires). All other tools use
+ * plain `.md`. `ruleExtForTool` returns the on-disk extension for a given tool.
+ */
+function ruleExtForTool(tool: string): '.md' | '.mdc' {
+  return tool === 'cursor' ? '.mdc' : '.md';
+}
 
 export class RulesHandler extends ResourceHandler {
   readonly type = 'rules' as const;
@@ -31,26 +41,40 @@ export class RulesHandler extends ResourceHandler {
     const candidates = new Map<string, { sourcePath: string; mtime: number; status: ResourceItemStatus }>();
 
     // Scan each tool's rules/ directory (recursively)
-    for (const [_tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
+    for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
       const rulesPath = toolPath.rules;
       if (!rulesPath) continue;
       const rulesDir = path.join(resolveBaseDir(localConfig), rulesPath);
       if (!await pathExists(rulesDir)) continue;
 
+      // Cursor stores rules as `.mdc`; every other tool as `.md`.
+      const ext = ruleExtForTool(tool);
+      const isCursor = tool === 'cursor';
+
       const files = await listFilesRecursive(rulesDir);
       for (const file of files) {
-        if (!file.endsWith('.md')) continue;
+        if (!file.endsWith(ext)) continue;
         // name includes subdirectory path, e.g. "common/coding-standards"
-        const name = file.replace(/\.md$/, '');
+        const name = file.slice(0, -ext.length);
         if (tombstones.has(name)) continue;
         if (EXCLUDED_RULE_NAMES.has(name)) continue; // Skip CLI built-in and legacy rules
 
         const localFilePath = path.join(rulesDir, file);
+        // Team repo always stores `.md`, keyed by rule name.
+        const teamFileName = `${name}.md`;
 
-        if (teamRules.has(file)) {
+        if (teamRules.has(teamFileName)) {
           // File exists in team repo — check if content differs
-          const teamFilePath = path.join(teamRulesDir, file);
-          const equal = await fileContentEqual(localFilePath, teamFilePath);
+          const teamFilePath = path.join(teamRulesDir, teamFileName);
+          // For Cursor, compare markdown bodies only: the `.mdc` frontmatter is
+          // machine-derived on pull, so a clean pull-then-push must not look
+          // modified. For other tools the files are byte-identical copies.
+          const equal = isCursor
+            ? cursorMdcBodyEqualsTeamMd(
+                (await readFileSafe(localFilePath)) ?? '',
+                (await readFileSafe(teamFilePath)) ?? '',
+              )
+            : await fileContentEqual(localFilePath, teamFilePath);
           if (equal) continue; // This tool dir's copy is identical, skip
 
           // Content differs — candidate for "modified"
@@ -109,7 +133,14 @@ export class RulesHandler extends ResourceHandler {
   async pushItem(item: ResourceItem, _teamConfig: TeamaiConfig, localConfig: LocalConfig): Promise<void> {
     const dest = path.join(localConfig.repo.localPath, 'rules', `${item.name}.md`);
     if (item.sourcePath !== dest) {
-      await copyFile(item.sourcePath, dest);
+      if (item.sourcePath.endsWith('.mdc')) {
+        // Source is a Cursor `.mdc`: strip its derived frontmatter and write the
+        // tool-neutral markdown body back to the team repo (`.md`).
+        const raw = await readFileSafe(item.sourcePath);
+        await writeFile(dest, cursorMdcToTeamMd(raw ?? ''));
+      } else {
+        await copyFile(item.sourcePath, dest);
+      }
     }
     log.debug(`Copied rule ${item.name} → team repo`);
   }
@@ -131,9 +162,15 @@ export class RulesHandler extends ResourceHandler {
 
       const destDir = path.join(baseDir, toolPath.rules);
       await ensureDir(destDir);
-      const dest = path.join(destDir, `${item.name}.md`);
+      const dest = path.join(destDir, `${item.name}${ruleExtForTool(tool)}`);
       try {
-        await copyFile(item.sourcePath, dest);
+        if (tool === 'cursor') {
+          // Cursor needs `.mdc` with derived frontmatter, not a raw `.md` copy.
+          const raw = await readFileSafe(item.sourcePath);
+          await writeFile(dest, teamRuleToCursorMdc(raw ?? ''));
+        } else {
+          await copyFile(item.sourcePath, dest);
+        }
         log.debug(`Synced rule ${item.name} → ${tool}`);
       } catch (e) {
         log.warn(`Failed to sync rule ${item.name} to ${tool}: ${(e as Error).message}`);
@@ -147,10 +184,9 @@ export class RulesHandler extends ResourceHandler {
   async removeItem(name: string, teamConfig: TeamaiConfig, localConfig: LocalConfig): Promise<string[]> {
     const removed: string[] = [];
     const baseDir = resolveBaseDir(localConfig);
-    const fileName = `${name}.md`;
 
-    // Remove from team repo
-    const teamFile = path.join(localConfig.repo.localPath, 'rules', fileName);
+    // Remove from team repo (always `.md`)
+    const teamFile = path.join(localConfig.repo.localPath, 'rules', `${name}.md`);
     if (await pathExists(teamFile)) {
       await remove(teamFile);
       removed.push(teamFile);
@@ -159,10 +195,10 @@ export class RulesHandler extends ResourceHandler {
     // Record tombstone so the resource won't be re-pushed
     await this.addTombstone(name, localConfig);
 
-    // Remove from each tool's rules directory
+    // Remove from each tool's rules directory (Cursor uses `.mdc`)
     for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
       if (!toolPath.rules) continue;
-      const filePath = path.join(baseDir, toolPath.rules, fileName);
+      const filePath = path.join(baseDir, toolPath.rules, `${name}${ruleExtForTool(tool)}`);
       if (await pathExists(filePath)) {
         await remove(filePath);
         removed.push(filePath);
@@ -223,7 +259,7 @@ export class RulesHandler extends ResourceHandler {
     }
 
     // 1.5. Clean up stale local rule files not present in team repo
-    const teamRuleFiles = new Set(rules.map((r) => `${r.name}.md`));
+    const teamRuleNames = new Set(rules.map((r) => r.name));
     const baseDir = resolveBaseDir(localConfig);
     for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
       if (!toolPath.rules) continue;
@@ -232,13 +268,14 @@ export class RulesHandler extends ResourceHandler {
       const destDir = path.join(baseDir, toolPath.rules);
       if (!await pathExists(destDir)) continue;
 
+      const ext = ruleExtForTool(tool);
       const localFiles = await listFilesRecursive(destDir);
       for (const localFile of localFiles) {
-        if (!localFile.endsWith('.md')) continue;
+        if (!localFile.endsWith(ext)) continue;
         // Skip built-in and legacy rules (managed by CLI, not team repo)
-        const ruleName = localFile.replace(/\.md$/, '');
+        const ruleName = localFile.slice(0, -ext.length);
         if (EXCLUDED_RULE_NAMES.has(ruleName)) continue;
-        if (!teamRuleFiles.has(localFile)) {
+        if (!teamRuleNames.has(ruleName)) {
           const fullPath = path.join(destDir, localFile);
           await remove(fullPath);
           log.debug(`Removed stale rule ${localFile} from ${tool}`);

--- a/src/resources/rules.ts
+++ b/src/resources/rules.ts
@@ -5,16 +5,13 @@ import { listFilesRecursive, pathExists, copyFile, ensureDir, remove, fileConten
 import { log } from '../utils/logger.js';
 import { TEAMAI_RULES_START, TEAMAI_RULES_END, resolveBaseDir, isAgentDisabled, scopedToolPaths } from '../types.js';
 import { EXCLUDED_RULE_NAMES } from '../builtin-rules.js';
-import { teamRuleToCursorMdc, cursorMdcToTeamMd, cursorMdcBodyEqualsTeamMd } from './cursor-mdc.js';
-
-/**
- * Cursor stores project rules as `.cursor/rules/*.mdc` and ignores plain `.md`
- * files there (they lack the frontmatter Cursor requires). All other tools use
- * plain `.md`. `ruleExtForTool` returns the on-disk extension for a given tool.
- */
-function ruleExtForTool(tool: string): '.md' | '.mdc' {
-  return tool === 'cursor' ? '.mdc' : '.md';
-}
+import { teamRuleToCursorMdc, mergeCursorBodyIntoTeamMd, cursorMdcBodyEqualsTeamMd } from './cursor-mdc.js';
+import {
+  ruleFileExtensionForTool,
+  ruleStemFromFilename,
+  usesCursorMdcRules,
+  isLegacyCursorRuleFile,
+} from './rule-format.js';
 
 export class RulesHandler extends ResourceHandler {
   readonly type = 'rules' as const;
@@ -39,6 +36,15 @@ export class RulesHandler extends ResourceHandler {
 
     // Collect the best candidate for each rule name across all tool directories
     const candidates = new Map<string, { sourcePath: string; mtime: number; status: ResourceItemStatus }>();
+    // One read per team rule, shared across every tool dir that compares against it.
+    const teamContentCache = new Map<string, string>();
+    const readTeamRule = async (filePath: string): Promise<string> => {
+      const cached = teamContentCache.get(filePath);
+      if (cached !== undefined) return cached;
+      const content = (await readFileSafe(filePath)) ?? '';
+      teamContentCache.set(filePath, content);
+      return content;
+    };
 
     // Scan each tool's rules/ directory (recursively)
     for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
@@ -48,8 +54,8 @@ export class RulesHandler extends ResourceHandler {
       if (!await pathExists(rulesDir)) continue;
 
       // Cursor stores rules as `.mdc`; every other tool as `.md`.
-      const ext = ruleExtForTool(tool);
-      const isCursor = tool === 'cursor';
+      const ext = ruleFileExtensionForTool(tool);
+      const isCursor = usesCursorMdcRules(tool);
 
       const files = await listFilesRecursive(rulesDir);
       for (const file of files) {
@@ -72,7 +78,7 @@ export class RulesHandler extends ResourceHandler {
           const equal = isCursor
             ? cursorMdcBodyEqualsTeamMd(
                 (await readFileSafe(localFilePath)) ?? '',
-                (await readFileSafe(teamFilePath)) ?? '',
+                await readTeamRule(teamFilePath),
               )
             : await fileContentEqual(localFilePath, teamFilePath);
           if (equal) continue; // This tool dir's copy is identical, skip
@@ -84,7 +90,14 @@ export class RulesHandler extends ResourceHandler {
             candidates.set(name, { sourcePath: localFilePath, mtime, status: 'modified' });
           }
         } else {
-          // File does not exist in team repo — candidate for "new"
+          // File does not exist in team repo — candidate for "new".
+          // Except in Cursor's dir: `.cursor/rules/*.mdc` is exactly where
+          // Cursor's own "New Cursor Rule" command writes a developer's personal
+          // rules, so treating them as new team resources would offer to publish
+          // private files (with their frontmatter stripped) to the whole team.
+          // teamai only ever authors `.mdc` there by pulling, so a Cursor-only
+          // file is by definition not ours to push.
+          if (isCursor) continue;
           const existing = candidates.get(name);
           if (!existing) {
             const mtime = await getFileMtime(localFilePath);
@@ -134,10 +147,16 @@ export class RulesHandler extends ResourceHandler {
     const dest = path.join(localConfig.repo.localPath, 'rules', `${item.name}.md`);
     if (item.sourcePath !== dest) {
       if (item.sourcePath.endsWith('.mdc')) {
-        // Source is a Cursor `.mdc`: strip its derived frontmatter and write the
-        // tool-neutral markdown body back to the team repo (`.md`).
+        // Source is a Cursor `.mdc`. Only its markdown body is pushed: the
+        // Cursor frontmatter is machine-derived, and the team file keeps its own
+        // tool-neutral frontmatter (`paths:`, …) — dropping that would silently
+        // un-scope the rule for the whole team on the next pull.
         const raw = await readFileSafe(item.sourcePath);
-        await writeFile(dest, cursorMdcToTeamMd(raw ?? ''));
+        if (raw === null) {
+          // Never turn an unreadable source into an empty team rule.
+          throw new Error(`Cannot read rule source ${item.sourcePath}`);
+        }
+        await writeFile(dest, mergeCursorBodyIntoTeamMd(raw, await readFileSafe(dest)));
       } else {
         await copyFile(item.sourcePath, dest);
       }
@@ -162,12 +181,19 @@ export class RulesHandler extends ResourceHandler {
 
       const destDir = path.join(baseDir, toolPath.rules);
       await ensureDir(destDir);
-      const dest = path.join(destDir, `${item.name}${ruleExtForTool(tool)}`);
+      const dest = path.join(destDir, `${item.name}${ruleFileExtensionForTool(tool)}`);
       try {
-        if (tool === 'cursor') {
+        if (usesCursorMdcRules(tool)) {
           // Cursor needs `.mdc` with derived frontmatter, not a raw `.md` copy.
           const raw = await readFileSafe(item.sourcePath);
-          await writeFile(dest, teamRuleToCursorMdc(raw ?? ''));
+          if (raw === null) {
+            // Never write a stub always-on rule in place of an unreadable source.
+            throw new Error(`Cannot read rule source ${item.sourcePath}`);
+          }
+          await writeFile(dest, teamRuleToCursorMdc(raw));
+          // Drop the copy an older teamai layout left as `.md` here: Cursor
+          // never reads it, and it would otherwise linger forever.
+          await remove(path.join(destDir, `${item.name}.md`));
         } else {
           await copyFile(item.sourcePath, dest);
         }
@@ -195,14 +221,19 @@ export class RulesHandler extends ResourceHandler {
     // Record tombstone so the resource won't be re-pushed
     await this.addTombstone(name, localConfig);
 
-    // Remove from each tool's rules directory (Cursor uses `.mdc`)
+    // Remove from each tool's rules directory. Cursor uses `.mdc`, but an older
+    // teamai layout wrote `.md` there, so both are removed — otherwise `remove`
+    // would report success while leaving the rule on disk.
     for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
       if (!toolPath.rules) continue;
-      const filePath = path.join(baseDir, toolPath.rules, `${name}${ruleExtForTool(tool)}`);
-      if (await pathExists(filePath)) {
-        await remove(filePath);
-        removed.push(filePath);
-        log.debug(`Removed rule ${name} from ${tool}`);
+      const extensions = new Set<string>([ruleFileExtensionForTool(tool), '.md']);
+      for (const extension of extensions) {
+        const filePath = path.join(baseDir, toolPath.rules, `${name}${extension}`);
+        if (await pathExists(filePath)) {
+          await remove(filePath);
+          removed.push(filePath);
+          log.debug(`Removed rule ${name} from ${tool}`);
+        }
       }
     }
 
@@ -268,12 +299,24 @@ export class RulesHandler extends ResourceHandler {
       const destDir = path.join(baseDir, toolPath.rules);
       if (!await pathExists(destDir)) continue;
 
-      const ext = ruleExtForTool(tool);
+      const ext = ruleFileExtensionForTool(tool);
       const localFiles = await listFilesRecursive(destDir);
       for (const localFile of localFiles) {
+        const ruleName = ruleStemFromFilename(localFile);
+        if (ruleName === null) continue;
+
+        // Cursor only reads `.mdc`, so any `.md` here is inert leftover from the
+        // layout that predates it — removed whether or not the rule is still
+        // active, and ahead of the built-in check, since built-ins now deploy to
+        // Cursor as `.mdc` too.
+        if (isLegacyCursorRuleFile(tool, localFile)) {
+          await remove(path.join(destDir, localFile));
+          log.debug(`Removed legacy .md rule ${localFile} from ${tool}`);
+          continue;
+        }
+
         if (!localFile.endsWith(ext)) continue;
         // Skip built-in and legacy rules (managed by CLI, not team repo)
-        const ruleName = localFile.slice(0, -ext.length);
         if (EXCLUDED_RULE_NAMES.has(ruleName)) continue;
         if (!teamRuleNames.has(ruleName)) {
           const fullPath = path.join(destDir, localFile);

--- a/src/uninstall.ts
+++ b/src/uninstall.ts
@@ -30,6 +30,7 @@ import {
   type ManagedMcpManifest,
 } from './types.js';
 import { BUILTIN_RULE_NAMES } from './builtin-rules.js';
+import { ruleStemFromFilename } from './resources/rule-format.js';
 import { BUILTIN_AGENT_NAMES } from './builtin-agents.js';
 import { BUILTIN_SKILL_NAMES } from './builtin-skills.js';
 import {
@@ -302,8 +303,10 @@ async function discoverToolResources(
     if (await pathExists(rulesDir)) {
       const files = await listFilesRecursive(rulesDir);
       for (const file of files) {
-        if (!file.endsWith('.md')) continue;
-        const ruleName = file.replace(/\.md$/, '');
+        // Cursor's copies are `.mdc`; match by stem so both extensions are
+        // collected and uninstall does not leave team rules behind.
+        const ruleName = ruleStemFromFilename(file);
+        if (ruleName === null) continue;
         if (teamRuleNames.has(ruleName)) {
           res.ruleFiles.push(path.join(rulesDir, file));
         }

--- a/src/utils/pre-push-sync.ts
+++ b/src/utils/pre-push-sync.ts
@@ -10,9 +10,13 @@ import {
   copyFile,
   copyDir,
   dirTeamSubsetEqual,
+  readFileSafe,
+  writeFile,
 } from './fs.js';
 import { getFileContentAtRev } from './git.js';
 import { ResourceHandler } from '../resources/base.js';
+import { ruleFileExtensionForTool, usesCursorMdcRules } from '../resources/rule-format.js';
+import { teamRuleToCursorMdc, cursorMdcBodyEqualsTeamMd } from '../resources/cursor-mdc.js';
 import { EXCLUDED_RULE_NAMES } from '../builtin-rules.js';
 import { log } from './logger.js';
 
@@ -70,21 +74,47 @@ async function syncRulesToLocal(
     const rulesDir = path.join(baseDir, toolPath.rules);
     if (!await pathExists(rulesDir)) continue;
 
+    // Cursor's copies are `.mdc` with derived frontmatter; every other tool's
+    // are verbatim `.md`. Matching only `.md` here would skip Cursor entirely,
+    // leaving a stale copy that push then reports as "modified" and sends
+    // upstream — silently reverting the teammate's update.
+    const ext = ruleFileExtensionForTool(tool);
+    const isCursor = usesCursorMdcRules(tool);
+
     const files = await listFilesRecursive(rulesDir);
     for (const file of files) {
-      if (!file.endsWith('.md')) continue;
-      const name = file.replace(/\.md$/, '');
+      if (!file.endsWith(ext)) continue;
+      const name = file.slice(0, -ext.length);
       if (EXCLUDED_RULE_NAMES.has(name)) continue;
 
       const localFilePath = path.join(rulesDir, file);
-      const teamFilePath = path.join(teamRulesDir, file);
+      // The team repo always stores the tool-neutral `.md`.
+      const teamRelPath = `rules/${name}.md`;
+      const teamFilePath = path.join(teamRulesDir, `${name}.md`);
 
       // Only process files that exist in both places but differ
       if (!await pathExists(teamFilePath)) continue;
+      if (isCursor) {
+        const localRaw = await readFileSafe(localFilePath);
+        const teamRaw = await readFileSafe(teamFilePath);
+        if (localRaw === null || teamRaw === null) continue;
+        if (cursorMdcBodyEqualsTeamMd(localRaw, teamRaw)) continue;
+
+        const oldContent = await getFileContentAtRev(repoPath, lastPullRev, teamRelPath);
+        if (oldContent === null) continue; // Didn't exist at lastPullRev — ambiguous, skip
+
+        // Compare bodies: the local `.mdc` never matched the team `.md` byte for byte.
+        if (cursorMdcBodyEqualsTeamMd(localRaw, oldContent.toString('utf-8'))) {
+          await writeFile(localFilePath, teamRuleToCursorMdc(teamRaw));
+          log.debug(`Pre-push sync: updated ${tool} rule ${name} to match team repo`);
+        }
+        continue;
+      }
+
       if (await fileContentEqual(localFilePath, teamFilePath)) continue;
 
       // They differ — check if local matches the old team repo version
-      const oldContent = await getFileContentAtRev(repoPath, lastPullRev, `rules/${file}`);
+      const oldContent = await getFileContentAtRev(repoPath, lastPullRev, teamRelPath);
       if (oldContent === null) continue; // File didn't exist at lastPullRev — ambiguous, skip
 
       if (await fileContentEqualToBuffer(localFilePath, oldContent)) {


### PR DESCRIPTION
## Problem

`teamai pull` synced team rules into `.cursor/rules/` as **`.md`** files, but Cursor project rules must be **`.mdc`** with YAML frontmatter (`description` / `globs` / `alwaysApply`). A plain `.md` there is silently ignored by Cursor, so team rules never entered a Cursor session — the sync reported success but had no effect. (Reported as git.woa.com/teamai/teamai-cli#3; confirmed against Cursor's current docs, which state *"Project rules must use the .mdc extension"* and *"a plain .md file in .cursor/rules is ignored."*)

`RulesHandler.pullItem` wrote `${item.name}.md` for every tool with no per-tool branch. Push scanning and stale cleanup also only matched `.md`.

## Fix

- **pull** — for Cursor, write `<name>.mdc` and derive frontmatter from the team rule:
  - a rule scoped with a `paths:` list → `globs: <comma-joined>` + `alwaysApply: false`
  - a rule with no `paths` (a mandatory team rule) → `alwaysApply: true`
  - other tools still get a plain `.md` copy.
- **push** — `scanLocalForPush` now also reads `.cursor/rules/*.mdc`, comparing **markdown bodies only** so a clean `pull` → `push` round-trip is not flagged as modified; `pushItem` strips the derived frontmatter when writing an `.mdc` back to the team repo (which stays tool-neutral `.md`).
- **cleanup** — stale-file cleanup, `removeItem`, and the `pull.ts` tombstone cleanup all handle the `.mdc` extension for Cursor.

Frontmatter mapping and the tool-neutral team format are isolated in a new `src/resources/cursor-mdc.ts`. Body extraction is **delimiter-based, not YAML-parsed**: the Cursor `globs` value (a leading-`*` glob) is invalid YAML, so a strict parse would fail and swallow the frontmatter into the body.

## Test Plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — **2284 passed** (18 new tests for `.mdc` conversion, round-trip stability, push read-back, stale cleanup, and `remove`; 1 stale assertion that encoded the old buggy behavior updated to expect `.mdc`)
- [x] Real CLI end-to-end (`teamai init . → pull → push --dry-run`):
  - Cursor dir gets `.mdc`, Claude dir stays `.md`
  - `paths:` rule → `globs` + `alwaysApply:false`; no-frontmatter rule → `alwaysApply:true`
  - `push` recognizes `.cursor/rules/*.mdc` (previously invisible)
  - second `pull` is idempotent, byte-identical output
  - deleting a team rule + `pull` removes the corresponding `.mdc`, keeps active ones

## Docs

Added a **Cursor** section to `docs/usage-guide.md` and `docs/usage-guide.zh-CN.md` describing the `.mdc` behavior and frontmatter mapping.