### PR TITLE
fix(push): update the open PR instead of opening duplicates

### DIFF
--- a/src/__tests__/exclude.test.ts
+++ b/src/__tests__/exclude.test.ts
@@ -50,6 +50,7 @@ describe('skill exclude commands', () => {
       pushedRules: [],
       pushedSkills: [],
       pushedEnvVars: [],
+      pendingPushes: [],
       lastUpdateCheck: null,
       availableUpdate: null,
     });

--- a/src/__tests__/pull-scope-isolation.test.ts
+++ b/src/__tests__/pull-scope-isolation.test.ts
@@ -171,6 +171,7 @@ describe('pull scope isolation (issue #73)', () => {
       pushedRules: [],
       pushedSkills: [],
       pushedEnvVars: [],
+      pendingPushes: [],
       lastUpdateCheck: null,
       availableUpdate: null,
     }));

--- a/src/__tests__/pull-skip-sync.test.ts
+++ b/src/__tests__/pull-skip-sync.test.ts
@@ -142,6 +142,7 @@ describe('pull skip-sync when repo HEAD unchanged', () => {
       pushedRules: [],
       pushedSkills: [],
       pushedEnvVars: [],
+      pendingPushes: [],
       lastUpdateCheck: null,
       availableUpdate: null,
     });
@@ -164,6 +165,7 @@ describe('pull skip-sync when repo HEAD unchanged', () => {
       pushedRules: [],
       pushedSkills: [],
       pushedEnvVars: [],
+      pendingPushes: [],
       lastUpdateCheck: null,
       availableUpdate: null,
     });
@@ -188,6 +190,7 @@ describe('pull skip-sync when repo HEAD unchanged', () => {
       pushedRules: [],
       pushedSkills: [],
       pushedEnvVars: [],
+      pendingPushes: [],
       lastUpdateCheck: null,
       availableUpdate: null,
     });
@@ -211,6 +214,7 @@ describe('pull skip-sync when repo HEAD unchanged', () => {
       pushedRules: [],
       pushedSkills: [],
       pushedEnvVars: [],
+      pendingPushes: [],
       lastUpdateCheck: null,
       availableUpdate: null,
     });
@@ -232,6 +236,7 @@ describe('pull skip-sync when repo HEAD unchanged', () => {
       pushedRules: [],
       pushedSkills: [],
       pushedEnvVars: [],
+      pendingPushes: [],
       lastUpdateCheck: null,
       availableUpdate: null,
     });
@@ -251,6 +256,7 @@ describe('pull skip-sync when repo HEAD unchanged', () => {
       pushedRules: [],
       pushedSkills: [],
       pushedEnvVars: [],
+      pendingPushes: [],
       lastUpdateCheck: null,
       availableUpdate: null,
     });
@@ -272,6 +278,7 @@ describe('pull skip-sync when repo HEAD unchanged', () => {
       pushedRules: [],
       pushedSkills: [],
       pushedEnvVars: [],
+      pendingPushes: [],
       lastUpdateCheck: null,
       availableUpdate: null,
     });
@@ -368,6 +375,7 @@ describe('pull skip-sync refreshes CLAUDE.md recall block (CLI upgrade)', () => 
       pushedRules: [],
       pushedSkills: [],
       pushedEnvVars: [],
+      pendingPushes: [],
       lastUpdateCheck: null,
       availableUpdate: null,
     });

--- a/src/__tests__/push-pending-pr.test.ts
+++ b/src/__tests__/push-pending-pr.test.ts
@@ -1,0 +1,394 @@
+/**
+ * Regression tests: `teamai push` must not open a duplicate PR for resources
+ * that are already waiting in an unmerged PR.
+ *
+ * push detects changes by diffing against the team repo's default branch, so an
+ * unmerged resource looks "new" forever. Before this guard, every re-run created
+ * another branch (names carry a timestamp) and another PR.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { push } from '../push.js';
+import {
+  findPendingForItem, partiallySelectedEntries, pendingNamespaceFor, planPushGroups,
+  prunePendingPushes, recordPendingPush,
+} from '../utils/pending-push.js';
+import type { PendingPush, ResourceItem, State } from '../types.js';
+
+const mockAutoDetectInit = vi.fn();
+const mockPullRepo = vi.fn();
+const mockPushRepoBranch = vi.fn();
+const mockCheckoutMaster = vi.fn();
+const mockGenerateBranchName = vi.fn();
+const mockRemoteBranchExists = vi.fn();
+const mockLoadStateForScope = vi.fn();
+const mockSaveStateForScope = vi.fn();
+const mockGetHandler = vi.fn();
+const mockCreatePullRequest = vi.fn();
+const mockAskSelection = vi.fn();
+
+vi.mock('../utils/prompt.js', () => ({
+  askQuestion: vi.fn(() => Promise.resolve('1')),
+  askConfirmation: vi.fn(() => Promise.resolve(true)),
+  askSelection: (...args: unknown[]) => mockAskSelection(...args),
+  parseSelection: vi.fn(),
+  closePrompt: vi.fn(),
+}));
+
+vi.mock('../config.js', () => ({
+  autoDetectInit: (...args: unknown[]) => mockAutoDetectInit(...args),
+  loadStateForScope: (...args: unknown[]) => mockLoadStateForScope(...args),
+  saveStateForScope: (...args: unknown[]) => mockSaveStateForScope(...args),
+}));
+
+vi.mock('../utils/git.js', () => ({
+  createGit: vi.fn().mockReturnValue({
+    status: vi.fn().mockResolvedValue({
+      modified: [], not_added: [], created: [], conflicted: [], staged: [],
+    }),
+    merge: vi.fn(),
+    stash: vi.fn(),
+    reset: vi.fn(),
+    clean: vi.fn(),
+  }),
+  pullRepo: (...args: unknown[]) => mockPullRepo(...args),
+  pushRepoBranch: (...args: unknown[]) => mockPushRepoBranch(...args),
+  checkoutMaster: (...args: unknown[]) => mockCheckoutMaster(...args),
+  generateBranchName: (...args: unknown[]) => mockGenerateBranchName(...args),
+  remoteBranchExists: (...args: unknown[]) => mockRemoteBranchExists(...args),
+  resetToCleanMaster: vi.fn(),
+  isDedicatedRepoRoot: vi.fn().mockResolvedValue(true),
+  getDefaultBranch: vi.fn().mockResolvedValue('main'),
+  getFileContentAtRev: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../resources/index.js', () => ({
+  getHandler: (...args: unknown[]) => mockGetHandler(...args),
+}));
+
+vi.mock('../resources/skills.js', () => ({
+  scanTeamRepoNamespaces: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../providers/index.js', () => ({
+  getProvider: vi.fn().mockReturnValue({
+    parseRepoInput: vi.fn().mockReturnValue({ owner: 'test', repo: 'repo' }),
+    createPullRequest: (...args: unknown[]) => mockCreatePullRequest(...args),
+  }),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  log: {
+    info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), dim: vi.fn(),
+  },
+  spinner: vi.fn(() => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    warn: vi.fn().mockReturnThis(),
+    info: vi.fn().mockReturnThis(),
+    stop: vi.fn().mockReturnThis(),
+  })),
+}));
+
+function makeItem(overrides: Partial<ResourceItem> = {}): ResourceItem {
+  return {
+    name: 'hello-skill',
+    type: 'skills',
+    sourcePath: '/home/u/.cursor/skills/hello-skill',
+    relativePath: 'skills/hello-skill',
+    status: 'new',
+    ...overrides,
+  } as ResourceItem;
+}
+
+function makeState(pendingPushes: PendingPush[] = []): State {
+  return {
+    lastPush: null,
+    lastPull: null,
+    lastPullRev: null,
+    pushedRules: [],
+    pushedSkills: [],
+    pushedEnvVars: [],
+    pendingPushes,
+    lastUpdateCheck: null,
+    availableUpdate: null,
+  };
+}
+
+function makeEntry(overrides: Partial<PendingPush> = {}): PendingPush {
+  return {
+    branch: 'teamai/push/testuser/20260827-065032',
+    prUrl: 'https://github.com/team/repo/pull/5',
+    createdAt: '2026-08-27T06:50:32.000Z',
+    items: [{
+      type: 'skills', name: 'hello-skill', relativePath: 'skills/js/hello-skill', namespace: 'js',
+    }],
+    ...overrides,
+  };
+}
+
+// ─── Pure helpers ────────────────────────────────────────
+
+describe('pending push records', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRemoteBranchExists.mockResolvedValue(true);
+  });
+
+  it('keeps a record whose branch still exists and whose resource is still scanned', async () => {
+    const result = await prunePendingPushes('/tmp/repo', [makeEntry()], [makeItem()]);
+    expect(result.pending).toHaveLength(1);
+    expect(result.changed).toBe(false);
+  });
+
+  it('drops a record whose branch is gone from origin (PR merged or closed)', async () => {
+    mockRemoteBranchExists.mockResolvedValue(false);
+    const result = await prunePendingPushes('/tmp/repo', [makeEntry()], [makeItem()]);
+    expect(result.pending).toHaveLength(0);
+    expect(result.changed).toBe(true);
+  });
+
+  it('keeps records when the remote is unreachable, so duplicates stay blocked', async () => {
+    mockRemoteBranchExists.mockResolvedValue(null);
+    const result = await prunePendingPushes('/tmp/repo', [makeEntry()], [makeItem()]);
+    expect(result.pending).toHaveLength(1);
+  });
+
+  it('drops a record whose resources no longer show up in the scan', async () => {
+    const result = await prunePendingPushes('/tmp/repo', [makeEntry()], []);
+    expect(result.pending).toHaveLength(0);
+    expect(mockRemoteBranchExists).not.toHaveBeenCalled();
+  });
+
+  it('tolerates a state file written before pendingPushes existed', async () => {
+    const result = await prunePendingPushes(
+      '/tmp/repo',
+      undefined as unknown as PendingPush[],
+      [makeItem()],
+    );
+    expect(result.pending).toEqual([]);
+    expect(result.changed).toBe(false);
+  });
+
+  it('matches a scanned resource by type and name, ignoring destination path', () => {
+    const found = findPendingForItem([makeEntry()], makeItem({ relativePath: 'skills/hello-skill' }));
+    expect(found).toHaveLength(1);
+    expect(findPendingForItem([makeEntry()], makeItem({ name: 'other' }))).toHaveLength(0);
+  });
+
+  it('reuses a record when the selection covers all of its resources', () => {
+    const entry = makeEntry({
+      items: [
+        { type: 'skills', name: 'hello-skill', relativePath: 'skills/js/hello-skill' },
+        { type: 'rules', name: 'common/test-rule', relativePath: 'rules/common/test-rule.md' },
+      ],
+    });
+    const skill = makeItem();
+    const rule = makeItem({ type: 'rules', name: 'common/test-rule', relativePath: 'rules/common/test-rule.md' });
+
+    expect(planPushGroups([skill, rule], [entry])).toEqual([{ items: [skill, rule], reuse: entry }]);
+  });
+
+  it('keeps unrelated resources out of the open PR by giving them their own group', () => {
+    const extra = makeItem({ name: 'extra' });
+    const groups = planPushGroups([makeItem(), extra], [makeEntry()]);
+    expect(groups).toHaveLength(2);
+    expect(groups[0].reuse?.branch).toBe('teamai/push/testuser/20260827-065032');
+    expect(groups[1]).toEqual({ items: [extra] });
+  });
+
+  it('opens a new PR for a partial selection rather than dropping the rest', () => {
+    const entry = makeEntry({
+      items: [
+        { type: 'skills', name: 'hello-skill', relativePath: 'skills/js/hello-skill' },
+        { type: 'rules', name: 'common/test-rule', relativePath: 'rules/common/test-rule.md' },
+      ],
+    });
+    const skill = makeItem();
+    expect(planPushGroups([skill], [entry])).toEqual([{ items: [skill] }]);
+    expect(partiallySelectedEntries([skill], [entry])).toEqual([entry]);
+  });
+
+  it('gives each open PR its own group', () => {
+    const first = makeEntry({ branch: 'b1', createdAt: '2026-08-01T00:00:00.000Z' });
+    const second = makeEntry({
+      branch: 'b2',
+      createdAt: '2026-08-27T00:00:00.000Z',
+      items: [{ type: 'rules', name: 'common/test-rule', relativePath: 'rules/common/test-rule.md' }],
+    });
+    const skill = makeItem();
+    const rule = makeItem({ type: 'rules', name: 'common/test-rule', relativePath: 'rules/common/test-rule.md' });
+
+    const groups = planPushGroups([skill, rule], [first, second]);
+    // Newest first, then the older record; nothing is left for a new PR.
+    expect(groups.map((g) => g.reuse?.branch)).toEqual(['b2', 'b1']);
+  });
+
+  it('claims a resource once when two records list it', () => {
+    const older = makeEntry({ branch: 'b1', createdAt: '2026-08-01T00:00:00.000Z' });
+    const newer = makeEntry({ branch: 'b2', createdAt: '2026-08-27T00:00:00.000Z' });
+    const groups = planPushGroups([makeItem()], [older, newer]);
+    expect(groups).toEqual([{ items: [makeItem()], reuse: newer }]);
+  });
+
+  it('recalls the namespace chosen when the PR was opened', () => {
+    expect(pendingNamespaceFor(makeEntry(), makeItem())).toBe('js');
+  });
+
+  it('replaces the record for a branch instead of appending a second one', () => {
+    const state = makeState([makeEntry({ prUrl: 'old' })]);
+    recordPendingPush(state, makeEntry({ prUrl: 'new' }));
+    expect(state.pendingPushes).toHaveLength(1);
+    expect(state.pendingPushes[0].prUrl).toBe('new');
+  });
+});
+
+// ─── push() flow ─────────────────────────────────────────
+
+function makeLocalConfig() {
+  return {
+    repo: { localPath: '/tmp/team-repo', remote: 'https://github.com/team/repo.git', kind: 'clone' },
+    username: 'testuser',
+    updatePolicy: 'auto',
+    additionalRoles: [],
+    resourceProfileVersion: 1,
+    scope: 'user',
+  };
+}
+
+function makeTeamConfig() {
+  return {
+    repo: 'https://github.com/team/repo.git',
+    provider: 'github',
+    reviewers: [],
+    sharing: {
+      skills: {},
+      rules: { enforced: [] },
+      docs: { localDir: '~/.teamai/docs' },
+      env: { injectShellProfile: true },
+    },
+    toolPaths: {},
+  };
+}
+
+describe('push() with an open PR', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.exitCode = 0;
+    mockPullRepo.mockResolvedValue('Already up to date.');
+    mockPushRepoBranch.mockResolvedValue(true);
+    mockCheckoutMaster.mockResolvedValue(undefined);
+    mockGenerateBranchName.mockReturnValue('teamai/push/testuser/20260827-070000');
+    mockRemoteBranchExists.mockResolvedValue(true);
+    mockCreatePullRequest.mockResolvedValue('https://github.com/team/repo/pull/9');
+    mockSaveStateForScope.mockResolvedValue(undefined);
+    mockAskSelection.mockImplementation(
+      (_p: string, count: number) => Promise.resolve(Array.from({ length: count }, (__, i) => i)),
+    );
+    mockAutoDetectInit.mockResolvedValue({
+      localConfig: makeLocalConfig(),
+      teamConfig: makeTeamConfig(),
+    });
+    mockGetHandler.mockImplementation((type: string) => ({
+      scanLocalForPush: vi.fn().mockResolvedValue(type === 'skills' ? [makeItem()] : []),
+      pushItem: vi.fn(),
+    }));
+  });
+
+  it('updates the open PR instead of opening a second one', async () => {
+    mockLoadStateForScope.mockResolvedValue(makeState([makeEntry()]));
+
+    await push({});
+
+    expect(mockCreatePullRequest).not.toHaveBeenCalled();
+    expect(mockPushRepoBranch).toHaveBeenCalledTimes(1);
+    const [, , , branch, opts] = mockPushRepoBranch.mock.calls[0];
+    expect(branch).toBe('teamai/push/testuser/20260827-065032');
+    expect(opts).toEqual({ reuseBranch: true });
+    // The namespace recorded with the PR is reused, not re-prompted.
+    expect(mockPushRepoBranch.mock.calls[0][2]).toContain('skills/js/hello-skill');
+  });
+
+  it('sends unrelated resources to their own PR in the same run', async () => {
+    mockLoadStateForScope.mockResolvedValue(makeState([makeEntry()]));
+    mockGetHandler.mockImplementation((type: string) => ({
+      scanLocalForPush: vi.fn().mockResolvedValue(
+        type === 'skills' ? [makeItem(), makeItem({ name: 'brand-new' })] : [],
+      ),
+      pushItem: vi.fn(),
+    }));
+
+    await push({});
+
+    expect(mockPushRepoBranch).toHaveBeenCalledTimes(2);
+    expect(mockPushRepoBranch.mock.calls[0][3]).toBe('teamai/push/testuser/20260827-065032');
+    expect(mockPushRepoBranch.mock.calls[0][4]).toEqual({ reuseBranch: true });
+    expect(mockPushRepoBranch.mock.calls[1][3]).toBe('teamai/push/testuser/20260827-070000');
+    expect(mockPushRepoBranch.mock.calls[1][4]).toEqual({ reuseBranch: false });
+    // Only the new resource needs a PR created; the other one updated its own.
+    expect(mockCreatePullRequest).toHaveBeenCalledTimes(1);
+    const saved = mockSaveStateForScope.mock.calls.at(-1)?.[0] as State;
+    expect(saved.pendingPushes.map((p) => p.branch)).toEqual([
+      'teamai/push/testuser/20260827-065032',
+      'teamai/push/testuser/20260827-070000',
+    ]);
+  });
+
+  it('keeps one record per branch across repeated pushes', async () => {
+    mockLoadStateForScope.mockResolvedValue(makeState([makeEntry()]));
+
+    await push({ all: true });
+
+    const saved = mockSaveStateForScope.mock.calls.at(-1)?.[0] as State;
+    expect(saved.pendingPushes).toHaveLength(1);
+    expect(saved.pendingPushes[0].prUrl).toBe('https://github.com/team/repo/pull/5');
+  });
+
+  it('opens a PR normally when nothing is under review', async () => {
+    mockLoadStateForScope.mockResolvedValue(makeState());
+
+    await push({ all: true });
+
+    expect(mockCreatePullRequest).toHaveBeenCalledTimes(1);
+    const [, , , branch, opts] = mockPushRepoBranch.mock.calls[0];
+    expect(branch).toBe('teamai/push/testuser/20260827-070000');
+    expect(opts).toEqual({ reuseBranch: false });
+    const saved = mockSaveStateForScope.mock.calls.at(-1)?.[0] as State;
+    expect(saved.pendingPushes).toEqual([expect.objectContaining({
+      branch: 'teamai/push/testuser/20260827-070000',
+      prUrl: 'https://github.com/team/repo/pull/9',
+    })]);
+  });
+
+  it('re-pushes as a new PR once the recorded branch is gone from origin', async () => {
+    mockRemoteBranchExists.mockResolvedValue(false);
+    mockLoadStateForScope.mockResolvedValue(makeState([makeEntry()]));
+
+    await push({});
+
+    expect(mockCreatePullRequest).toHaveBeenCalledTimes(1);
+    expect(mockPushRepoBranch.mock.calls[0][3]).toBe('teamai/push/testuser/20260827-070000');
+  });
+
+  it('updates the open PR in silent mode rather than duplicating it', async () => {
+    mockLoadStateForScope.mockResolvedValue(makeState([makeEntry()]));
+
+    await push({ silent: true });
+
+    expect(mockCreatePullRequest).not.toHaveBeenCalled();
+    expect(mockPushRepoBranch.mock.calls[0][4]).toEqual({ reuseBranch: true });
+  });
+
+  it('reports an unchanged PR without touching its branch', async () => {
+    // pushRepoBranch returns false when the rebuilt tree matches the remote.
+    mockPushRepoBranch.mockResolvedValue(false);
+    mockLoadStateForScope.mockResolvedValue(makeState([makeEntry()]));
+
+    await push({});
+
+    expect(mockCreatePullRequest).not.toHaveBeenCalled();
+    const saved = mockSaveStateForScope.mock.calls.at(-1)?.[0] as State;
+    expect(saved.pendingPushes).toHaveLength(1);
+    expect(saved.pendingPushes[0].branch).toBe('teamai/push/testuser/20260827-065032');
+  });
+});

--- a/src/__tests__/roles-set-state.test.ts
+++ b/src/__tests__/roles-set-state.test.ts
@@ -97,6 +97,7 @@ describe('rolesSet — state invalidation', () => {
             pushedRules: [],
             pushedSkills: [],
             pushedEnvVars: [],
+            pendingPushes: [],
             lastUpdateCheck: null,
             availableUpdate: null,
         });

--- a/src/__tests__/scope.test.ts
+++ b/src/__tests__/scope.test.ts
@@ -410,7 +410,7 @@ describe('loadStateForScope / saveStateForScope', () => {
 
   it('should save and load state for user scope', async () => {
     await fse.ensureDir(path.join(tmpDir, '.teamai'));
-    await saveStateForScope({ lastPull: '2025-01-01', lastPullRev: null, lastPush: null, pushedRules: [], pushedSkills: [], pushedEnvVars: [], lastUpdateCheck: null, availableUpdate: null }, 'user');
+    await saveStateForScope({ lastPull: '2025-01-01', lastPullRev: null, lastPush: null, pushedRules: [], pushedSkills: [], pushedEnvVars: [], pendingPushes: [], lastUpdateCheck: null, availableUpdate: null }, 'user');
     const state = await loadStateForScope('user');
     expect(state.lastPull).toBe('2025-01-01');
   });
@@ -418,7 +418,7 @@ describe('loadStateForScope / saveStateForScope', () => {
   it('should save and load state for project scope', async () => {
     const projectRoot = path.join(tmpDir, 'proj');
     await fse.ensureDir(path.join(projectRoot, '.teamai'));
-    await saveStateForScope({ lastPull: '2025-06-01', lastPullRev: null, lastPush: null, pushedRules: [], pushedSkills: [], pushedEnvVars: [], lastUpdateCheck: null, availableUpdate: null }, 'project', projectRoot);
+    await saveStateForScope({ lastPull: '2025-06-01', lastPullRev: null, lastPush: null, pushedRules: [], pushedSkills: [], pushedEnvVars: [], pendingPushes: [], lastUpdateCheck: null, availableUpdate: null }, 'project', projectRoot);
     const state = await loadStateForScope('project', projectRoot);
     expect(state.lastPull).toBe('2025-06-01');
   });

--- a/src/push.ts
+++ b/src/push.ts
@@ -5,12 +5,18 @@ import {
   createGit, pullRepo, pushRepoBranch, checkoutMaster, generateBranchName,
   resetToCleanMaster, isDedicatedRepoRoot, getDefaultBranch, getFileContentAtRev,
 } from './utils/git.js';
+import {
+  findPendingForItem, partiallySelectedEntries, pendingNamespaceFor, planPushGroups,
+  prunePendingPushes, recordPendingPush, toPendingItems, type PushGroup,
+} from './utils/pending-push.js';
 import { syncTeamUpdatesToLocal } from './utils/pre-push-sync.js';
 import { getProvider } from './providers/index.js';
 import { log, spinner } from './utils/logger.js';
 import { getHandler } from './resources/index.js';
 import { scanTeamRepoNamespaces } from './resources/skills.js';
-import type { GlobalOptions, ResourceItem, ResourceType, LocalConfig, TeamaiConfig } from './types.js';
+import type {
+  GlobalOptions, ResourceItem, ResourceType, LocalConfig, TeamaiConfig, State,
+} from './types.js';
 import { assertSafePath, assertSafeResourceName, defaultAllowedRoots } from './utils/path-safety.js';
 import { loadRolesManifest, resolveRoleResourceNamespaces } from './roles.js';
 import { askQuestion, askSelection } from './utils/prompt.js';
@@ -114,6 +120,139 @@ async function createPrWithFallback(
 }
 
 export { createPrWithFallback };
+
+/**
+ * Push each selected resource into the team repo, commit it on a branch, and
+ * open (or update) the matching PR. Returns false when the push failed, after
+ * rolling back the copies so the next scan sees a clean tree.
+ */
+async function pushGroup(args: {
+  group: PushGroup;
+  teamConfig: TeamaiConfig;
+  localConfig: LocalConfig;
+  pushState: State;
+  includeTeamConfig: boolean;
+}): Promise<boolean> {
+  const { group, teamConfig, localConfig, pushState, includeTeamConfig } = args;
+  const { items, reuse } = group;
+
+  // pushItem copies files into the team repo's working tree. If any later
+  // step (refreshMarketplace, pushRepoBranch, createPullRequest) fails, we
+  // must wipe those copies + any staging so the next `teamai push` scans
+  // cleanly instead of reporting "No new resources" (BUG #2).
+  const pushSpin = spinner('Pushing resources...').start();
+  const pushedFiles: string[] = [];
+  let workingTreeDirtied = false;
+
+  try {
+    for (const item of items) {
+      const handler = getHandler(item.type);
+      await handler.pushItem(item, teamConfig, localConfig);
+      workingTreeDirtied = true;
+      pushedFiles.push(item.relativePath);
+    }
+
+    // Refresh marketplace.json if it exists and skills were pushed
+    if (items.some((i) => i.type === 'skills')) {
+      try {
+        const { refreshMarketplace } = await import('./resources/marketplace.js');
+        const updated = await refreshMarketplace(localConfig.repo.localPath);
+        if (updated) {
+          pushedFiles.push('.codebuddy-plugin/marketplace.json');
+          log.debug('Refreshed marketplace.json');
+        }
+      } catch (e) {
+        log.debug(`Marketplace refresh skipped: ${(e as Error).message}`);
+      }
+    }
+
+    // Create branch, commit, and push.
+    // Only include "sweeper" directories (rules/, env/) that actually
+    // exist — otherwise `git add 'rules/'` throws `pathspec did not match
+    // any files` and the whole push aborts (BUG #1). A team may not have
+    // rules/ or env/ yet.
+    const sweeperCandidates = ['rules/', 'env/', '.codebuddy-plugin/'];
+    const existingSweepers = await filterExistingTopLevelPaths(
+      localConfig.repo.localPath,
+      sweeperCandidates,
+    );
+    // Include teamai.yaml when the user edited it (e.g. `teamai source add`), so
+    // sources / publicSkills changes ride along in the same PR as the resources.
+    const configFiles = includeTeamConfig ? ['teamai.yaml'] : [];
+    const gitFiles = [...new Set([...pushedFiles, ...existingSweepers, ...configFiles])];
+    const branchName = reuse?.branch ?? generateBranchName(localConfig.username);
+    const commitMsg = `[teamai] Push ${items.length} resource(s) from ${localConfig.username}`;
+
+    const hasChanges = await pushRepoBranch(
+      localConfig.repo.localPath,
+      commitMsg,
+      gitFiles,
+      branchName,
+      { reuseBranch: Boolean(reuse) },
+    );
+    // pushRepoBranch committed (or deleted the branch) — working tree is
+    // clean either way from the branch's perspective.
+    workingTreeDirtied = false;
+
+    if (!hasChanges) {
+      pushSpin.succeed(
+        reuse
+          ? `No changes to push (PR already up to date: ${reuse.prUrl ?? branchName})`
+          : 'No changes to push (files already up to date)',
+      );
+      return true;
+    }
+
+    pushSpin.succeed(`Pushed branch ${branchName}`);
+
+    let prUrl: string | null;
+    if (reuse) {
+      // The PR tracks this branch, so the force-push above already updated it.
+      prUrl = reuse.prUrl;
+      log.success(`Existing PR updated: ${prUrl ?? branchName}`);
+    } else {
+      prUrl = await createPrWithFallback(
+        teamConfig,
+        localConfig,
+        branchName,
+        commitMsg,
+        `Pushed ${items.length} resource(s):\n${items.map((i) => `- [${i.type}] ${i.name}`).join('\n')}`,
+      );
+      if (!prUrl) {
+        process.exitCode = 1;
+      }
+    }
+
+    // Remember the open PR so the next run updates it instead of opening a
+    // duplicate. Recorded even when PR creation failed: the branch is on the
+    // remote, so pushing again must reuse it.
+    recordPendingPush(pushState, {
+      branch: branchName,
+      prUrl,
+      createdAt: new Date().toISOString(),
+      items: toPendingItems(items),
+    });
+
+    // Switch back to the default branch so the next group starts clean
+    await checkoutMaster(localConfig.repo.localPath);
+    return true;
+  } catch (e) {
+    pushSpin.fail(`Push failed: ${(e as Error).message}`);
+    if (workingTreeDirtied) {
+      try {
+        const git = createGit(localConfig.repo.localPath);
+        await git.reset(['--hard', 'HEAD']);
+        await git.clean('f', ['-d']);
+        log.debug('Rolled back team repo working tree after failed push');
+      } catch (cleanupErr) {
+        log.warn(
+          `Warning: team repo may be in a dirty state. Run \`git -C ${localConfig.repo.localPath} reset --hard && git clean -fd\` manually. (${(cleanupErr as Error).message})`,
+        );
+      }
+    }
+    return false;
+  }
+}
 
 export async function push(options: GlobalOptions & { all?: boolean; role?: string }): Promise<void> {
   // Auto-detect scope: project scope if cwd has project config, else user scope
@@ -397,6 +536,22 @@ async function pushCore(
     }
   }
 
+  // ── Step 0: Cross-check against still-open push PRs ────────────────
+  // Resources waiting in an unmerged PR are absent from the default branch, so
+  // the scan above flags them as new every single time. Without this check each
+  // run opens another duplicate PR.
+  const pushState = await loadStateForScope(localConfig.scope, localConfig.projectRoot);
+  const pruned = await prunePendingPushes(
+    localConfig.repo.localPath,
+    pushState.pendingPushes,
+    allItems,
+  );
+  pushState.pendingPushes = pruned.pending;
+  if (pruned.changed) {
+    await saveStateForScope(pushState, localConfig.scope, localConfig.projectRoot);
+  }
+  const pendingPushes = pushState.pendingPushes;
+
   if (allItems.length === 0) {
     // No resource changes, but the user may have edited teamai.yaml (sources /
     // publicSkills) via `teamai source add`. Push that config change on its own
@@ -413,6 +568,7 @@ async function pushCore(
   console.log('');
   console.log(`Found ${allItems.length} resource(s) to push:`);
   console.log('');
+  const pendingIndices = new Set<number>();
   for (let i = 0; i < allItems.length; i++) {
     const item = allItems[i];
     const statusLabel = item.status === 'modified' ? ' (modified)' : ' (new)';
@@ -423,8 +579,23 @@ async function pushCore(
     if (item.type === 'skills' && item.namespace) {
       console.log(`       to:   skills/${item.namespace}/${item.name}`);
     }
+    const openPrs = findPendingForItem(pendingPushes, item);
+    if (openPrs.length > 0) {
+      pendingIndices.add(i);
+      for (const entry of openPrs) {
+        console.log(`       awaiting review: ${entry.prUrl ?? `branch ${entry.branch}`}`);
+      }
+    }
   }
   console.log('');
+
+  if (pendingIndices.size > 0) {
+    log.info(
+      `${pendingIndices.size} resource(s) already belong to an open PR. Keeping them selected updates `
+      + 'that PR instead of opening a duplicate; deselect them to leave it untouched.',
+    );
+    console.log('');
+  }
 
   // ── Step 2: Dry run exits after display ────────────────────────────
   if (options.dryRun) {
@@ -448,8 +619,38 @@ async function pushCore(
     selectedItems = indices.map((i) => allItems[i]);
   }
 
+  // ── Step 3b: Split the selection into per-PR groups ────────────────
+  // Resources that belong to an open PR are pushed by force-pushing that PR's
+  // branch, which updates it in place; everything else goes into a new PR. Both
+  // can happen in one run, so editing a resource under review updates its PR
+  // without dragging unrelated resources into that review.
+  const groups = planPushGroups(selectedItems, pendingPushes);
+  for (const group of groups) {
+    if (!group.reuse) continue;
+    log.info(
+      `Updating existing PR instead of creating a new one: ${group.reuse.prUrl ?? group.reuse.branch}`,
+    );
+    // Reuse the destination chosen when that PR was opened rather than asking
+    // again — a different answer would silently move the skill.
+    for (const item of group.items) {
+      if (item.type !== 'skills' || item.status !== 'new') continue;
+      const ns = pendingNamespaceFor(group.reuse, item);
+      if (!ns) continue;
+      item.namespace = ns;
+      item.relativePath = `skills/${ns}/${item.name}`;
+    }
+  }
+  for (const entry of partiallySelectedEntries(selectedItems, pendingPushes)) {
+    log.warn(
+      `Only part of ${entry.prUrl ?? entry.branch} is selected, so the selected resources go into a `
+      + 'new PR and will exist in both. Select all of its resources to update it in place instead.',
+    );
+  }
+
   // ── Step 4: Resolve namespace for NEW skills only (after selection) ─
-  const newSkills = selectedItems.filter((i) => i.type === 'skills' && i.status === 'new');
+  const newSkills = selectedItems.filter(
+    (i) => i.type === 'skills' && i.status === 'new' && !i.namespace,
+  );
   let resolvedNamespaceForNew: string | undefined;
 
   if (newSkills.length > 0) {
@@ -533,105 +734,29 @@ async function pushCore(
     }
   }
 
-  // ── Step 5: Push each selected item to local repo ──────────────────
-  // pushItem copies files into the team repo's working tree. If any later
-  // step (refreshMarketplace, pushRepoBranch, createPullRequest) fails, we
-  // must wipe those copies + any staging so the next `teamai push` scans
-  // cleanly instead of reporting "No new resources" (BUG #2).
-  const pushSpin = spinner('Pushing resources...').start();
-  const pushedFiles: string[] = [];
-  let workingTreeDirtied = false;
-
-  try {
-    for (const item of selectedItems) {
-      const handler = getHandler(item.type);
-      await handler.pushItem(item, teamConfig, localConfig);
-      workingTreeDirtied = true;
-      pushedFiles.push(item.relativePath);
-    }
-
-    // Refresh marketplace.json if it exists and skills were pushed
-    if (selectedItems.some((i) => i.type === 'skills')) {
-      try {
-        const { refreshMarketplace } = await import('./resources/marketplace.js');
-        const updated = await refreshMarketplace(localConfig.repo.localPath);
-        if (updated) {
-          pushedFiles.push('.codebuddy-plugin/marketplace.json');
-          log.debug('Refreshed marketplace.json');
-        }
-      } catch (e) {
-        log.debug(`Marketplace refresh skipped: ${(e as Error).message}`);
-      }
-    }
-
-    // Create branch, commit, and push.
-    // Only include "sweeper" directories (rules/, env/) that actually
-    // exist — otherwise `git add 'rules/'` throws `pathspec did not match
-    // any files` and the whole push aborts (BUG #1). A team may not have
-    // rules/ or env/ yet.
-    const sweeperCandidates = ['rules/', 'env/', '.codebuddy-plugin/'];
-    const existingSweepers = await filterExistingTopLevelPaths(
-      localConfig.repo.localPath,
-      sweeperCandidates,
-    );
-    // Include teamai.yaml when the user edited it (e.g. `teamai source add`), so
-    // sources / publicSkills changes ride along in the same PR as the resources.
-    const configFiles = pendingTeamConfig !== null ? ['teamai.yaml'] : [];
-    const gitFiles = [...new Set([...pushedFiles, ...existingSweepers, ...configFiles])];
-    const branchName = generateBranchName(localConfig.username);
-    const commitMsg = `[teamai] Push ${selectedItems.length} resource(s) from ${localConfig.username}`;
-
-    const hasChanges = await pushRepoBranch(
-      localConfig.repo.localPath,
-      commitMsg,
-      gitFiles,
-      branchName,
-    );
-    // pushRepoBranch committed (or deleted the branch) — working tree is
-    // clean either way from the branch's perspective.
-    workingTreeDirtied = false;
-
-    if (!hasChanges) {
-      pushSpin.succeed('No changes to push (files already up to date)');
-      return;
-    }
-
-    pushSpin.succeed(`Pushed branch ${branchName}`);
-
-    // Create PR/MR via provider
-    const prUrl = await createPrWithFallback(
+  // ── Step 5: Push each group — one branch/PR per group ──────────────
+  // Config edits ride along with the first group so they land in a single PR.
+  let configRider = pendingTeamConfig !== null;
+  for (const group of groups) {
+    const ok = await pushGroup({
+      group,
       teamConfig,
       localConfig,
-      branchName,
-      commitMsg,
-      `Pushed ${selectedItems.length} resource(s):\n${selectedItems.map((i) => `- [${i.type}] ${i.name}`).join('\n')}`,
-    );
-    if (!prUrl) {
+      pushState,
+      includeTeamConfig: configRider,
+    });
+    if (!ok) {
+      // The branch/PR for earlier groups is already on the remote, so their
+      // records must survive this failure or the next run would duplicate them.
+      await saveStateForScope(pushState, localConfig.scope, localConfig.projectRoot);
       process.exitCode = 1;
+      return;
     }
-
-    // Switch back to master after PR creation
-    await checkoutMaster(localConfig.repo.localPath);
-  } catch (e) {
-    pushSpin.fail(`Push failed: ${(e as Error).message}`);
-    if (workingTreeDirtied) {
-      try {
-        const git = createGit(localConfig.repo.localPath);
-        await git.reset(['--hard', 'HEAD']);
-        await git.clean('f', ['-d']);
-        log.debug('Rolled back team repo working tree after failed push');
-      } catch (cleanupErr) {
-        log.warn(
-          `Warning: team repo may be in a dirty state. Run \`git -C ${localConfig.repo.localPath} reset --hard && git clean -fd\` manually. (${(cleanupErr as Error).message})`,
-        );
-      }
-    }
-    process.exitCode = 1;
-    return;
+    configRider = false;
   }
 
-  // Update state
-  const state = await loadStateForScope(localConfig.scope, localConfig.projectRoot);
+  // Update state (pushState already carries the pendingPushes records above)
+  const state = pushState;
   state.lastPush = new Date().toISOString();
   for (const item of selectedItems) {
     if (item.type === 'skills' && !state.pushedSkills.includes(item.name)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -299,6 +299,37 @@ export type LocalConfigInput = z.input<typeof LocalConfigSchema>;
 
 // ─── Local state (~/.teamai/state.json) ────────────────────
 
+/**
+ * A resource that was included in a still-open push PR.
+ * Matched against fresh scan results by `type` + `name`.
+ */
+export const PendingPushItemSchema = z.object({
+  type: z.string(),
+  name: z.string(),
+  /** Destination path inside the team repo, e.g. "skills/js/hello-skill". */
+  relativePath: z.string(),
+  /** Skill namespace chosen at push time, reapplied when the PR is updated. */
+  namespace: z.string().optional(),
+});
+
+/**
+ * A push branch that has been sent to the remote but whose PR is not merged yet.
+ *
+ * `teamai push` detects changes by diffing against the team repo's default
+ * branch, so resources sitting in an unmerged PR look "new" on every run and
+ * used to produce an endless stream of duplicate PRs. Recording them here lets
+ * push skip them by default and offer to update the existing PR instead.
+ */
+export const PendingPushSchema = z.object({
+  branch: z.string(),
+  prUrl: z.string().nullable().default(null),
+  createdAt: z.string(),
+  items: z.array(PendingPushItemSchema).default([]),
+});
+
+export type PendingPushItem = z.infer<typeof PendingPushItemSchema>;
+export type PendingPush = z.infer<typeof PendingPushSchema>;
+
 export const StateSchema = z.object({
   lastPush: z.string().nullable().default(null),
   lastPull: z.string().nullable().default(null),
@@ -313,6 +344,8 @@ export const StateSchema = z.object({
   pushedRules: z.array(z.string()).default([]),
   pushedSkills: z.array(z.string()).default([]),
   pushedEnvVars: z.array(z.string()).default([]),
+  /** Push branches whose PR is still open — see PendingPushSchema. */
+  pendingPushes: z.array(PendingPushSchema).default([]),
   lastUpdateCheck: z.string().nullable().default(null),
   availableUpdate: z.string().nullable().default(null),
 });

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -349,23 +349,61 @@ export function isMetadataOnlyDiff(diff: string): boolean {
 }
 
 /**
+ * Check whether a branch still exists on the `origin` remote.
+ *
+ * Used to decide whether a recorded push branch is still alive (its PR is open)
+ * or has been merged/closed and deleted. Returns null when the remote cannot be
+ * reached, so callers can distinguish "gone" from "unknown".
+ */
+export async function remoteBranchExists(
+  localPath: string,
+  branchName: string,
+): Promise<boolean | null> {
+  try {
+    const out = await createGit(localPath).listRemote(['--heads', 'origin', `refs/heads/${branchName}`]);
+    return out.trim().length > 0;
+  } catch (e) {
+    log.debug(`ls-remote failed for ${branchName}: ${(e as Error).message}`);
+    return null;
+  }
+}
+
+/**
  * Create a new branch, commit files, and push the branch to remote.
  * Returns false if there are no changes to commit (or only metadata changes).
  * Leaves the local repo on the new branch after pushing so that
  * the provider's createPullRequest (which may internally push HEAD)
  * sees the correct branch.
  * Callers should call `checkoutMaster()` when they are done.
+ *
+ * With `opts.reuseBranch`, `branchName` is an existing remote branch backing an
+ * open PR: the branch is rebuilt from the current default branch and
+ * force-pushed, which updates that PR in place instead of opening another one.
+ * If the rebuilt tree matches what the remote branch already holds, nothing is
+ * pushed and the function returns false.
  */
 export async function pushRepoBranch(
   localPath: string,
   message: string,
   files: string[],
   branchName: string,
+  opts: { reuseBranch?: boolean } = {},
 ): Promise<boolean> {
   const git = createGit(localPath);
 
-  // Create and switch to new branch
-  await git.checkoutLocalBranch(branchName);
+  if (opts.reuseBranch) {
+    // Fetch so the tree comparison below can see the remote branch's content.
+    try {
+      await git.fetch(['origin', branchName]);
+    } catch (e) {
+      log.debug(`Could not fetch ${branchName}: ${(e as Error).message}`);
+    }
+    // -B resets a leftover local branch of the same name onto the default branch.
+    await git.checkout(['-B', branchName]);
+  } else {
+    // Create and switch to new branch
+    await git.checkoutLocalBranch(branchName);
+  }
 
   // Stage files
   await git.add(files);
@@ -396,9 +434,37 @@ export async function pushRepoBranch(
 
   // Commit and push branch
   await git.commit(message);
+
+  if (opts.reuseBranch) {
+    // Re-running push with no real change would otherwise force-push an
+    // identical tree under a new commit sha, spamming the open PR.
+    if (await treeMatchesRemoteBranch(git, branchName)) {
+      log.debug(`Remote branch ${branchName} already holds this tree, skipping force-push`);
+      const defaultBranch = await getDefaultBranch(localPath);
+      await switchToDefaultBranch(git, defaultBranch);
+      return false;
+    }
+    await git.push(['--force-with-lease', '-u', 'origin', branchName]);
+    return true;
+  }
+
   await git.push(['-u', 'origin', branchName]);
 
   return true;
+}
+
+/**
+ * Compare the tree of the currently checked-out branch with the tree of its
+ * remote counterpart. Returns false when the remote ref is unknown locally.
+ */
+async function treeMatchesRemoteBranch(git: SimpleGit, branchName: string): Promise<boolean> {
+  try {
+    const local = (await git.revparse([`${branchName}^{tree}`])).trim();
+    const remote = (await git.revparse([`refs/remotes/origin/${branchName}^{tree}`])).trim();
+    return local.length > 0 && local === remote;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/src/utils/pending-push.ts
+++ b/src/utils/pending-push.ts
@@ -1,0 +1,145 @@
+/**
+ * Open-PR bookkeeping for `teamai push`.
+ *
+ * push decides what to send by diffing local resources against the team repo's
+ * default branch. A resource sitting in an unmerged PR is absent from that
+ * branch, so it looks brand new on every run — re-running push used to open one
+ * duplicate PR after another (each branch name carries a fresh timestamp, so
+ * git-level deduplication never kicked in either).
+ *
+ * After a successful push we therefore remember the branch, its PR URL and the
+ * resources it carries. Later runs cross-check the scan against those records
+ * and force-push the recorded branch — updating the existing PR in place —
+ * instead of opening a duplicate.
+ */
+import { remoteBranchExists } from './git.js';
+import { log } from './logger.js';
+import type { PendingPush, ResourceItem, State } from '../types.js';
+
+/** Identity used to match a recorded resource against a fresh scan result. */
+function itemKey(type: string, name: string): string {
+  return `${type}:${name}`;
+}
+
+/**
+ * Drop records that no longer describe an open PR:
+ *   - the branch is gone from origin (PR merged or closed, branch deleted)
+ *   - none of its resources show up in the current scan (PR merged with the
+ *     branch retained, so the resources now live on the default branch)
+ *
+ * Records are kept when the remote cannot be reached, so a flaky network never
+ * resurrects the duplicate-PR behaviour.
+ */
+export async function prunePendingPushes(
+  repoPath: string,
+  pending: PendingPush[],
+  scanned: ResourceItem[],
+): Promise<{ pending: PendingPush[]; changed: boolean }> {
+  const scannedKeys = new Set(scanned.map((i) => itemKey(i.type, i.name)));
+  const kept: PendingPush[] = [];
+  // State files written before this field existed parse to undefined.
+  const entries = pending ?? [];
+
+  for (const entry of entries) {
+    const stillScanned = entry.items.some((i) => scannedKeys.has(itemKey(i.type, i.name)));
+    if (!stillScanned) {
+      log.debug(`Dropping pending push ${entry.branch}: resources no longer pending`);
+      continue;
+    }
+    const exists = await remoteBranchExists(repoPath, entry.branch);
+    if (exists === false) {
+      log.debug(`Dropping pending push ${entry.branch}: branch gone from origin`);
+      continue;
+    }
+    kept.push(entry);
+  }
+
+  return { pending: kept, changed: kept.length !== entries.length };
+}
+
+/** All open-PR records that already carry the given resource. */
+export function findPendingForItem(pending: PendingPush[], item: ResourceItem): PendingPush[] {
+  const key = itemKey(item.type, item.name);
+  return (pending ?? []).filter(
+    (entry) => entry.items.some((i) => itemKey(i.type, i.name) === key),
+  );
+}
+
+/** One branch + PR worth of resources. `reuse` set = update that open PR. */
+export interface PushGroup {
+  items: ResourceItem[];
+  reuse?: PendingPush;
+}
+
+/**
+ * Split a selection into one group per branch/PR.
+ *
+ * An open PR is updated by rebuilding its branch from the default branch and
+ * force-pushing, which only holds up if every resource that PR carries is in
+ * the group — the ones left out would otherwise vanish from the PR. So a record
+ * is reused only when the selection covers all of its resources, and whatever
+ * is left over goes into a new PR of its own rather than being absorbed into
+ * someone else's review. Newest records claim their resources first, and reuse
+ * groups run before the new-PR group.
+ */
+export function planPushGroups(
+  selected: ResourceItem[],
+  pending: PendingPush[],
+): PushGroup[] {
+  const byKey = new Map(selected.map((i) => [itemKey(i.type, i.name), i]));
+  const claimed = new Set<string>();
+  const groups: PushGroup[] = [];
+
+  const newestFirst = [...(pending ?? [])].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  for (const entry of newestFirst) {
+    const keys = entry.items.map((i) => itemKey(i.type, i.name));
+    if (keys.length === 0) continue;
+    if (!keys.every((k) => byKey.has(k) && !claimed.has(k))) continue;
+    for (const k of keys) claimed.add(k);
+    groups.push({ items: keys.map((k) => byKey.get(k)!), reuse: entry });
+  }
+
+  const rest = selected.filter((i) => !claimed.has(itemKey(i.type, i.name)));
+  if (rest.length > 0) groups.push({ items: rest });
+
+  return groups;
+}
+
+/**
+ * Records the selection only partly covers. Those resources cannot update their
+ * PR in place, so they end up in a second PR — worth warning about.
+ */
+export function partiallySelectedEntries(
+  selected: ResourceItem[],
+  pending: PendingPush[],
+): PendingPush[] {
+  const selectedKeys = new Set(selected.map((i) => itemKey(i.type, i.name)));
+  return (pending ?? []).filter((entry) => {
+    const keys = entry.items.map((i) => itemKey(i.type, i.name));
+    const hits = keys.filter((k) => selectedKeys.has(k)).length;
+    return hits > 0 && hits < keys.length;
+  });
+}
+
+/** Namespace recorded for a skill in an open PR, so updates keep its destination. */
+export function pendingNamespaceFor(entry: PendingPush, item: ResourceItem): string | undefined {
+  const key = itemKey(item.type, item.name);
+  return entry.items.find((i) => itemKey(i.type, i.name) === key)?.namespace;
+}
+
+/** Insert or replace the record for a branch. */
+export function recordPendingPush(state: State, entry: PendingPush): void {
+  state.pendingPushes = [
+    ...(state.pendingPushes ?? []).filter((e) => e.branch !== entry.branch),
+    entry,
+  ];
+}
+
+export function toPendingItems(items: ResourceItem[]): PendingPush['items'] {
+  return items.map((i) => ({
+    type: i.type,
+    name: i.name,
+    relativePath: i.relativePath,
+    namespace: i.namespace,
+  }));
+}


### PR DESCRIPTION
`teamai push` diffs against the team repo's default branch, where a resource waiting in an unmerged PR is absent — so every run flagged it as new and opened another PR, and the timestamped branch names kept git-level deduplication from kicking in.

Push now records each branch, PR URL and its resources in the machine-local state, and splits the selection into one branch/PR per group:

- Resources already in an open PR force-push that branch, updating the PR in place and reusing its original namespace. An unchanged tree is not pushed, so a repeated push is a no-op.
- Everything else still gets its own new PR, so unrelated resources are never pulled into someone else's review. A partially selected PR also goes to a new PR, with a warning.
- Records are pruned once the branch is gone from origin or its resources reach the default branch, and kept when the remote is unreachable.

The listing marks these resources with `awaiting review: <url>`.

<!--
Thanks for opening a PR! Please fill out this template to help reviewers understand your change quickly.
-->

## Summary

<!-- 1-3 sentences: what does this PR do and why? -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing behavior to change)
- [ ] Documentation only
- [ ] Refactor / internal cleanup

## Test Plan

<!-- How did you verify this works? Include commands you ran, new tests added, etc. -->

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` passes
- [x] Added/updated tests for the change

## Related Issues

<!-- Closes #123, Fixes #456 -->

## Notes for Reviewers

<!-- Anything reviewers should pay particular attention to (tricky logic, trade-offs, follow-ups) -->
