### PR TITLE
fix(hooks): resolve Cursor SessionStart project via workspace_roots

### DIFF
--- a/src/__tests__/dashboard-collector.test.ts
+++ b/src/__tests__/dashboard-collector.test.ts
@@ -147,6 +147,17 @@ describe('parseHookEvent', () => {
     expect(event!.tool).toBe('cursor');
   });
 
+  it('parses Cursor sessionStart workspace_roots as cwd', async () => {
+    const raw = JSON.stringify({
+      hook_event_name: 'sessionStart',
+      session_id: 'sess-cursor-roots',
+      workspace_roots: ['/Users/jeffxu/Project/teamai-cli'],
+    });
+    const event = await parseHookEvent(raw, 'cursor');
+    expect(event).not.toBeNull();
+    expect(event!.cwd).toBe('/Users/jeffxu/Project/teamai-cli');
+  });
+
   it('parses Cursor camelCase stop event', async () => {
     const raw = JSON.stringify({
       hook_event_name: 'stop',

--- a/src/__tests__/e2e/project-agent-cold-start.test.ts
+++ b/src/__tests__/e2e/project-agent-cold-start.test.ts
@@ -250,6 +250,28 @@ describe('project-scope sequential agent cold start (#342)', () => {
     expect(fs.existsSync(path.join(projectRoot, '.codebuddy'))).toBe(false);
   }, 30_000);
 
+  it('SessionStart --tool cursor uses workspace_roots when process cwd is not the project', async () => {
+    for (const agentRoot of ['.claude', '.cursor', '.codex', '.codebuddy']) {
+      fs.rmSync(path.join(projectRoot, agentRoot), { recursive: true, force: true });
+    }
+    fs.rmSync(path.join(projectRoot, '.teamai', 'state.json'), { force: true });
+
+    // Cursor user hooks run with process.cwd() = ~/.cursor and send
+    // workspace_roots instead of cwd (captured from Cursor 3.17.8).
+    const result = await runCLI(
+      ['hook-dispatch', 'session-start', '--tool', 'cursor', '--bg-only'],
+      { HOME: homeDir },
+      homeDir,
+      JSON.stringify({ workspace_roots: [projectRoot] }),
+    );
+    expect(result.code, result.output).toBe(0);
+    expect(fs.existsSync(path.join(projectRoot, '.cursor', 'skills', 'team-skill', 'SKILL.md'))).toBe(true);
+    expect(fs.existsSync(path.join(projectRoot, '.claude'))).toBe(false);
+    expect(JSON.parse(
+      fs.readFileSync(path.join(projectRoot, '.teamai', 'state.json'), 'utf8'),
+    ).lastPullTargets).toEqual(['cursor']);
+  }, 30_000);
+
   it('SessionStart does not seed a disabled agent', async () => {
     for (const agentRoot of ['.claude', '.cursor', '.codex', '.codebuddy']) {
       fs.rmSync(path.join(projectRoot, agentRoot), { recursive: true, force: true });

--- a/src/__tests__/hook-cwd.test.ts
+++ b/src/__tests__/hook-cwd.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { resolveHookCwd } from '../utils/hook-cwd.js';
+
+describe('resolveHookCwd', () => {
+  it('prefers a non-empty cwd over workspace_roots', () => {
+    expect(resolveHookCwd({
+      cwd: '/from-cwd',
+      workspace_roots: ['/from-roots'],
+    })).toBe('/from-cwd');
+  });
+
+  it('uses the first workspace_roots entry when cwd is missing', () => {
+    expect(resolveHookCwd({
+      hook_event_name: 'sessionStart',
+      workspace_roots: ['/Users/jeffxu/Project/teamai-cli'],
+    })).toBe('/Users/jeffxu/Project/teamai-cli');
+  });
+
+  it('treats empty cwd as missing and falls back to workspace_roots', () => {
+    expect(resolveHookCwd({
+      cwd: '',
+      workspace_roots: ['/project'],
+    })).toBe('/project');
+  });
+
+  it('skips blank workspace_roots entries', () => {
+    expect(resolveHookCwd({
+      workspace_roots: ['', '  ', '/real-root'],
+    })).toBe('/real-root');
+  });
+
+  it('returns undefined when neither cwd nor workspace_roots is usable', () => {
+    expect(resolveHookCwd({})).toBeUndefined();
+    expect(resolveHookCwd({ cwd: '  ', workspace_roots: [] })).toBeUndefined();
+    expect(resolveHookCwd({ workspace_roots: [123, null] })).toBeUndefined();
+  });
+});

--- a/src/__tests__/hook-handlers.test.ts
+++ b/src/__tests__/hook-handlers.test.ts
@@ -106,6 +106,31 @@ describe('hook-handlers registry', () => {
     );
   });
 
+  it('session-start pull seeds from workspace_roots when cwd is absent', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'session-start' && r.handler.name === 'pull',
+    )!.handler;
+
+    await handler.execute({ workspace_roots: ['/tmp/cursor-project'] }, 'cursor');
+
+    expect(mockSeedProjectAgentRoot).toHaveBeenCalledWith('cursor', '/tmp/cursor-project');
+  });
+
+  it('session-start pull prefers cwd over workspace_roots', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'session-start' && r.handler.name === 'pull',
+    )!.handler;
+
+    await handler.execute(
+      { cwd: '/from-cwd', workspace_roots: ['/from-roots'] },
+      'claude',
+    );
+
+    expect(mockSeedProjectAgentRoot).toHaveBeenCalledWith('claude', '/from-cwd');
+  });
+
   it('stop has update, contribute-check, and dashboard-report handlers', () => {
     const registry = buildHandlerRegistry();
     const stopHandlers = registry

--- a/src/__tests__/session-id.test.ts
+++ b/src/__tests__/session-id.test.ts
@@ -44,4 +44,13 @@ describe('deriveSessionId', () => {
         const result = deriveSessionId({}, { includeCwd: true });
         expect(result).toContain(process.cwd());
     });
+
+    it('uses workspace_roots in pid fallback when cwd is absent', () => {
+        delete process.env.CLAUDE_SESSION_ID;
+        const result = deriveSessionId(
+            { workspace_roots: ['/Users/jeffxu/Project/teamai-cli'] },
+            { includeCwd: true },
+        );
+        expect(result).toMatch(/^pid-\d+-\/Users\/jeffxu\/Project\/teamai-cli$/);
+    });
 });

--- a/src/contribute-check.ts
+++ b/src/contribute-check.ts
@@ -6,6 +6,7 @@ import { readJson, writeJson, ensureDir } from './utils/fs.js';
 import { readEvents, aggregateSessionMetrics } from './dashboard-collector.js';
 import { readRecallQuality } from './recall-quality.js';
 import { deriveSessionId } from './utils/session-id.js';
+import { resolveHookCwd } from './utils/hook-cwd.js';
 import { redactWithEnv } from './utils/redact.js';
 import type { ContributeState, DashboardEvent, SessionFriction } from './types.js';
 import {
@@ -349,7 +350,7 @@ async function readStdinAndDeriveSession(): Promise<{ sessionId: string; cwd?: s
     const hookData = JSON.parse(raw) as Record<string, unknown>;
     // Derive session ID: session_id field > env > PID+cwd fallback
     const sessionId = deriveSessionId(hookData, { includeCwd: true });
-    const cwd = typeof hookData.cwd === 'string' ? hookData.cwd : undefined;
+    const cwd = resolveHookCwd(hookData);
     return { sessionId, cwd };
   } catch {
     return null;

--- a/src/dashboard-collector.ts
+++ b/src/dashboard-collector.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import readline from 'node:readline';
 import { log } from './utils/logger.js';
 import { deriveSessionId } from './utils/session-id.js';
+import { resolveHookCwd } from './utils/hook-cwd.js';
 import { ensureDir } from './utils/fs.js';
 import { resolveMonitorPid } from './pid-monitor.js';
 import { normalizeToolName } from './utils/tool-names.js';
@@ -448,7 +449,7 @@ export async function parseHookEvent(
   }
 
   const sessionId = deriveSessionId(hookData, { includeCwd: true });
-  const cwd = typeof hookData.cwd === 'string' ? hookData.cwd : undefined;
+  const cwd = resolveHookCwd(hookData);
 
   const event: DashboardEvent = {
     type: eventType,

--- a/src/hook-dispatch-cli.ts
+++ b/src/hook-dispatch-cli.ts
@@ -18,6 +18,7 @@ import { spawn } from 'node:child_process';
 
 import { createDispatcher, type Dispatcher } from './hook-dispatch.js';
 import { buildHandlerRegistry, filterHandlersForConfig } from './hook-handlers.js';
+import { resolveHookCwd } from './utils/hook-cwd.js';
 import { log, setStderrOnly } from './utils/logger.js';
 
 /**
@@ -69,7 +70,13 @@ async function readStdin(): Promise<string> {
  * caller's process.exit(0) — without waiting for or killing it; its
  * stdout/stderr are ignored so no open pipe keeps the parent alive.
  */
-function spawnBackground(event: string, tool: string, matcher: string, raw: string): void {
+function spawnBackground(
+  event: string,
+  tool: string,
+  matcher: string,
+  raw: string,
+  cwd?: string,
+): void {
   try {
     const args = [
       process.argv[1],
@@ -85,6 +92,7 @@ function spawnBackground(event: string, tool: string, matcher: string, raw: stri
     const child = spawn(process.execPath, args, {
       detached: true,
       stdio: ['pipe', 'ignore', 'ignore'],
+      ...(cwd ? { cwd } : {}),
     });
     child.on('error', () => {});
     if (child.stdin) {
@@ -121,6 +129,8 @@ function parseStdin(raw: string, event: string): Record<string, unknown> | null 
     };
     stdin.hook_event_name = EVENT_MAP[event] ?? event;
   }
+  const cwd = resolveHookCwd(stdin);
+  if (cwd) stdin.cwd = cwd;
   return stdin;
 }
 
@@ -163,7 +173,14 @@ export async function hookDispatchCli(
     // config when the host tells us the working directory (#264), so
     // filterHandlersForConfig can honour a project-level repo.kind.
     const { loadLocalConfig, detectProjectConfig } = await import('./config.js');
-    const cwd = typeof stdin.cwd === 'string' ? stdin.cwd : undefined;
+    const cwd = resolveHookCwd(stdin);
+    if (cwd) {
+      try {
+        process.chdir(cwd);
+      } catch (e) {
+        log.debug(`hook-dispatch: chdir to ${cwd} failed: ${(e as Error).message}`);
+      }
+    }
     const localConfig = (cwd ? await detectProjectConfig(cwd) : null) ?? await loadLocalConfig();
     const handlers = filterHandlersForConfig(buildHandlerRegistry(), localConfig);
     const dispatcher = createDispatcher({ handlers });
@@ -178,7 +195,7 @@ export async function hookDispatchCli(
     // Parent: kick off background handlers in a detached process first so they
     // start working while we run the inline (foreground) pass.
     if (dispatcher.hasBackground(event, matcher)) {
-      spawnBackground(event, tool, matcher, raw);
+      spawnBackground(event, tool, matcher, raw, cwd);
     }
 
     const output = await runDispatch(dispatcher, event, matcher, stdin, tool, 'foreground');

--- a/src/hook-handlers.ts
+++ b/src/hook-handlers.ts
@@ -16,6 +16,7 @@ import type { LocalConfig } from './types.js';
 import { deriveSessionId } from './utils/session-id.js';
 import { log } from './utils/logger.js';
 import { normalizeToolName } from './utils/tool-names.js';
+import { resolveHookCwd } from './utils/hook-cwd.js';
 
 // ─── Public types ───────────────────────────────────────
 
@@ -83,7 +84,7 @@ const LOCAL_AGENT_TIMEOUT_MS = 15_000;
 const pullHandler: HookHandler = {
   name: 'pull',
   async execute(stdin, tool) {
-    const cwd = typeof stdin.cwd === 'string' ? stdin.cwd : undefined;
+    const cwd = resolveHookCwd(stdin);
     try {
       const { seedProjectAgentRoot } = await import('./project-agent-root.js');
       await seedProjectAgentRoot(tool, cwd);
@@ -190,7 +191,7 @@ const contributeCheckHandler: HookHandler = {
     // Match dashboard-collector's derivation so events and contribute state
     // share the same session id even when stdin.session_id is absent.
     const sessionId = deriveSessionId(stdin, { includeCwd: true });
-    const cwd = typeof stdin.cwd === 'string' ? stdin.cwd : undefined;
+    const cwd = resolveHookCwd(stdin);
     const { hint } = await contributeCheckForSession(sessionId, cwd);
     if (hint) {
       return formatStopHookOutput(hint, tool);

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -23,6 +23,7 @@ import { ResourceHandler } from './resources/base.js';
 import { RulesHandler, SkillsHandler } from './resources/index.js';
 import { injectHooksToAllTools, applyAgentHook, removeAgentHook, isAgentHookSupportedTool, isAgentHookEvent, OPENCLAW_TOOLS } from './hooks.js';
 import { parseHookEvent } from './dashboard-collector.js';
+import { resolveHookCwd } from './utils/hook-cwd.js';
 import { getAgentVersion } from './agent-version.js';
 import { getMachineId, deriveLocalAgentId } from './machine-id.js';
 import { EXCLUDED_RULE_NAMES } from './builtin-rules.js';
@@ -2536,7 +2537,7 @@ export async function reportAndSyncFromHook(
 ): Promise<string | null> {
   const raw = JSON.stringify(stdin);
   const event = await parseHookEvent(raw, tool);
-  const cwd = typeof stdin.cwd === 'string' ? stdin.cwd : event?.cwd ?? process.cwd();
+  const cwd = resolveHookCwd(stdin) ?? event?.cwd ?? process.cwd();
 
   // SessionStart and UserPromptSubmit run this handler in the *foreground*, where
   // it blocks the host IDE's hook (UserPromptSubmit cap = 10s). Narrow the

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -2537,7 +2537,9 @@ export async function reportAndSyncFromHook(
 ): Promise<string | null> {
   const raw = JSON.stringify(stdin);
   const event = await parseHookEvent(raw, tool);
-  const cwd = resolveHookCwd(stdin) ?? event?.cwd ?? process.cwd();
+  // parseHookEvent resolves cwd via resolveHookCwd too, so event?.cwd would be
+  // identical here — resolve once and fall back to process.cwd().
+  const cwd = resolveHookCwd(stdin) ?? process.cwd();
 
   // SessionStart and UserPromptSubmit run this handler in the *foreground*, where
   // it blocks the host IDE's hook (UserPromptSubmit cap = 10s). Narrow the

--- a/src/utils/hook-cwd.ts
+++ b/src/utils/hook-cwd.ts
@@ -1,0 +1,23 @@
+/**
+ * Resolve the project working directory from an AI-tool hook payload.
+ *
+ * Claude Code (and most other hosts) send `cwd`. Cursor SessionStart does not:
+ * it sends `workspace_roots: ["<project>"]` instead, and runs the hook process
+ * with cwd set to the hooks.json directory (e.g. ~/.cursor). Empty-string `cwd`
+ * (seen on some Cursor tool events) is treated as missing.
+ */
+export function resolveHookCwd(data: Record<string, unknown>): string | undefined {
+  if (typeof data.cwd === 'string') {
+    const trimmed = data.cwd.trim();
+    if (trimmed) return trimmed;
+  }
+  const roots = data.workspace_roots;
+  if (!Array.isArray(roots)) return undefined;
+  for (const root of roots) {
+    if (typeof root === 'string') {
+      const trimmed = root.trim();
+      if (trimmed) return trimmed;
+    }
+  }
+  return undefined;
+}

--- a/src/utils/session-id.ts
+++ b/src/utils/session-id.ts
@@ -6,6 +6,8 @@
  * fallback logic.
  */
 
+import { resolveHookCwd } from './hook-cwd.js';
+
 export interface DeriveSessionIdOptions {
     /** When true, include the working directory in the PID fallback. */
     includeCwd?: boolean;
@@ -33,7 +35,7 @@ export function deriveSessionId(
 
     const ppid = process.ppid ?? process.pid;
     if (options.includeCwd) {
-        const cwd = typeof data.cwd === 'string' ? data.cwd : process.cwd();
+        const cwd = resolveHookCwd(data) ?? process.cwd();
         return `pid-${ppid}-${cwd}`;
     }
 


### PR DESCRIPTION
## Summary
- Cursor `sessionStart` payloads send `workspace_roots` (not `cwd`) and run the hook with cwd `~/.cursor`, so project-scope SessionStart never seeded `<project>/.cursor` or pulled into it.
- Add `resolveHookCwd()` (prefer non-empty `cwd`, else first `workspace_roots` entry) and use it in hook-dispatch, seed/pull, dashboard, local-agent, and contribute-check.
- `chdir` + spawn `cwd` so the background `teamai pull` still sees the project when the host process started in `~/.cursor`.

## Test plan
- [x] `npx vitest run src/__tests__/hook-cwd.test.ts src/__tests__/hook-handlers.test.ts src/__tests__/session-id.test.ts src/__tests__/dashboard-collector.test.ts`
- [x] `npx tsc --noEmit && npm run build`
- [x] `npx vitest run --config vitest.e2e.config.ts src/__tests__/e2e/project-agent-cold-start.test.ts` (includes HOME cwd + `workspace_roots` only)
- [x] Full `npx vitest run` (2276 passed)
- [x] Real CLI: from `~/.cursor`, `echo '{"workspace_roots":["<project>"]}' | node dist/index.js hook-dispatch session-start --tool cursor --bg-only` created `<project>/.cursor/skills` and set `lastPullTargets` to `["claude","cursor"]`


Made with [Cursor](https://cursor.com)