### PR TITLE
test(e2e): fix stale Cursor rule .md assertion broken by #349

### DIFF
--- a/src/__tests__/e2e/project-agent-cold-start.test.ts
+++ b/src/__tests__/e2e/project-agent-cold-start.test.ts
@@ -166,7 +166,7 @@ describe('project-scope sequential agent cold start (#342)', () => {
     expect(secondPull.code, secondPull.output).toBe(0);
     expect(secondPull.output).not.toContain('Already synced');
     expect(fs.existsSync(path.join(projectRoot, '.cursor', 'skills', 'team-skill', 'SKILL.md'))).toBe(true);
-    expect(fs.existsSync(path.join(projectRoot, '.cursor', 'rules', 'team-rule.md'))).toBe(true);
+    expect(fs.existsSync(path.join(projectRoot, '.cursor', 'rules', 'team-rule.mdc'))).toBe(true);
     expect(fs.existsSync(path.join(projectRoot, '.cursor', 'agents', 'team-helper.md'))).toBe(true);
     expect(JSON.parse(
       fs.readFileSync(path.join(projectRoot, '.teamai', 'state.json'), 'utf8'),


### PR DESCRIPTION
## Problem

The latest CI run on `main` failed in the **E2E (GitHub provider, full surface)** job:

```
src/__tests__/e2e/project-agent-cold-start.test.ts:169
"tracks the exact target set across sequential and recreated agent roots"
→ AssertionError: expected false to be true
```

## Root cause

#349 (`fix(rules): write Cursor rules as .mdc with derived frontmatter`) moved Cursor rules from `.md` to `.mdc` (`ruleFileExtensionForTool` returns `.mdc` for `cursor`). But this E2E still asserted the old path:

```ts
expect(fs.existsSync(path.join(projectRoot, '.cursor', 'rules', 'team-rule.md'))).toBe(true);
```

Since the file is now `team-rule.mdc`, `existsSync` returns `false` and the assertion fails. The `.claude/rules/team-rule.md` assertion (line 157) still passes because only Cursor moved to `.mdc`.

## Fix

Update the single stale assertion to expect `team-rule.mdc`.

## Test Plan

- [x] `npm run build`
- [x] `TEAMAI_TEST_PROVIDER=github npx vitest run --config vitest.e2e.config.ts src/__tests__/e2e/project-agent-cold-start.test.ts` → 5/5 pass