### PR TITLE
feat(hooks): remind users to trust Codex hooks after inject

### DIFF
--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -892,6 +892,8 @@ teamai hooks remove    # Remove
 
 Both commands only touch tools you actually have installed (i.e. whose `~/.<tool>/` root directory already exists). They never create root directories for tools listed in `toolPaths` but not installed.
 
+> **Codex trust gate** — Codex (the OpenAI / ChatGPT Codex app, tool id `codex`) gates non-managed hooks behind an explicit user trust step. After teamai writes `~/.codex/hooks.json`, Codex may skip a newly added or changed hook until you review/trust it in `/hooks` or Settings → Hooks. `teamai hooks inject` and `teamai doctor` print a reminder when Codex hooks are installed; teamai never edits Codex's `[hooks.state]` to auto-trust — trusting is left to you. (The internal variants `codex-internal` / `tcodex` share the hooks.json format but have no trust gate, so no reminder is shown for them.)
+
 ### Team Hooks Declaration
 
 A team can declare custom hooks in the repo's `hooks/hooks.yaml`; `teamai pull` automatically distributes them to all members' AI tools:

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -887,6 +887,8 @@ teamai hooks remove    # 移除
 
 这两个命令只会操作你实际已安装的工具（即 `~/.<tool>/` 根目录已存在的工具）。对于 `toolPaths` 中已配置但未安装的工具，命令不会为其凭空创建根目录。
 
+> **Codex 信任门槛** — Codex（OpenAI / ChatGPT Codex 应用，工具 id 为 `codex`）对非托管 hooks 设有显式的用户信任机制。teamai 写入 `~/.codex/hooks.json` 后，对于新增或变更的 hook，Codex 可能会跳过执行，直到你在 `/hooks` 或 Settings → Hooks 中 review/trust。当检测到 Codex hooks 已安装时，`teamai hooks inject` 与 `teamai doctor` 会输出提示；teamai 从不修改 Codex 的 `[hooks.state]` 来自动信任 —— 信任操作交由你手动完成。（内部变体 `codex-internal` / `tcodex` 共用 hooks.json 格式但没有信任门槛，因此不会为它们输出提示。）
+
 ### 团队 Hooks 声明
 
 团队可在仓库 `hooks/hooks.yaml` 中声明自定义 hooks，`teamai pull` 自动分发到所有成员的 AI 工具：

--- a/src/__tests__/doctor.test.ts
+++ b/src/__tests__/doctor.test.ts
@@ -34,12 +34,14 @@ vi.mock('../providers/tgit/index.js', () => ({
 import { loadLocalConfig, loadTeamConfig } from '../config.js';
 import { pathExists, readFileSafe } from '../utils/fs.js';
 import { TEAMAI_HOOK_SUBCOMMANDS } from '../hooks.js';
+import { log } from '../utils/logger.js';
 import { doctor } from '../doctor.js';
 
 const mockedLoadLocalConfig = loadLocalConfig as Mock;
 const mockedLoadTeamConfig = loadTeamConfig as Mock;
 const mockedPathExists = pathExists as Mock;
 const mockedReadFileSafe = readFileSafe as Mock;
+const mockedLog = log as unknown as { info: Mock; success: Mock; warn: Mock; error: Mock; debug: Mock };
 
 const mockLocalConfig = {
     repo: { localPath: '/tmp/repo', remote: 'https://git.woa.com/team/repo.git' },
@@ -178,6 +180,37 @@ describe('doctor — hook checks', () => {
         const allCalls = consoleSpy.mock.calls.map((c) => c[0]);
         const envLine = allCalls.find((msg: string) => msg.includes('Env variables'));
         expect(envLine).toContain('✔');
+    });
+
+    it('notes Codex may require trust when Codex hooks are installed', async () => {
+        mockedLoadTeamConfig.mockResolvedValue({
+            ...mockTeamConfig,
+            toolPaths: {
+                claude: { settings: '.claude/settings.json', skills: '.claude/skills' },
+                codex: { settings: '.codex/hooks.json', skills: '.codex/skills' },
+            },
+        });
+        // Both settings files exist and contain the hook-dispatch command.
+        mockedReadFileSafe.mockImplementation(async (filePath: string) => {
+            if (filePath.includes('settings.json') || filePath.includes('hooks.json')) {
+                return buildFullHooksContent();
+            }
+            return null;
+        });
+
+        await doctor({});
+
+        const infoLines = mockedLog.info.mock.calls.map((c) => String(c[0]));
+        const note = infoLines.find((msg) => msg.includes('review/trust'));
+        expect(note).toBeDefined();
+        expect(note).toContain('Codex');
+    });
+
+    it('does not note Codex trust when no Codex hooks are installed', async () => {
+        // Default mockTeamConfig has only claude; readFileSafe returns full hooks.
+        await doctor({});
+        const infoLines = mockedLog.info.mock.calls.map((c) => String(c[0]));
+        expect(infoLines.some((msg) => msg.includes('review/trust'))).toBe(false);
     });
 
     it('should skip tools whose parent directory does not exist', async () => {

--- a/src/__tests__/hooks-cmd.test.ts
+++ b/src/__tests__/hooks-cmd.test.ts
@@ -7,10 +7,16 @@ vi.mock('../config.js', () => ({
     autoDetectInit: vi.fn(),
 }));
 
-vi.mock('../hooks.js', () => ({
-    getHookStatus: vi.fn(),
-    reconcileHooksToAllTools: vi.fn(),
-}));
+vi.mock('../hooks.js', async () => {
+    const actual = await vi.importActual<typeof import('../hooks.js')>('../hooks.js');
+    return {
+        getHookStatus: vi.fn(),
+        reconcileHooksToAllTools: vi.fn(),
+        hasInstalledCodexTrustGatedTool: vi.fn(),
+        // Keep the real reminder text so assertions verify the actual wording.
+        codexTrustReminder: actual.codexTrustReminder,
+    };
+});
 
 vi.mock('../resources/hooks.js', () => ({
     parseTeamHooks: vi.fn(),
@@ -30,7 +36,7 @@ vi.mock('../utils/logger.js', () => ({
 // ── Imports (after mocks) ────────────────────────────────
 
 import { autoDetectInit } from '../config.js';
-import { getHookStatus, reconcileHooksToAllTools } from '../hooks.js';
+import { getHookStatus, reconcileHooksToAllTools, hasInstalledCodexTrustGatedTool } from '../hooks.js';
 import { parseTeamHooks, resolveTeamHooks } from '../resources/hooks.js';
 import { log } from '../utils/logger.js';
 import { hooksInject, hooksRemove, hooksList } from '../hooks-cmd.js';
@@ -38,6 +44,7 @@ import { hooksInject, hooksRemove, hooksList } from '../hooks-cmd.js';
 const mockedAutoDetectInit = autoDetectInit as Mock;
 const mockedGetHookStatus = getHookStatus as Mock;
 const mockedReconcile = reconcileHooksToAllTools as Mock;
+const mockedHasCodexTrustGated = hasInstalledCodexTrustGatedTool as Mock;
 const mockedParseTeamHooks = parseTeamHooks as Mock;
 const mockedResolveTeamHooks = resolveTeamHooks as Mock;
 const mockedLog = log as unknown as { info: Mock; success: Mock; warn: Mock; error: Mock; debug: Mock };
@@ -74,6 +81,7 @@ beforeEach(() => {
     mockedAutoDetectInit.mockResolvedValue({ localConfig: mockLocalConfig, teamConfig: mockTeamConfig });
     mockedGetHookStatus.mockResolvedValue('missing');
     mockedReconcile.mockResolvedValue(undefined);
+    mockedHasCodexTrustGated.mockResolvedValue(false);
     mockedParseTeamHooks.mockResolvedValue(TEAM_DEFS);
     mockedResolveTeamHooks.mockResolvedValue({ defs: TEAM_DEFS, builtin: undefined });
 });
@@ -99,6 +107,29 @@ describe('hooksInject', () => {
         await hooksInject({ silent: true });
         expect(mockedReconcile).toHaveBeenCalled();
         expect(mockedLog.success).not.toHaveBeenCalled();
+    });
+
+    it('warns to trust Codex hooks when the public Codex is installed', async () => {
+        mockedHasCodexTrustGated.mockResolvedValue(true);
+        await hooksInject({});
+        expect(mockedLog.success).toHaveBeenCalledWith(expect.stringContaining('Hooks injected'));
+        const warned = mockedLog.warn.mock.calls.map((c) => String(c[0])).join('\n');
+        expect(warned).toContain('Codex');
+        expect(warned).toMatch(/review\/trust|trust them/i);
+        expect(warned).toContain('/hooks');
+    });
+
+    it('does not warn about Codex trust when no trust-gated Codex is installed', async () => {
+        mockedHasCodexTrustGated.mockResolvedValue(false);
+        await hooksInject({});
+        expect(mockedLog.warn).not.toHaveBeenCalled();
+    });
+
+    it('suppresses the Codex trust reminder with --silent', async () => {
+        mockedHasCodexTrustGated.mockResolvedValue(true);
+        await hooksInject({ silent: true });
+        expect(mockedLog.success).not.toHaveBeenCalled();
+        expect(mockedLog.warn).not.toHaveBeenCalled();
     });
 
     it('propagates error when not initialized', async () => {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -10,7 +10,7 @@ import {
   getTeamaiHome,
   type TeamaiConfig,
 } from './types.js';
-import { TEAMAI_HOOK_SUBCOMMANDS } from './hooks.js';
+import { TEAMAI_HOOK_SUBCOMMANDS, isCodexTrustGatedTool, codexTrustReminder } from './hooks.js';
 import { getUserHome } from './utils/home.js';
 
 interface Check {
@@ -46,6 +46,24 @@ async function buildHookChecks(toolPaths: TeamaiConfig['toolPaths'], baseDir: st
     });
   }
   return checks;
+}
+
+/**
+ * True if a trust-gated Codex tool (the public `codex`) already has teamai hooks
+ * installed on disk (settings file exists and contains the hook-dispatch
+ * command). Used to emit a lightweight reminder that Codex may still require the
+ * user to trust them. Read-only — never inspects or modifies Codex's
+ * [hooks.state] trust store. Internal variants are excluded (no trust gate).
+ */
+async function hasInstalledCodexHooks(toolPaths: TeamaiConfig['toolPaths'], baseDir: string): Promise<boolean> {
+  for (const [tool, paths] of Object.entries(toolPaths)) {
+    if (!isCodexTrustGatedTool(tool) || !paths.settings) continue;
+    const settingsPath = path.join(baseDir, paths.settings);
+    if (!await pathExists(settingsPath)) continue;
+    const content = await readFileSafe(settingsPath);
+    if (content?.includes('teamai hook-dispatch')) return true;
+  }
+  return false;
 }
 
 export async function doctor(options: GlobalOptions): Promise<void> {
@@ -179,6 +197,14 @@ export async function doctor(options: GlobalOptions): Promise<void> {
       if (fix) console.log(`    → ${fix}`);
       allPassed = false;
     }
+  }
+
+  // Codex trust-gate reminder: even when hooks are installed, Codex may not run
+  // them until the user reviews/trusts them. Note only — teamai never writes
+  // [hooks.state] to auto-trust.
+  if (await hasInstalledCodexHooks(toolPaths, baseDir)) {
+    console.log('');
+    log.info(codexTrustReminder());
   }
 
   console.log('');

--- a/src/hooks-cmd.ts
+++ b/src/hooks-cmd.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { autoDetectInit } from './config.js';
-import { reconcileHooksToAllTools, getHookStatus, type HookStatus } from './hooks.js';
+import { reconcileHooksToAllTools, getHookStatus, hasInstalledCodexTrustGatedTool, codexTrustReminder, type HookStatus } from './hooks.js';
 import { builtinHookDefs } from './builtin-hooks.js';
 import { parseTeamHooks, resolveTeamHooks } from './resources/hooks.js';
 import { log } from './utils/logger.js';
@@ -84,12 +84,22 @@ export async function hooksInject(options: GlobalOptions): Promise<void> {
         auto: false,
         silent: options.silent,
     });
+    let codexTrustGated = false;
     for (const { baseDir, manifestPath } of resolveHookScopeTargets(localConfig)) {
         await reconcileHooksToAllTools(teamConfig.toolPaths, baseDir, teamDefs, manifestPath, { builtinOverride: builtin });
+        if (await hasInstalledCodexTrustGatedTool(teamConfig.toolPaths, baseDir)) {
+            codexTrustGated = true;
+        }
     }
 
     if (!options.silent) {
         log.success('Hooks injected into all AI tool settings');
+        // The public Codex gates non-managed hooks behind an explicit trust step;
+        // remind the user to trust them in Codex. teamai never edits [hooks.state]
+        // to auto-trust (constraint: reminder only, no bypass).
+        if (codexTrustGated) {
+            log.warn(codexTrustReminder());
+        }
     }
 }
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -105,6 +105,35 @@ function detectFormat(tool: string): ToolFormat {
   return CURSOR_TOOLS.has(tool) ? 'cursor' : 'claude';
 }
 
+/**
+ * Tools that enforce a user trust gate on non-managed hooks. Only the public
+ * Codex (the OpenAI / ChatGPT Codex app, tool id `codex`) does: even after
+ * teamai writes `<repo>/.codex/hooks.json` or `~/.codex/hooks.json`, Codex may
+ * skip a newly added or changed hook until the user reviews/trusts it in
+ * `/hooks` or Settings → Hooks. The internal variants (`codex-internal`,
+ * `tcodex`) share the codex hooks.json *format* but not this trust gate, so
+ * they are intentionally excluded.
+ */
+const CODEX_TRUST_GATE_TOOLS = new Set(['codex']);
+
+/**
+ * True for a tool that gates hooks behind an explicit user trust step (only the
+ * public `codex`). teamai never edits Codex's `[hooks.state]` to auto-trust —
+ * the reminder is UX only. Exported so `hooks inject` / `doctor` can surface it.
+ */
+export function isCodexTrustGatedTool(tool: string): boolean {
+  return CODEX_TRUST_GATE_TOOLS.has(tool);
+}
+
+/**
+ * One-line reminder that Codex may require the user to trust newly written hooks
+ * before they run. Shared by `hooks inject` (post-write notice) and `doctor`
+ * (installed-hooks note) so the wording stays identical.
+ */
+export function codexTrustReminder(): string {
+  return 'Codex hooks written, but Codex may require you to review/trust them before they run — open /hooks or Settings → Hooks in Codex to trust them.';
+}
+
 /** Known teamai command substrings used to identify built-in / legacy hooks. */
 const TEAMAI_COMMAND_MARKERS = [
   'teamai pull', 'teamai update', 'teamai track', 'teamai dashboard', 'teamai contribute-check',
@@ -879,6 +908,28 @@ export async function reconcileHooksToAllTools(
       log.warn(`Failed to reconcile hooks for ${tool}: ${(e as Error).message}`);
     }
   }
+}
+
+/**
+ * True if a trust-gated Codex tool (the public `codex`) is both configured with
+ * a settings path and actually installed on disk under baseDir.
+ *
+ * "Installed" uses the same root-directory gate as reconcileHooksToAllTools, so
+ * a true result means inject just wrote hooks that Codex may require the user to
+ * trust. Internal variants (codex-internal / tcodex) are excluded — they share
+ * the format but not the trust gate. Used to decide whether to print the
+ * reminder after inject.
+ */
+export async function hasInstalledCodexTrustGatedTool(
+  toolPaths: Record<string, { settings?: string }>,
+  baseDir: string,
+): Promise<boolean> {
+  for (const [tool, paths] of Object.entries(toolPaths)) {
+    if (!isCodexTrustGatedTool(tool) || !paths.settings) continue;
+    const toolRoot = path.join(baseDir, paths.settings.split('/')[0]);
+    if (await pathExists(toolRoot)) return true;
+  }
+  return false;
 }
 
 /**


### PR DESCRIPTION
## What & Why

The public Codex (the OpenAI / ChatGPT Codex app, tool id `codex`) gates
non-managed hooks behind an explicit user **trust** step. Even after teamai
writes `<repo>/.codex/hooks.json` or `~/.codex/hooks.json`, Codex may skip a
newly added or changed hook until the user reviews/trusts it in `/hooks` or
Settings → Hooks. This PR adds a **UX reminder** so users know they may need to
trust the hooks — without ever auto-trusting.

**teamai does NOT auto-trust Codex hooks.** It never reads or writes Codex's
`~/.codex/config.toml` `[hooks.state]`. The reminder is purely informational,
and stays conservative ("may require you to review/trust") since teamai has no
model of Codex's trust-gate state.

**Scope:** only the public `codex`. The internal variants (`codex-internal` /
`tcodex`) share the hooks.json format but have **no trust gate**, so no reminder
is shown for them.

## Changes

- **`src/hooks.ts`** — export `isCodexTrustGatedTool()` (only the public
  `codex`), `codexTrustReminder()` (shared wording), and
  `hasInstalledCodexTrustGatedTool()` (is the public Codex installed under a
  base dir, using the same root-dir gate as reconcile).
- **`src/hooks-cmd.ts`** — after `teamai hooks inject`, `log.warn` the trust
  reminder when the public Codex received hooks. Suppressed under `--silent`.
- **`src/doctor.ts`** — when public-Codex hooks are installed, print the same
  note (read-only; never inspects/writes `hooks.state`). Kept small — `status`
  output left unchanged as it has no hook-status section.
- **Tests** — hooks-cmd (reminder shown / not-shown / `--silent` suppressed) and
  doctor (note shown / not-shown). Golden byte-compat tests unchanged and
  passing — no hook command content changed.
- **Docs** — bilingual usage-guide note (EN + zh-CN).

## Where the reminder appears

| Command | Behavior |
|---------|----------|
| `teamai hooks inject` | `⚠` trust reminder when the public Codex is installed; suppressed with `--silent` |
| `teamai doctor` | `ℹ` note when public-Codex hooks are installed |

## Test Plan

All executed against the built CLI (`npm run build` + real `node dist/index.js`):

- [x] `npm run build` passes
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` (full suite, 2308 tests) passes; golden tests included
- [x] E2E: public `codex` installed → inject prints the trust reminder; `hooks.json` written; `--silent` prints nothing; `doctor` shows the note; **no `~/.codex/config.toml` written** (no auto-trust)
- [x] E2E: only `codex-internal` installed → **no** reminder (scope correctly narrowed)
- [x] E2E: no Codex tool installed → no reminder

## Not auto-trusting

Confirmed: teamai never writes `[hooks.state]` or `~/.codex/config.toml`. The
E2E run verified the file is absent after inject. Trusting is left to the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)