### PR TITLE
fix(local-agent): write container agent hooks/skills to engine-read paths

### DIFF
--- a/src/__tests__/openclaw-hooks.test.ts
+++ b/src/__tests__/openclaw-hooks.test.ts
@@ -5,10 +5,18 @@ import os from 'node:os';
 import { injectOpenClawHooks, removeOpenClawHooks, OPENCLAW_HOOK_DIR } from '../openclaw-hooks.js';
 
 let tmpDir: string;
+let wsDir: string;
 let origStateDir: string | undefined;
 
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-openclaw-test-'));
+  // OPENCLAW_STATE_DIR holds openclaw.json; the engine workspace lives under it.
+  wsDir = path.join(tmpDir, 'workspace');
+  fs.mkdirSync(wsDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(tmpDir, 'openclaw.json'),
+    JSON.stringify({ agents: { defaults: { workspace: wsDir } } }, null, 2),
+  );
   origStateDir = process.env.OPENCLAW_STATE_DIR;
   process.env.OPENCLAW_STATE_DIR = tmpDir;
 });
@@ -20,11 +28,11 @@ afterEach(() => {
 });
 
 describe('injectOpenClawHooks', () => {
-  it('writes HOOK.md + handler.ts under <hooksDir>/teamai-status-report', async () => {
-    await injectOpenClawHooks('unused-when-env-set', 'openclaw');
+  it('writes HOOK.md + handler.ts under <workspace>/hooks/teamai-status-report', async () => {
+    await injectOpenClawHooks(wsDir, 'openclaw');
 
-    // OPENCLAW_STATE_DIR is set to tmpDir, so hooks land at tmpDir/hooks/
-    const dir = path.join(tmpDir, 'hooks', OPENCLAW_HOOK_DIR);
+    // Hooks land in the resolved workspace dir, where the engine reads them.
+    const dir = path.join(wsDir, 'hooks', OPENCLAW_HOOK_DIR);
     const hookMd = fs.readFileSync(path.join(dir, 'HOOK.md'), 'utf-8');
     const handler = fs.readFileSync(path.join(dir, 'handler.ts'), 'utf-8');
 
@@ -39,19 +47,28 @@ describe('injectOpenClawHooks', () => {
     expect(handler).toContain('prompt-submit');
   });
 
+  it('enables hooks.internal.enabled in openclaw.json, preserving existing fields', async () => {
+    await injectOpenClawHooks(wsDir, 'openclaw');
+
+    const cfg = JSON.parse(fs.readFileSync(path.join(tmpDir, 'openclaw.json'), 'utf-8'));
+    expect(cfg.hooks.internal.enabled).toBe(true);
+    // Deep-merge must not clobber pre-existing fields.
+    expect(cfg.agents.defaults.workspace).toBe(wsDir);
+  });
+
   it('is idempotent (re-inject overwrites cleanly)', async () => {
-    await injectOpenClawHooks('unused-when-env-set', 'openclaw');
-    await injectOpenClawHooks('unused-when-env-set', 'openclaw');
-    const dir = path.join(tmpDir, 'hooks', OPENCLAW_HOOK_DIR);
+    await injectOpenClawHooks(wsDir, 'openclaw');
+    await injectOpenClawHooks(wsDir, 'openclaw');
+    const dir = path.join(wsDir, 'hooks', OPENCLAW_HOOK_DIR);
     expect(fs.existsSync(path.join(dir, 'HOOK.md'))).toBe(true);
   });
 });
 
 describe('removeOpenClawHooks', () => {
   it('removes the injected hook dir and is a no-op when absent', async () => {
-    const hooksDir = path.join(tmpDir, 'hooks');
-    await injectOpenClawHooks('unused-when-env-set', 'openclaw');
-    // removeOpenClawHooks checks both the passed-in dir and OPENCLAW_STATE_DIR
+    const hooksDir = path.join(wsDir, 'hooks');
+    await injectOpenClawHooks(wsDir, 'openclaw');
+    // removeOpenClawHooks removes the passed-in hooks dir's teamai-status-report.
     await removeOpenClawHooks(hooksDir);
     expect(fs.existsSync(path.join(hooksDir, OPENCLAW_HOOK_DIR))).toBe(false);
     // second removal does not throw

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -778,14 +778,11 @@ export async function injectHooksToAllTools(toolPaths: Record<string, { settings
         log.warn(`Failed to inject hook into ${tool}: ${(e as Error).message}`);
       }
     } else if (OPENCLAW_TOOLS.has(tool)) {
-      const agentRoot = path.join(resolvedBaseDir, `.${tool}`);
-      if (await pathExists(agentRoot)) {
-        try {
-          const { injectOpenClawHooks } = await import('./openclaw-hooks.js');
-          await injectOpenClawHooks(path.join(agentRoot, 'hooks'), tool);
-        } catch (e) {
-          log.warn(`Failed to inject OpenClaw hook into ${tool}: ${(e as Error).message}`);
-        }
+      try {
+        const { injectOpenClawHooks } = await import('./openclaw-hooks.js');
+        await injectOpenClawHooks(undefined, tool);
+      } catch (e) {
+        log.warn(`Failed to inject OpenClaw hook into ${tool}: ${(e as Error).message}`);
       }
     } else if (tool === 'hermes') {
       try {

--- a/src/openclaw-hooks.ts
+++ b/src/openclaw-hooks.ts
@@ -20,7 +20,7 @@
  */
 
 import path from 'node:path';
-import { writeFile, ensureDir, pathExists, readFileSafe, remove } from './utils/fs.js';
+import { writeFile, ensureDir, pathExists, readFileSafe, readJson, writeJsonAtomic, remove } from './utils/fs.js';
 import { log } from './utils/logger.js';
 import { getUserHome } from './utils/home.js';
 
@@ -96,16 +96,71 @@ export default async function handler(ctx: { event?: string } = {}): Promise<voi
 }
 
 /**
- * Inject (or refresh) the teamai OpenClaw hook into `<hooksDir>`.
- * Idempotent — rewrites the two files each time.
+ * Inject (or refresh) the teamai OpenClaw hook.
+ *
+ * Writes into the resolved OpenClaw workspace directory (the same location
+ * skills sync to and the engine reads from), NOT the HOME-relative
+ * `~/.<tool>/hooks` — writing there left the hook where the engine never
+ * looks, so status reporting silently stopped. Idempotent — rewrites the two
+ * files each time. Skips (no-op) when the workspace dir cannot be resolved.
+ *
+ * @param workspacePath optional server-sent workspace path (highest priority)
+ * @param tool          claw variant (openclaw/qclaw/easyclaw/autoclaw)
  */
-export async function injectOpenClawHooks(hooksDir: string, tool = 'openclaw'): Promise<void> {
-  const effectiveHooksDir = resolveOpenClawHooksDir(tool);
-  const dir = path.join(effectiveHooksDir, OPENCLAW_HOOK_DIR);
+export async function injectOpenClawHooks(workspacePath?: string, tool = 'openclaw'): Promise<void> {
+  const wsDir = await resolveOpenclawWorkspaceDir(workspacePath);
+  if (!wsDir) {
+    log.debug(`openclaw: skip hook injection for ${tool} — workspace dir not found`);
+    return;
+  }
+  const dir = path.join(wsDir, 'hooks', OPENCLAW_HOOK_DIR);
   await ensureDir(dir);
   await writeFile(path.join(dir, 'HOOK.md'), buildHookMd(tool));
   await writeFile(path.join(dir, 'handler.ts'), buildHandlerTs(tool));
   log.success(`Injected teamai OpenClaw hook into ${dir}`);
+  await enableOpenClawInternalHooks(tool);
+}
+
+/**
+ * Enable workspace-hook loading in the OpenClaw engine config.
+ *
+ * The engine does not load workspace hooks unless `hooks.internal.enabled` is
+ * true in `$OPENCLAW_STATE_DIR/openclaw.json`. Writing the hook files alone is
+ * therefore insufficient. This performs a deep merge: it preserves every
+ * existing field (e.g. `agents.defaults.workspace`) and only sets that one
+ * flag. No-op (debug log) when OPENCLAW_STATE_DIR is unset or not absolute.
+ * Idempotent.
+ *
+ * openclaw-only: other claw variants are not known to use this flag.
+ *
+ * @param tool claw variant; only `openclaw` uses this flag
+ */
+export async function enableOpenClawInternalHooks(tool = 'openclaw'): Promise<void> {
+  if (tool !== 'openclaw') return;
+  const stateDir = process.env.OPENCLAW_STATE_DIR;
+  if (!stateDir || !path.isAbsolute(stateDir)) {
+    log.debug('openclaw: skip enabling internal hooks — OPENCLAW_STATE_DIR unset or not absolute');
+    return;
+  }
+  const cfgPath = path.join(stateDir, 'openclaw.json');
+  try {
+    const cfg = (await readJson<Record<string, unknown>>(cfgPath)) ?? {};
+    const hooksVal = cfg.hooks;
+    const hooks = (hooksVal && typeof hooksVal === 'object') ? hooksVal as Record<string, unknown> : {};
+    const internalVal = hooks.internal;
+    const internal = (internalVal && typeof internalVal === 'object') ? internalVal as Record<string, unknown> : {};
+    if (internal.enabled === true) {
+      log.debug('openclaw: internal hooks already enabled');
+      return;
+    }
+    internal.enabled = true;
+    hooks.internal = internal;
+    cfg.hooks = hooks;
+    await writeJsonAtomic(cfgPath, cfg);
+    log.success(`Enabled OpenClaw internal hooks in ${cfgPath}`);
+  } catch (e) {
+    log.warn(`openclaw: failed to enable internal hooks: ${(e as Error).message}`);
+  }
 }
 
 /** Remove the teamai OpenClaw hook from `<hooksDir>` if present. */

--- a/src/resources/skills.ts
+++ b/src/resources/skills.ts
@@ -6,6 +6,7 @@ import { listDirs, pathExists, copyDir, remove, dirTeamSubsetEqual, getDirLatest
 import { log } from '../utils/logger.js';
 import { BUILTIN_SKILL_NAMES } from '../builtin-skills.js';
 import { resolveOpenclawWorkspaceDir } from '../openclaw-hooks.js';
+import { getHermesHome } from '../hermes-home.js';
 import { loadRolesManifest, resolveRoleResourceNamespaces } from '../roles.js';
 import { assertWithinRoot } from '../utils/path-safety.js';
 
@@ -442,6 +443,8 @@ export class SkillsHandler extends ResourceHandler {
           continue;
         }
         dest = path.join(wsDir, 'skills', item.name);
+      } else if (tool === 'hermes') {
+        dest = path.join(getHermesHome(), 'skills', item.name);
       } else {
         if (!await ResourceHandler.isToolInstalled(toolPath.skills, baseDir)) {
           log.debug(`Skipping skill sync for ${tool}: tool not installed`);

--- a/src/uninstall.ts
+++ b/src/uninstall.ts
@@ -255,11 +255,17 @@ async function discoverToolResources(
     }
   } else {
     // OpenClaw-style agents (no settings file) inject a HOOK.md + handler.ts
-    // under <hooksDir>/<OPENCLAW_HOOK_DIR>. Check both the default path and
-    // the OPENCLAW_STATE_DIR override to cover imate container environments.
+    // under <hooksDir>/<OPENCLAW_HOOK_DIR>. Check the default path, the
+    // OPENCLAW_STATE_DIR override (imate containers), and the resolved
+    // workspace dir — injection now targets `<workspace>/hooks`, so teardown
+    // must cover it too, otherwise the hook is orphaned on uninstall.
     const defaultHooksDir = path.join(baseDir, `.${tool}`, 'hooks');
     const resolvedHooksDir = resolveOpenClawHooksDir(tool);
     const dirsToCheck = new Set([defaultHooksDir, resolvedHooksDir]);
+    const workspaceDir = await resolveOpenclawWorkspaceDir();
+    if (workspaceDir) {
+      dirsToCheck.add(path.join(workspaceDir, 'hooks'));
+    }
     for (const hooksDir of dirsToCheck) {
       if (await pathExists(path.join(hooksDir, OPENCLAW_HOOK_DIR))) {
         res.openclawHookDirs.push({ hooksDir, tool });


### PR DESCRIPTION
## Problem

Container-based agents (OpenClaw family and Hermes) could have their hook and skill files written to a directory the engine never reads, so status reporting silently stopped. In containers the HOME layer is not persisted (containers are reclaimed when idle and rescheduled fresh), while the workspace / `$HERMES_HOME` directory is on a persistent mount — so a hook written to the HOME-relative path disappears after the container is recycled and is never recreated. This matches the field symptom "worked for a while, then stopped recording, with no error in the logs."

Closes #351.

## Root cause (two independent bugs, one per agent)

- **OpenClaw hooks** — `injectOpenClawHooks(hooksDir, tool)` accepted a `hooksDir` argument but overwrote it on the first line with `resolveOpenClawHooksDir(tool)`, which always returns `~/.<tool>/hooks`. The passed-in target was discarded. Meanwhile OpenClaw *skills* already sync to `resolveOpenclawWorkspaceDir()` → `<workspace>/skills`. So hooks and skills used inconsistent bases, and the hooks one was wrong.
- **OpenClaw enable flag** — the engine does not load workspace hooks unless `hooks.internal.enabled` is `true` in `$OPENCLAW_STATE_DIR/openclaw.json`. Writing the hook files alone was insufficient.
- **Hermes skills** — `SkillsHandler.pullItem` had no hermes branch and fell through to `resolveBaseDir` (HOME), landing skills in `~/.hermes/skills` while hermes hooks correctly resolve `getHermesHome()` → `$HERMES_HOME/hooks`. The two were split across different roots.

## Changes

- `src/openclaw-hooks.ts`
  - `injectOpenClawHooks(workspacePath?, tool)` — resolve the workspace dir (via `resolveOpenclawWorkspaceDir`, the same resolver skills use) and write to `<workspace>/hooks`; no-op with a debug log when it cannot be resolved.
  - New `enableOpenClawInternalHooks(tool)` — deep-merges `hooks.internal.enabled = true` into `$OPENCLAW_STATE_DIR/openclaw.json`, preserving every existing field; idempotent; no-op when `OPENCLAW_STATE_DIR` is unset/not absolute. Called after the hook files are written.
- `src/hooks.ts` — OpenClaw injection call site updated to `injectOpenClawHooks(undefined, tool)`; removed the now-unused HOME-relative `agentRoot`.
- `src/resources/skills.ts` — added a hermes branch: skills deploy to `getHermesHome()/skills`, matching hermes hooks.
- `src/uninstall.ts` — `removeOpenClawHooks` candidate set now also includes the resolved `<workspace>/hooks`, so teardown covers the new injection target.
- `src/__tests__/openclaw-hooks.test.ts` — updated for the new signature/behavior; added an assertion that the enable flag is written via deep-merge without clobbering existing fields.

`removeOpenClawHooks` still also checks the legacy HOME / `$OPENCLAW_STATE_DIR/hooks` locations, so uninstalling an agent set up by an older version stays clean.

## Test Plan

- [x] `npx tsc --noEmit` — passes.
- [x] `npm run build` — success.
- [x] `npx vitest run` — 2268 passed (full suite).
- [x] E2E (built dist, real `injectOpenClawHooks`): hook files land in `<workspace>/hooks/teamai-status-report/`; **not** in the old `~/.openclaw/hooks`.
- [x] E2E: `hooks.internal.enabled` written `true` in `openclaw.json`; pre-existing fields (`agents.defaults.workspace`, others) preserved; second run idempotent (file unchanged).
- [x] E2E: a hook injected under `<workspace>/hooks` is removed by `removeOpenClawHooks` (uninstall coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
