### PR TITLE
fix(skills): deploy team-wiki-codebase on init, decouple from recall

### DIFF
--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -94,6 +94,11 @@ vi.mock('../hooks.js', () => ({
   reconcileTeamHooksForConfig: vi.fn(),
 }));
 
+const mockDeployBuiltinSkills = vi.fn().mockResolvedValue(0);
+vi.mock('../builtin-skills.js', () => ({
+  deployBuiltinSkills: (...args: unknown[]) => mockDeployBuiltinSkills(...args),
+}));
+
 vi.mock('../roles.js', () => ({
   loadRolesManifest: vi.fn().mockResolvedValue({
     version: 1,
@@ -444,6 +449,46 @@ describe('init', () => {
         additionalRoles: [],
         resourceProfileVersion: 1,
       }));
+    });
+  });
+
+  describe('deploys built-in skills after init', () => {
+    it('calls deployBuiltinSkills with teamConfig and skipRecall when loadTeamConfig returns non-null', async () => {
+      let cloneDone = false;
+      pathExistsFn = (p: string) => {
+        if (p === localPath) return cloneDone;
+        return false;
+      };
+
+      mockGfRepoClone.mockImplementation(() => {
+        cloneDone = true;
+      });
+
+      const mockedLoadTeamConfig = vi.mocked(await import('../config.js')).loadTeamConfig;
+      mockedLoadTeamConfig.mockResolvedValue({
+        team: 'my-team',
+        repo: 'https://git.woa.com/HyperAI/teamai-test.git',
+        provider: 'tgit',
+        reviewers: [],
+        sharing: {
+          skills: {},
+          rules: { enforced: [] },
+          docs: { localDir: '~/.teamai/docs' },
+          env: { injectShellProfile: true },
+        },
+        toolPaths: {},
+      } as never);
+
+      questionAnswers = ['n', '1'];
+
+      await init({ repo: 'https://git.woa.com/HyperAI/teamai-test.git', scope: 'user' });
+
+      expect(mockDeployBuiltinSkills).toHaveBeenCalled();
+      expect(mockDeployBuiltinSkills).toHaveBeenCalledWith(
+        expect.objectContaining({ team: expect.any(String) }),
+        expect.anything(),
+        expect.objectContaining({ skipRecall: expect.any(Boolean) }),
+      );
     });
   });
 

--- a/src/__tests__/skip-uninstalled-tools.test.ts
+++ b/src/__tests__/skip-uninstalled-tools.test.ts
@@ -532,4 +532,44 @@ describe('deployBuiltinSkills — skip uninstalled tools', () => {
     expect(await fse.pathExists(path.join(homeDir, '.config/opencode/skills/team-wiki-codebase/SKILL.md'))).toBe(true);
     expect(await fse.pathExists(path.join(homeDir, '.opencode'))).toBe(false);
   });
+
+  it('should still deploy team-wiki-codebase when recall is disabled (skipRecall)', async () => {
+    const { deployBuiltinSkills } = await import('../builtin-skills.js');
+
+    const teamConfig = {
+      team: 'test',
+      description: '',
+      repo: 'https://git.woa.com/test/repo.git',
+      provider: 'tgit' as const,
+      reviewers: [],
+      sharing: {
+        skills: {},
+        rules: { enforced: [] },
+        docs: { localDir: '' },
+        env: { injectShellProfile: true },
+      },
+      toolPaths: {
+        claude: { skills: '.claude/skills' },
+      },
+    };
+
+    const localConfig = {
+      repo: { localPath: path.join(tmpDir, 'repo'), remote: 'https://git.woa.com/test/repo.git' },
+      username: 'testuser',
+      updatePolicy: 'auto' as const,
+      additionalRoles: [],
+      scope: 'user' as const,
+    };
+
+    const deployed = await deployBuiltinSkills(teamConfig, localConfig, { skipRecall: true });
+
+    expect(deployed).toBeGreaterThan(0);
+    expect(await fse.pathExists(path.join(homeDir, '.claude/skills/team-wiki-codebase/SKILL.md'))).toBe(true);
+    const wikiEnrichFile = path.join(
+      homeDir,
+      '.claude/skills/team-wiki-codebase/references/methodology/phase3-ai-enhancement.md',
+    );
+    expect(await fse.pathExists(wikiEnrichFile)).toBe(true);
+    expect(await fse.pathExists(path.join(homeDir, '.claude/skills/teamai-share-learnings/SKILL.md'))).toBe(false);
+  });
 });

--- a/src/builtin-skills.ts
+++ b/src/builtin-skills.ts
@@ -43,8 +43,14 @@ function getBuiltinSkillsDir(): string {
 /** Names of CLI built-in skills. Used by push to exclude them from team repo push. */
 export const BUILTIN_SKILL_NAMES = new Set(['teamai-share-learnings', 'team-wiki-codebase', 'teamai-workflow', 'teamai-import']);
 
-/** Built-in skills that depend on recall being enabled. Skipped when recall is disabled. */
-export const RECALL_DEPENDENT_SKILLS = new Set(['teamai-share-learnings', 'team-wiki-codebase']);
+/**
+ * Built-in skills that depend on recall being enabled. Skipped when recall is disabled.
+ *
+ * Only teamai-share-learnings belongs here: it contributes learnings back to the
+ * team repo, which is meaningful only when recall is on. team-wiki-codebase is a
+ * knowledge-base generator and does not depend on recall, so it must always deploy.
+ */
+export const RECALL_DEPENDENT_SKILLS = new Set(['teamai-share-learnings']);
 
 async function copyBuiltinSkillDir(srcDir: string, destDir: string): Promise<void> {
   await fse.copy(srcDir, destDir, {

--- a/src/init.ts
+++ b/src/init.ts
@@ -8,7 +8,16 @@ import { pushRepoDirectly } from './utils/git.js';
 import { getProvider, detectProvider, RepoNotFoundError } from './providers/index.js';
 import { ensureDir, writeFile, pathExists, expandHome, readFileSafe, remove } from './utils/fs.js';
 import { log, spinner } from './utils/logger.js';
-import { TEAMAI_HOME, REPORTS_BRANCH, type GlobalOptions, type LocalConfig, type Scope, getTeamaiHome, getConfigPath } from './types.js';
+import {
+  TEAMAI_HOME,
+  REPORTS_BRANCH,
+  type GlobalOptions,
+  type LocalConfig,
+  type Scope,
+  getTeamaiHome,
+  getConfigPath,
+  isRecallEnabled,
+} from './types.js';
 import { getUserHome } from './utils/home.js';
 import { describeRoles, loadRolesManifest } from './roles.js';
 import { askQuestion, askConfirmation, askSelection, closePrompt } from './utils/prompt.js';
@@ -1277,9 +1286,23 @@ export async function init(options: GlobalOptions & {
   if (reloadedTeamConfig) {
     const filterAgents = requestedAgents.length > 0 ? requestedAgents : undefined;
     await reconcileTeamHooksForConfig(reloadedTeamConfig, localConfig, { filterAgents });
+
+    // Step 7.5: Deploy CLI built-in skills immediately so team-wiki-codebase
+    // is available in the IDE right after init, without waiting for first pull.
+    try {
+      const { deployBuiltinSkills } = await import('./builtin-skills.js');
+      const skipRecall = !isRecallEnabled(localConfig, reloadedTeamConfig);
+      const deployed = await deployBuiltinSkills(reloadedTeamConfig, localConfig, { skipRecall });
+      if (deployed > 0) {
+        log.debug(`Deployed ${deployed} built-in skill(s)`);
+      }
+    } catch (e) {
+      log.debug(`Built-in skills deployment skipped: ${(e as Error).message}`);
+    }
   }
 
   log.success('teamai initialized successfully!');
+  log.info('Built-in skills (e.g. team-wiki-codebase) are ready to use in your IDE now.');
   log.info('Skills, rules, env and docs will auto-sync on each session start (via hooks).');
   log.info('Run `teamai status` to check current config.');
 


### PR DESCRIPTION
## Summary

On fresh installs, `team-wiki-codebase` never reached the IDE skill directories, so the `import` AI-enrich flow was unavailable. Two independent root causes:

1. **Silently gated behind recall.** `team-wiki-codebase` was listed in `RECALL_DEPENDENT_SKILLS`, so when recall was disabled (the default) it was silently skipped during deployment. But it is a knowledge-base *generator* and does not depend on recall at runtime — recall only *consumes* the knowledge base it produces. Removed it from the set; only `teamai-share-learnings` (which contributes learnings back to the team repo) legitimately remains.

2. **`teamai init` never deployed built-in skills.** Built-in skills were only deployed by `teamai pull`, never by `init`. So right after `init` the user had nothing in the IDE until the first pull. Added a Step 7.5 to `init` that deploys built-in skills immediately, mirroring pull's proven deployment path (dynamic import + `isRecallEnabled`-derived `skipRecall` + fault-tolerant try/catch).

Net effect: after `teamai init`, `team-wiki-codebase` is present in every installed IDE's skill dir regardless of recall state, so the `/team-wiki-codebase` skill and its AI-enrich phase work out of the box.

## Changes

- `src/builtin-skills.ts` — remove `team-wiki-codebase` from `RECALL_DEPENDENT_SKILLS`; document why only `teamai-share-learnings` belongs there.
- `src/init.ts` — deploy built-in skills at end of `init` (Step 7.5); add a success line noting skills are ready.
- `src/__tests__/skip-uninstalled-tools.test.ts` — real-filesystem regression: with `skipRecall: true`, `team-wiki-codebase` (incl. its AI-enrich `phase3` file) still deploys while `teamai-share-learnings` is correctly skipped.
- `src/__tests__/init.test.ts` — verify `init` calls `deployBuiltinSkills` with a boolean `skipRecall` when a team config is present.

## Test Plan

- [x] `npx tsc --noEmit` — passes
- [x] `npx vitest run` — full suite passes (2325 tests)
- [x] `npm run build` — succeeds
- [x] Regression test proves `team-wiki-codebase` + its AI-enrich `phase3-ai-enhancement.md` land on disk under `skipRecall: true` (real fs)
- [x] Init call-site test proves `deployBuiltinSkills` is invoked from `init`
- [ ] Full real-CLI `teamai init` end-to-end deployment — blocked locally by GitHub/`gh` auth in an isolated `$HOME`; covered by the CI-gated init e2e (`TEAMAI_TEST_TOKEN` + GitHub provider) instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
