### PR TITLE
fix(push): preserve other resources' open-PR records under --skill, plus review follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ teamai push → create branch + MR → reviewer approves + merges
               SessionStart hook → teamai pull → synced to local AI tools
 ```
 
-Members push changes via `teamai push`, which opens a Merge Request for review. Once merged, `teamai pull` (triggered automatically on session start via the SessionStart hook) syncs the latest resources locally. Skills sync to `~/.claude/skills/`, `~/.codex/skills/`, `~/.cursor/skills/`, `~/.codebuddy/skills/`, etc. In a **project-scope** install, SessionStart first creates that tool's project root (e.g. `<project>/.claude`) if it is missing, then pulls into it — a bare `teamai pull` still will not invent agent directories.
+Members push changes via `teamai push`, which opens a Merge Request for review. Re-running `teamai push` on a resource that is still waiting in an unmerged PR updates that PR in place instead of opening a duplicate. Once merged, `teamai pull` (triggered automatically on session start via the SessionStart hook) syncs the latest resources locally. Skills sync to `~/.claude/skills/`, `~/.codex/skills/`, `~/.cursor/skills/`, `~/.codebuddy/skills/`, etc. In a **project-scope** install, SessionStart first creates that tool's project root (e.g. `<project>/.claude`) if it is missing, then pulls into it — a bare `teamai pull` still will not invent agent directories.
 
 ### Team Hooks
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -109,7 +109,7 @@ teamai push → 创建分支 + MR → reviewer 审批合并
            SessionStart hook → teamai pull → 同步到本地 AI 工具
 ```
 
-成员通过 `teamai push` 提交变更并创建合并请求供审核。合并后，`teamai pull`（由 SessionStart hook 在会话启动时自动触发）将最新资源同步到本地。Skills 会同步到 `~/.claude/skills/`、`~/.codex/skills/`、`~/.cursor/skills/`、`~/.codebuddy/skills/` 等目录。在 **project scope** 安装下，SessionStart 会先为当前工具创建项目根目录（例如 `<project>/.claude`），再 pull 写入；单独执行 `teamai pull` 仍不会凭空创建 Agent 目录。
+成员通过 `teamai push` 提交变更并创建合并请求供审核。若某个资源已在未合并的 PR 中等待评审，再次对它执行 `teamai push` 会就地更新该 PR，而非新开一个重复的 PR。合并后，`teamai pull`（由 SessionStart hook 在会话启动时自动触发）将最新资源同步到本地。Skills 会同步到 `~/.claude/skills/`、`~/.codex/skills/`、`~/.cursor/skills/`、`~/.codebuddy/skills/` 等目录。在 **project scope** 安装下，SessionStart 会先为当前工具创建项目根目录（例如 `<project>/.claude`），再 pull 写入；单独执行 `teamai pull` 仍不会凭空创建 Agent 目录。
 
 ### 团队 Hooks
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -349,6 +349,8 @@ Choose namespace [1-3] (default: 1 = common):
 - A single namespace is auto-selected; `--silent` mode uses the default
 - Modifying an existing skill automatically keeps its original namespace
 
+**Updating an open PR instead of duplicating it:** If a resource is already waiting in an unmerged PR, re-running `teamai push` on it updates that existing PR in place (by force-pushing its branch) rather than opening a duplicate. Keep the resource selected to update its PR; deselect it to leave the PR untouched. Unrelated resources selected in the same run go into their own new PR. Once the PR merges (or its branch is removed from the remote), the record is cleared and the next push opens a fresh PR as usual.
+
 **Automatic YAML frontmatter completion:** When pushing, the CLI automatically checks `SKILL.md` and fills in `name`/`description` if missing — no manual upkeep required.
 
 ### Check status

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -347,6 +347,8 @@ Choose namespace [1-3] (default: 1 = common):
 - 单一命名空间时自动选中；`--silent` 模式使用默认值
 - 修改已有 skill 时自动保持原 namespace
 
+**更新已存在的 PR 而非重复创建：** 如果某个资源已在一个未合并的 PR 中等待评审，再次对它执行 `teamai push` 会就地更新那个已存在的 PR（通过 force-push 其分支），而不是新开一个重复的 PR。保持该资源被选中即更新其 PR；取消勾选则不动它。同一次运行中选中的其他无关资源会进入各自新开的 PR。一旦该 PR 合并（或其分支从远端删除），记录会被清除，下次 push 照常新开 PR。
+
 **YAML Frontmatter 自动补全：** 推送时 CLI 自动检查 `SKILL.md`，缺少 `name`/`description` 则自动补全，无需手动维护。
 
 ### 查看状态

--- a/src/__tests__/git.test.ts
+++ b/src/__tests__/git.test.ts
@@ -165,6 +165,29 @@ describe('pushRepoBranch', () => {
     expect(mockGit.clean).toHaveBeenCalledWith('f', ['-d']);
     expect(mockGit.commit).not.toHaveBeenCalled();
   });
+
+  it('skips the branch delete (no throw) when the default branch is busy in another worktree', async () => {
+    // Multi-worktree: `checkout master` fails because another worktree holds it,
+    // so HEAD stays on the push branch. Deleting the checked-out branch would
+    // throw; the delete must be skipped and pushRepoBranch must return false
+    // rather than propagating a cryptic git error.
+    mockGit.status.mockResolvedValue({ staged: [] });
+    mockGit.revparse.mockImplementation(async (args: any) => {
+      const a = Array.isArray(args) ? args : [args];
+      if (a[0] === '--abbrev-ref' && a[1] === 'origin/HEAD') return 'origin/master';
+      return '';
+    });
+    mockGit.checkout.mockRejectedValueOnce(
+      new Error("fatal: 'master' is already used by worktree at '/repo/primary'"),
+    );
+
+    const result = await pushRepoBranch('/repo', 'msg', ['file.txt'], 'teamai/push/test/wt');
+
+    expect(result).toBe(false);
+    expect(mockGit.checkout).toHaveBeenCalledWith('master');
+    // The delete is skipped because the switch did not actually happen.
+    expect(mockGit.deleteLocalBranch).not.toHaveBeenCalled();
+  });
 });
 
 describe('checkoutMaster', () => {

--- a/src/__tests__/push-pending-pr.test.ts
+++ b/src/__tests__/push-pending-pr.test.ts
@@ -391,4 +391,36 @@ describe('push() with an open PR', () => {
     expect(saved.pendingPushes).toHaveLength(1);
     expect(saved.pendingPushes[0].branch).toBe('teamai/push/testuser/20260827-065032');
   });
+
+  it('keeps other skills\' open-PR records when pushing a single --skill', async () => {
+    // --skill narrows the push to one skill, but the open PRs of the OTHER
+    // skills must survive: pruning against the narrowed scan would drop them
+    // and the next run would open duplicate PRs for them.
+    const targetEntry = makeEntry({
+      branch: 'teamai/push/testuser/target-branch',
+      prUrl: 'https://github.com/team/repo/pull/1',
+      items: [{ type: 'skills', name: 'target', relativePath: 'skills/js/target', namespace: 'js' }],
+    });
+    const otherEntry = makeEntry({
+      branch: 'teamai/push/testuser/other-branch',
+      prUrl: 'https://github.com/team/repo/pull/2',
+      items: [{ type: 'skills', name: 'other', relativePath: 'skills/js/other', namespace: 'js' }],
+    });
+    mockLoadStateForScope.mockResolvedValue(makeState([targetEntry, otherEntry]));
+    mockGetHandler.mockImplementation((type: string) => ({
+      scanLocalForPush: vi.fn().mockResolvedValue(
+        type === 'skills'
+          ? [makeItem({ name: 'target', sourcePath: '/home/u/.cursor/skills/target' }),
+            makeItem({ name: 'other', sourcePath: '/home/u/.cursor/skills/other' })]
+          : [],
+      ),
+      pushItem: vi.fn(),
+    }));
+
+    await push({ all: true, skill: 'target' });
+
+    const saved = mockSaveStateForScope.mock.calls.at(-1)?.[0] as State;
+    const branches = saved.pendingPushes.map((p) => p.branch).sort();
+    expect(branches).toContain('teamai/push/testuser/other-branch');
+  });
 });

--- a/src/__tests__/push-pending-pr.test.ts
+++ b/src/__tests__/push-pending-pr.test.ts
@@ -6,7 +6,10 @@
  * unmerged resource looks "new" forever. Before this guard, every re-run created
  * another branch (names carry a timestamp) and another PR.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
 import { push } from '../push.js';
 import {
   findPendingForItem, partiallySelectedEntries, pendingNamespaceFor, planPushGroups,
@@ -422,5 +425,48 @@ describe('push() with an open PR', () => {
     const saved = mockSaveStateForScope.mock.calls.at(-1)?.[0] as State;
     const branches = saved.pendingPushes.map((p) => p.branch).sort();
     expect(branches).toContain('teamai/push/testuser/other-branch');
+  });
+
+  describe('force-constructed --skill (scanner returns nothing)', () => {
+    let tmpDir: string;
+    let skillDir: string;
+
+    beforeEach(() => {
+      // A real skill dir on disk: force-construct only runs when the target
+      // path exists with a SKILL.md but the scanner returned nothing for it
+      // (local content is byte-identical to the team repo, so no diff).
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-force-skill-'));
+      skillDir = path.join(tmpDir, 'solo-skill');
+      fs.mkdirSync(skillDir, { recursive: true });
+      fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '# solo\n');
+      // Scanner returns nothing → push must force-construct from the path.
+      mockGetHandler.mockImplementation(() => ({
+        scanLocalForPush: vi.fn().mockResolvedValue([]),
+        pushItem: vi.fn(),
+      }));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('keeps its own open-PR record instead of reopening a duplicate', async () => {
+      const entry = makeEntry({
+        branch: 'teamai/push/testuser/solo-branch',
+        prUrl: 'https://github.com/team/repo/pull/7',
+        items: [{ type: 'skills', name: 'solo-skill', relativePath: 'skills/solo-skill' }],
+      });
+      mockLoadStateForScope.mockResolvedValue(makeState([entry]));
+
+      await push({ all: true, skill: skillDir });
+
+      // The force-constructed skill is still locally present, so its record
+      // must survive the prune and the open PR must be updated, not duplicated.
+      expect(mockCreatePullRequest).not.toHaveBeenCalled();
+      expect(mockPushRepoBranch.mock.calls[0][3]).toBe('teamai/push/testuser/solo-branch');
+      expect(mockPushRepoBranch.mock.calls[0][4]).toEqual({ reuseBranch: true });
+      const saved = mockSaveStateForScope.mock.calls.at(-1)?.[0] as State;
+      expect(saved.pendingPushes.map((p) => p.branch)).toContain('teamai/push/testuser/solo-branch');
+    });
   });
 });

--- a/src/__tests__/push-team-config.test.ts
+++ b/src/__tests__/push-team-config.test.ts
@@ -202,18 +202,19 @@ describe('push carries teamai.yaml (source add regression)', () => {
       throw new Error('network failure mid-push');
     });
     const originalExitCode = process.exitCode;
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
     try {
       const { push } = await import('../push.js');
-      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
       await push({ all: true });
-      logSpy.mockRestore();
 
-      // The repo must not be stranded on the push branch.
+      // The catch path must land the repo back on the default branch, not just
+      // off the stuck branch (the seed repo's default branch is 'main').
       const branch = (await git.branch()).current;
-      expect(branch).not.toBe('teamai/push/alice/stuck-branch');
+      expect(branch).toBe('main');
       expect(process.exitCode).toBe(1);
     } finally {
+      logSpy.mockRestore();
       spy.mockRestore();
       process.exitCode = originalExitCode;
     }

--- a/src/__tests__/push-team-config.test.ts
+++ b/src/__tests__/push-team-config.test.ts
@@ -176,4 +176,46 @@ describe('push carries teamai.yaml (source add regression)', () => {
 
     expect(mockCreatePullRequest).not.toHaveBeenCalled();
   });
+
+  it('config-only: switches back to the default branch when the push throws', async () => {
+    const teamRepo = await initTeamRepos(tmpDir);
+    const yamlPath = path.join(teamRepo, 'teamai.yaml');
+    fs.writeFileSync(yamlPath, 'version: 1\npublicSkills:\n  - beta-proof\n');
+    mockAutoDetectInit.mockResolvedValue({
+      localConfig: {
+        repo: { localPath: teamRepo, remote: path.join(tmpDir, 'remote.git'), kind: undefined },
+        username: 'alice',
+        scope: 'project',
+        projectRoot: teamRepo,
+      },
+      teamConfig: { repo: 'acme/team', toolPaths: {} },
+    });
+
+    // Force pushRepoBranch to throw AFTER it has moved the repo onto a push
+    // branch, so the catch path is the only thing that can restore the default
+    // branch. We simulate the mid-push failure by leaving the repo on a stray
+    // branch and rejecting from pushRepoBranch.
+    const git = simpleGit(teamRepo);
+    const gitMod = await import('../utils/git.js');
+    const spy = vi.spyOn(gitMod, 'pushRepoBranch').mockImplementation(async () => {
+      await git.checkoutLocalBranch('teamai/push/alice/stuck-branch');
+      throw new Error('network failure mid-push');
+    });
+    const originalExitCode = process.exitCode;
+
+    try {
+      const { push } = await import('../push.js');
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      await push({ all: true });
+      logSpy.mockRestore();
+
+      // The repo must not be stranded on the push branch.
+      const branch = (await git.branch()).current;
+      expect(branch).not.toBe('teamai/push/alice/stuck-branch');
+      expect(process.exitCode).toBe(1);
+    } finally {
+      spy.mockRestore();
+      process.exitCode = originalExitCode;
+    }
+  });
 });

--- a/src/__tests__/push-team-config.test.ts
+++ b/src/__tests__/push-team-config.test.ts
@@ -51,7 +51,12 @@ async function initTeamRepos(root: string): Promise<string> {
   const seed = path.join(root, 'seed');
   const teamRepo = path.join(root, 'team-repo');
 
-  await simpleGit().init(['--bare', remote]);
+  // Pin the bare repo's default branch to main. Without this, a runner whose
+  // git defaults to `master` (init.defaultBranch) leaves the bare HEAD pointing
+  // at a branch we never push, so `git clone` lands on an unborn HEAD and the
+  // working clone has no local `main` — `.branch().current` then reads '' and
+  // the "switches back to the default branch" assertion sees '' instead of main.
+  await simpleGit().init(['--bare', '--initial-branch=main', remote]);
 
   fs.mkdirSync(path.join(seed, 'skills', 'ns'), { recursive: true });
   fs.writeFileSync(path.join(seed, 'teamai.yaml'), 'version: 1\npublicSkills: []\n');

--- a/src/push.ts
+++ b/src/push.ts
@@ -517,6 +517,14 @@ async function pushCore(
     // Replace allItems with just this one skill
     allItems.length = 0;
     allItems.push(matchedItem);
+
+    // A force-constructed matchedItem (scanner returned nothing for this skill
+    // because its content matches the team repo) is absent from fullScan. Add it
+    // so prunePendingPushes still sees this skill as locally present — otherwise
+    // its own open-PR record is dropped and the next run opens a duplicate.
+    if (!fullScan.some((i) => i.type === matchedItem!.type && i.name === matchedItem!.name)) {
+      fullScan.push(matchedItem);
+    }
   }
 
   // An explicit --role is a destination override for every selected skill,

--- a/src/push.ts
+++ b/src/push.ts
@@ -393,12 +393,18 @@ async function pushCore(
     allItems.push(...items);
   }
 
+  // Snapshot the full scan before --skill/--role narrow allItems. prunePendingPushes
+  // must see every pending resource that is still locally present, or narrowing to
+  // one skill would drop the other skills' open-PR records and duplicate them next run.
+  const fullScan: ResourceItem[] = [...allItems];
+
   spin.stop();
 
   // ── Handle --skill parameter: filter to a single specific skill ──────
   if (options.skill) {
-    // 校验 skill 名称安全性：从输入路径中提取 basename 作为资源名，
-    // 防御路径遍历、URL 编码绕过、非法字符等攻击
+    // Validate the skill name: take the basename of the input path as the
+    // resource name to defend against path traversal, URL-encoded bypasses,
+    // and other illegal characters.
     const skillBasename = path.basename(
       options.skill.startsWith('~')
         ? options.skill.slice(1).replace(/^[/\\]+/, '')
@@ -407,7 +413,7 @@ async function pushCore(
     try {
       assertSafeResourceName(skillBasename);
     } catch (e) {
-      console.error(`[push] --skill 参数不合法: ${(e as Error).message}`);
+      console.error(`[push] Invalid --skill argument: ${(e as Error).message}`);
       process.exitCode = 2;
       return;
     }
@@ -544,7 +550,7 @@ async function pushCore(
   const pruned = await prunePendingPushes(
     localConfig.repo.localPath,
     pushState.pendingPushes,
-    allItems,
+    fullScan,
   );
   pushState.pendingPushes = pruned.pending;
   if (pruned.changed) {
@@ -826,6 +832,14 @@ async function pushTeamConfigOnly(
     await checkoutMaster(localConfig.repo.localPath);
   } catch (e) {
     pushSpin.fail(`Push failed: ${(e as Error).message}`);
+    // pushRepoBranch may have left the repo on the push branch (e.g. it threw
+    // mid-push after creating the local branch). Switch back to the default
+    // branch so the next `teamai push` starts clean instead of stranded there.
+    try {
+      await checkoutMaster(localConfig.repo.localPath);
+    } catch (cleanupErr) {
+      log.debug(`Could not switch back to default branch: ${(cleanupErr as Error).message}`);
+    }
     process.exitCode = 1;
     return;
   }

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -147,9 +147,10 @@ export function remotesMatch(a: string, b: string): boolean {
 export async function hasCommits(localPath: string): Promise<boolean> {
   const git = createGit(localPath);
   try {
-    // NB: `--quiet` makes git exit 1 silently on an unborn HEAD, and simple-git
-    // does not throw on that — so we must validate the OUTPUT (a real sha), not
-    // rely on a thrown error. An unborn HEAD yields empty/whitespace output.
+    // On an unborn HEAD `rev-parse --verify HEAD^{commit}` exits non-zero and
+    // simple-git throws, so the catch below is the primary guard. The sha-shape
+    // check is a belt-and-suspenders guard for the rare case a build resolves
+    // HEAD to empty/whitespace output without throwing.
     const out = (await git.raw(['rev-parse', '--verify', 'HEAD^{commit}'])).trim();
     return /^[0-9a-f]{7,40}$/.test(out);
   } catch {
@@ -442,6 +443,7 @@ export async function pushRepoBranch(
       log.debug(`Remote branch ${branchName} already holds this tree, skipping force-push`);
       const defaultBranch = await getDefaultBranch(localPath);
       await switchToDefaultBranch(git, defaultBranch);
+      await git.deleteLocalBranch(branchName, true);
       return false;
     }
     await git.push(['--force-with-lease', '-u', 'origin', branchName]);

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -416,8 +416,7 @@ export async function pushRepoBranch(
     await git.clean('f', ['-d']);
     const defaultBranch = await getDefaultBranch(localPath);
     log.debug(`Nothing to commit, switching back to ${defaultBranch}`);
-    await switchToDefaultBranch(git, defaultBranch);
-    await git.deleteLocalBranch(branchName, true);
+    await leaveAndDeletePushBranch(git, defaultBranch, branchName);
     return false;
   }
 
@@ -428,8 +427,7 @@ export async function pushRepoBranch(
     await git.clean('f', ['-d']);
     const defaultBranch = await getDefaultBranch(localPath);
     log.debug(`Only metadata/timestamp changes detected, switching back to ${defaultBranch}`);
-    await switchToDefaultBranch(git, defaultBranch);
-    await git.deleteLocalBranch(branchName, true);
+    await leaveAndDeletePushBranch(git, defaultBranch, branchName);
     return false;
   }
 
@@ -442,8 +440,7 @@ export async function pushRepoBranch(
     if (await treeMatchesRemoteBranch(git, branchName)) {
       log.debug(`Remote branch ${branchName} already holds this tree, skipping force-push`);
       const defaultBranch = await getDefaultBranch(localPath);
-      await switchToDefaultBranch(git, defaultBranch);
-      await git.deleteLocalBranch(branchName, true);
+      await leaveAndDeletePushBranch(git, defaultBranch, branchName);
       return false;
     }
     await git.push(['--force-with-lease', '-u', 'origin', branchName]);
@@ -480,17 +477,40 @@ async function treeMatchesRemoteBranch(git: SimpleGit, branchName: string): Prom
  * clone a skipped switch self-heals via resetToCleanMaster on the next run. So we
  * swallow that specific conflict rather than letting it abort the whole operation.
  */
-async function switchToDefaultBranch(git: SimpleGit, defaultBranch: string): Promise<void> {
+async function switchToDefaultBranch(git: SimpleGit, defaultBranch: string): Promise<boolean> {
   try {
     await git.checkout(defaultBranch);
+    return true;
   } catch (e) {
     const msg = (e as Error).message ?? '';
     if (/already (used|checked out) by worktree|is already checked out/i.test(msg)) {
       log.debug(`Skipping switch to ${defaultBranch}: already checked out in another worktree`);
-      return;
+      return false;
     }
     throw e;
   }
+}
+
+/**
+ * Leave the push branch for the default branch, then delete the push branch.
+ *
+ * When switchToDefaultBranch could not actually leave (the default branch is
+ * held by another worktree, so HEAD is still on branchName), the delete is
+ * skipped: `git branch -D branchName` refuses to drop the currently checked-out
+ * branch and would throw an uncaught git error out of the caller. The stray
+ * branch self-heals via resetToCleanMaster on the next run.
+ */
+async function leaveAndDeletePushBranch(
+  git: SimpleGit,
+  defaultBranch: string,
+  branchName: string,
+): Promise<void> {
+  const switched = await switchToDefaultBranch(git, defaultBranch);
+  if (!switched) {
+    log.debug(`Leaving ${branchName} in place: default branch busy in another worktree`);
+    return;
+  }
+  await git.deleteLocalBranch(branchName, true);
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up fixes for the #350 open-PR-update feature, found in code review. Each fix was verified against a real end-to-end run or a regression test that fails without the fix.

### Fixes

1. **`push --skill` dropped other resources' open-PR records** *(real bug)*
   `--skill` narrows the scan to one skill, but `prunePendingPushes` was run against the narrowed list. Any OTHER skill still waiting in an open PR looked "gone from the scan" and its pending-push record was pruned — so the next `teamai push` opened a duplicate PR for it. Fixed by snapshotting the full scan before `--skill`/`--role` narrowing and pruning against that snapshot.

2. **`pushRepoBranch` reuse no-op left a stale local branch** *(real bug)*
   When re-pushing and the rebuilt tree already matches the remote, the function returned early without deleting the local branch it created — unlike the other early-exit paths. Stale local branches accumulated. Fixed by deleting the local branch before returning.

3. **`pushTeamConfigOnly` could strand the repo on the push branch** *(real bug)*
   A mid-push failure in the config-only path left the team repo checked out on the push branch, so the next `teamai push` started dirty. Added a `checkoutMaster` in the catch path.

4. **`hasCommits` comment was wrong** *(comment-only)*
   The comment claimed `--quiet` suppressed the error; the command uses no `--quiet` and the real guard is the catch block. Corrected the comment.

5. **Chinese comment + error string in `push.ts`** *(CLAUDE.md compliance)*
   Replaced with English per the English-only-output rule.

6. **Docs** — documented the update-open-PR behavior in README (both languages) and usage-guide (both languages).

### Findings intentionally NOT fixed

Review findings #5, #6, #7 were speculative (defensive handling for scenarios that cannot occur given the callers). Per the repo's "简洁优先 / don't fix what isn't broken" conduct, they were left alone.

## Test Plan

- [x] `npm run build` — succeeds
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 2339 tests pass (170 files)
- [x] New regression test: `keeps other skills' open-PR records when pushing a single --skill` — fails without fix #1, passes with it
- [x] New regression test: `config-only: switches back to the default branch when the push throws` — fails without fix #3, passes with it
- [x] Real CLI e2e: two pending open-PR records, `teamai push --skill target` — verified the `other-branch` record survives (fix #1)
- [x] Real CLI e2e: second no-op `teamai push` on a reused branch — verified the local target-branch is deleted (fix #2)
