### PR TITLE
fix(import): run reconcile and deep enrich in --dir mode

### DIFF
--- a/src/import.ts
+++ b/src/import.ts
@@ -68,6 +68,58 @@ interface ImportOptions extends GlobalOptions {
 }
 
 /**
+ * Run knowledge reconciliation followed by deep enrichment for a freshly
+ * extracted codebase, mirroring the reconcile → deep-enrich stages used by
+ * the --from-repo flow.
+ *
+ * Both stages are non-blocking: failures are logged at debug level and
+ * swallowed so they never abort the import. Deep enrich runs only when AI
+ * enrichment produced a `_manifest.json` and `skipEnrich` is not set.
+ *
+ * @param params - Reconcile/enrich parameters
+ * @param params.slug - Project slug, used for evidence dir naming and logging
+ * @param params.evidenceDir - Path to evidence/code/<slug> under the wiki root
+ * @param params.wikiRoot - teamwiki root directory to reconcile/enrich against
+ * @param params.cacheDir - Source code directory (the resolved --dir path)
+ * @param params.skipEnrich - When true, skip the deep-enrich stage
+ */
+async function reconcileAndDeepEnrich(params: {
+  slug: string;
+  evidenceDir: string;
+  wikiRoot: string;
+  cacheDir: string;
+  skipEnrich: boolean;
+}): Promise<void> {
+  const { slug, evidenceDir, wikiRoot, cacheDir, skipEnrich } = params;
+
+  // Reconcile product docs ↔ code knowledge (if product docs exist)
+  try {
+    const { reconcileKnowledge } = await import('./wiki-engine/adapters/index.js');
+    const result = await reconcileKnowledge({ wikiRoot, dryRun: false });
+    if (result.mappings > 0 || result.gaps.length > 0) {
+      log.info(
+        `  reconcile: ${result.mappings} mappings, ` +
+        `${result.gaps.length} gaps, ${result.graphEdges.length} MAPS_TO edges`,
+      );
+    }
+  } catch (err) {
+    log.debug(`reconcile skipped: ${(err as Error).message}`);
+  }
+
+  // Deep enrich (synchronous, before push — so all content goes into one MR)
+  const manifestExists = await fs.pathExists(path.join(evidenceDir, '_manifest.json'));
+  if (!skipEnrich && manifestExists) {
+    try {
+      const { deepEnrich } = await import('./deep-enrich.js');
+      await deepEnrich({ project: slug, evidenceDir, wikiRoot, cacheDir });
+      log.info(`Deep enrich complete: ${slug}`);
+    } catch (err) {
+      log.debug(`deep-enrich failed for ${slug} (non-blocking): ${(err as Error).message}`);
+    }
+  }
+}
+
+/**
  * Main entry point for the import command, orchestrating dir, MR, org, and other import flows.
  *
  * @param opts - Merged global and subcommand options object
@@ -298,6 +350,13 @@ export async function importCmd(opts: ImportOptions): Promise<void> {
             if (await fs.pathExists(srcWiki)) {
               await fs.copy(srcWiki, outputWiki, { overwrite: true });
               log.info(`Output written: ${outputWiki}`);
+              await reconcileAndDeepEnrich({
+                slug,
+                evidenceDir: path.join(outputWiki, 'evidence', 'code', slug),
+                wikiRoot: outputWiki,
+                cacheDir: dirPath,
+                skipEnrich: opts.skipEnrich ?? false,
+              });
             }
           } else {
             // 默认模式：写入 team-repo 并推送
@@ -319,6 +378,13 @@ export async function importCmd(opts: ImportOptions): Promise<void> {
                 await fs.copy(srcGraph, path.join(destGraphDir, 'graph-index.json'), { overwrite: true });
               }
               log.info(`teamwiki/ knowledge graph updated: ${slug}`);
+              await reconcileAndDeepEnrich({
+                slug,
+                evidenceDir: evidenceDest,
+                wikiRoot: teamwikiRoot,
+                cacheDir: dirPath,
+                skipEnrich: opts.skipEnrich ?? false,
+              });
             }
 
             const { aggregateGlobalGraph } = await import('./graph-aggregate.js');


### PR DESCRIPTION
## Summary

`import --dir` extracted code knowledge but stopped short of the **reconcile** and **deep-enrich** stages that `--from-repo` runs. As a result, local-directory imports produced only shallow evidence — no per-component design docs, no architecture overview, and no AI graph docs (G5/G6).

This PR adds the `reconcile → deep-enrich` stages to **both** `--dir` sub-paths, mirroring the `--from-repo` pipeline:

- **`--output` sub-path** (writes to a target dir, no push) — enriches against the output `teamwiki/`.
- **default team-repo push sub-path** — enriches against the team repo `teamwiki/`, before `aggregateGlobalGraph`/`rebuildWikiIndex`/push, so all content lands in one MR.

The shared logic is factored into a `reconcileAndDeepEnrich` helper to avoid duplication across the two sub-paths.

Behavior guards (unchanged from `--from-repo`):
- Deep enrich runs only when AI enrichment produced a `_manifest.json` **and** `--skip-enrich` is not set.
- Both stages are non-blocking — failures are logged at debug level and never abort the import.

## Test Plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — success
- [x] `npx vitest run src/__tests__/import-org.test.ts` — pass
- [x] Real e2e: `teamai import --dir <sample> --output <tmp>` against a multi-service sample codebase — log confirms the ordering `AI enrich → reconcile → deep-enrich Phase 1–5 → Deep enrich complete`, and the enriched artifacts (`docs/architecture.md`, per-component design doc, G1/G2/G3/G6 graph docs, `_manifest.json`) are written under `evidence/code/<slug>/`.

Note: `--dir --output` was used for e2e so the run stays fully local (no team-repo push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)