### PR TITLE
feat(coauthor): team-controlled commit co-author attribution across AI tools

### DIFF
--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -578,6 +578,35 @@ When disabled, `teamai pull` skips deploying the recall subagent, the recall rul
 
 ---
 
+## Commit Co-Author Attribution
+
+AI coding tools stamp a `Co-Authored-By:` / attribution trailer on the commits they make. Teams that prefer a clean history can turn this off for everyone; individual members can still override it on their own machine. `teamai pull` applies the resolved intent to each installed tool's own config file.
+
+The feature is controlled by the same two-tier pattern as recall:
+
+| Tier | Config file | Field | Description |
+|------|----------|------|------|
+| Team default | `teamai.yaml` | `sharing.coAuthor.enabled` | `true` = keep the trailer / `false` = strip it. Omit the block entirely for "no opinion" (teamai touches nothing) |
+| User override | `~/.teamai/config.yaml` | `coAuthorEnabled` | `true` / `false`, takes priority over the team default |
+
+Per tool family, the trailer maps to a different setting:
+
+| Tool family | File | Setting written | Scope | Reliability |
+|------|------|------|------|------|
+| Claude (`claude`, `codebuddy`, `workbuddy`) | `settings.json` | `attribution.commit` / `attribution.pr` set to `""` | user **or** project (follows the active scope) | Deterministic |
+| Codex (`codex`) | `~/.codex/config.toml` | `commit_attribution = ""` | user only | Best-effort — only takes effect when `[features].codex_git_commit = true`, which teamai does not force |
+| Cursor | `~/.cursor/cli-config.json` | `attribution.attributeCommitsToAgent = false` | user only | Best-effort — a [known upstream bug](https://forum.cursor.com/t/local-executor-ignores-cli-config-attribution-opt-out-forcing-co-authored-by-trailer/167722) can cause the local executor to ignore this |
+
+Semantics:
+
+- **Write-only, never delete.** Once teamai has written a value, dropping the team policy later leaves that value untouched — teamai never restores a trailer it stripped. To re-enable, set the intent back to `true` explicitly (which removes teamai's override so the tool's own default returns).
+- **Idempotent.** teamai records what it last wrote per file (in `state.json` under `coAuthorManaged`) and skips a write when nothing would change.
+- **Only installed tools are touched**, and existing keys/comments in each config file are preserved (key-level surgery, not regenerate-from-scratch).
+
+Restart your AI tool session after a `pull` for the change to take effect.
+
+---
+
 ## Team Culture
 
 TeamAI supports injecting your team's culture into AI tools, so your AI coding assistant is aware of your team's culture, values, and coding standards in every session.
@@ -1071,6 +1100,8 @@ sharing:
     localDir: ./.teamai/docs
   env:
     injectShellProfile: true
+  coAuthor:
+    enabled: false             # optional; strip AI-tool commit trailers team-wide
 ```
 
 ### config.yaml (local config)
@@ -1084,6 +1115,7 @@ updatePolicy: auto
 scope: project                 # project (default from init) or user
 projectRoot: /path/to/project  # project scope only
 inheritUserScope: true         # optional; project scope only, defaults to false
+coAuthorEnabled: true          # optional; per-machine co-author override
 ```
 
 ---

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -576,6 +576,35 @@ teamai recall status     # 查看当前生效状态（团队默认 + 用户覆�
 
 ---
 
+## 提交 Co-Author 署名（Commit Co-Author Attribution）
+
+AI 编码工具会在它生成的提交上打一个 `Co-Authored-By:` / attribution 尾注。希望保持干净历史的团队可以为全员关闭它，成员仍可在自己机器上覆盖。`teamai pull` 会把最终生效的意图写入每个已安装工具各自的配置文件。
+
+该功能采用与 recall 相同的两级配置：
+
+| 层级 | 配置文件 | 字段 | 说明 |
+|------|----------|------|------|
+| 团队默认 | `teamai.yaml` | `sharing.coAuthor.enabled` | `true` = 保留尾注 / `false` = 去除尾注。整块省略表示"无意见"（teamai 不做任何改动） |
+| 用户覆盖 | `~/.teamai/config.yaml` | `coAuthorEnabled` | `true` / `false`，优先级高于团队默认 |
+
+不同工具家族映射到不同的设置项：
+
+| 工具家族 | 文件 | 写入的设置 | 作用域 | 可靠性 |
+|------|------|------|------|------|
+| Claude（`claude`、`codebuddy`、`workbuddy`） | `settings.json` | `attribution.commit` / `attribution.pr` 置为 `""` | 用户 **或** 项目（跟随当前 scope） | 确定生效 |
+| Codex（`codex`） | `~/.codex/config.toml` | `commit_attribution = ""` | 仅用户 | 尽力而为 —— 仅当 `[features].codex_git_commit = true` 时生效，teamai 不会强制开启该开关 |
+| Cursor | `~/.cursor/cli-config.json` | `attribution.attributeCommitsToAgent = false` | 仅用户 | 尽力而为 —— 存在[上游已知 bug](https://forum.cursor.com/t/local-executor-ignores-cli-config-attribution-opt-out-forcing-co-authored-by-trailer/167722)，local executor 可能忽略该设置 |
+
+语义：
+
+- **只写不删。** teamai 一旦写入某个值，之后团队撤下策略也不会改动该值 —— teamai 绝不还原它去除过的尾注。若要重新启用，请显式把意图设回 `true`（这会移除 teamai 的覆盖，从而恢复工具自身的默认行为）。
+- **幂等。** teamai 在 `state.json` 的 `coAuthorManaged` 中记录每个文件上次写入的值，无变化时跳过写入。
+- **只改动已安装的工具**，并保留各配置文件中已有的键与注释（键级别的精修，而非整文件重生成）。
+
+`pull` 之后请重启 AI 工具会话使改动生效。
+
+---
+
 ## 团队文化（Culture）
 
 TeamAI 支持将团队文化注入到 AI 工具中，让 AI 编码助手在每次会话中都能感知你的团队文化、价值观和编码准则。
@@ -1066,6 +1095,8 @@ sharing:
     localDir: ./.teamai/docs
   env:
     injectShellProfile: true
+  coAuthor:
+    enabled: false             # 可选，为全团队去除 AI 工具提交尾注
 ```
 
 ### config.yaml（本地配置）
@@ -1079,6 +1110,7 @@ updatePolicy: auto
 scope: project                 # project（init 默认）或 user
 projectRoot: /path/to/project  # 仅 project scope
 inheritUserScope: true         # 可选，仅 project scope，默认 false
+coAuthorEnabled: true          # 可选，每机器的 co-author 覆盖
 ```
 
 ---

--- a/src/__tests__/coauthor-reconcile.test.ts
+++ b/src/__tests__/coauthor-reconcile.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import os from 'node:os';
+import fse from 'fs-extra';
+
+vi.mock('../utils/logger.js', () => ({
+  log: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    dim: vi.fn(),
+  },
+}));
+
+import {
+  reconcileCoAuthorForConfig,
+  spliceCodexAttribution,
+} from '../coauthor-reconcile.js';
+import { StateSchema } from '../types.js';
+import type { TeamaiConfig, LocalConfig, State } from '../types.js';
+
+const TOOL_PATHS = {
+  claude: { skills: '.claude/skills', settings: '.claude/settings.json' },
+  codex: { skills: '.codex/skills', settings: '.codex/hooks.json' },
+  cursor: { skills: '.cursor/skills', settings: '.cursor/hooks.json' },
+};
+
+describe('co-author reconcile', () => {
+  let tmpDir: string;
+  let homeDir: string;
+  let repoPath: string;
+  let baseTeam: TeamaiConfig;
+  let baseLocal: LocalConfig;
+
+  function team(coAuthor?: { enabled: boolean }): TeamaiConfig {
+    return {
+      ...baseTeam,
+      sharing: { ...baseTeam.sharing, ...(coAuthor ? { coAuthor } : {}) },
+    } as TeamaiConfig;
+  }
+
+  const freshState = (): State => StateSchema.parse({});
+
+  beforeEach(async () => {
+    tmpDir = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-coauthor-test-'));
+    homeDir = path.join(tmpDir, 'home');
+    repoPath = path.join(tmpDir, 'team-repo');
+
+    // All three tools "installed" at user scope.
+    await fse.ensureDir(path.join(homeDir, '.claude', 'skills'));
+    await fse.ensureDir(path.join(homeDir, '.codex', 'skills'));
+    await fse.ensureDir(path.join(homeDir, '.cursor', 'skills'));
+    await fse.ensureDir(path.join(homeDir, '.teamai'));
+
+    vi.stubEnv('HOME', homeDir);
+
+    baseTeam = {
+      team: 't',
+      description: '',
+      repo: 'r',
+      provider: 'tgit',
+      reviewers: [],
+      sharing: {
+        skills: {},
+        rules: { enforced: [] },
+        docs: { localDir: '~/.teamai/docs' },
+        env: { injectShellProfile: false },
+      },
+      toolPaths: TOOL_PATHS,
+    } as unknown as TeamaiConfig;
+
+    baseLocal = {
+      repo: { localPath: repoPath, remote: 'r' },
+      username: 'u',
+      scope: 'user',
+      additionalRoles: [],
+    } as unknown as LocalConfig;
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await fse.remove(tmpDir);
+  });
+
+  const claudeSettings = () => path.join(homeDir, '.claude', 'settings.json');
+  const codexToml = () => path.join(homeDir, '.codex', 'config.toml');
+  const cursorConfig = () => path.join(homeDir, '.cursor', 'cli-config.json');
+
+  it('does nothing when neither team nor user has an opinion', async () => {
+    const { changes } = await reconcileCoAuthorForConfig(team(), baseLocal, freshState());
+    expect(changes).toEqual([]);
+    expect(await fse.pathExists(claudeSettings())).toBe(false);
+    expect(await fse.pathExists(codexToml())).toBe(false);
+    expect(await fse.pathExists(cursorConfig())).toBe(false);
+  });
+
+  it('disables the trailer across all three tool families when team says off', async () => {
+    const { changes, managed } = await reconcileCoAuthorForConfig(
+      team({ enabled: false }),
+      baseLocal,
+      freshState(),
+    );
+
+    // Claude: attribution.commit / .pr = ""
+    const claude = await fse.readJson(claudeSettings());
+    expect(claude.attribution).toEqual({ commit: '', pr: '' });
+
+    // Codex: commit_attribution = ""
+    const toml = await fse.readFile(codexToml(), 'utf-8');
+    expect(toml).toContain('commit_attribution = ""');
+
+    // Cursor: attribution.attributeCommitsToAgent = false
+    const cursor = await fse.readJson(cursorConfig());
+    expect(cursor.attribution).toEqual({ attributeCommitsToAgent: false });
+
+    expect(changes.every((c) => c.action === 'updated' && c.enabled === false)).toBe(true);
+    expect(Object.values(managed).every((v) => v === false)).toBe(true);
+  });
+
+  it('is idempotent: a second pass makes no writes', async () => {
+    const first = await reconcileCoAuthorForConfig(team({ enabled: false }), baseLocal, freshState());
+    const state = { ...freshState(), coAuthorManaged: first.managed };
+    const second = await reconcileCoAuthorForConfig(team({ enabled: false }), baseLocal, state);
+    expect(second.changes.every((c) => c.action === 'skipped')).toBe(true);
+  });
+
+  it('user override beats team default', async () => {
+    // Team says OFF, but user overrides to ON. Seed a stripped trailer so there
+    // is something for enabled=true to restore, proving the override is applied.
+    await fse.writeJson(claudeSettings(), { attribution: { commit: '', pr: '' } });
+    const local = { ...baseLocal, coAuthorEnabled: true } as LocalConfig;
+    await reconcileCoAuthorForConfig(team({ enabled: false }), local, freshState());
+    // enabled=true restores default → attribution override removed.
+    const claude = await fse.readJson(claudeSettings());
+    expect(claude.attribution).toBeUndefined();
+  });
+
+  it('write-only: dropping the team policy leaves the trailer untouched', async () => {
+    // Round 1: team says off, we strip.
+    const r1 = await reconcileCoAuthorForConfig(team({ enabled: false }), baseLocal, freshState());
+    const state = { ...freshState(), coAuthorManaged: r1.managed };
+
+    // Round 2: team drops the policy entirely (no coAuthor block).
+    const r2 = await reconcileCoAuthorForConfig(team(), baseLocal, state);
+    expect(r2.changes).toEqual([]); // no-op, nothing rewritten
+
+    // The stripped trailer is still stripped — we never restored it.
+    const claude = await fse.readJson(claudeSettings());
+    expect(claude.attribution).toEqual({ commit: '', pr: '' });
+  });
+
+  it('preserves unrelated keys in each config file', async () => {
+    await fse.writeJson(claudeSettings(), { model: 'opus', attribution: { commit: 'keep-me' } });
+    await fse.writeFile(codexToml(), '# my config\nmodel = "gpt-5"\n\n[features]\ncodex_git_commit = true\n');
+    await fse.writeJson(cursorConfig(), { editor: { theme: 'dark' } });
+
+    await reconcileCoAuthorForConfig(team({ enabled: false }), baseLocal, freshState());
+
+    const claude = await fse.readJson(claudeSettings());
+    expect(claude.model).toBe('opus');
+    expect(claude.attribution.commit).toBe(''); // overridden
+    expect(claude.attribution.pr).toBe('');
+
+    const toml = await fse.readFile(codexToml(), 'utf-8');
+    expect(toml).toContain('# my config');
+    expect(toml).toContain('model = "gpt-5"');
+    expect(toml).toContain('[features]');
+    expect(toml).toContain('commit_attribution = ""');
+
+    const cursor = await fse.readJson(cursorConfig());
+    expect(cursor.editor).toEqual({ theme: 'dark' });
+    expect(cursor.attribution.attributeCommitsToAgent).toBe(false);
+  });
+
+  it('skips uninstalled tools', async () => {
+    await fse.remove(path.join(homeDir, '.cursor'));
+    const { changes } = await reconcileCoAuthorForConfig(team({ enabled: false }), baseLocal, freshState());
+    expect(changes.find((c) => c.tool === 'cursor')).toBeUndefined();
+    expect(changes.find((c) => c.tool === 'claude')).toBeDefined();
+  });
+
+  it('skips codex/cursor in project scope (user-scope only)', async () => {
+    const projRoot = path.join(tmpDir, 'proj');
+    await fse.ensureDir(path.join(projRoot, '.claude', 'skills'));
+    const local = {
+      ...baseLocal,
+      scope: 'project',
+      projectRoot: projRoot,
+    } as LocalConfig;
+
+    const { changes } = await reconcileCoAuthorForConfig(team({ enabled: false }), local, freshState());
+    expect(changes.find((c) => c.tool === 'codex')).toBeUndefined();
+    expect(changes.find((c) => c.tool === 'cursor')).toBeUndefined();
+    // Claude writes into the PROJECT settings.json.
+    const projClaude = await fse.readJson(path.join(projRoot, '.claude', 'settings.json'));
+    expect(projClaude.attribution).toEqual({ commit: '', pr: '' });
+  });
+});
+
+describe('spliceCodexAttribution', () => {
+  it('inserts the key before the first table', () => {
+    const src = 'model = "gpt-5"\n\n[features]\ncodex_git_commit = true\n';
+    const out = spliceCodexAttribution(src, false);
+    expect(out).toContain('commit_attribution = ""');
+    // must land in the head region, before [features]
+    expect(out.indexOf('commit_attribution')).toBeLessThan(out.indexOf('[features]'));
+    // and keep a blank line before the table header, never flush against it
+    expect(out).not.toContain('commit_attribution = ""\n[features]');
+    expect(out).toContain('commit_attribution = ""\n\n[features]');
+  });
+
+  it('replaces an existing top-level key', () => {
+    const src = 'commit_attribution = "Codex <x>"\nmodel = "gpt-5"\n';
+    const out = spliceCodexAttribution(src, false);
+    expect(out).toContain('commit_attribution = ""');
+    expect(out).not.toContain('Codex <x>');
+  });
+
+  it('removes the key when restoring the default (enabled=true)', () => {
+    const src = 'commit_attribution = ""\nmodel = "gpt-5"\n';
+    const out = spliceCodexAttribution(src, true);
+    expect(out).not.toContain('commit_attribution');
+    expect(out).toContain('model = "gpt-5"');
+  });
+
+  it('is a no-op restoring default when the key is absent', () => {
+    const src = 'model = "gpt-5"\n';
+    expect(spliceCodexAttribution(src, true)).toBe(src);
+  });
+
+  it('handles an empty file', () => {
+    expect(spliceCodexAttribution('', false)).toBe('commit_attribution = ""\n');
+  });
+});

--- a/src/coauthor-reconcile.ts
+++ b/src/coauthor-reconcile.ts
@@ -1,0 +1,294 @@
+import path from 'node:path';
+import type { LocalConfig, TeamaiConfig, State } from './types.js';
+import { resolveBaseDir, resolveCoAuthor, scopedToolPaths } from './types.js';
+import { getUserHome } from './utils/home.js';
+import {
+  readJson,
+  writeJson,
+  readFileSafe,
+  writeFile,
+  pathExists,
+} from './utils/fs.js';
+import { log } from './utils/logger.js';
+
+// ─── Co-author reconcile engine ──────────────────────────────
+//
+//  Applies the team's co-author intent (does an AI tool stamp a
+//  Co-Authored-By / attribution trailer on the commits it makes?) to each
+//  installed tool's own config file, idempotently.
+//
+//  Like MCP, the target files are NOT owned by teamai — ~/.codex/config.toml
+//  holds model/trust settings, ~/.cursor/cli-config.json and the Claude
+//  settings.json hold unrelated user config. So every write is key-level
+//  surgery on an existing document, never a regenerate-from-scratch, and the
+//  Codex TOML is patched by text surgery so the user's comments survive.
+//
+//  Write-only, never delete (issue: team may later drop the policy). The intent
+//  we last wrote per file is recorded in state.coAuthorManaged so the pass stays
+//  idempotent; when neither user nor team has an opinion we leave every file
+//  untouched rather than removing a trailer the user may now depend on.
+//
+//  The three tool families express the same intent differently:
+//
+//    Claude family   settings.json  attribution.{commit,pr}   deterministic
+//                    (claude, tclaude, codebuddy, workbuddy, *-internal, ...)
+//                    "" = strip the trailer, non-empty = default trailer.
+//                    Scope-aware: project scope writes <root>/.claude/settings.json.
+//    Codex family    ~/.codex/config.toml  commit_attribution   best-effort
+//                    (codex, codex-internal, tcodex) — user scope only.
+//                    Only takes effect when [features].codex_git_commit = true,
+//                    which we do NOT force; "" strips, unset = default trailer.
+//    Cursor          ~/.cursor/cli-config.json  attribution.attributeCommitsToAgent
+//                    user scope only. Known upstream bug: the local executor may
+//                    ignore this, so treat it as best-effort.
+
+const CODEX_TOOLS = new Set(['codex', 'codex-internal', 'tcodex']);
+const CURSOR_TOOLS = new Set(['cursor']);
+
+type Family = 'claude' | 'codex' | 'cursor';
+
+function familyOf(tool: string): Family {
+  if (CODEX_TOOLS.has(tool)) return 'codex';
+  return CURSOR_TOOLS.has(tool) ? 'cursor' : 'claude';
+}
+
+export interface CoAuthorChange {
+  tool: string;
+  file: string;
+  /** The intent applied: true = keep trailer, false = strip it. */
+  enabled: boolean;
+  action: 'updated' | 'skipped';
+  reason?: string;
+}
+
+export interface CoAuthorReconcileResult {
+  changes: CoAuthorChange[];
+  /** The next state.coAuthorManaged map (caller persists it). */
+  managed: Record<string, boolean>;
+}
+
+interface Target {
+  tool: string;
+  family: Family;
+  /** Absolute path of the config file to edit. */
+  file: string;
+}
+
+/**
+ * Resolve which tools to write, and where. A tool is only targeted when it is
+ * actually installed (its resource dir exists) — we never conjure a config file
+ * on a machine that does not have that tool.
+ */
+async function resolveTargets(
+  teamConfig: TeamaiConfig,
+  localConfig: LocalConfig,
+): Promise<Target[]> {
+  const baseDir = resolveBaseDir(localConfig);
+  const projectScope = localConfig.scope === 'project';
+  const userHome = getUserHome();
+  const targets: Target[] = [];
+  const disabled = new Set(localConfig.disabledAgents ?? []);
+  const whitelist = localConfig.enabledAgents;
+
+  for (const [tool, paths] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
+    if (disabled.has(tool)) continue;
+    if (whitelist && !whitelist.includes(tool)) continue;
+    const family = familyOf(tool);
+
+    // Installation probe: the tool's root dir (parent of its resource dir), same
+    // heuristic MCP reconcile uses. Skip tools we can't locate on disk.
+    const probe = paths.settings ?? paths.skills ?? paths.agents;
+    if (!probe) continue;
+    const probeDir = path.dirname(probe);
+    const toolRoot = probeDir === '.' ? path.join(baseDir, probe) : path.join(baseDir, probeDir);
+    if (!(await pathExists(toolRoot))) {
+      log.debug(`[coauthor] Skipping ${tool}: tool not installed`);
+      continue;
+    }
+
+    if (family === 'claude') {
+      // Scope-aware settings.json. Requires a `settings` path (some tools —
+      // openclaw, hermes, dsh — have none and get no co-author control).
+      if (!paths.settings) continue;
+      targets.push({ tool, family, file: path.join(baseDir, paths.settings) });
+    } else if (family === 'codex') {
+      // User scope only: Codex reads commit_attribution from ~/.codex/config.toml.
+      if (projectScope) {
+        log.debug(`[coauthor] Skipping ${tool}: co-author is user-scope only`);
+        continue;
+      }
+      // tcodex relocates its home to ~/.tcodex; codex-internal to ~/.codex-internal.
+      const home = tool === 'tcodex' ? '.tcodex' : tool === 'codex-internal' ? '.codex-internal' : '.codex';
+      targets.push({ tool, family, file: path.join(userHome, home, 'config.toml') });
+    } else {
+      // Cursor: user scope only, ~/.cursor/cli-config.json.
+      if (projectScope) {
+        log.debug(`[coauthor] Skipping ${tool}: co-author is user-scope only`);
+        continue;
+      }
+      targets.push({ tool, family, file: path.join(userHome, '.cursor', 'cli-config.json') });
+    }
+  }
+  return targets;
+}
+
+// ─── Per-family writers ──────────────────────────────────────
+
+/**
+ * Patch a Claude-family settings.json: `attribution.commit` and
+ * `attribution.pr`. Empty string strips the trailer; a non-empty default is
+ * restored by DELETING the keys (absent = tool's built-in default) so we never
+ * pin an arbitrary trailer string of our own.
+ *
+ * Returns true when the file changed.
+ */
+async function applyClaude(file: string, enabled: boolean): Promise<boolean> {
+  const settings = (await readJson<Record<string, unknown>>(file)) ?? {};
+  const attribution = (typeof settings.attribution === 'object' && settings.attribution !== null
+    ? { ...(settings.attribution as Record<string, unknown>) }
+    : {}) as Record<string, unknown>;
+
+  const before = JSON.stringify(settings.attribution ?? null);
+  if (enabled) {
+    // Restore the default: remove our override rather than guess a trailer.
+    if (attribution.commit === '') delete attribution.commit;
+    if (attribution.pr === '') delete attribution.pr;
+  } else {
+    attribution.commit = '';
+    attribution.pr = '';
+  }
+
+  if (Object.keys(attribution).length === 0) {
+    delete settings.attribution;
+  } else {
+    settings.attribution = attribution;
+  }
+  if (JSON.stringify(settings.attribution ?? null) === before) return false;
+  await writeJson(file, settings);
+  return true;
+}
+
+/**
+ * Patch Codex's config.toml top-level `commit_attribution` scalar by text
+ * surgery, leaving the rest of the file (comments included) byte-identical.
+ * enabled=true removes the key (restore default trailer); enabled=false sets
+ * `commit_attribution = ""`.
+ *
+ * Only rewrites/removes a top-level occurrence — a `commit_attribution` nested
+ * under some `[table]` is left alone. Returns true when the file changed.
+ */
+export function spliceCodexAttribution(source: string, enabled: boolean): string {
+  // A top-level key is one that appears before the first `[table]` header, or
+  // (defensively) any line matching the key at column 0. Codex config.toml keeps
+  // scalars at the top, so we operate on the pre-first-table region.
+  const firstTable = source.search(/^\[/m);
+  const head = firstTable === -1 ? source : source.slice(0, firstTable);
+  const tail = firstTable === -1 ? '' : source.slice(firstTable);
+
+  const keyRe = /^[ \t]*commit_attribution[ \t]*=.*$(?:\r?\n)?/m;
+  const hasKey = keyRe.test(head);
+
+  if (enabled) {
+    // Restore default: drop our line if present, else no-op.
+    if (!hasKey) return source;
+    const cleanedHead = head.replace(keyRe, '');
+    return cleanedHead + tail;
+  }
+
+  const line = 'commit_attribution = ""\n';
+  if (hasKey) {
+    const replacedHead = head.replace(keyRe, line);
+    return replacedHead + tail;
+  }
+  // Insert at the end of the head region (before the first table / EOF).
+  const lead = head.length === 0 || head.endsWith('\n') ? '' : '\n';
+  // Keep a blank line before a following `[table]` so the inserted scalar does
+  // not sit flush against a table header (valid TOML, but visually misleading).
+  const trail = tail.startsWith('[') ? '\n' : '';
+  return head + lead + line + trail + tail;
+}
+
+async function applyCodex(file: string, enabled: boolean): Promise<boolean> {
+  const source = (await readFileSafe(file)) ?? '';
+  const next = spliceCodexAttribution(source, enabled);
+  if (next === source) return false;
+  await writeFile(file, next);
+  return true;
+}
+
+/**
+ * Patch Cursor's cli-config.json `attribution.attributeCommitsToAgent`.
+ * enabled=true removes the override (restore default); enabled=false sets it to
+ * false. Returns true when the file changed.
+ */
+async function applyCursor(file: string, enabled: boolean): Promise<boolean> {
+  const config = (await readJson<Record<string, unknown>>(file)) ?? {};
+  const attribution = (typeof config.attribution === 'object' && config.attribution !== null
+    ? { ...(config.attribution as Record<string, unknown>) }
+    : {}) as Record<string, unknown>;
+
+  const before = JSON.stringify(config.attribution ?? null);
+  if (enabled) {
+    if (attribution.attributeCommitsToAgent === false) delete attribution.attributeCommitsToAgent;
+  } else {
+    attribution.attributeCommitsToAgent = false;
+  }
+
+  if (Object.keys(attribution).length === 0) {
+    delete config.attribution;
+  } else {
+    config.attribution = attribution;
+  }
+  if (JSON.stringify(config.attribution ?? null) === before) return false;
+  await writeJson(file, config);
+  return true;
+}
+
+// ─── Main entry ──────────────────────────────────────────────
+
+/**
+ * Reconcile one scope's tool configs to the team's desired co-author intent.
+ * Idempotent. Returns the changes plus the next `coAuthorManaged` map.
+ */
+export async function reconcileCoAuthorForConfig(
+  teamConfig: TeamaiConfig,
+  localConfig: LocalConfig,
+  state: State,
+): Promise<CoAuthorReconcileResult> {
+  const managed: Record<string, boolean> = { ...(state.coAuthorManaged ?? {}) };
+  const changes: CoAuthorChange[] = [];
+
+  const intent = resolveCoAuthor(localConfig, teamConfig);
+  // No opinion from user or team → write-only means touch nothing.
+  if (intent === undefined) {
+    return { changes, managed };
+  }
+
+  const targets = await resolveTargets(teamConfig, localConfig);
+  for (const t of targets) {
+    // Idempotence: skip when we already wrote this exact intent to this file.
+    if (managed[t.file] === intent) {
+      changes.push({ tool: t.tool, file: t.file, enabled: intent, action: 'skipped', reason: 'already applied' });
+      continue;
+    }
+    try {
+      let changed: boolean;
+      if (t.family === 'claude') changed = await applyClaude(t.file, intent);
+      else if (t.family === 'codex') changed = await applyCodex(t.file, intent);
+      else changed = await applyCursor(t.file, intent);
+
+      managed[t.file] = intent;
+      changes.push({
+        tool: t.tool,
+        file: t.file,
+        enabled: intent,
+        action: changed ? 'updated' : 'skipped',
+        reason: changed ? undefined : 'already up-to-date',
+      });
+    } catch (e) {
+      changes.push({ tool: t.tool, file: t.file, enabled: intent, action: 'skipped', reason: (e as Error).message });
+    }
+  }
+
+  return { changes, managed };
+}

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -1289,6 +1289,12 @@ export async function pull(options: GlobalOptions): Promise<void> {
   // hooks. User-scope MCP remains isolated in project mode.
   await reconcileMcpAllScopes(activeUserConfig, projectConfig, options);
 
+  // 3.7. Reconcile the team co-author policy (does an AI tool stamp a
+  // Co-Authored-By / attribution trailer on its commits?). Outside pullForScope
+  // for the same reason as hooks/MCP; write-only, so it self-heals but never
+  // strips a trailer once the team drops the policy.
+  await reconcileCoAuthorAllScopes(activeUserConfig, projectConfig, options);
+
   // 4. Auto-report usage data to all active scopes. Events live in a single
   //    shared file (~/.teamai/usage.jsonl), so we report to each repo with
   //    skipTruncate=true first, then truncate once at the end.
@@ -1414,6 +1420,46 @@ async function reconcileMcpAllScopes(
       }
     } catch (e) {
       log.debug(`[${localConfig.scope}] MCP reconcile skipped: ${(e as Error).message}`);
+    }
+  }
+}
+
+/**
+ * Reconcile the co-author policy across active scopes. Mirrors
+ * reconcileMcpAllScopes: loops the installed scopes, loads each team config,
+ * applies the resolved intent to every installed tool, and persists the
+ * per-file `coAuthorManaged` markers so the pass stays idempotent.
+ */
+async function reconcileCoAuthorAllScopes(
+  userConfig: LocalConfig | null,
+  projectConfig: LocalConfig | null,
+  options: GlobalOptions,
+): Promise<void> {
+  if (options.dryRun) return;
+  const scopes = [userConfig, projectConfig].filter((c): c is LocalConfig => !!c);
+  for (const localConfig of scopes) {
+    try {
+      const teamConfig = await loadTeamConfig(localConfig.repo.localPath);
+      if (!teamConfig) continue;
+      const { reconcileCoAuthorForConfig } = await import('./coauthor-reconcile.js');
+      const state = await loadStateForScope(localConfig.scope, localConfig.projectRoot);
+      const { changes, managed } = await reconcileCoAuthorForConfig(teamConfig, localConfig, state);
+
+      const applied = changes.filter((c) => c.action !== 'skipped');
+      for (const c of changes) {
+        if (c.action === 'skipped') log.debug(`[coauthor] ${c.tool}: skipped — ${c.reason}`);
+      }
+      if (applied.length > 0) {
+        state.coAuthorManaged = managed;
+        await saveStateForScope(state, localConfig.scope, localConfig.projectRoot);
+        if (!options.silent) {
+          const verb = applied[0].enabled ? 'enabled' : 'disabled';
+          const tools = [...new Set(applied.map((c) => c.tool))];
+          log.info(`Co-author trailer ${verb} for ${tools.join(', ')}. Restart your AI tool session to apply.`);
+        }
+      }
+    } catch (e) {
+      log.debug(`[${localConfig.scope}] co-author reconcile skipped: ${(e as Error).message}`);
     }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,15 @@ export const SharingConfigSchema = z.object({
   recall: z.object({
     enabled: z.boolean().default(false),
   }).optional(),
+  // Optional (not .default) so existing TeamaiConfig literals stay valid, AND so
+  // "team has no opinion" (block absent) stays distinct from "team says off"
+  // (enabled: false). Only the former is a no-op; see resolveCoAuthor().
+  coAuthor: z.object({
+    /** Team default: whether members' AI-tool commits carry a Co-Authored-By /
+     *  attribution trailer. false = strip it (clean history). Users can override
+     *  per-machine via `coAuthorEnabled` in local config. */
+    enabled: z.boolean().default(true),
+  }).optional(),
   // Optional (not .default) so existing TeamaiConfig literals stay valid; use
   // getMcpSharing() for the defaulted view.
   mcp: z.object({
@@ -118,6 +127,21 @@ export function isRecallEnabled(
 ): boolean {
   if (localConfig.recallEnabled !== undefined) return localConfig.recallEnabled;
   return getRecallSharing(teamConfig).enabled;
+}
+
+/**
+ * Resolve the effective co-author intent: user override > team config > no-op.
+ *
+ * Returns `undefined` when neither the user nor the team has an opinion — the
+ * caller must then leave every tool's config untouched (write-only, never
+ * delete). A boolean means "make the trailer on/off"; only then do we write.
+ */
+export function resolveCoAuthor(
+  localConfig: { coAuthorEnabled?: boolean },
+  teamConfig: { sharing?: { coAuthor?: { enabled?: boolean } } },
+): boolean | undefined {
+  if (localConfig.coAuthorEnabled !== undefined) return localConfig.coAuthorEnabled;
+  return teamConfig.sharing?.coAuthor?.enabled;
 }
 
 // ─── Source config (cross-team subscription) ─────────
@@ -288,6 +312,10 @@ export const LocalConfigSchema = z.object({
   excludedSkills: z.array(z.string()).optional(),
   /** User-level override for recall feature. When set, takes precedence over team config. */
   recallEnabled: z.boolean().optional(),
+  /** Per-machine override for the co-author trailer in AI-tool commits. When set,
+   *  takes precedence over the team `sharing.coAuthor` default. Undefined means
+   *  "defer to the team" (see resolveCoAuthor). */
+  coAuthorEnabled: z.boolean().optional(),
   /** When set, only inject hooks into these agents. Additive across multiple init --agent runs. */
   enabledAgents: z.array(z.string()).optional(),
   /** Tools explicitly excluded from all teamai sync (set by `uninstall --agent`). Removed again by `init --agent`. */
@@ -346,6 +374,16 @@ export const StateSchema = z.object({
   pushedEnvVars: z.array(z.string()).default([]),
   /** Push branches whose PR is still open — see PendingPushSchema. */
   pendingPushes: z.array(PendingPushSchema).default([]),
+  /**
+   * Last co-author intent teamai actually wrote to tool configs, per tool file.
+   * Key = absolute config path, value = the boolean we last applied. Lets the
+   * reconciler stay idempotent (skip a no-op write) while honoring write-only
+   * semantics: we never remove a trailer field, we only stop touching it when
+   * neither user nor team has an opinion. Absent key = never managed by teamai.
+   * Optional (like lastPullTargets) so historical state.json and hand-built State
+   * literals stay valid; the reconciler treats absent as an empty map.
+   */
+  coAuthorManaged: z.record(z.string(), z.boolean()).optional(),
   lastUpdateCheck: z.string().nullable().default(null),
   availableUpdate: z.string().nullable().default(null),
 });


### PR DESCRIPTION
## Summary

Adds a team-controlled **commit co-author attribution** policy: a team can decide whether members' AI tools stamp a `Co-Authored-By` / attribution trailer on the commits and PRs those tools create, and each member can override that default per machine. On `teamai pull`, the resolved intent is applied idempotently to every installed AI tool's own config file.

- **Two-tier resolution** (`user > team > no-op`): `sharing.coAuthor.enabled` in the team config sets the default; `coAuthorEnabled` in local config overrides it. When neither has an opinion, nothing is touched.
- **Three tool families**, one neutral intent rendered per format:
  - **Claude family** (claude, codebuddy, workbuddy, …) — `settings.json` `attribution.commit` / `attribution.pr`. Deterministic, **scope-aware** (project scope writes `<root>/.claude/settings.json`).
  - **Codex** — `~/.codex/config.toml` `commit_attribution`, patched by text surgery so comments survive. User scope only; best-effort (only active when `[features].codex_git_commit = true`, which we do not force).
  - **Cursor** — `~/.cursor/cli-config.json` `attribution.attributeCommitsToAgent`. User scope only; best-effort (known upstream bug).
- **Write-only, never delete**: `""` / `false` strips the trailer; restoring the default removes *our* override key rather than pinning a trailer string. Dropping the team policy leaves whatever is on disk untouched.
- **Idempotent**: `state.coAuthorManaged` records the last-applied intent per file, so a second pass makes no writes.
- Unrelated keys and comments in each config file are preserved (key-level surgery, never regenerate-from-scratch).

## Test Plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 2352 tests pass (171 files), incl. 13 new tests in `src/__tests__/coauthor-reconcile.test.ts`
- [x] `npm run build` — success
- [x] Real end-to-end run against a live filesystem (three tools "installed" with pre-existing configs):
  - Claude `settings.json` → `attribution.commit/pr = ""`, `model: "opus"` preserved
  - Codex `config.toml` → `commit_attribution = ""` inserted before `[features]` with a blank line, comment + `model` preserved
  - Cursor `cli-config.json` → `attribution.attributeCommitsToAgent = false`, `editor.theme` preserved
  - 2nd pass = all skipped (idempotent); dropping the team policy = no changes, stripped trailer stays stripped

## Docs

Documented in `docs/usage-guide.md` and `docs/usage-guide.zh-CN.md` (kept in sync). Not added to README per scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
