### PR TITLE
fix(hooks): stop hook-dispatch from blocking on tty prompt

### DIFF
--- a/src/__tests__/local-agent.test.ts
+++ b/src/__tests__/local-agent.test.ts
@@ -428,6 +428,67 @@ describe('local-agent: emitBindingHint via reportAndSyncLocalAgent', () => {
       process.stdout.write = origWrite;
     }
   });
+
+  it('session_start with unbound workspace emits stdout hint instead of blocking on TTY prompt', async () => {
+    process.env.TEAMAI_BIND_PROMPT_ENABLED = '1';
+    await setupConfig();
+    const projectDir = path.join(tmpDir, 'session-start-project');
+    await fse.ensureDir(projectDir);
+    const { execFileSync } = await import('node:child_process');
+    execFileSync('git', ['init'], { cwd: projectDir, stdio: 'ignore' });
+
+    // Guarantee non-TTY so askViaTty returns null immediately (no /dev/tty open).
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/api/projects/mine')) {
+        return new Response(JSON.stringify({
+          ok: true,
+          projects: [
+            { id: 100, name: 'alpha' },
+            { id: 200, name: 'beta' },
+          ],
+        }));
+      }
+      return new Response(JSON.stringify({ ok: true }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const stdoutChunks: string[] = [];
+    const origWrite = process.stdout.write;
+    process.stdout.write = ((chunk: string | Buffer) => {
+      stdoutChunks.push(typeof chunk === 'string' ? chunk : chunk.toString());
+      return true;
+    }) as typeof process.stdout.write;
+
+    try {
+      const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+      // Assertion 1: call resolves without hanging (no /dev/tty readline block).
+      const promise = reportAndSyncLocalAgent({
+        cwd: projectDir,
+        tool: 'claude',
+        event: {
+          type: 'session_start',
+          timestamp: new Date().toISOString(),
+          sessionId: TEST_SESSION_ID,
+          tool: 'claude',
+        },
+      });
+      await expect(promise).resolves.not.toThrow();
+    } finally {
+      process.stdout.write = origWrite;
+    }
+
+    const output = stdoutChunks.join('');
+    // Assertion 2: stdout contains hookSpecificOutput (the ensureWorkspaceBinding fallback path).
+    expect(output).toContain('hookSpecificOutput');
+
+    // Assertion 3: additionalContext carries the unbound-workspace hint keywords.
+    const parsed = JSON.parse(output.trim().split('\n').find((l) => l.includes('hookSpecificOutput'))!);
+    const ctx = parsed.hookSpecificOutput.additionalContext as string;
+    expect(ctx).toContain('当前工作区尚未绑定项目');
+    expect(ctx).toContain('teamai bind-project');
+  });
 });
 
 describe('local-agent: security — install command hardening', () => {

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import readline from 'node:readline';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import fse from 'fs-extra';
@@ -895,33 +894,18 @@ export async function runPluginReconcileWorker(): Promise<void> {
 }
 
 async function askViaTty(prompt: string): Promise<string | null> {
+  // Only prompt on a real interactive terminal (e.g. the user running
+  // `teamai bind-project` directly). In non-interactive contexts such as an
+  // IDE-invoked hook, stdin is piped; opening /dev/tty there succeeds when the
+  // host GUI keeps a controlling terminal, and readline then blocks forever
+  // waiting for input that never comes — hanging the hook until the host's
+  // timeout and stalling the IDE. Callers fall back to injecting a stdout
+  // binding hint when this returns null, so degrade to that instead.
   if (process.stdin.isTTY) {
     const { askQuestion } = await import('./utils/prompt.js');
     return askQuestion(prompt, '');
   }
-
-  if (process.platform === 'win32') return null;
-
-  let fd: number | null = null;
-  let input: fs.ReadStream | null = null;
-  let output: fs.WriteStream | null = null;
-  let rl: readline.Interface | null = null;
-  try {
-    fd = fs.openSync('/dev/tty', 'r+');
-    input = fs.createReadStream('', { fd, autoClose: false });
-    output = fs.createWriteStream('', { fd, autoClose: false });
-    rl = readline.createInterface({ input, output });
-    return await new Promise<string>((resolve) => {
-      rl!.question(prompt, (answer) => resolve(answer.trim()));
-    });
-  } catch {
-    return null;
-  } finally {
-    rl?.close();
-    input?.destroy();
-    output?.destroy();
-    if (fd !== null) try { fs.closeSync(fd); } catch {}
-  }
+  return null;
 }
 
 async function promptForProjectBinding(


### PR DESCRIPTION
## Problem

In non-interactive contexts such as an IDE-invoked hook, `teamai hook-dispatch` could hang until the host's hook timeout fired, stalling the IDE. Reported in the field as CodeBuddy showing `Hook timed out after 15000ms` (error 3003) on `SessionStart` / `UserPromptSubmit` / `PostToolUse` / `Stop`, making the IDE unusable.

### Root cause

`askViaTty` in `src/local-agent.ts`, when `process.stdin.isTTY` is false, still did `fs.openSync('/dev/tty', 'r+')` and ran `readline.question` on it. When a hook runs non-interactively its stdin is a pipe (non-TTY), but the host GUI process often keeps a controlling terminal, so opening `/dev/tty` **succeeds** and `readline` then **blocks forever** waiting for input that never comes. Upper-layer soft timeouts / `unref()` hard-exit timers cannot interrupt this ref'd readline handle, so the hook hangs until the host aborts it.

The blocking path is reached from the workspace binding prompt (`是否绑定到一个项目？[y/N]`) triggered on `SessionStart` for an unbound workspace.

## Fix

Degrade `askViaTty` to only prompt on a **real interactive terminal** (`process.stdin.isTTY`); return `null` otherwise (dropping the `/dev/tty` + readline branch and the now-orphaned `readline` import). Callers already fall back to injecting a stdout binding hint when this returns `null`, so the non-interactive path now takes that existing safe route. Interactive `teamai bind-project` is unaffected.

## Test Plan

- [x] `npx tsc --noEmit` — no new errors from this change (pre-existing `wiki-engine/ast` errors are unrelated and present on `main` without this change)
- [x] `npx vitest run src/__tests__/local-agent.test.ts` — 63 passed, including a new `session_start` regression test asserting the handler emits the stdout hint instead of blocking when stdin is non-TTY
- [x] `npm run build` — success
- [x] E2E: ran `teamai hook-dispatch session-start --tool codebuddy` non-interactively (piped stdin) against an unbound workspace with a reachable projects endpoint → returned in ~700ms with the stdout binding hint, **no `[y/N]` block** (previously hung until timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)