### PR TITLE
feat(viz): add knowledge base health report command

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Insight into how the team actually uses its AI tools:
 | **Usage** | `teamai digest` | Weekly team digest — token usage, conversation volume, and intervention rate. |
 | **Sessions** | `teamai session save` | Privacy-scrubbed per-session summaries (tool sequence, prompt turns, interventions) that feed the digest's Session Highlights. |
 | **Dashboard** | `teamai dashboard` | Web dashboard showing team members' live coding-session status, intervention count, and token usage. |
+| **KB Health** | `teamai dashboard` → KB Health | Built-in dashboard page reporting knowledge-base usage & health — coverage by type, top recalled entries, silent entries, recall trend, author contributions, and a maintenance console. |
 
 ## Harness Management & Distribution
 
@@ -233,6 +234,8 @@ The WASM parser is a pure-JavaScript dependency — no native toolchain is requi
 | `teamai contribute` | Share session experience to team repo |
 | `teamai recall <query>` | Search the team knowledge base (BM25 + graph-boost) |
 | `teamai recall enable/disable/status` | Toggle or check recall state |
+| `teamai recall promote [learningId]` | Promote a high-confidence learning to formal knowledge (skills/rules/docs) |
+| `teamai recall maintenance` | Maintain knowledge base health: prune low-confidence learnings, writeback confidence scores, flag stale entries |
 | `teamai import` | Import knowledge (`--dir`, `--from-repo`, `--from-org`, `--from-repo-list`, `--from-mr`, `--from-iwiki`) |
 | `teamai codebase --lint` | Knowledge graph health check |
 | `teamai ci extract-mr --url <url>` | CI: extract knowledge from MR, post comments, write after merge |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -96,6 +96,7 @@ teamai init https://github.com/yourorg/yourrepo --scope user
 | **用量（Usage）** | `teamai digest` | 团队周报——token 用量、会话量、干预率。 |
 | **会话（Sessions）** | `teamai session save` | 脱敏的单会话摘要（工具序列、对话轮次、干预次数），喂给周报的 Session Highlights。 |
 | **看板（Dashboard）** | `teamai dashboard` | Web 看板，实时展示成员的编码会话状态、干预次数和 token 用量。 |
+| **知识库健康（KB Health）** | `teamai dashboard` → KB Health | 内置于看板的报告页面，展示知识库使用情况与健康状态——各类型覆盖率、高频召回条目、沉默条目、召回趋势、作者贡献及维护控制台。 |
 
 ## Harness 管理和分发
 
@@ -233,6 +234,8 @@ WASM 解析器是纯 JavaScript 依赖，无需任何原生编译工具链。若
 | `teamai contribute` | 将 session 经验分享到团队仓库 |
 | `teamai recall <query>` | 搜索团队知识库（BM25 + 图谱增强） |
 | `teamai recall enable/disable/status` | 开关或查看 recall 状态 |
+| `teamai recall promote [learningId]` | 将高置信度 learning 晋升为正式知识（skills/rules/docs） |
+| `teamai recall maintenance` | 维护知识库健康：清理低置信度 learnings、回写置信度、标记过时条目 |
 | `teamai import` | 导入知识（`--dir`、`--from-repo`、`--from-org`、`--from-repo-list`、`--from-mr`、`--from-iwiki`） |
 | `teamai codebase --lint` | 知识图谱健康检查 |
 | `teamai ci extract-mr --url <url>` | CI：从 MR 提取知识、发评论、合并后写入 |

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -580,6 +580,108 @@ teamai recall status     # View the current effective status (team default + use
 
 When disabled, `teamai pull` skips deploying the recall subagent, the recall rules injection block, and the TodoWrite reminder hook. Manually running `teamai recall <query>` to search is not affected by this switch.
 
+### Knowledge Base Maintenance
+
+Over time, some learnings accumulate low confidence scores (nobody upvoted them) or become stale. `teamai recall maintenance` keeps the knowledge base healthy:
+
+| Flag | Description |
+|------|-------------|
+| `--prune` | Find learnings below the confidence threshold and remove them |
+| `--threshold <n>` | Confidence threshold for pruning (default: `0.15`) |
+| `--archive` | Move pruned entries to `archive/` instead of deleting permanently |
+| `--confidence-writeback` | Recompute confidence scores from vote history and write them back to frontmatter |
+| `--update-quality` | Identify high-recall but low-approval docs/rules/skills and generate AI-powered update drafts (`.draft.md` files) |
+| `--dry-run` | Preview what would be done without making any changes |
+
+```bash
+# Preview stale entries without changing anything
+teamai recall maintenance --prune --dry-run
+
+# Archive low-confidence learnings (confidence < 0.15)
+teamai recall maintenance --prune --archive
+
+# Rewrite confidence scores to frontmatter based on current votes
+teamai recall maintenance --confidence-writeback
+
+# Find stale entries and generate update drafts
+teamai recall maintenance --update-quality
+```
+
+After `--update-quality`, review the generated `.draft.md` files and rename them to `.md` to apply the updates.
+
+### Promoting Learnings
+
+When a learning reaches maturity, promote it to formal team knowledge (a skill, rule, or doc). Promotion criteria: confidence ≥ 0.90, ≥ 5 upvotes, ≥ 2 distinct contributors, age ≥ 14 days.
+
+```bash
+# List all promotion candidates
+teamai recall promote
+
+# Promote a specific learning (AI rewrites it into the target format)
+teamai recall promote <learningId>
+
+# Promote to a specific category
+teamai recall promote <learningId> --category skills
+
+# Preview what would happen without writing files
+teamai recall promote <learningId> --dry-run
+```
+
+Options:
+
+| Option | Description |
+|--------|-------------|
+| `--category <cat>` | Target category: `skills` \| `rules` \| `docs` |
+| `--dry-run` | Show what would be done without making changes |
+
+---
+
+## Knowledge Base Health Report
+
+The dashboard includes a built-in **KB Health** report page showing your team knowledge base's usage and health, covering everything captured by `teamai recall` votes, learnings, docs, rules, and skills.
+
+```bash
+# Start the dashboard, then click "KB Health" in the header
+teamai dashboard
+
+# The report is served directly at:
+#   http://localhost:3721/kb-report
+```
+
+The report aggregates your local `~/.teamai` knowledge base (or the configured team repo) and renders on demand — no flags to pass.
+
+### What the Report Shows
+
+| Section | Description |
+|---------|-------------|
+| **Overview cards** | Total entries, total recalls, overall coverage %, contributors |
+| **Coverage by type** | Breakdown of recall coverage across skills, rules, docs, learnings |
+| **Top recalled** | Ranked list of most frequently recalled entries |
+| **Silent entries** | Entries that have never been recalled — candidates for pruning or rewriting |
+| **Recall trend** | Recall activity over time |
+| **Author contributions** | Per-contributor entry counts and recall share |
+| **Maintenance console** | Three action zones: entries ready to promote, entries suggested for archiving, and stale entries needing updates — each with a copyable command |
+
+### Typical Workflow
+
+```
+Open the dashboard → KB Health page
+   ↓
+Review the Maintenance Console
+   ↓
+Promote mature learnings:
+   teamai recall promote <learningId>
+   ↓
+Archive low-value entries:
+   teamai recall maintenance --prune --archive
+   ↓
+Update stale docs/rules/skills:
+   teamai recall maintenance --update-quality
+   (review .draft.md → rename to .md)
+   ↓
+teamai push   # share the cleaned-up knowledge base with the team
+```
+
 ---
 
 ## Commit Co-Author Attribution

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -578,6 +578,108 @@ teamai recall status     # 查看当前生效状态（团队默认 + 用户覆�
 
 关闭后，`teamai pull` 将跳过部署 recall subagent、recall rules 注入块和 TodoWrite 提醒 hook。手动执行 `teamai recall <query>` 搜索不受此开关影响。
 
+### 知识库维护
+
+随着时间推移，部分 learnings 会积累低置信度（无人 upvote）或变得过时。`teamai recall maintenance` 可保持知识库健康：
+
+| 选项 | 说明 |
+|------|------|
+| `--prune` | 查找低于置信度阈值的 learnings 并删除 |
+| `--threshold <n>` | 剪枝用置信度阈值（默认 `0.15`） |
+| `--archive` | 将剪枝条目移至 `archive/` 而非直接删除 |
+| `--confidence-writeback` | 从投票历史重新计算置信度，并回写到 frontmatter |
+| `--update-quality` | 找出高召回但低认可的 docs/rules/skills，生成 AI 更新草稿（`.draft.md` 文件） |
+| `--dry-run` | 预览将要执行的操作，不做任何实际修改 |
+
+```bash
+# 预览过时条目，不做任何修改
+teamai recall maintenance --prune --dry-run
+
+# 归档低置信度 learnings（置信度 < 0.15）
+teamai recall maintenance --prune --archive
+
+# 按当前投票重新计算并回写置信度分数
+teamai recall maintenance --confidence-writeback
+
+# 查找过时条目并生成更新草稿
+teamai recall maintenance --update-quality
+```
+
+运行 `--update-quality` 后，审查生成的 `.draft.md` 文件，将满意的文件重命名为 `.md` 即可应用更新。
+
+### 晋升 Learnings
+
+当 learning 达到成熟标准时，可将其晋升为正式团队知识（skill、rule 或 doc）。晋升判据：置信度 ≥ 0.90、≥ 5 次 upvote、≥ 2 个不同贡献者、存在时长 ≥ 14 天。
+
+```bash
+# 列出所有可晋升候选
+teamai recall promote
+
+# 晋升指定 learning（AI 将其改写为目标格式）
+teamai recall promote <learningId>
+
+# 晋升到指定类别
+teamai recall promote <learningId> --category skills
+
+# 预览操作，不写入文件
+teamai recall promote <learningId> --dry-run
+```
+
+选项：
+
+| 选项 | 说明 |
+|------|------|
+| `--category <cat>` | 目标类别：`skills` \| `rules` \| `docs` |
+| `--dry-run` | 预览操作，不做任何实际修改 |
+
+---
+
+## 知识库健康报告
+
+看板内置了一个 **KB Health**（知识库健康）报告页面，展示团队知识库的使用情况与健康状态，涵盖 `teamai recall` 投票、learnings、docs、rules 和 skills 采集到的所有数据。
+
+```bash
+# 启动看板后，点击顶部的 "KB Health" 链接
+teamai dashboard
+
+# 报告也可直接访问：
+#   http://localhost:3721/kb-report
+```
+
+报告会聚合本地 `~/.teamai` 知识库（或已配置的团队仓库），打开页面即按需渲染，无需任何参数。
+
+### 报告内容
+
+| 区块 | 说明 |
+|------|------|
+| **概览卡片** | 总条目数、总召回次数、整体覆盖率%、贡献者数 |
+| **各类型覆盖率** | skills、rules、docs、learnings 的召回覆盖率分类 |
+| **高频召回排行** | 召回次数最多的条目排名列表 |
+| **沉默条目** | 从未被召回的条目——待剪枝或重写的候选 |
+| **召回趋势** | 召回活跃度随时间的变化 |
+| **作者贡献** | 每位贡献者的条目数与召回占比 |
+| **维护控制台** | 三个操作区：待晋升条目、建议归档条目、过时待更新条目，每条附可复制命令 |
+
+### 典型工作流
+
+```
+打开看板 → KB Health 页面
+   ↓
+查看维护控制台
+   ↓
+晋升成熟 learnings：
+   teamai recall promote <learningId>
+   ↓
+归档低价值条目：
+   teamai recall maintenance --prune --archive
+   ↓
+更新过时的 docs/rules/skills：
+   teamai recall maintenance --update-quality
+   （审查 .draft.md → 重命名为 .md）
+   ↓
+teamai push   # 将清理后的知识库分享给团队
+```
+
 ---
 
 ## 提交 Co-Author 署名（Commit Co-Author Attribution）

--- a/src/__tests__/viz.test.ts
+++ b/src/__tests__/viz.test.ts
@@ -1,0 +1,294 @@
+// -*- coding: utf-8 -*-
+/**
+ * Tests for viz.ts aggregation logic and viz-render.ts HTML output.
+ *
+ * Pure-function and tmpdir-based tests only — no real ~/.teamai access.
+ * buildCoverage / buildTrend / buildAuthors are private helpers inlined in buildVizData
+ * and cannot be tested independently without hitting real I/O; their logic is therefore
+ * covered indirectly through renderReport assertions on a hand-crafted VizData fixture.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import { promises as fs } from 'node:fs';
+
+import { aggregateTeamVotes, resolveVizRoot, buildVizData } from '../viz.js';
+import { renderReport } from '../viz-render.js';
+import type { VizData } from '../viz.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Build a complete minimal VizData fixture, allowing partial overrides. */
+function makeVizData(overrides: Partial<VizData> = {}): VizData {
+  return {
+    generatedAt: '2026-08-31T00:00:00.000Z',
+    root: '/tmp/teamai-test',
+    source: { scope: 'local', label: 'Local ~/.teamai · your recalls only' },
+    totalEntries: 0,
+    totalRecalls: 0,
+    overallCoveragePct: 0,
+    contributorCount: 0,
+    coverage: [],
+    topRecalled: [],
+    silent: [],
+    trend: [],
+    authors: [],
+    maintenance: { promote: [], prune: [], stale: [] },
+    ...overrides,
+  };
+}
+
+/** Create a YAML string in the v2 votes format expected by loadUserVotes. */
+function votesYaml(
+  entries: Record<string, { recalled_count: number; upvoted_count: number; last_recalled_at: string | null }>,
+): string {
+  const lines = ['version: 2', 'votes:'];
+  for (const [docId, e] of Object.entries(entries)) {
+    lines.push(`  ${docId}:`);
+    lines.push(`    recalled_count: ${e.recalled_count}`);
+    lines.push(`    upvoted_count: ${e.upvoted_count}`);
+    lines.push(`    last_recalled_at: ${e.last_recalled_at ? `"${e.last_recalled_at}"` : 'null'}`);
+  }
+  lines.push('deltas: {}');
+  return lines.join('\n') + '\n';
+}
+
+// ─── aggregateTeamVotes ────────────────────────────────────────────────────────
+
+describe('aggregateTeamVotes', () => {
+  const tmpBase = path.join(os.tmpdir(), 'teamai-viz-test');
+  const votesDir = path.join(tmpBase, 'votes');
+
+  afterEach(async () => {
+    await fs.rm(tmpBase, { recursive: true, force: true });
+  });
+
+  it('accumulates recalled_count and takes the larger last_recalled_at across two users', async () => {
+    await fs.mkdir(votesDir, { recursive: true });
+
+    // User A: doc-abc recalled 3 times, upvoted 1, older timestamp
+    await fs.writeFile(
+      path.join(votesDir, 'user-a.yaml'),
+      votesYaml({
+        'doc-abc': { recalled_count: 3, upvoted_count: 1, last_recalled_at: '2026-01-10T08:00:00Z' },
+      }),
+      'utf-8',
+    );
+
+    // User B: doc-abc recalled 5 times, upvoted 2, newer timestamp
+    await fs.writeFile(
+      path.join(votesDir, 'user-b.yaml'),
+      votesYaml({
+        'doc-abc': { recalled_count: 5, upvoted_count: 2, last_recalled_at: '2026-06-20T12:00:00Z' },
+      }),
+      'utf-8',
+    );
+
+    const result = await aggregateTeamVotes(votesDir);
+
+    expect(result.byDoc['doc-abc']).toBeDefined();
+    // recalled_count should be summed: 3 + 5 = 8
+    expect(result.byDoc['doc-abc'].recalledCount).toBe(8);
+    // upvoted_count should be summed: 1 + 2 = 3
+    expect(result.byDoc['doc-abc'].upvotedCount).toBe(3);
+    // last_recalled_at should be the larger value
+    expect(result.byDoc['doc-abc'].lastRecalledAt).toBe('2026-06-20T12:00:00Z');
+  });
+
+  it('returns {} when the votes directory does not exist', async () => {
+    const missing = path.join(tmpBase, 'no-such-dir');
+    const result = await aggregateTeamVotes(missing);
+    expect(result.byDoc).toEqual({});
+    expect(result.activeContributors).toBe(0);
+  });
+
+  it('handles a doc present in only one user file and null last_recalled_at in one file', async () => {
+    await fs.mkdir(votesDir, { recursive: true });
+
+    await fs.writeFile(
+      path.join(votesDir, 'user-a.yaml'),
+      votesYaml({
+        'doc-solo': { recalled_count: 2, upvoted_count: 0, last_recalled_at: null },
+      }),
+      'utf-8',
+    );
+
+    await fs.writeFile(
+      path.join(votesDir, 'user-b.yaml'),
+      votesYaml({
+        'doc-solo': { recalled_count: 1, upvoted_count: 1, last_recalled_at: '2026-03-01T00:00:00Z' },
+      }),
+      'utf-8',
+    );
+
+    const result = await aggregateTeamVotes(votesDir);
+
+    expect(result.byDoc['doc-solo'].recalledCount).toBe(3);
+    expect(result.byDoc['doc-solo'].upvotedCount).toBe(1);
+    // null should lose to any non-null timestamp
+    expect(result.byDoc['doc-solo'].lastRecalledAt).toBe('2026-03-01T00:00:00Z');
+  });
+
+  it('counts only users with at least one recalled_count > 0 as active contributors', async () => {
+    await fs.mkdir(votesDir, { recursive: true });
+
+    // User A: has recalls
+    await fs.writeFile(
+      path.join(votesDir, 'user-a.yaml'),
+      votesYaml({
+        'doc-x': { recalled_count: 2, upvoted_count: 0, last_recalled_at: null },
+      }),
+      'utf-8',
+    );
+
+    // User B: no recalls at all
+    await fs.writeFile(
+      path.join(votesDir, 'user-b.yaml'),
+      votesYaml({
+        'doc-x': { recalled_count: 0, upvoted_count: 0, last_recalled_at: null },
+      }),
+      'utf-8',
+    );
+
+    const result = await aggregateTeamVotes(votesDir);
+    expect(result.activeContributors).toBe(1);
+  });
+});
+
+// ─── renderReport ─────────────────────────────────────────────────────────────
+
+describe('renderReport', () => {
+  it('returns a string that starts with <!DOCTYPE html', () => {
+    const html = renderReport(makeVizData());
+    expect(html.trimStart()).toMatch(/^<!DOCTYPE html/i);
+  });
+
+  it('contains key section headings', () => {
+    const html = renderReport(makeVizData());
+    expect(html).toContain('Coverage by Type');
+    expect(html).toContain('Top Recalled Entries');
+    expect(html).toContain('Maintenance Console');
+    expect(html).toContain('Overview');
+    expect(html).toContain('Author Contributions');
+  });
+
+  it('escapes XSS in EntryMetric.title (topRecalled)', () => {
+    const xssTitle = '<script>alert(1)</script>';
+    const data = makeVizData({
+      topRecalled: [
+        {
+          docId: 'xss-doc',
+          title: xssTitle,
+          type: 'learnings',
+          author: 'tester',
+          date: '2026-01-01',
+          tags: [],
+          recalledCount: 5,
+          upvotedCount: 1,
+          lastRecalledAt: '2026-01-01T00:00:00Z',
+        },
+      ],
+    });
+
+    const html = renderReport(data);
+    // Raw script tag must not appear in the output
+    expect(html).not.toContain('<script>alert(1)</script>');
+    // The title should be escaped instead
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('escapes XSS in EntryMetric.title (silent entries)', () => {
+    const xssTitle = '<img src=x onerror=alert(1)>';
+    const data = makeVizData({
+      silent: [
+        {
+          docId: 'xss-silent',
+          title: xssTitle,
+          type: 'docs',
+          author: 'tester',
+          date: '2026-01-01',
+          tags: [],
+          recalledCount: 0,
+          upvotedCount: 0,
+          lastRecalledAt: null,
+        },
+      ],
+    });
+
+    const html = renderReport(data);
+    expect(html).not.toContain('<img src=x onerror=alert(1)>');
+    expect(html).toContain('&lt;img');
+  });
+
+  it('shows "None right now." for all three empty maintenance sub-blocks', () => {
+    const html = renderReport(makeVizData({ maintenance: { promote: [], prune: [], stale: [] } }));
+    // Each of the three blocks emits "None right now." when empty
+    const occurrences = (html.match(/None right now\./g) ?? []).length;
+    expect(occurrences).toBeGreaterThanOrEqual(3);
+  });
+
+  it('shows "All entries have been recalled at least once." when silent is empty', () => {
+    const html = renderReport(makeVizData({ silent: [] }));
+    expect(html).toContain('All entries have been recalled at least once.');
+  });
+
+  it('reflects totalEntries and overallCoveragePct in the output', () => {
+    const html = renderReport(makeVizData({ totalEntries: 42, overallCoveragePct: 75 }));
+    expect(html).toContain('42');
+    expect(html).toContain('75%');
+  });
+});
+
+// ─── resolveVizRoot + buildVizData integration ────────────────────────────────
+
+describe('buildVizData with explicit --repo', () => {
+  let tmpRepo: string;
+
+  afterEach(async () => {
+    if (tmpRepo) {
+      await fs.rm(tmpRepo, { recursive: true, force: true });
+    }
+  });
+
+  it('sources corpus from the given repo and does not fall back to global index', async () => {
+    tmpRepo = await fs.mkdtemp(path.join(os.tmpdir(), 'teamai-viz-repo-'));
+
+    // Create a skill: skills/team-only-skill/SKILL.md
+    const skillDir = path.join(tmpRepo, 'skills', 'team-only-skill');
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(
+      path.join(skillDir, 'SKILL.md'),
+      [
+        '---',
+        'title: "TEAM ONLY skill"',
+        'author: alice',
+        'tags: [team]',
+        '---',
+        '',
+        'This skill belongs to the team repo only.',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    // Create an empty votes directory so aggregateTeamVotes gets a valid path
+    await fs.mkdir(path.join(tmpRepo, 'votes'), { recursive: true });
+
+    const paths = await resolveVizRoot({ repo: tmpRepo });
+
+    // Bug A: explicit --repo must not fall back to the global user index
+    expect(paths.indexPath).toBeUndefined();
+    expect(paths.source.scope).toBe('team');
+
+    const data = await buildVizData(paths);
+
+    expect(data.source.scope).toBe('team');
+    expect(data.totalEntries).toBeGreaterThanOrEqual(1);
+
+    // The skill title must appear somewhere in the report corpus
+    const allTitles = [
+      ...data.topRecalled.map((e) => e.title),
+      ...data.silent.map((e) => e.title),
+    ];
+    expect(allTitles.some((t) => t.includes('TEAM ONLY skill'))).toBe(true);
+  });
+});

--- a/src/dashboard-html.ts
+++ b/src/dashboard-html.ts
@@ -47,6 +47,40 @@ export function getDashboardHtml(port: number): string {
       align-items: center;
       gap: 8px;
     }
+    .kb-health-card {
+      display: flex;
+      align-items: center;
+      gap: 18px;
+      padding: 14px 20px;
+      margin-bottom: 20px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      text-decoration: none;
+      color: var(--text);
+      transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+    }
+    .kb-health-card:hover {
+      border-color: var(--blue);
+      box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+      transform: translateY(-1px);
+    }
+    .kb-health-card svg { flex: none; }
+    .kb-health-card .kbc-body { flex: 1; min-width: 0; }
+    .kb-health-card .kbc-title { font-size: 15px; font-weight: 600; }
+    .kb-health-card .kbc-desc { font-size: 12.5px; color: var(--text-muted); margin-top: 3px; }
+    .kb-health-card .kbc-cta { font-size: 13px; font-weight: 600; color: var(--blue); white-space: nowrap; }
+    .kb-health-card .kbc-stat {
+      margin-top: 6px;
+      font-size: 12px;
+      color: var(--text-muted);
+      font-variant-numeric: tabular-nums;
+    }
+    .kb-health-card .kbc-source {
+      margin-top: 4px;
+      font-size: 11px;
+      color: var(--text-muted);
+    }
     .connection-status {
       display: flex;
       align-items: center;
@@ -393,6 +427,78 @@ export function getDashboardHtml(port: number): string {
       <span id="conn-text">Connecting...</span>
     </div>
   </header>
+  <a class="kb-health-card" href="/kb-report" target="_blank" rel="noopener">
+    <svg viewBox="0 0 148 76" width="132" height="68" aria-hidden="true">
+      <circle cx="30" cy="38" r="21" fill="none" stroke="#30363d" stroke-width="7"/>
+      <circle id="kbcRing" cx="30" cy="38" r="21" fill="none"
+              stroke="#58a6ff" stroke-width="7" stroke-linecap="round"
+              stroke-dasharray="0 132" transform="rotate(-90 30 38)"/>
+      <text id="kbcRingLabel" x="30" y="38" text-anchor="middle"
+            dominant-baseline="central" fill="#e6edf3"
+            font-size="12" font-weight="600">…</text>
+      <g id="kbcBars"></g>
+    </svg>
+    <div class="kbc-body">
+      <div class="kbc-title">📊 Knowledge Base Health</div>
+      <div class="kbc-desc">Coverage by type, top-recalled &amp; silent entries,
+        recall trend, and a maintenance console.</div>
+      <div class="kbc-stat" id="kbcStat"></div>
+      <div class="kbc-source" id="kbcSource"></div>
+    </div>
+    <span class="kbc-cta">View report →</span>
+  </a>
+  <script>
+    (function loadKbSummary() {
+      var controller = new AbortController();
+      var timeout = setTimeout(function () { controller.abort(); }, 8000);
+      fetch('/api/kb-summary', { signal: controller.signal })
+        .then(function (resp) {
+          return resp.ok ? resp.json() : Promise.reject(new Error('kb-summary ' + resp.status));
+        })
+        .then(function (summary) {
+          var radius = 21;
+          var circumference = 2 * Math.PI * radius;
+          var pct = Math.max(0, Math.min(100, Math.round(summary.overallCoveragePct || 0)));
+          var filled = circumference * pct / 100;
+          var ring = document.getElementById('kbcRing');
+          if (ring) {
+            ring.setAttribute('stroke-dasharray', filled.toFixed(1) + ' ' + (circumference - filled).toFixed(1));
+          }
+          var label = document.getElementById('kbcRingLabel');
+          if (label) label.textContent = pct + '%';
+          var stat = document.getElementById('kbcStat');
+          if (stat) stat.textContent = (summary.totalEntries || 0) + ' entries · ' + pct + '% coverage';
+          var source = document.getElementById('kbcSource');
+          if (source && summary.source && summary.source.label) source.textContent = summary.source.label;
+          var bars = document.getElementById('kbcBars');
+          var coverage = Array.isArray(summary.coverage) ? summary.coverage.slice(0, 6) : [];
+          if (bars && coverage.length) {
+            var x0 = 70, x1 = 142;
+            var slot = (x1 - x0) / coverage.length;
+            var barWidth = Math.min(12, slot - 4);
+            var svgNs = 'http://www.w3.org/2000/svg';
+            while (bars.firstChild) bars.removeChild(bars.firstChild);
+            coverage.forEach(function (covItem, index) {
+              var pctVal = Math.max(0, Math.min(100, covItem.coveragePct || 0));
+              var barHeight = Math.max(3, Math.round(52 * pctVal / 100));
+              var rect = document.createElementNS(svgNs, 'rect');
+              rect.setAttribute('x', (x0 + index * slot + (slot - barWidth) / 2).toFixed(1));
+              rect.setAttribute('y', String(68 - barHeight));
+              rect.setAttribute('width', barWidth.toFixed(1));
+              rect.setAttribute('height', String(barHeight));
+              rect.setAttribute('rx', '2');
+              rect.setAttribute('fill', index % 2 ? '#3fb950' : '#58a6ff');
+              bars.appendChild(rect);
+            });
+          }
+        })
+        .catch(function () {
+          var label = document.getElementById('kbcRingLabel');
+          if (label) label.textContent = '';
+        })
+        .then(function () { clearTimeout(timeout); });
+    })();
+  </script>
   <div id="stats"></div>
   <div id="app"></div>
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -14,6 +14,7 @@ import {
 } from './types.js';
 import { getDashboardHtml } from './dashboard-html.js';
 import { getUserHome } from './utils/home.js';
+import type { VizSummary } from './viz.js';
 
 // ─── Dashboard server architecture ──────────────────────
 //
@@ -29,6 +30,9 @@ import { getUserHome } from './utils/home.js';
 //
 
 type SSEClient = http.ServerResponse;
+
+const KB_SUMMARY_TTL_MS = 30_000;
+let kbSummaryCache: { ts: number; data: VizSummary } | null = null;
 
 /**
  * Start the dashboard HTTP server.
@@ -159,6 +163,38 @@ export async function startDashboard(port?: number): Promise<void> {
       req.on('close', () => {
         clients.delete(res);
       });
+      return;
+    }
+
+    if (url.pathname === '/kb-report') {
+      // Knowledge-base health report (reuses the viz aggregation + renderer)
+      try {
+        const { generateReportHtml } = await import('./viz.js');
+        const html = await generateReportHtml();
+        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+        res.end(html);
+      } catch (e) {
+        res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
+        res.end('Failed to generate KB health report: ' + (e instanceof Error ? e.message : String(e)));
+      }
+      return;
+    }
+
+    if (url.pathname === '/api/kb-summary') {
+      // Compact KB summary for the preview card, cached briefly so we don't
+      // re-aggregate the whole knowledge base on every dashboard page load
+      try {
+        const now = Date.now();
+        if (!kbSummaryCache || now - kbSummaryCache.ts > KB_SUMMARY_TTL_MS) {
+          const { getVizSummary } = await import('./viz.js');
+          kbSummaryCache = { ts: now, data: await getVizSummary() };
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(kbSummaryCache.data));
+      } catch (e) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: e instanceof Error ? e.message : String(e) }));
+      }
       return;
     }
 

--- a/src/viz-render.ts
+++ b/src/viz-render.ts
@@ -1,0 +1,770 @@
+// -*- coding: utf-8 -*-
+/**
+ * TeamAI knowledge base visualization — pure HTML report renderer.
+ *
+ * No I/O, no external dependencies. Returns a complete standalone HTML document string.
+ * All user-supplied data strings are HTML-escaped before insertion to prevent XSS.
+ */
+import type { VizData, EntryMetric, CoverageStat, TrendPoint, AuthorStat } from './viz.js';
+import type { PromotionCandidate } from './maintenance/promote.js';
+import type { PruneCandidate } from './maintenance/prune.js';
+import type { StaleEntry } from './maintenance/quality-update.js';
+
+// ─── XSS helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Escape a string for safe insertion into HTML content and attribute values.
+ * Converts &, <, >, ", and ' to their HTML entity equivalents.
+ */
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// ─── SVG chart helpers ────────────────────────────────────────────────────────
+
+/** Truncate a string to a maximum length, appending '…' if trimmed. */
+function trunc(s: string, max: number): string {
+  return s.length > max ? s.substring(0, max - 1) + '…' : s;
+}
+
+/**
+ * Render a horizontal SVG bar chart from a list of labelled numeric values.
+ *
+ * @param items  - Array of { label, value, badge } tuples.
+ */
+function renderBarChart(items: Array<{ label: string; value: number; badge: string }>): string {
+  if (items.length === 0) return '<p>No data.</p>';
+
+  const BAR_H = 22;
+  const GAP = 10;
+  const LABEL_W = 220;
+  const BAR_AREA = 300;
+  const VALUE_W = 50;
+  const BADGE_W = 70;
+  const ROW_H = BAR_H + GAP;
+  const W = LABEL_W + BAR_AREA + VALUE_W + BADGE_W + 20;
+  const H = items.length * ROW_H + 10;
+  const maxVal = Math.max(...items.map((i) => i.value), 1);
+  const mono = 'font-family:var(--mono)';
+
+  const rows = items.map((item, idx) => {
+    const y = idx * ROW_H + 5;
+    const barW = Math.max(2, Math.round((item.value / maxVal) * BAR_AREA));
+    const textY = y + BAR_H / 2 + 5;
+    const labelEl =
+      `<text x="${LABEL_W - 4}" y="${textY}" text-anchor="end"` +
+      ` style="${mono};font-size:12px;fill:var(--text2)">` +
+      `${escapeHtml(trunc(item.label, 32))}</text>`;
+    const barEl =
+      `<rect x="${LABEL_W}" y="${y}" width="${barW}" height="${BAR_H}"` +
+      ` style="fill:var(--accent);opacity:0.9" rx="4"/>`;
+    const valEl =
+      `<text x="${LABEL_W + BAR_AREA + 6}" y="${textY}"` +
+      ` style="${mono};font-size:12px;fill:var(--accent)">${item.value}</text>`;
+    const badgeEl =
+      `<text x="${LABEL_W + BAR_AREA + VALUE_W + 10}" y="${textY}"` +
+      ` style="${mono};font-size:11px;fill:var(--text2)">${escapeHtml(item.badge)}</text>`;
+    return labelEl + barEl + valEl + badgeEl;
+  });
+
+  return [
+    `<svg viewBox="0 0 ${W} ${H}" xmlns="http://www.w3.org/2000/svg"` +
+      ` style="width:100%;max-width:${W}px">`,
+    ...rows,
+    '</svg>',
+  ].join('\n');
+}
+
+/**
+ * Render an SVG line chart from monthly trend data points.
+ *
+ * @param points - Array of TrendPoint sorted ascending by period.
+ */
+function renderLineChart(points: TrendPoint[]): string {
+  if (points.length < 2) {
+    return '<p class="muted">Not enough data (need at least 2 months of activity).</p>';
+  }
+
+  const W = 600;
+  const H = 180;
+  const PAD_L = 50;
+  const PAD_R = 20;
+  const PAD_T = 15;
+  const PAD_B = 40;
+  const PLOT_W = W - PAD_L - PAD_R;
+  const PLOT_H = H - PAD_T - PAD_B;
+
+  const maxY = Math.max(...points.map((p) => p.count), 1);
+  const n = points.length;
+
+  const toX = (i: number): number => PAD_L + Math.round((i / (n - 1)) * PLOT_W);
+  const toY = (v: number): number => PAD_T + PLOT_H - Math.round((v / maxY) * PLOT_H);
+
+  const polyPoints = points.map((p, i) => `${toX(i)},${toY(p.count)}`).join(' ');
+
+  // Area fill polygon: bottom-left → data points → bottom-right
+  const bottomY = PAD_T + PLOT_H;
+  const areaPoints = [
+    `${PAD_L},${bottomY}`,
+    ...points.map((p, i) => `${toX(i)},${toY(p.count)}`),
+    `${W - PAD_R},${bottomY}`,
+  ].join(' ');
+
+  const mono = 'font-family:var(--mono)';
+
+  // Y-axis ticks (0, mid, max)
+  const yTicks = [0, Math.round(maxY / 2), maxY].map((v) => {
+    const y = toY(v);
+    return (
+      `<line x1="${PAD_L - 4}" y1="${y}" x2="${PAD_L}" y2="${y}"` +
+      ` style="stroke:var(--border)" stroke-width="1"/>` +
+      `<text x="${PAD_L - 8}" y="${y + 4}" text-anchor="end"` +
+      ` style="${mono};font-size:11px;fill:var(--text2)">${v}</text>`
+    );
+  });
+
+  // X-axis labels (show every Nth label to avoid overlap)
+  const step = Math.max(1, Math.ceil(n / 8));
+  const xLabels = points
+    .map((p, origIdx) => ({ p, origIdx }))
+    .filter(({ origIdx }) => origIdx % step === 0 || origIdx === n - 1)
+    .map(({ p, origIdx }) => {
+      const x = toX(origIdx);
+      return (
+        `<text x="${x}" y="${H - 8}" text-anchor="middle"` +
+        ` style="${mono};font-size:10px;fill:var(--text2)">${escapeHtml(p.period)}</text>`
+      );
+    });
+
+  const axisVert =
+    `<line x1="${PAD_L}" y1="${PAD_T}" x2="${PAD_L}" y2="${bottomY}"` +
+    ` style="stroke:var(--border)" stroke-width="1"/>`;
+  const axisHoriz =
+    `<line x1="${PAD_L}" y1="${bottomY}" x2="${W - PAD_R}" y2="${bottomY}"` +
+    ` style="stroke:var(--border)" stroke-width="1"/>`;
+  const areaEl = `<polygon points="${areaPoints}" style="fill:var(--accent);opacity:0.08"/>`;
+  const lineEl =
+    `<polyline points="${polyPoints}" fill="none"` +
+    ` style="stroke:var(--accent)" stroke-width="2" stroke-linejoin="round"/>`;
+  const dots = points.map(
+    (p, i) => `<circle cx="${toX(i)}" cy="${toY(p.count)}" r="3.5" style="fill:var(--accent)"/>`,
+  );
+
+  return [
+    `<svg viewBox="0 0 ${W} ${H}" xmlns="http://www.w3.org/2000/svg"` +
+      ` style="width:100%;max-width:${W}px">`,
+    axisVert,
+    axisHoriz,
+    ...yTicks,
+    ...xLabels,
+    areaEl,
+    lineEl,
+    ...dots,
+    '</svg>',
+  ].join('\n');
+}
+
+// ─── Section renderers ────────────────────────────────────────────────────────
+
+/** Render the four overview metric cards (total entries, recalls, coverage, contributors) as an HTML section. */
+function renderOverviewCards(data: VizData): string {
+  const cards = [
+    { label: 'Total Entries', value: String(data.totalEntries) },
+    { label: 'Total Recalls', value: String(data.totalRecalls) },
+    { label: 'Overall Coverage', value: `${data.overallCoveragePct}%` },
+    { label: 'Contributors', value: String(data.contributorCount) },
+  ];
+  const cardHtml = cards
+    .map(
+      (c) =>
+        `<div class="card">` +
+        `<div class="card-label">${escapeHtml(c.label)}</div>` +
+        `<div class="card-value">${escapeHtml(c.value)}</div>` +
+        `</div>`,
+    )
+    .join('');
+  return `<section id="overview"><h2>Overview</h2><div class="cards">${cardHtml}</div></section>`;
+}
+
+/** Render the coverage-by-type progress bar section as an HTML string. */
+function renderCoverageSection(coverage: CoverageStat[]): string {
+  const rows = coverage
+    .map((stat) => {
+      const label = escapeHtml(stat.type);
+      const pct = stat.coveragePct;
+      return [
+        `<div class="cov-row">`,
+        `  <div class="cov-label">${label}</div>`,
+        `  <div class="cov-bar-wrap">`,
+        `    <div class="cov-bar" style="width:${pct}%"></div>`,
+        `  </div>`,
+        `  <div class="cov-stat">${stat.covered}/${stat.total} (${pct}%)</div>`,
+        `</div>`,
+      ].join('');
+    })
+    .join('');
+  return `<section id="coverage"><h2>Coverage by Type</h2>${rows}</section>`;
+}
+
+/** Render the top-recalled entries bar chart section as an HTML string. */
+function renderTopRecalledSection(topRecalled: EntryMetric[]): string {
+  const items = topRecalled.map((m) => ({
+    label: m.title || m.docId,
+    value: m.recalledCount,
+    badge: m.type,
+  }));
+  const chart = renderBarChart(items);
+  return `<section id="top-recalled"><h2>Top Recalled Entries</h2>${chart}</section>`;
+}
+
+/** Render the never-recalled entries section, grouped by type with collapsible details, as an HTML string. */
+function renderSilentSection(silent: EntryMetric[]): string {
+  if (silent.length === 0) {
+    return (
+      `<section id="silent"><h2>Never-Recalled Entries</h2>` +
+      `<p>All entries have been recalled at least once.</p></section>`
+    );
+  }
+
+  const byType = new Map<string, EntryMetric[]>();
+  for (const m of silent) {
+    const list = byType.get(m.type) ?? [];
+    list.push(m);
+    byType.set(m.type, list);
+  }
+
+  const groups = Array.from(byType.entries())
+    .map(([type, entries]) => {
+      const rows = entries
+        .map(
+          (m) =>
+            `<li><span class="entry-title">${escapeHtml(m.title || m.docId)}</span>` +
+            ` <span class="muted">— ${escapeHtml(m.author || 'unknown')}</span></li>`,
+        )
+        .join('');
+      return [
+        `<details>`,
+        `  <summary>${escapeHtml(type)} (${entries.length})</summary>`,
+        `  <ul>${rows}</ul>`,
+        `</details>`,
+      ].join('');
+    })
+    .join('');
+
+  return [
+    `<section id="silent">`,
+    `  <h2>Never-Recalled Entries (${silent.length} total)</h2>`,
+    `  ${groups}`,
+    `</section>`,
+  ].join('');
+}
+
+/** Render the monthly last-recall trend line chart section as an HTML string. */
+function renderTrendSection(trend: TrendPoint[]): string {
+  const chart = renderLineChart(trend);
+  const note = '<p class="muted">Each entry is counted once, in the month it was last recalled.</p>';
+  return `<section id="trend"><h2>Entries by Last-Recall Month</h2>${note}${chart}</section>`;
+}
+
+/** Render the author contributions table section as an HTML string. */
+function renderAuthorsSection(authors: AuthorStat[]): string {
+  if (authors.length === 0) {
+    return `<section id="authors"><h2>Author Contributions</h2><p>No author data.</p></section>`;
+  }
+  const header = '<tr><th>Author</th><th>Entries</th><th>Total Recalled</th></tr>';
+  const rows = authors
+    .map(
+      (a) =>
+        `<tr><td>${escapeHtml(a.author)}</td><td>${a.entries}</td><td>${a.totalRecalled}</td></tr>`,
+    )
+    .join('');
+  return [
+    `<section id="authors">`,
+    `  <h2>Author Contributions</h2>`,
+    `  <table><thead>${header}</thead><tbody>${rows}</tbody></table>`,
+    `</section>`,
+  ].join('');
+}
+
+/** Render the promotable learnings maintenance block as an HTML string. */
+function renderPromotionBlock(promote: PromotionCandidate[]): string {
+  const intro =
+    '<p class="muted">Learnings with high confidence (&ge;0.90) and adoption across ' +
+    'multiple users — good candidates to promote to formal skills, rules, or docs.</p>';
+  const guide =
+    '<div class="maint-guide"><strong>How to promote</strong>' +
+    ' — Review a candidate below, then run (each entry shows its own ready-to-copy command):' +
+    '<code>teamai recall promote &lt;learning-id&gt; --category skill|rule|doc</code></div>';
+  if (promote.length === 0) {
+    return `<div class="maint-block"><h3>Promotable Learnings</h3>${intro}${guide}<p>None right now.</p></div>`;
+  }
+  const rows = promote
+    .map((c) => {
+      const cmd =
+        `teamai recall promote ${escapeHtml(c.docId)} --category ${escapeHtml(c.suggestedCategory)}`;
+      return [
+        `<div class="maint-item">`,
+        `  <div><strong>${escapeHtml(c.title)}</strong>`,
+        `    <span class="badge">${escapeHtml(c.suggestedCategory)}</span></div>`,
+        `  <div class="muted">Confidence: ${(c.confidence * 100).toFixed(0)}%`,
+        ` | Upvotes: ${c.upvotedCount} | Users: ${c.userCount}</div>`,
+        `  <code>${cmd}</code>`,
+        `</div>`,
+      ].join('');
+    })
+    .join('');
+  return `<div class="maint-block"><h3>Promotable Learnings</h3>${intro}${guide}${rows}</div>`;
+}
+
+/** Render the suggested-for-archive maintenance block as an HTML string. */
+function renderPruneBlock(prune: PruneCandidate[]): string {
+  const intro =
+    '<p class="muted">Learnings below confidence threshold or inactive for &gt;180 days.</p>';
+  const guide =
+    '<div class="maint-guide"><strong>How to archive</strong>' +
+    ' — These are batch-archived together. Review the list below, then run:' +
+    '<code>teamai recall maintenance --prune --archive</code></div>';
+  if (prune.length === 0) {
+    return `<div class="maint-block"><h3>Suggested for Archive</h3>${intro}${guide}<p>None right now.</p></div>`;
+  }
+  const rows = prune
+    .map((c) => {
+      const activity = c.lastActivity ? escapeHtml(c.lastActivity.substring(0, 10)) : 'unknown';
+      return [
+        `<div class="maint-item">`,
+        `  <div><strong>${escapeHtml(c.filename)}</strong></div>`,
+        `  <div class="muted">Confidence: ${(c.confidence * 100).toFixed(0)}%`,
+        ` | Last activity: ${activity} | Reason: ${escapeHtml(c.reason)}</div>`,
+        `</div>`,
+      ].join('');
+    })
+    .join('');
+  return `<div class="maint-block"><h3>Suggested for Archive</h3>${intro}${guide}${rows}</div>`;
+}
+
+/** Render the stale-entries (needs quality update) maintenance block as an HTML string. */
+function renderStaleBlock(stale: StaleEntry[]): string {
+  const intro =
+    '<p class="muted">Entries recalled frequently but rarely upvoted — ' +
+    'likely stale or low quality. Run the command below to review and refresh them.</p>';
+  const guide =
+    '<div class="maint-guide"><strong>How to update</strong>' +
+    ' — Run the command below to review and refresh these entries:' +
+    '<code>teamai recall maintenance --update-quality</code></div>';
+  if (stale.length === 0) {
+    return (
+      `<div class="maint-block"><h3>Stale (Needs Quality Update)</h3>` +
+      `${intro}${guide}<p>None right now.</p></div>`
+    );
+  }
+  const header =
+    '<tr><th>Doc ID</th><th>Type</th><th>Recalls</th><th>Upvotes</th><th>Users</th></tr>';
+  const rows = stale
+    .map(
+      (s) =>
+        `<tr><td>${escapeHtml(s.docId)}</td><td>${escapeHtml(s.type)}</td>` +
+        `<td>${s.recalledCount}</td><td>${s.upvotedCount}</td><td>${s.userCount}</td></tr>`,
+    )
+    .join('');
+  return [
+    `<div class="maint-block">`,
+    `  <h3>Stale (Needs Quality Update)</h3>`,
+    `  ${intro}`,
+    `  ${guide}`,
+    `  <table><thead>${header}</thead><tbody>${rows}</tbody></table>`,
+    `</div>`,
+  ].join('');
+}
+
+/** Render the full maintenance console section combining promote, prune, and stale blocks. */
+function renderMaintenanceSection(data: VizData): string {
+  const promote = renderPromotionBlock(data.maintenance.promote);
+  const prune = renderPruneBlock(data.maintenance.prune);
+  const stale = renderStaleBlock(data.maintenance.stale);
+  return `<section id="maintenance"><h2>Maintenance Console</h2>${promote}${prune}${stale}</section>`;
+}
+
+// ─── CSS ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Return the complete inline <style> block for the report.
+ *
+ * Design direction: refined technical instrument — monospace data readouts,
+ * structured hierarchy, electric-blue (#38bdf8 dark / #0284c7 light) as sole accent.
+ * Zero external resources; all styles self-contained.
+ */
+function renderStyles(): string {
+  return `
+<style>
+  /* === Design tokens === */
+  /* Dark palette aligned with the dashboard (dashboard-html.ts) */
+  :root {
+    --bg:         #0d1117;
+    --bg2:        #161b22;
+    --bg3:        #1c2129;
+    --text:       #e6edf3;
+    --text2:      #8b949e;
+    --accent:     #58a6ff;
+    --accent-dim: #1f6feb;
+    --border:     #30363d;
+    --badge-bg:   #1c2129;
+    --badge-text: #58a6ff;
+    --code-bg:    #0d1117;
+    --mono: ui-monospace, 'SF Mono', 'JetBrains Mono', Menlo, Consolas, monospace;
+  }
+
+  .source-badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 6px;
+    font-size: 12px;
+    background: var(--badge-bg);
+    color: var(--badge-text);
+  }
+  /* team scope uses the default .source-badge style; only local needs an override */
+  .source-local {
+    background: #3d2e12;
+    color: #d29922;
+  }
+
+  /* === Reset === */
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  html { font-size: 15px; }
+  body {
+    font-family: -apple-system, system-ui, 'Segoe UI', sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.65;
+  }
+
+  /* === Header — instrument panel with dot-matrix texture === */
+  header {
+    background-color: var(--bg2);
+    background-image: radial-gradient(circle, var(--border) 1px, transparent 1px);
+    background-size: 24px 24px;
+    border-bottom: 1px solid var(--border);
+    padding: 32px 40px;
+    position: relative;
+  }
+  header::after {
+    content: '';
+    position: absolute;
+    bottom: -1px;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: linear-gradient(90deg, var(--accent), transparent 70%);
+  }
+  .header-inner {
+    position: relative;
+    max-width: 960px;
+    margin: 0 auto;
+  }
+  header h1 {
+    font-family: 'Iowan Old Style', 'Palatino Linotype', Georgia, serif;
+    font-size: 1.65rem;
+    font-weight: 700;
+    letter-spacing: -0.025em;
+    color: var(--text);
+    margin-bottom: 10px;
+  }
+  .header-meta {
+    font-family: var(--mono);
+    font-size: 0.74rem;
+    color: var(--text2);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 20px;
+  }
+  .header-meta span::before {
+    content: '◆ ';
+    color: var(--accent);
+    font-size: 0.6em;
+    vertical-align: middle;
+  }
+
+  /* === Main layout + section counter === */
+  main {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 32px 40px;
+    counter-reset: section-num;
+  }
+  section {
+    margin-bottom: 52px;
+    counter-increment: section-num;
+    animation: fadeInUp 0.45s ease both;
+  }
+  section:nth-child(1) { animation-delay: 0.04s; }
+  section:nth-child(2) { animation-delay: 0.10s; }
+  section:nth-child(3) { animation-delay: 0.16s; }
+  section:nth-child(4) { animation-delay: 0.22s; }
+  section:nth-child(5) { animation-delay: 0.28s; }
+  section:nth-child(6) { animation-delay: 0.34s; }
+  section:nth-child(7) { animation-delay: 0.40s; }
+  @keyframes fadeInUp {
+    from { opacity: 0; transform: translateY(10px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    section { animation: none; }
+  }
+
+  /* === Headings === */
+  section > h2 {
+    font-family: -apple-system, system-ui, 'Segoe UI', sans-serif;
+    font-size: 0.82rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--text);
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 10px;
+    margin-bottom: 22px;
+  }
+  section > h2::before {
+    content: counter(section-num, decimal-leading-zero) ' ── ';
+    font-family: var(--mono);
+    font-size: 0.72rem;
+    color: var(--accent);
+    letter-spacing: 0.06em;
+    opacity: 0.85;
+  }
+  h3 {
+    font-size: 0.88rem;
+    font-weight: 600;
+    color: var(--text);
+    margin-bottom: 12px;
+  }
+  p  { margin-bottom: 10px; }
+  .muted { color: var(--text2); font-size: 0.875rem; }
+
+  /* === Overview cards — instrument readout === */
+  .cards { display: flex; gap: 16px; flex-wrap: wrap; }
+  .card {
+    background: var(--bg2);
+    border: 1px solid var(--border);
+    border-top: 2px solid var(--accent);
+    border-radius: 6px;
+    padding: 20px 24px;
+    min-width: 150px;
+    flex: 1;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+  }
+  .card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.12);
+  }
+  .card-label {
+    font-family: var(--mono);
+    font-size: 0.66rem;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--text2);
+    margin-bottom: 10px;
+  }
+  .card-value {
+    font-family: var(--mono);
+    font-size: 2.1rem;
+    font-weight: 700;
+    color: var(--accent);
+    line-height: 1;
+  }
+
+  /* === Coverage bars === */
+  .cov-row { display: flex; align-items: center; gap: 12px; margin-bottom: 10px; }
+  .cov-label {
+    font-family: var(--mono);
+    width: 110px;
+    font-size: 0.76rem;
+    text-align: right;
+    color: var(--text2);
+  }
+  .cov-bar-wrap {
+    flex: 1;
+    height: 8px;
+    background: var(--bg3);
+    border-radius: 4px;
+    overflow: hidden;
+  }
+  .cov-bar {
+    height: 100%;
+    background: linear-gradient(90deg, var(--accent-dim), var(--accent));
+    border-radius: 4px;
+    transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+  .cov-stat {
+    font-family: var(--mono);
+    width: 130px;
+    font-size: 0.76rem;
+    color: var(--text2);
+  }
+
+  /* === Tables === */
+  table { width: 100%; border-collapse: collapse; font-size: 0.875rem; }
+  th, td { padding: 9px 12px; border-bottom: 1px solid var(--border); text-align: left; }
+  th {
+    font-family: var(--mono);
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    background: var(--bg2);
+    font-weight: 600;
+    color: var(--text2);
+  }
+  td { color: var(--text); }
+  tr:hover td { background: var(--bg3); }
+
+  /* === Silent entries (details/summary) === */
+  details { margin-bottom: 8px; }
+  summary {
+    cursor: pointer;
+    padding: 8px 12px;
+    border-radius: 6px;
+    font-weight: 500;
+    font-size: 0.875rem;
+    background: var(--bg2);
+    border: 1px solid var(--border);
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    user-select: none;
+  }
+  summary::marker, summary::-webkit-details-marker { display: none; }
+  summary::before {
+    content: '▶';
+    font-size: 0.55rem;
+    color: var(--accent);
+    transition: transform 0.2s ease;
+    flex-shrink: 0;
+  }
+  details[open] summary::before { transform: rotate(90deg); }
+  summary:hover { background: var(--bg3); }
+  ul { list-style: none; padding: 4px 16px 8px; }
+  li { padding: 5px 0; font-size: 0.875rem; border-bottom: 1px solid var(--border); }
+  li:last-child { border-bottom: none; }
+  .entry-title { color: var(--text); }
+
+  /* === Badges === */
+  .badge {
+    display: inline-block;
+    font-family: var(--mono);
+    font-size: 0.66rem;
+    padding: 2px 8px;
+    border-radius: 10px;
+    background: var(--badge-bg);
+    color: var(--badge-text);
+    margin-left: 6px;
+    letter-spacing: 0.04em;
+  }
+
+  /* === Maintenance blocks === */
+  .maint-block {
+    background: var(--bg2);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 20px 24px;
+    margin-bottom: 20px;
+  }
+  .maint-item {
+    border-top: 1px solid var(--border);
+    padding: 12px 0;
+  }
+  .maint-item:first-of-type { border-top: none; padding-top: 4px; }
+
+  /* === Maintenance guide bars === */
+  .maint-guide {
+    border-left: 3px solid var(--accent);
+    background: var(--bg3);
+    border-radius: 0 6px 6px 0;
+    padding: 10px 16px;
+    margin: 10px 0 16px;
+    font-size: 0.845rem;
+    color: var(--text2);
+  }
+  .maint-guide code {
+    display: block;
+    margin-top: 8px;
+    font-size: 0.82rem;
+    border-left: 3px solid var(--accent);
+    border-radius: 0 4px 4px 0;
+    padding: 7px 14px;
+    color: var(--accent);
+    background: var(--code-bg);
+  }
+  .maint-guide code::before {
+    content: '$ ';
+    opacity: 0.5;
+    user-select: none;
+  }
+
+  /* === Inline code === */
+  code {
+    display: inline-block;
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 3px 10px;
+    font-family: var(--mono);
+    font-size: 0.76rem;
+    color: var(--accent);
+    margin-top: 6px;
+    transition: border-color 0.15s;
+  }
+  code:hover { border-color: var(--accent); }
+</style>`;
+}
+
+// ─── Main renderer ────────────────────────────────────────────────────────────
+
+/**
+ * Render a complete standalone HTML report from the given VizData payload.
+ *
+ * @param data - Aggregated knowledge base metrics produced by buildVizData.
+ * @returns A complete HTML document string, safe to write directly to a .html file.
+ */
+export function renderReport(data: VizData): string {
+  const ts = escapeHtml(data.generatedAt);
+  const root = escapeHtml(data.root);
+
+  const sections = [
+    renderOverviewCards(data),
+    renderCoverageSection(data.coverage),
+    renderTopRecalledSection(data.topRecalled),
+    renderSilentSection(data.silent),
+    renderTrendSection(data.trend),
+    renderAuthorsSection(data.authors),
+    renderMaintenanceSection(data),
+  ].join('\n');
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>TeamAI Knowledge Base Report</title>
+  ${renderStyles()}
+</head>
+<body>
+  <header>
+    <div class="header-inner">
+      <h1>TeamAI Knowledge Base Report</h1>
+      <div class="header-meta">
+        <span>Generated: ${ts}</span>
+        <span>Root: ${root}</span>
+        <span class="source-badge source-${data.source.scope}">${escapeHtml(data.source.label)}</span>
+      </div>
+    </div>
+  </header>
+  <main>
+    ${sections}
+  </main>
+</body>
+</html>`;
+}

--- a/src/viz.ts
+++ b/src/viz.ts
@@ -1,0 +1,444 @@
+// -*- coding: utf-8 -*-
+/**
+ * TeamAI knowledge base visualization — data loading and aggregation.
+ *
+ * Resolves filesystem paths, aggregates per-user vote data, builds index entries,
+ * and assembles the complete VizData payload used by the HTML renderer.
+ */
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { loadIndex, buildIndex } from './utils/search-index.js';
+import { loadUserVotes } from './votes.js';
+import { detectProjectConfig, loadLocalConfig } from './config.js';
+import {
+  VOTES_LOCAL_DIR,
+  SEARCH_INDEX_PATH,
+  LEARNINGS_LOCAL_DIR,
+  getKnowledgeDir,
+  getReportsDir,
+  getTeamaiHome,
+} from './types.js';
+import type { SearchIndexEntry } from './types.js';
+import { findPromotionCandidates, type PromotionCandidate } from './maintenance/promote.js';
+import { findPruneCandidates, type PruneCandidate } from './maintenance/prune.js';
+import { findStaleEntries, type StaleEntry } from './maintenance/quality-update.js';
+import { renderReport } from './viz-render.js';
+
+export type { PromotionCandidate, PruneCandidate, StaleEntry };
+
+// ─── Public option / data types ──────────────────────────────────────────────
+
+export interface VizOptions {
+  /** Path to a team repo root directory to aggregate instead of local ~/.teamai. */
+  repo?: string;
+}
+
+/** Aggregated recall and vote metrics for a single knowledge entry. */
+export interface EntryMetric {
+  docId: string;
+  title: string;
+  type: 'learnings' | 'docs' | 'rules' | 'skills';
+  author: string;
+  date: string;
+  tags: string[];
+  recalledCount: number;
+  upvotedCount: number;
+  lastRecalledAt: string | null;
+}
+
+/** Coverage statistics for a single knowledge type. */
+export interface CoverageStat {
+  type: string;
+  total: number;
+  /** Number of entries with recalledCount > 0. */
+  covered: number;
+  /** covered / total * 100, rounded. 0 when total is 0. */
+  coveragePct: number;
+}
+
+/** A single monthly recall activity data point for trend charts. */
+export interface TrendPoint {
+  /** ISO year-month period, e.g. '2026-04'. */
+  period: string;
+  count: number;
+}
+
+/** Contribution statistics per author. */
+export interface AuthorStat {
+  author: string;
+  entries: number;
+  totalRecalled: number;
+}
+
+/** Maintenance action candidates grouped by category. */
+export interface MaintenanceCandidates {
+  promote: PromotionCandidate[];
+  prune: PruneCandidate[];
+  stale: StaleEntry[];
+}
+
+/** Where the report's data came from, shown to the reader. */
+export interface VizSource {
+  /** 'team' = aggregated team repo; 'local' = this machine's personal ~/.teamai. */
+  scope: 'team' | 'local';
+  /** Human-readable description shown in the report header and dashboard card. */
+  label: string;
+}
+
+/** Complete data payload for the HTML visualization report. */
+export interface VizData {
+  generatedAt: string;
+  root: string;
+  source: VizSource;
+  totalEntries: number;
+  totalRecalls: number;
+  overallCoveragePct: number;
+  contributorCount: number;
+  coverage: CoverageStat[];
+  /** Top 20 entries by recalledCount (only entries with recalledCount > 0). */
+  topRecalled: EntryMetric[];
+  /** All entries with recalledCount === 0. */
+  silent: EntryMetric[];
+  /** Monthly recall activity, ascending by period. */
+  trend: TrendPoint[];
+  /** Top 15 authors by totalRecalled. */
+  authors: AuthorStat[];
+  maintenance: MaintenanceCandidates;
+}
+
+// ─── Internal types ───────────────────────────────────────────────────────────
+
+/** Resolved filesystem paths used internally by the viz pipeline. */
+interface VizPaths {
+  root: string;
+  /** Root under which docs/rules/skills live (may differ from the reports root in self mode). */
+  knowledgeRoot: string;
+  votesDir: string;
+  learningsDir: string;
+  statsDir: string;
+  indexPath: string | undefined;
+  source: VizSource;
+}
+
+// ─── Path resolution ──────────────────────────────────────────────────────────
+
+/**
+ * Resolve the data root and derivative directories for the viz pipeline.
+ *
+ * Precedence: explicit `--repo` flag → project-scope config → user config → ~/.teamai fallback.
+ * `config.repo.kind` is 'git' | 'http' | 'self'. In self mode, votes/stats live in the reports
+ * worktree (ensureReportsWorktree), while learnings remain in the local ~/.teamai tree.
+ */
+export async function resolveVizRoot(opts: VizOptions): Promise<VizPaths> {
+  // Explicit --repo: everything lives under the given repo; no shared index
+  // exists for an ad-hoc path, so loadEntries builds a temporary one from it.
+  if (opts.repo) {
+    const root = path.resolve(opts.repo);
+    return {
+      root,
+      knowledgeRoot: root,
+      votesDir: path.join(root, 'votes'),
+      learningsDir: path.join(root, 'learnings'),
+      statsDir: path.join(root, 'stats'),
+      indexPath: undefined,
+      source: { scope: 'team', label: 'Team repo · aggregated across the team' },
+    };
+  }
+
+  const config = await detectProjectConfig() ?? await loadLocalConfig();
+
+  if (config?.repo?.localPath) {
+    if (config.repo.kind === 'self') {
+      const { ensureReportsWorktree } = await import('./utils/reports-branch.js');
+      await ensureReportsWorktree(config);
+    }
+    const knowledgeRoot = getKnowledgeDir(config);
+    const reportsRoot = getReportsDir(config);
+    const useProjectScope = config.scope === 'project' && Boolean(config.projectRoot);
+    const teamaiHome = useProjectScope
+      ? getTeamaiHome('project', config.projectRoot!)
+      : getTeamaiHome('user');
+    const learningsDir = useProjectScope
+      ? path.join(knowledgeRoot, 'learnings')
+      : LEARNINGS_LOCAL_DIR;
+    const source: VizSource = config.repo.kind === 'self'
+      ? { scope: 'local', label: 'Personal repo · your recalls only' }
+      : { scope: 'team', label: 'Team repo · aggregated across the team' };
+    return {
+      root: knowledgeRoot,
+      knowledgeRoot,
+      votesDir: path.join(reportsRoot, 'votes'),
+      learningsDir,
+      statsDir: path.join(reportsRoot, 'stats'),
+      indexPath: path.join(teamaiHome, 'search-index.json'),
+      source,
+    };
+  }
+
+  // Pure local / no team repo configured: fall back to ~/.teamai.
+  const teamaiHome = path.dirname(VOTES_LOCAL_DIR);
+  return {
+    root: teamaiHome,
+    knowledgeRoot: teamaiHome,
+    votesDir: VOTES_LOCAL_DIR,
+    learningsDir: LEARNINGS_LOCAL_DIR,
+    statsDir: path.join(teamaiHome, 'stats'),
+    indexPath: SEARCH_INDEX_PATH,
+    source: { scope: 'local', label: 'Local ~/.teamai · your recalls only' },
+  };
+}
+
+// ─── Vote aggregation ─────────────────────────────────────────────────────────
+
+/**
+ * Aggregate vote data across all per-user YAML files in the given directory.
+ *
+ * Returns a map from docId to cumulative recalled/upvoted counts and the latest
+ * recall ISO timestamp across all users, plus the count of users who have at least
+ * one recalled_count > 0 entry. Returns empty results when the directory is absent.
+ */
+export async function aggregateTeamVotes(votesDir: string): Promise<{
+  byDoc: Record<string, { recalledCount: number; upvotedCount: number; lastRecalledAt: string | null }>;
+  activeContributors: number;
+}> {
+  let files: string[];
+  try {
+    const entries = await fs.readdir(votesDir);
+    files = entries.filter((f) => f.endsWith('.yaml'));
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT') {
+      console.warn(`Failed to read votes directory ${votesDir}: ${(err as Error).message}`);
+    }
+    return { byDoc: {}, activeContributors: 0 };
+  }
+
+  const byDoc: Record<string, { recalledCount: number; upvotedCount: number; lastRecalledAt: string | null }> =
+    {};
+  let activeContributors = 0;
+
+  for (const file of files) {
+    const fullPath = path.join(votesDir, file);
+    const userVotes = await loadUserVotes(fullPath);
+    let userHasRecall = false;
+    for (const [docId, entry] of Object.entries(userVotes.votes)) {
+      if (!byDoc[docId]) {
+        byDoc[docId] = { recalledCount: 0, upvotedCount: 0, lastRecalledAt: null };
+      }
+      byDoc[docId].recalledCount += entry.recalled_count;
+      byDoc[docId].upvotedCount += entry.upvoted_count;
+      const ts = entry.last_recalled_at;
+      if (ts && (!byDoc[docId].lastRecalledAt || ts > byDoc[docId].lastRecalledAt!)) {
+        byDoc[docId].lastRecalledAt = ts;
+      }
+      if (entry.recalled_count > 0) userHasRecall = true;
+    }
+    if (userHasRecall) activeContributors++;
+  }
+
+  return { byDoc, activeContributors };
+}
+
+// ─── Index loading ────────────────────────────────────────────────────────────
+
+/** Load search index entries, falling back to a fresh buildIndex call when absent. */
+async function loadEntries(paths: VizPaths): Promise<SearchIndexEntry[]> {
+  // Only read a prebuilt index when we have an explicit path for it. Passing
+  // undefined to loadIndex would silently fall back to the global user index,
+  // which can misrepresent an explicit --repo corpus.
+  let index = paths.indexPath ? await loadIndex(paths.indexPath) : null;
+  if (!index || index.entries.length === 0) {
+    // Build into a unique throwaway path. A fixed shared temp file would let a
+    // previous run's larger index trip buildIndex's "new index too small" guard,
+    // leaving this run reading a stale corpus from a different repo.
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'teamai-viz-'));
+    const tmpIndexPath = path.join(tmpDir, 'index.json');
+    try {
+      await buildIndex({
+        learningsDir: paths.learningsDir,
+        docsDir: path.join(paths.knowledgeRoot, 'docs'),
+        rulesDir: path.join(paths.knowledgeRoot, 'rules'),
+        skillsDir: path.join(paths.knowledgeRoot, 'skills'),
+        votesDir: paths.votesDir,
+        indexPath: tmpIndexPath,
+      });
+      index = await loadIndex(tmpIndexPath);
+    } catch (err) {
+      console.warn(`Warning: could not build search index: ${(err as Error).message}`);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }
+  return index?.entries ?? [];
+}
+
+// ─── Aggregation helpers ──────────────────────────────────────────────────────
+
+/** Compute per-type and overall coverage statistics from the full metrics array. */
+function buildCoverage(
+  metrics: EntryMetric[],
+): { coverage: CoverageStat[]; overallCoveragePct: number } {
+  const byType = new Map<string, { total: number; covered: number }>();
+  for (const m of metrics) {
+    const cur = byType.get(m.type) ?? { total: 0, covered: 0 };
+    cur.total++;
+    if (m.recalledCount > 0) cur.covered++;
+    byType.set(m.type, cur);
+  }
+  const coverage: CoverageStat[] = Array.from(byType.entries()).map(([type, { total, covered }]) => ({
+    type,
+    total,
+    covered,
+    coveragePct: total > 0 ? Math.round((covered / total) * 100) : 0,
+  }));
+  const total = metrics.length;
+  const covered = metrics.filter((m) => m.recalledCount > 0).length;
+  const overallCoveragePct = total > 0 ? Math.round((covered / total) * 100) : 0;
+  return { coverage, overallCoveragePct };
+}
+
+/** Build monthly last-recall trend data points, sorted ascending by period. */
+function buildTrend(metrics: EntryMetric[]): TrendPoint[] {
+  const buckets = new Map<string, number>();
+  for (const m of metrics) {
+    if (!m.lastRecalledAt) continue;
+    const period = m.lastRecalledAt.substring(0, 7);
+    buckets.set(period, (buckets.get(period) ?? 0) + 1);
+  }
+  return Array.from(buckets.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([period, count]) => ({ period, count }));
+}
+
+/** Aggregate per-author entry and recall totals, returning the top 15 by total recalls. */
+function buildAuthors(metrics: EntryMetric[]): AuthorStat[] {
+  const map = new Map<string, { entries: number; totalRecalled: number }>();
+  for (const m of metrics) {
+    const author = m.author || 'unknown';
+    const cur = map.get(author) ?? { entries: 0, totalRecalled: 0 };
+    cur.entries++;
+    cur.totalRecalled += m.recalledCount;
+    map.set(author, cur);
+  }
+  return Array.from(map.entries())
+    .map(([author, stats]) => ({ author, ...stats }))
+    .sort((a, b) => b.totalRecalled - a.totalRecalled)
+    .slice(0, 15);
+}
+
+// ─── Core build function ──────────────────────────────────────────────────────
+
+/**
+ * Build the complete visualization data payload from resolved paths.
+ *
+ * @param paths - Resolved filesystem paths from resolveVizRoot.
+ */
+export async function buildVizData(paths: VizPaths): Promise<VizData> {
+  const [entries, { byDoc: votesAgg, activeContributors: contributorCount }] = await Promise.all([
+    loadEntries(paths),
+    aggregateTeamVotes(paths.votesDir),
+  ]);
+
+  const metrics: EntryMetric[] = entries.map((entry) => {
+    const docId = entry.filename.replace(/\.md$/i, '');
+    const voteData = votesAgg[docId];
+    return {
+      docId,
+      title: entry.title,
+      type: entry.type,
+      author: entry.author,
+      date: entry.date,
+      tags: entry.tags,
+      recalledCount: voteData?.recalledCount ?? 0,
+      upvotedCount: voteData?.upvotedCount ?? 0,
+      lastRecalledAt: voteData?.lastRecalledAt ?? null,
+    };
+  });
+
+  const { coverage, overallCoveragePct } = buildCoverage(metrics);
+  const totalRecalls = metrics.reduce((sum, m) => sum + m.recalledCount, 0);
+  const topRecalled = metrics
+    .filter((m) => m.recalledCount > 0)
+    .sort((a, b) => b.recalledCount - a.recalledCount)
+    .slice(0, 20);
+  const silent = metrics.filter((m) => m.recalledCount === 0);
+  const trend = buildTrend(metrics);
+  const authors = buildAuthors(metrics);
+
+  const [promote, prune, stale] = await Promise.all([
+    findPromotionCandidates(paths.learningsDir, paths.votesDir).catch((err: Error) => {
+      console.warn(`Warning: could not load promotion candidates: ${err.message}`);
+      return [] as PromotionCandidate[];
+    }),
+    findPruneCandidates(paths.learningsDir, paths.votesDir).catch((err: Error) => {
+      console.warn(`Warning: could not load prune candidates: ${err.message}`);
+      return [] as PruneCandidate[];
+    }),
+    findStaleEntries(paths.votesDir, {
+      docs: path.join(paths.knowledgeRoot, 'docs'),
+      rules: path.join(paths.knowledgeRoot, 'rules'),
+      skills: path.join(paths.knowledgeRoot, 'skills'),
+    }).catch((err: Error) => {
+      console.warn(`Warning: could not load stale entries: ${err.message}`);
+      return [] as StaleEntry[];
+    }),
+  ]);
+
+  return {
+    generatedAt: new Date().toISOString(),
+    root: paths.root,
+    source: paths.source,
+    totalEntries: metrics.length,
+    totalRecalls,
+    overallCoveragePct,
+    contributorCount,
+    coverage,
+    topRecalled,
+    silent,
+    trend,
+    authors,
+    maintenance: { promote, prune, stale },
+  };
+}
+
+// ─── Service entry point ──────────────────────────────────────────────────────
+
+/**
+ * Build the knowledge-base health report as a standalone HTML string.
+ *
+ * Resolves data paths, aggregates VizData, and renders the report. Performs
+ * no file I/O — the caller (the dashboard `/kb-report` route) streams the
+ * returned HTML directly to the response.
+ */
+export async function generateReportHtml(opts: VizOptions = {}): Promise<string> {
+  const paths = await resolveVizRoot(opts);
+  const data = await buildVizData(paths);
+  return renderReport(data);
+}
+
+/** Compact knowledge-base summary for the dashboard preview card. */
+export interface VizSummary {
+  totalEntries: number;
+  overallCoveragePct: number;
+  coverage: Array<{ type: string; coveragePct: number }>;
+  source: VizSource;
+}
+
+/**
+ * Build a compact knowledge-base summary for the dashboard preview card.
+ *
+ * Runs the same aggregation as the full report but returns only the headline
+ * coverage figures the card needs, keeping the response payload small.
+ */
+export async function getVizSummary(opts: VizOptions = {}): Promise<VizSummary> {
+  const paths = await resolveVizRoot(opts);
+  const data = await buildVizData(paths);
+  return {
+    totalEntries: data.totalEntries,
+    overallCoveragePct: data.overallCoveragePct,
+    coverage: (data.coverage ?? []).map((stat) => ({ type: stat.type, coveragePct: stat.coveragePct })),
+    source: data.source,
+  };
+}


### PR DESCRIPTION
## Summary

Add a **KB Health** view to the `teamai dashboard` Web UI: a knowledge-base usage & health report served at `/kb-report`, entered through a **live preview card** on the dashboard home. All the underlying signals (recall counts, adoption, skill usage) already live in the repo (`votes/`, `stats/`) but were invisible to users — this surfaces them so teams can see TeamAI's impact and curate their knowledge base.

It doubles as a **maintenance console**: the report lists promote / prune / stale candidates produced by the existing (but previously undocumented and manually-triggered) self-cleaning mechanisms, each with a ready-to-copy command — turning dormant machinery into something visible and actionable.

> Design note: this started as a standalone `teamai viz` command. Per review it was folded into the dashboard so the report lives where teams already watch their coding activity, keeping the top-level command surface small. There is no separate `viz` command — the report is a dashboard page.

## What's included

- **Preview card**: the dashboard home shows a KB Health card with an inline-SVG coverage ring + per-type bars + an `N entries · X% coverage` line, populated from **real data** (async, non-blocking); the whole card links to the full report
- **Report page**: `GET /kb-report` renders the full report on demand (500 with a safe message on failure)
- **Summary endpoint**: `GET /api/kb-summary` returns the headline coverage figures for the card, with a 30s in-memory TTL cache so a page load doesn't re-aggregate the whole knowledge base every time
- **Metrics**: coverage by type, top-recalled ranking, never-recalled entries, entries-by-last-recall-month, author contributions
- **Maintenance console**: promote / archive / stale blocks, each with usage guidance + copyable commands (shown even when empty)
- **Data reuse**: builds on `loadIndex` / `loadUserVotes` / `findPromotionCandidates` etc. — **no new data pipeline**. Aggregates the local `~/.teamai` knowledge base (or the configured team repo), resolved via the existing config/`self`-mode logic
- **Path resolution**: resolves `knowledgeRoot` / `reportsRoot` / scope-aware `indexPath` separately (`getKnowledgeDir` / `getReportsDir` / `getTeamaiHome`), so self-mode and project-scope reports read the right corpus and index; an explicit `--repo` builds its index from that repo (into a unique temp path) rather than falling back to the global user index. **Behavioral note:** for a user-scope git/http team repo, learnings now come from the pull-synced `~/.teamai/learnings` (matching `recall`), and self-mode's `Root:` line shows the main repo path rather than the reports worktree
- **Data-source label**: the report header and the card show whether the numbers are an aggregated team repo, a personal self-repo, or local `~/.teamai` (your recalls only) — so personal-only coverage isn't misread as team-wide
- **Unified theme**: the report shares the dashboard's dark palette (single theme, common color tokens) instead of its own light/dark scheme
- **Zero external deps in the report**: inline CSS + inline SVG charts; `renderReport` stays a pure `VizData → HTML` function reused by the route
- **Docs**: describe the in-dashboard KB Health page plus the previously-undocumented `recall promote` / `recall maintenance` commands (EN + zh-CN)

Note: `teamwiki` is intentionally excluded from votes/coverage metrics — it has its own code-knowledge-graph recall path and is (by design) immune to promote/cold mechanisms.

## Test plan

- [x] `npx vitest run src/__tests__/viz.test.ts` — 11 tests green (`aggregateTeamVotes` + `renderReport`)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — success
- [x] E2E: start `teamai dashboard`, `GET /kb-report` → HTTP 200 `text/html`, full report page (169 entries) rendered from real `~/.teamai` data
- [x] E2E: `GET /api/kb-summary` → real JSON (`169 entries / 53% coverage / per-type`), served from cache on repeat calls
- [x] Dashboard `/` home renders the preview card; the ring/bars/stat populate from `/api/kb-summary` and degrade gracefully on error
- [x] `teamai dashboard --help` no longer lists a `viz` subcommand; the old `teamai viz` errors as unknown

🤖 Generated with [Claude Code](https://claude.com/claude-code)


