### PR TITLE
fix(hooks): unify hook-injection scope so project-scope init installs the SessionStart hook

### DIFF
--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -300,7 +300,7 @@ teamai pull              # Manual pull
 teamai pull --dry-run    # Dry run, no actual changes
 ```
 
-> Project scope is isolated by default. When the current working directory contains a project-scope `.teamai/config.yaml`, `pull` processes that project and skips user scope unless the local config has `inheritUserScope: true`; in that case it first refreshes the safe user-resource channel. Without a project config in the current directory, `pull` processes user scope. User `env`, hooks, MCP definitions, sources, reporting, and writes remain isolated in project mode.
+> Project scope is isolated by default. When the current working directory contains a project-scope `.teamai/config.yaml`, `pull` processes that project and skips user scope unless the local config has `inheritUserScope: true`; in that case it first refreshes the safe user-resource channel. Without a project config in the current directory, `pull` processes user scope. User `env`, MCP definitions, sources, reporting, and writes remain isolated in project mode. Hooks are the one exception: a project scope's hooks are injected into your **HOME** tool settings (`~/.claude/settings.json`, …), not `<projectRoot>`, because the built-in hooks gate on the `cwd` handed to `hook-dispatch` and `~/.claude` always exists so the "installed tool" gate passes (see the Hooks section). Self single-repo mode keeps its hooks in the business repo so they travel on clone.
 
 With role-based skills enabled, `pull`'s skill sync source becomes the contents of `skills/<namespace>/`, expanded according to `primaryRole + additionalRoles` and flattened into each local AI tool's skills directory. `rules/`, `docs/`, and `learnings/` keep their original global sync behavior.
 
@@ -1173,7 +1173,7 @@ teamai pull
 
 **Q: Can user scope and project scope coexist?**
 
-Yes, but project scope remains isolated by default. When the current working directory contains a project-scope config, it is active and user scope is skipped. Initialize user scope first, then initialize the project with `--inherit-user-scope` (or set `inheritUserScope: true` in the project's local config) to compose safe resources and Recall results. Executable and control-plane configuration remains project-only.
+Yes, but project scope remains isolated by default. When the current working directory contains a project-scope config, it is active and user scope is skipped. Initialize user scope first, then initialize the project with `--inherit-user-scope` (or set `inheritUserScope: true` in the project's local config) to compose safe resources and Recall results. Executable and control-plane configuration (`env`, MCP) remains project-only; hooks are the exception — a non-self project scope injects them into HOME so `hook-dispatch` can gate on `cwd` (see the Hooks section).
 
 **Q: `teamai init` says it's already initialized?**
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -298,7 +298,7 @@ teamai pull              # 手动拉取
 teamai pull --dry-run    # 试运行，不实际修改
 ```
 
-> Project scope 默认与 user scope 隔离。当前工作目录包含 project scope 的 `.teamai/config.yaml` 时，`pull` 会处理该项目并跳过 user scope；仅当本地配置包含 `inheritUserScope: true` 时，才会先刷新安全的 user 资源通道。当前目录没有 project 配置时，`pull` 处理 user scope。project 模式下，user 的 `env`、hooks、MCP 定义、sources、reporting 和写入行为仍保持隔离。
+> Project scope 默认与 user scope 隔离。当前工作目录包含 project scope 的 `.teamai/config.yaml` 时，`pull` 会处理该项目并跳过 user scope；仅当本地配置包含 `inheritUserScope: true` 时，才会先刷新安全的 user 资源通道。当前目录没有 project 配置时，`pull` 处理 user scope。project 模式下，user 的 `env`、MCP 定义、sources、reporting 和写入行为仍保持隔离。hooks 是唯一例外：project scope 的 hooks 会注入到你的 **HOME** 工具设置（`~/.claude/settings.json` 等），而非 `<projectRoot>`——因为内置 hooks 依据传给 `hook-dispatch` 的 `cwd` 门控，且 `~/.claude` 恒存在、能通过「已安装工具」门槛（详见 Hooks 章节）。self 单仓模式则把 hooks 保留在业务仓库里，随 clone 传播。
 
 启用角色化 skills 后，`pull` 的 skills 同步来源会变成 `skills/<namespace>/` 中的内容，按 `primaryRole + additionalRoles` 展开对应的 namespace，拍平安装到本地各 AI 工具 skills 目录。`rules/`、`docs/`、`learnings/` 仍然保持原有全局同步逻辑。
 
@@ -1168,7 +1168,7 @@ teamai pull
 
 **Q: User scope 和 Project scope 可以共存吗？**
 
-可以，但 project scope 默认保持隔离。当前工作目录包含 project scope 配置时，该项目生效并跳过 user scope。先初始化 user scope，再使用 `--inherit-user-scope` 初始化项目（或在项目本地配置中设置 `inheritUserScope: true`），即可组合安全资源和 Recall 结果；可执行配置和控制面配置仍只使用 project scope。
+可以，但 project scope 默认保持隔离。当前工作目录包含 project scope 配置时，该项目生效并跳过 user scope。先初始化 user scope，再使用 `--inherit-user-scope` 初始化项目（或在项目本地配置中设置 `inheritUserScope: true`），即可组合安全资源和 Recall 结果；可执行配置和控制面配置（`env`、MCP）仍只使用 project scope；hooks 例外——非-self 的 project scope 会把 hooks 注入到 HOME，以便 `hook-dispatch` 依据 `cwd` 门控（详见 Hooks 章节）。
 
 **Q: `teamai init` 提示已初始化？**
 

--- a/src/__tests__/doctor.test.ts
+++ b/src/__tests__/doctor.test.ts
@@ -144,6 +144,52 @@ describe('doctor — hook checks', () => {
         expect(TEAMAI_HOOK_SUBCOMMANDS).toHaveLength(1);
     });
 
+    // Lock the resolveHookScope branch the doctor fix rides on (#264/#370): the
+    // hook check must look where hooks are actually injected, not at resolveBaseDir.
+    function hookCheckLine(): string | undefined {
+        return consoleSpy.mock.calls
+            .map((c) => c[0] as string)
+            .find((m) => typeof m === 'string' && m.includes('hooks in claude settings'));
+    }
+
+    it('non-self project scope resolves the hook check to HOME, not <projectRoot>', async () => {
+        const projectRoot = '/tmp/teamai-doctor-proj';
+        mockedLoadLocalConfig.mockResolvedValue({ ...mockLocalConfig, scope: 'project', projectRoot });
+        // HOME carries the hooks; <projectRoot> is empty. If doctor still used
+        // resolveBaseDir (→ projectRoot) this check would report ✖.
+        mockedReadFileSafe.mockImplementation(async (filePath: string) => {
+            if (filePath.includes('settings.json')) {
+                return filePath.includes(projectRoot) ? '{ "hooks": {} }' : buildFullHooksContent();
+            }
+            return null;
+        });
+
+        await doctor({});
+
+        expect(hookCheckLine()).toContain('✔');
+    });
+
+    it('self single-repo mode resolves the hook check to <projectRoot>, not HOME', async () => {
+        const projectRoot = '/tmp/teamai-doctor-self';
+        mockedLoadLocalConfig.mockResolvedValue({
+            ...mockLocalConfig,
+            scope: 'project',
+            projectRoot,
+            repo: { ...mockLocalConfig.repo, kind: 'self' },
+        });
+        // Only <projectRoot> carries the hooks (committed to the business repo).
+        mockedReadFileSafe.mockImplementation(async (filePath: string) => {
+            if (filePath.includes('settings.json')) {
+                return filePath.includes(projectRoot) ? buildFullHooksContent() : '{ "hooks": {} }';
+            }
+            return null;
+        });
+
+        await doctor({});
+
+        expect(hookCheckLine()).toContain('✔');
+    });
+
     it('should pass env check when env/env.yaml does not exist in team repo', async () => {
         mockedPathExists.mockImplementation(async (filePath: string) => {
             if (filePath.includes('env/env.yaml')) return false;

--- a/src/__tests__/hooks-cmd.test.ts
+++ b/src/__tests__/hooks-cmd.test.ts
@@ -137,7 +137,7 @@ describe('hooksInject', () => {
         await expect(hooksInject({})).rejects.toThrow('not initialized');
     });
 
-    it('reconciles only into HOME when project config detected (#264)', async () => {
+    it('injects into HOME and sweeps the legacy <projectRoot> copy (#264/#370)', async () => {
         const restoreHome = mockHome('/home/testuser');
         mockedAutoDetectInit.mockResolvedValue({
             localConfig: { ...mockLocalConfig, scope: 'project', projectRoot: '/path/to/project' },
@@ -149,15 +149,21 @@ describe('hooksInject', () => {
             restoreHome();
         }
 
-        // #264: project scope no longer writes a redundant copy into projectRoot;
-        // HOME covers all cwds, and dispatch identifies the project via stdin.cwd.
-        expect(mockedReconcile).toHaveBeenCalledTimes(1);
-        expect(mockedReconcile).toHaveBeenCalledWith(
-            mockTeamConfig.toolPaths, '/home/testuser', TEAM_DEFS, expect.any(String), { builtinOverride: undefined },
+        // #264: project scope injects the single copy into HOME (covers all cwds;
+        // dispatch identifies the project via stdin.cwd). #370: it also sweeps any
+        // legacy <projectRoot> copy an older CLI wrote, so only HOME's copy fires.
+        expect(mockedReconcile).toHaveBeenCalledTimes(2);
+        // Call 1 — inject team defs into HOME with the user manifest.
+        expect(mockedReconcile).toHaveBeenNthCalledWith(
+            1, mockTeamConfig.toolPaths, '/home/testuser', TEAM_DEFS, expect.any(String), { builtinOverride: undefined },
         );
-        const manifestPath = mockedReconcile.mock.calls[0][3] as string;
-        expect(manifestPath).toContain('/home/testuser');
-        expect(manifestPath).not.toContain('/path/to/project');
+        const injectManifest = mockedReconcile.mock.calls[0][3] as string;
+        expect(injectManifest).toContain('/home/testuser');
+        expect(injectManifest).not.toContain('/path/to/project');
+        // Call 2 — removeAll sweep of the legacy <projectRoot> copy + its manifest.
+        expect(mockedReconcile).toHaveBeenNthCalledWith(
+            2, mockTeamConfig.toolPaths, '/path/to/project', [], expect.stringContaining('/path/to/project'), { removeAll: true },
+        );
     });
 });
 
@@ -305,6 +311,31 @@ describe('hooksRemove', () => {
         );
         const legacyManifest = mockedReconcile.mock.calls[1][3] as string;
         expect(legacyManifest).toContain('/path/to/project');
+    });
+
+    it('self single-repo mode removes once, without a redundant legacy sweep (#370)', async () => {
+        const restoreHome = mockHome('/home/testuser');
+        mockedAutoDetectInit.mockResolvedValue({
+            localConfig: {
+                ...mockLocalConfig,
+                scope: 'project',
+                projectRoot: '/path/to/project',
+                repo: { ...mockLocalConfig.repo, kind: 'self' },
+            },
+            teamConfig: mockTeamConfig,
+        });
+        try {
+            await hooksRemove({});
+        } finally {
+            restoreHome();
+        }
+        // Self mode's primary target is <projectRoot>; the legacy sweep would be
+        // the same location (double work) or HOME (would clobber user scope), so
+        // it must not fire — exactly one removal against <projectRoot>.
+        expect(mockedReconcile).toHaveBeenCalledTimes(1);
+        expect(mockedReconcile).toHaveBeenCalledWith(
+            mockTeamConfig.toolPaths, '/path/to/project', [], expect.any(String), { removeAll: true },
+        );
     });
 
     it('propagates error when not initialized', async () => {

--- a/src/__tests__/hooks-cmd.test.ts
+++ b/src/__tests__/hooks-cmd.test.ts
@@ -12,6 +12,7 @@ vi.mock('../hooks.js', async () => {
     return {
         getHookStatus: vi.fn(),
         reconcileHooksToAllTools: vi.fn(),
+        sweepLegacyProjectHooks: vi.fn(),
         hasInstalledCodexTrustGatedTool: vi.fn(),
         // Keep the real reminder text so assertions verify the actual wording.
         codexTrustReminder: actual.codexTrustReminder,
@@ -36,13 +37,14 @@ vi.mock('../utils/logger.js', () => ({
 // ── Imports (after mocks) ────────────────────────────────
 
 import { autoDetectInit } from '../config.js';
-import { getHookStatus, reconcileHooksToAllTools, hasInstalledCodexTrustGatedTool } from '../hooks.js';
+import { getHookStatus, reconcileHooksToAllTools, sweepLegacyProjectHooks, hasInstalledCodexTrustGatedTool } from '../hooks.js';
 import { parseTeamHooks, resolveTeamHooks } from '../resources/hooks.js';
 import { log } from '../utils/logger.js';
 import { hooksInject, hooksRemove, hooksList } from '../hooks-cmd.js';
 
 const mockedAutoDetectInit = autoDetectInit as Mock;
 const mockedGetHookStatus = getHookStatus as Mock;
+const mockedSweep = sweepLegacyProjectHooks as Mock;
 const mockedReconcile = reconcileHooksToAllTools as Mock;
 const mockedHasCodexTrustGated = hasInstalledCodexTrustGatedTool as Mock;
 const mockedParseTeamHooks = parseTeamHooks as Mock;
@@ -152,17 +154,19 @@ describe('hooksInject', () => {
         // #264: project scope injects the single copy into HOME (covers all cwds;
         // dispatch identifies the project via stdin.cwd). #370: it also sweeps any
         // legacy <projectRoot> copy an older CLI wrote, so only HOME's copy fires.
-        expect(mockedReconcile).toHaveBeenCalledTimes(2);
-        // Call 1 — inject team defs into HOME with the user manifest.
-        expect(mockedReconcile).toHaveBeenNthCalledWith(
-            1, mockTeamConfig.toolPaths, '/home/testuser', TEAM_DEFS, expect.any(String), { builtinOverride: undefined },
+        // The sweep is delegated to the shared sweepLegacyProjectHooks so this
+        // command, init/pull and hooks remove all clean up identically; what that
+        // helper does on disk is covered in hooks-reconcile-scope.test.ts.
+        expect(mockedReconcile).toHaveBeenCalledTimes(1);
+        expect(mockedReconcile).toHaveBeenCalledWith(
+            mockTeamConfig.toolPaths, '/home/testuser', TEAM_DEFS, expect.any(String), { builtinOverride: undefined },
         );
         const injectManifest = mockedReconcile.mock.calls[0][3] as string;
         expect(injectManifest).toContain('/home/testuser');
         expect(injectManifest).not.toContain('/path/to/project');
-        // Call 2 — removeAll sweep of the legacy <projectRoot> copy + its manifest.
-        expect(mockedReconcile).toHaveBeenNthCalledWith(
-            2, mockTeamConfig.toolPaths, '/path/to/project', [], expect.stringContaining('/path/to/project'), { removeAll: true },
+        expect(mockedSweep).toHaveBeenCalledWith(
+            mockTeamConfig.toolPaths,
+            expect.objectContaining({ scope: 'project', projectRoot: '/path/to/project' }),
         );
     });
 });
@@ -295,22 +299,18 @@ describe('hooksRemove', () => {
         } finally {
             restoreHome();
         }
-        // 1 main (HOME) + 1 legacy cleanup (projectRoot)
-        expect(mockedReconcile).toHaveBeenCalledTimes(2);
-
-        // Main removal targets HOME with user manifest.
-        expect(mockedReconcile).toHaveBeenNthCalledWith(1,
+        // Main removal targets HOME with the user manifest; the legacy
+        // <projectRoot> cleanup is delegated to the shared sweep helper.
+        expect(mockedReconcile).toHaveBeenCalledTimes(1);
+        expect(mockedReconcile).toHaveBeenCalledWith(
             mockTeamConfig.toolPaths, '/home/testuser', [], expect.any(String), { removeAll: true },
         );
         const userManifest = mockedReconcile.mock.calls[0][3] as string;
         expect(userManifest).toContain('/home/testuser');
-
-        // Legacy cleanup targets projectRoot with project manifest.
-        expect(mockedReconcile).toHaveBeenNthCalledWith(2,
-            mockTeamConfig.toolPaths, '/path/to/project', [], expect.any(String), { removeAll: true },
+        expect(mockedSweep).toHaveBeenCalledWith(
+            mockTeamConfig.toolPaths,
+            expect.objectContaining({ scope: 'project', projectRoot: '/path/to/project' }),
         );
-        const legacyManifest = mockedReconcile.mock.calls[1][3] as string;
-        expect(legacyManifest).toContain('/path/to/project');
     });
 
     it('self single-repo mode removes once, without a redundant legacy sweep (#370)', async () => {
@@ -331,7 +331,9 @@ describe('hooksRemove', () => {
         }
         // Self mode's primary target is <projectRoot>; the legacy sweep would be
         // the same location (double work) or HOME (would clobber user scope), so
-        // it must not fire — exactly one removal against <projectRoot>.
+        // it must not fire — exactly one removal against <projectRoot>. The
+        // "must not fire" half lives in resolveLegacyProjectHookScope, which
+        // returns null for self mode (see types.test.ts).
         expect(mockedReconcile).toHaveBeenCalledTimes(1);
         expect(mockedReconcile).toHaveBeenCalledWith(
             mockTeamConfig.toolPaths, '/path/to/project', [], expect.any(String), { removeAll: true },

--- a/src/__tests__/hooks-reconcile-scope.test.ts
+++ b/src/__tests__/hooks-reconcile-scope.test.ts
@@ -202,3 +202,79 @@ builtin:
     expect(await fse.pathExists(path.join(home, '.claude', 'settings.json'))).toBe(false);
   });
 });
+
+// ── Legacy <projectRoot> sweep (#370 follow-up) ──────────────
+//
+// The sweep that clears the pre-#370 <projectRoot> copy must not damage the
+// HOME copy the primary pass just wrote. Two ways it did:
+//  1. Hermes/OpenCode reconcile through global adapters that ignore baseDir, so
+//     a removeAll sweep against <projectRoot> deleted their HOME hooks.
+//  2. When projectRoot IS the home dir, "legacy" and "live" are the same file.
+describe('reconcileTeamHooksForConfig — legacy projectRoot sweep', () => {
+  const withOpencodeAndHermes = {
+    toolPaths: {
+      claude: { settings: '.claude/settings.json' },
+      opencode: { skills: '.opencode/skills' },
+      hermes: {},
+    },
+  } as unknown as TeamaiConfig;
+
+  const opencodePlugin = () =>
+    path.join(home, '.config', 'opencode', 'plugin', 'teamai-hooks.ts');
+  const hermesScript = () => path.join(home, '.hermes', 'hooks', 'teamai-status-report.sh');
+
+  it('keeps the HOME OpenCode plugin and Hermes hook it just installed', async () => {
+    vi.stubEnv('HERMES_HOME', path.join(home, '.hermes'));
+    await fse.ensureDir(path.join(home, '.config', 'opencode'));
+    await fse.ensureDir(path.join(home, '.hermes'));
+
+    await reconcileTeamHooksForConfig(withOpencodeAndHermes, localConfig());
+
+    expect(await fse.pathExists(opencodePlugin())).toBe(true);
+    expect(await fse.pathExists(hermesScript())).toBe(true);
+  });
+
+  it('still deletes the legacy <projectRoot> OpenCode plugin', async () => {
+    await fse.ensureDir(path.join(home, '.config', 'opencode'));
+    const legacyPlugin = path.join(project, '.opencode', 'plugin', 'teamai-hooks.ts');
+    await fse.ensureDir(path.dirname(legacyPlugin));
+    await fse.writeFile(legacyPlugin, '// stale project copy');
+
+    await reconcileTeamHooksForConfig(withOpencodeAndHermes, localConfig());
+
+    expect(await fse.pathExists(legacyPlugin)).toBe(false);
+    expect(await fse.pathExists(opencodePlugin())).toBe(true);
+  });
+
+  it('sweeps the legacy copy of a tool excluded by filterAgents', async () => {
+    // cursor wrote <projectRoot>/.cursor/hooks.json back when it was enabled;
+    // disabling it today must not strand that copy.
+    await fse.ensureDir(path.join(project, '.cursor'));
+    await fse.writeJson(path.join(project, '.cursor', 'hooks.json'), {
+      version: 1,
+      hooks: { stop: [{ command: 'teamai hook-dispatch stop --tool cursor' }] },
+    });
+
+    await reconcileTeamHooksForConfig(teamConfig, localConfig(), { filterAgents: ['claude'] });
+
+    const stale = await fse.readJson(path.join(project, '.cursor', 'hooks.json'));
+    expect(stale.hooks.stop ?? []).toHaveLength(0);
+  });
+
+  it('does not wipe the live hooks when projectRoot IS the home dir', async () => {
+    // `teamai init .` run in ~ (dotfiles-style repo): the legacy location and
+    // the live HOME target are the same file, so there is nothing to sweep.
+    const cfg = {
+      repo: { localPath: repo, remote: 'x' },
+      username: 'u',
+      scope: 'project',
+      projectRoot: home,
+      additionalRoles: [],
+    } as unknown as LocalConfig;
+
+    await reconcileTeamHooksForConfig(teamConfig, cfg);
+
+    const claude = await claudeSettings();
+    expect(claude.hooks.SessionStart).toHaveLength(1);
+  });
+});

--- a/src/__tests__/hooks-reconcile-scope.test.ts
+++ b/src/__tests__/hooks-reconcile-scope.test.ts
@@ -12,6 +12,7 @@ import type { LocalConfig, TeamaiConfig } from '../types.js';
 
 let project: string;
 let repo: string;
+let home: string;
 
 const teamConfig = {
   toolPaths: {
@@ -35,30 +36,40 @@ async function writeYaml(content: string): Promise<void> {
   await fse.ensureDir(path.join(repo, 'hooks'));
   await fse.writeFile(path.join(repo, 'hooks', 'hooks.yaml'), content);
 }
+// Non-self project scope injects into HOME (#264 / the init↔inject unification):
+// ~/.claude always exists so the "installed tool" gate passes, and the dispatch
+// runtime resolves the active project by cwd — so settings live under HOME, not
+// <projectRoot>. These readers therefore all read from `home`.
 function claudeSettings(): Promise<{ hooks: Record<string, Array<{ description?: string; hooks: Array<{ command: string }> }>> }> {
-  return fse.readJson(path.join(project, '.claude', 'settings.json'));
+  return fse.readJson(path.join(home, '.claude', 'settings.json'));
 }
 function cursorSettings(): Promise<{ hooks: Record<string, Array<{ command: string }>> }> {
-  return fse.readJson(path.join(project, '.cursor', 'hooks.json'));
+  return fse.readJson(path.join(home, '.cursor', 'hooks.json'));
 }
 function codexSettings(): Promise<{ hooks: Record<string, Array<{ matcher?: string; hooks: Array<{ command: string; timeout?: number }> }>> }> {
-  return fse.readJson(path.join(project, '.codex', 'hooks.json'));
+  return fse.readJson(path.join(home, '.codex', 'hooks.json'));
 }
 function manifest(): Promise<Record<string, Array<{ id: string }>>> {
-  return fse.readJson(path.join(project, '.teamai', 'managed-hooks.json'));
+  return fse.readJson(path.join(home, '.teamai', 'managed-hooks.json'));
 }
 
 beforeEach(async () => {
   project = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-recon-proj-'));
   repo = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-recon-repo-'));
-  // Pre-create tool root dirs so they are detected as installed
-  await fse.ensureDir(path.join(project, '.claude'));
-  await fse.ensureDir(path.join(project, '.cursor'));
-  await fse.ensureDir(path.join(project, '.codex'));
+  home = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-recon-home-'));
+  // Point HOME at the sandbox so the non-self project scope resolves its hook
+  // base dir to this dir rather than the developer's real home.
+  vi.stubEnv('HOME', home);
+  // Pre-create the tool root dirs under HOME so they are detected as installed.
+  await fse.ensureDir(path.join(home, '.claude'));
+  await fse.ensureDir(path.join(home, '.cursor'));
+  await fse.ensureDir(path.join(home, '.codex'));
 });
 afterEach(async () => {
+  vi.unstubAllEnvs();
   await fse.remove(project);
   await fse.remove(repo);
+  await fse.remove(home);
 });
 
 describe('reconcileTeamHooksForConfig — pull/init core path', () => {
@@ -169,6 +180,25 @@ builtin:
     const claude = await claudeSettings();
     expect(claude.hooks.SessionStart).toHaveLength(1);
     // No manifest written when there are no team hooks.
-    expect(await fse.pathExists(path.join(project, '.teamai', 'managed-hooks.json'))).toBe(false);
+    expect(await fse.pathExists(path.join(home, '.teamai', 'managed-hooks.json'))).toBe(false);
+  });
+
+  it('self single-repo mode injects into projectRoot, not HOME (committed to main, travels on clone)', async () => {
+    // Pre-create the tool root under projectRoot so it counts as installed there.
+    await fse.ensureDir(path.join(project, '.claude'));
+    const selfConfig = {
+      repo: { localPath: repo, remote: 'x', kind: 'self', businessRepoRoot: project },
+      username: 'u',
+      scope: 'project',
+      projectRoot: project,
+      additionalRoles: [],
+    } as unknown as LocalConfig;
+
+    await reconcileTeamHooksForConfig(teamConfig, selfConfig);
+
+    // Self mode writes to the business repo tree (projectRoot), never HOME.
+    const projectClaude = await fse.readJson(path.join(project, '.claude', 'settings.json'));
+    expect(projectClaude.hooks.SessionStart).toHaveLength(1);
+    expect(await fse.pathExists(path.join(home, '.claude', 'settings.json'))).toBe(false);
   });
 });

--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -1,11 +1,15 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import path from 'node:path';
+import os from 'node:os';
 import {
   MemberConfigSchema,
   TeamaiConfigSchema,
   SharingConfigSchema,
   StateSchema,
   LocalConfigSchema,
+  resolveLegacyProjectHookScope,
 } from '../types.js';
+import type { LocalConfig } from '../types.js';
 
 describe('MemberConfigSchema', () => {
   it('should parse a complete member config', () => {
@@ -280,5 +284,46 @@ describe('LocalConfigSchema inheritUserScope', () => {
 
   it('rejects non-boolean values', () => {
     expect(() => LocalConfigSchema.parse({ ...baseConfig, inheritUserScope: 'yes' })).toThrow();
+  });
+});
+
+describe('resolveLegacyProjectHookScope', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  const base = {
+    repo: { localPath: '/tmp/repo', remote: 'x' },
+    username: 'u',
+    additionalRoles: [],
+  };
+  const project = (extra: Record<string, unknown> = {}) =>
+    ({ ...base, scope: 'project', projectRoot: '/path/to/project', ...extra }) as unknown as LocalConfig;
+
+  it('returns the <projectRoot> pair for a non-self project scope', () => {
+    const legacy = resolveLegacyProjectHookScope(project());
+    expect(legacy?.baseDir).toBe('/path/to/project');
+    expect(legacy?.manifestPath).toContain('/path/to/project');
+  });
+
+  it('returns null for user scope (hooks only ever lived in HOME)', () => {
+    expect(resolveLegacyProjectHookScope({ ...base, scope: 'user' } as unknown as LocalConfig)).toBeNull();
+  });
+
+  it('returns null without a projectRoot', () => {
+    expect(resolveLegacyProjectHookScope({ ...base, scope: 'project' } as unknown as LocalConfig)).toBeNull();
+  });
+
+  it('returns null in self mode (its alternate location is HOME, shared with user scope)', () => {
+    expect(resolveLegacyProjectHookScope(project({ repo: { ...base.repo, kind: 'self' } }))).toBeNull();
+  });
+
+  it('returns null when projectRoot IS the home dir — never sweeps the live target', () => {
+    // `teamai init .` run in ~ (dotfiles repo): the "legacy" copy and the live
+    // HOME copy are the same file, so sweeping it would delete the hooks the
+    // primary pass just wrote.
+    const home = path.join(os.tmpdir(), 'teamai-legacy-home');
+    vi.stubEnv('HOME', home);
+    expect(resolveLegacyProjectHookScope(project({ projectRoot: home }))).toBeNull();
+    // Also when the two differ only by a trailing separator / relative segment.
+    expect(resolveLegacyProjectHookScope(project({ projectRoot: path.join(home, '.') }))).toBeNull();
   });
 });

--- a/src/__tests__/uninstall.test.ts
+++ b/src/__tests__/uninstall.test.ts
@@ -680,6 +680,44 @@ describe('uninstall', () => {
     expect(await fse.pathExists(teamaiHome)).toBe(false);
   });
 
+  it('non-self project scope removes hooks from HOME, where #370 injects them (not <projectRoot>)', async () => {
+    const projectRoot = path.join(tmpDir, 'proj-hooks');
+    const repoPath = path.join(projectRoot, '.teamai', 'team-repo');
+    const homeDir = path.join(tmpDir, 'home');
+    await fse.ensureDir(repoPath);
+    await fse.ensureDir(path.join(projectRoot, '.teamai'));
+    await fse.writeFile(path.join(projectRoot, '.teamai', 'config.yaml'), 'scope: project');
+
+    // #370: a non-self project scope injects its hooks into HOME, not projectRoot.
+    await fse.ensureDir(path.join(homeDir, '.claude'));
+    await fse.writeJson(path.join(homeDir, '.claude', 'settings.json'), {
+      hooks: { SessionStart: [{ matcher: '*', hooks: [{ type: 'command', command: 'teamai hook-dispatch session-start' }], description: '[teamai] Auto-pull' }] },
+    });
+
+    vi.stubEnv('HOME', homeDir);
+    vi.stubEnv('SHELL', '/bin/bash');
+
+    const teamConfig = makeTeamConfig();
+    const localConfig = makeLocalConfig(projectRoot, repoPath, { scope: 'project', projectRoot });
+    mockAutoDetectInit.mockResolvedValue({ localConfig, teamConfig });
+
+    await uninstall({ force: true });
+
+    // The reported bug (#1): uninstall scanned <projectRoot> and left the HOME
+    // SessionStart hook live forever. It must target the HOME settings file.
+    expect(mockReconcileHooks).toHaveBeenCalledWith(
+      path.join(homeDir, '.claude', 'settings.json'),
+      'claude',
+      [],
+      expect.objectContaining({ removeAll: true, manifestPath: expect.stringContaining('managed-hooks.json') }),
+    );
+    // …and never a <projectRoot> settings copy (there is none in this fixture).
+    const targetedProjectRoot = mockReconcileHooks.mock.calls.some(
+      (c) => String(c[0]).startsWith(path.join(projectRoot, '.claude')),
+    );
+    expect(targetedProjectRoot).toBe(false);
+  });
+
   it('命名空间 skills 正确处理', async () => {
     const { homeDir, repoPath } = await setupFixture(tmpDir);
     vi.stubEnv('HOME', homeDir);

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -6,7 +6,7 @@ import type { GlobalOptions, Scope } from './types.js';
 import {
   TeamaiConfigSchema,
   TEAMAI_ENV_START,
-  resolveBaseDir,
+  resolveHookScope,
   getTeamaiHome,
   type TeamaiConfig,
 } from './types.js';
@@ -85,7 +85,11 @@ export async function doctor(options: GlobalOptions): Promise<void> {
   // Fall back to schema defaults if team config is unavailable
   const toolPaths = teamConfig?.toolPaths ?? TeamaiConfigSchema.shape.toolPaths.parse(undefined);
   const providerName = teamConfig?.provider ?? 'tgit';
-  const baseDir = localConfig ? resolveBaseDir(localConfig) : getUserHome();
+  // Hook checks must look where hooks are actually injected. resolveHookScope
+  // maps a non-self project scope to HOME (#264), matching the injection path in
+  // init/pull/hooks-cmd — otherwise doctor checks <projectRoot>/.claude while the
+  // hooks live in ~/.claude and always reports them missing.
+  const baseDir = localConfig ? resolveHookScope(localConfig).baseDir : getUserHome();
 
   const checks: Check[] = [];
 

--- a/src/hooks-cmd.ts
+++ b/src/hooks-cmd.ts
@@ -4,8 +4,8 @@ import { reconcileHooksToAllTools, getHookStatus, hasInstalledCodexTrustGatedToo
 import { builtinHookDefs } from './builtin-hooks.js';
 import { parseTeamHooks, resolveTeamHooks } from './resources/hooks.js';
 import { log } from './utils/logger.js';
-import type { GlobalOptions, LocalConfig } from './types.js';
-import { resolveHookScope, getManagedHooksPath } from './types.js';
+import type { GlobalOptions } from './types.js';
+import { resolveHookScope, resolveLegacyProjectHookScope } from './types.js';
 import { getUserHome } from './utils/home.js';
 
 type HookListStatus = HookStatus | 'not configured';
@@ -14,25 +14,6 @@ interface HookListRow {
     tool: string;
     status: HookListStatus;
     settingsPath: string;
-}
-
-interface HookScopeTarget {
-    baseDir: string;
-    manifestPath: string;
-}
-
-/**
- * Resolve the (baseDir, manifestPath) pairs for hook reconciliation.
- *
- * Delegates to the shared `resolveHookScope` so this command uses the exact same
- * on-disk target as `init`/`pull`/`bootstrap` and `doctor`:
- * - Non-self project scope → HOME + user manifest (#264). HOME covers every cwd;
- *   the dispatch runtime identifies the active project via detectProjectConfig.
- * - Self single-repo mode → projectRoot (hooks committed to main travel on clone).
- * - User scope → HOME.
- */
-function resolveHookScopeTargets(localConfig: LocalConfig): HookScopeTarget[] {
-    return [resolveHookScope(localConfig)];
 }
 
 function formatDisplayPath(settingsPath: string): string {
@@ -76,11 +57,17 @@ export async function hooksInject(options: GlobalOptions): Promise<void> {
         silent: options.silent,
     });
     let codexTrustGated = false;
-    for (const { baseDir, manifestPath } of resolveHookScopeTargets(localConfig)) {
-        await reconcileHooksToAllTools(teamConfig.toolPaths, baseDir, teamDefs, manifestPath, { builtinOverride: builtin });
-        if (await hasInstalledCodexTrustGatedTool(teamConfig.toolPaths, baseDir)) {
-            codexTrustGated = true;
-        }
+    const { baseDir, manifestPath } = resolveHookScope(localConfig);
+    await reconcileHooksToAllTools(teamConfig.toolPaths, baseDir, teamDefs, manifestPath, { builtinOverride: builtin });
+    if (await hasInstalledCodexTrustGatedTool(teamConfig.toolPaths, baseDir)) {
+        codexTrustGated = true;
+    }
+
+    // Sweep any legacy <projectRoot> copy a pre-#370 CLI left behind, so the
+    // HOME copy this command just wrote is the only one that fires (#264/#370).
+    const legacy = resolveLegacyProjectHookScope(localConfig);
+    if (legacy) {
+        await reconcileHooksToAllTools(teamConfig.toolPaths, legacy.baseDir, [], legacy.manifestPath, { removeAll: true });
     }
 
     if (!options.silent) {
@@ -101,7 +88,7 @@ export async function hooksInject(options: GlobalOptions): Promise<void> {
  */
 export async function hooksList(_options: GlobalOptions): Promise<void> {
     const { localConfig, teamConfig } = await autoDetectInit();
-    const baseDirs = resolveHookScopeTargets(localConfig).map((t) => t.baseDir);
+    const { baseDir } = resolveHookScope(localConfig);
     const rows: HookListRow[] = [];
 
     for (const [tool, paths] of Object.entries(teamConfig.toolPaths)) {
@@ -109,14 +96,12 @@ export async function hooksList(_options: GlobalOptions): Promise<void> {
             rows.push({ tool, status: 'not configured', settingsPath: 'no settings configured' });
             continue;
         }
-        for (const baseDir of baseDirs) {
-            const settingsPath = path.join(baseDir, paths.settings);
-            rows.push({
-                tool,
-                status: await getHookStatus(settingsPath, tool),
-                settingsPath: formatDisplayPath(settingsPath),
-            });
-        }
+        const settingsPath = path.join(baseDir, paths.settings);
+        rows.push({
+            tool,
+            status: await getHookStatus(settingsPath, tool),
+            settingsPath: formatDisplayPath(settingsPath),
+        });
     }
 
     console.log(formatHooksList(rows));
@@ -151,15 +136,16 @@ export async function hooksList(_options: GlobalOptions): Promise<void> {
 export async function hooksRemove(_options: GlobalOptions): Promise<void> {
     const { localConfig, teamConfig } = await autoDetectInit();
 
-    for (const { baseDir, manifestPath } of resolveHookScopeTargets(localConfig)) {
-        await reconcileHooksToAllTools(teamConfig.toolPaths, baseDir, [], manifestPath, { removeAll: true });
-    }
+    const { baseDir, manifestPath } = resolveHookScope(localConfig);
+    await reconcileHooksToAllTools(teamConfig.toolPaths, baseDir, [], manifestPath, { removeAll: true });
 
-    // Clean up legacy projectRoot entries left by older versions that wrote
-    // hooks into both <projectRoot> and HOME (#264 migration).
-    if (localConfig.scope === 'project' && localConfig.projectRoot) {
-        const legacyManifest = getManagedHooksPath('project', localConfig.projectRoot);
-        await reconcileHooksToAllTools(teamConfig.toolPaths, localConfig.projectRoot, [], legacyManifest, { removeAll: true });
+    // Clean up the legacy <projectRoot> copy a pre-#370 CLI wrote alongside HOME
+    // for a non-self project scope. Gated to a project-owned location that
+    // differs from the primary target — never HOME (shared with user scope), and
+    // never re-running on the primary target itself (self mode).
+    const legacy = resolveLegacyProjectHookScope(localConfig);
+    if (legacy) {
+        await reconcileHooksToAllTools(teamConfig.toolPaths, legacy.baseDir, [], legacy.manifestPath, { removeAll: true });
     }
 
     log.success('Hooks removed from all AI tool settings');

--- a/src/hooks-cmd.ts
+++ b/src/hooks-cmd.ts
@@ -5,7 +5,7 @@ import { builtinHookDefs } from './builtin-hooks.js';
 import { parseTeamHooks, resolveTeamHooks } from './resources/hooks.js';
 import { log } from './utils/logger.js';
 import type { GlobalOptions, LocalConfig } from './types.js';
-import { resolveBaseDir, getManagedHooksPath } from './types.js';
+import { resolveHookScope, getManagedHooksPath } from './types.js';
 import { getUserHome } from './utils/home.js';
 
 type HookListStatus = HookStatus | 'not configured';
@@ -22,26 +22,17 @@ interface HookScopeTarget {
 }
 
 /**
- * Resolve the (baseDir, manifestPath) pair for hook reconciliation.
+ * Resolve the (baseDir, manifestPath) pairs for hook reconciliation.
  *
- * User scope → HOME + user manifest (unchanged).
- * Project scope → HOME + user manifest only (#264). The previous behaviour
- * duplicated entries into <projectRoot> as well (for #44 subdirectory
- * coverage), but HOME already covers every cwd. The dispatch runtime now
- * identifies the active project via detectProjectConfig(stdin.cwd), so a
- * redundant projectRoot copy is unnecessary.
+ * Delegates to the shared `resolveHookScope` so this command uses the exact same
+ * on-disk target as `init`/`pull`/`bootstrap` and `doctor`:
+ * - Non-self project scope → HOME + user manifest (#264). HOME covers every cwd;
+ *   the dispatch runtime identifies the active project via detectProjectConfig.
+ * - Self single-repo mode → projectRoot (hooks committed to main travel on clone).
+ * - User scope → HOME.
  */
 function resolveHookScopeTargets(localConfig: LocalConfig): HookScopeTarget[] {
-    if (localConfig.scope !== 'project') {
-        return [{
-            baseDir: resolveBaseDir(localConfig) ?? '',
-            manifestPath: getManagedHooksPath(localConfig.scope, localConfig.projectRoot),
-        }];
-    }
-    return [{
-        baseDir: getUserHome(),
-        manifestPath: getManagedHooksPath('user'),
-    }];
+    return [resolveHookScope(localConfig)];
 }
 
 function formatDisplayPath(settingsPath: string): string {

--- a/src/hooks-cmd.ts
+++ b/src/hooks-cmd.ts
@@ -1,11 +1,11 @@
 import path from 'node:path';
 import { autoDetectInit } from './config.js';
-import { reconcileHooksToAllTools, getHookStatus, hasInstalledCodexTrustGatedTool, codexTrustReminder, type HookStatus } from './hooks.js';
+import { reconcileHooksToAllTools, sweepLegacyProjectHooks, getHookStatus, hasInstalledCodexTrustGatedTool, codexTrustReminder, type HookStatus } from './hooks.js';
 import { builtinHookDefs } from './builtin-hooks.js';
 import { parseTeamHooks, resolveTeamHooks } from './resources/hooks.js';
 import { log } from './utils/logger.js';
 import type { GlobalOptions } from './types.js';
-import { resolveHookScope, resolveLegacyProjectHookScope } from './types.js';
+import { resolveHookScope } from './types.js';
 import { getUserHome } from './utils/home.js';
 
 type HookListStatus = HookStatus | 'not configured';
@@ -65,10 +65,7 @@ export async function hooksInject(options: GlobalOptions): Promise<void> {
 
     // Sweep any legacy <projectRoot> copy a pre-#370 CLI left behind, so the
     // HOME copy this command just wrote is the only one that fires (#264/#370).
-    const legacy = resolveLegacyProjectHookScope(localConfig);
-    if (legacy) {
-        await reconcileHooksToAllTools(teamConfig.toolPaths, legacy.baseDir, [], legacy.manifestPath, { removeAll: true });
-    }
+    await sweepLegacyProjectHooks(teamConfig.toolPaths, localConfig);
 
     if (!options.silent) {
         log.success('Hooks injected into all AI tool settings');
@@ -141,12 +138,10 @@ export async function hooksRemove(_options: GlobalOptions): Promise<void> {
 
     // Clean up the legacy <projectRoot> copy a pre-#370 CLI wrote alongside HOME
     // for a non-self project scope. Gated to a project-owned location that
-    // differs from the primary target — never HOME (shared with user scope), and
-    // never re-running on the primary target itself (self mode).
-    const legacy = resolveLegacyProjectHookScope(localConfig);
-    if (legacy) {
-        await reconcileHooksToAllTools(teamConfig.toolPaths, legacy.baseDir, [], legacy.manifestPath, { removeAll: true });
-    }
+    // differs from the primary target — never HOME (shared with user scope, and
+    // the primary target itself when projectRoot IS the home dir), and never
+    // re-running on the primary target in self mode.
+    await sweepLegacyProjectHooks(teamConfig.toolPaths, localConfig);
 
     log.success('Hooks removed from all AI tool settings');
 }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -834,13 +834,20 @@ export async function injectHooksToAllTools(toolPaths: Record<string, { settings
  * Reconcile built-in (A) + team (B) hooks across every tool that has a settings
  * path, using a shared managed-hooks manifest. This is the authoritative
  * injection path used by `teamai pull` / `init` / `hooks inject`.
+ *
+ * `settingsOnly` restricts the pass to tools reconciled through their settings
+ * file, skipping Hermes and OpenCode. Those two go through global adapters that
+ * ignore `baseDir` — `removeHermesHooks()` takes none, and the OpenCode
+ * adapter's removeAll branch always targets HOME — so a caller sweeping a
+ * secondary location (the legacy `<projectRoot>` copy) must opt out, or it
+ * deletes the hooks the primary pass just installed.
  */
 export async function reconcileHooksToAllTools(
   toolPaths: Record<string, { settings?: string }>,
   baseDir: string,
   teamDefs: HookDef[],
   manifestPath: string,
-  opts: { removeAll?: boolean; builtinOverride?: BuiltinHookOverride; filterAgents?: string[] } = {},
+  opts: { removeAll?: boolean; builtinOverride?: BuiltinHookOverride; filterAgents?: string[]; settingsOnly?: boolean } = {},
 ): Promise<void> {
   const activeTools = Object.keys(toolPaths).filter(t => !opts.filterAgents || opts.filterAgents.includes(t));
   let shellAvailable = true;
@@ -860,6 +867,7 @@ export async function reconcileHooksToAllTools(
     // JSON settings file, so it bypasses the settings-based reconcile path.
     // Install when the .hermes home exists; removeAll clears the teamai hook.
     if (tool === 'hermes') {
+      if (opts.settingsOnly) continue;
       try {
         const { getHermesHome } = await import('./hermes-home.js');
         const hermesRoot = getHermesHome();
@@ -879,6 +887,7 @@ export async function reconcileHooksToAllTools(
     // its config dirs. Route it to the plugin-file adapter instead of the
     // settings-based path.
     if (tool === 'opencode') {
+      if (opts.settingsOnly) continue;
       try {
         await reconcileOpencodePlugin(baseDir, opts.removeAll);
       } catch (e) {
@@ -930,6 +939,45 @@ export async function hasInstalledCodexTrustGatedTool(
 }
 
 /**
+ * Sweep the legacy `<projectRoot>` hook copy a pre-#370 CLI wrote alongside
+ * HOME for a non-self project scope. Without it both copies stay live after an
+ * upgrade and every session start fires hook-dispatch twice (two concurrent
+ * background pulls), and the auto-migrate guard never converges.
+ *
+ * Shared by the inject path (`init`/`pull`/`bootstrap`), `hooks inject`, and
+ * `hooks remove` so all three sweep identically. Two rules this encodes:
+ *
+ * - `settingsOnly` — Hermes and OpenCode reconcile through global adapters that
+ *   ignore `baseDir` (removeHermesHooks() takes none; the OpenCode adapter's
+ *   removeAll branch always targets HOME), so letting a secondary-location
+ *   sweep reach them deletes the hooks the primary pass just installed. The
+ *   project-scope OpenCode plugin is instead removed directly below, which is
+ *   the only OpenCode copy this legacy location can own.
+ * - No `filterAgents` — cleanup of a legacy location must be unconditional. A
+ *   tool disabled today may well be the one that wrote the stale copy back when
+ *   it was enabled; filtering it out would leave that copy firing forever.
+ */
+export async function sweepLegacyProjectHooks(
+  toolPaths: Record<string, { settings?: string }>,
+  localConfig: LocalConfig,
+): Promise<void> {
+  const legacy = resolveLegacyProjectHookScope(localConfig);
+  if (!legacy) return;
+  await reconcileHooksToAllTools(toolPaths, legacy.baseDir, [], legacy.manifestPath, {
+    removeAll: true,
+    settingsOnly: true,
+  });
+  if (toolPaths.opencode) {
+    try {
+      const { removeOpencodeHooks } = await import('./opencode-hooks.js');
+      await removeOpencodeHooks(legacy.baseDir, 'project');
+    } catch (e) {
+      log.warn(`Failed to remove legacy OpenCode project plugin: ${(e as Error).message}`);
+    }
+  }
+}
+
+/**
  * Reconcile built-in (A) + team (B) hooks for a single scope's tools.
  * Parses the scope's hooks/hooks.yaml, resolves the scope base dir + manifest,
  * and reconciles every tool. Returns the team defs that were applied (for
@@ -957,18 +1005,6 @@ export async function reconcileTeamHooksForConfig(
     builtinOverride: builtin,
     filterAgents,
   });
-  // Sweep the legacy <projectRoot> copy a pre-#370 CLI wrote alongside HOME for
-  // a non-self project scope. Without this, both copies stay live after upgrade
-  // and every session start fires hook-dispatch twice (two background pulls) —
-  // and the auto-migrate guard never converges. Project-owned location only
-  // (resolveLegacyProjectHookScope never returns HOME), so this cannot touch a
-  // coexisting user-scope install.
-  const legacy = resolveLegacyProjectHookScope(localConfig);
-  if (legacy) {
-    await reconcileHooksToAllTools(teamConfig.toolPaths, legacy.baseDir, [], legacy.manifestPath, {
-      removeAll: true,
-      filterAgents,
-    });
-  }
+  await sweepLegacyProjectHooks(teamConfig.toolPaths, localConfig);
   return teamDefs;
 }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { readJson, writeJson, expandHome, ensureDir, pathExists } from './utils/fs.js';
 import { log } from './utils/logger.js';
-import { TEAMAI_HOOK_DESCRIPTION_PREFIX, TEAMAI_CUSTOM_HOOK_PREFIX, TEAMAI_AGENT_HOOK_PREFIX, getManagedHooksPath, resolveBaseDir } from './types.js';
+import { TEAMAI_HOOK_DESCRIPTION_PREFIX, TEAMAI_CUSTOM_HOOK_PREFIX, TEAMAI_AGENT_HOOK_PREFIX, resolveHookScope } from './types.js';
 import type { HookDef, TeamaiConfig, LocalConfig } from './types.js';
 import { builtinHookDefs, applyBuiltinOverride, ensureWrapperIfShellAvailable, SHELL_DEPENDENT_TOOLS } from './builtin-hooks.js';
 import type { BuiltinHookOverride } from './builtin-hooks.js';
@@ -943,8 +943,7 @@ export async function reconcileTeamHooksForConfig(
   const { defs: teamDefs, builtin } = opts.removeAll
     ? { defs: [] as HookDef[], builtin: undefined }
     : await resolveTeamHooks(teamConfig, localConfig.repo.localPath, { auto: opts.auto, silent: opts.silent });
-  const baseDir = resolveBaseDir(localConfig);
-  const manifestPath = getManagedHooksPath(localConfig.scope, localConfig.projectRoot);
+  const { baseDir, manifestPath } = resolveHookScope(localConfig);
   let filterAgents = opts.filterAgents ?? localConfig.enabledAgents;
   const disabled = localConfig.disabledAgents;
   if (disabled && disabled.length > 0) {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { readJson, writeJson, expandHome, ensureDir, pathExists } from './utils/fs.js';
 import { log } from './utils/logger.js';
-import { TEAMAI_HOOK_DESCRIPTION_PREFIX, TEAMAI_CUSTOM_HOOK_PREFIX, TEAMAI_AGENT_HOOK_PREFIX, resolveHookScope } from './types.js';
+import { TEAMAI_HOOK_DESCRIPTION_PREFIX, TEAMAI_CUSTOM_HOOK_PREFIX, TEAMAI_AGENT_HOOK_PREFIX, resolveHookScope, resolveLegacyProjectHookScope } from './types.js';
 import type { HookDef, TeamaiConfig, LocalConfig } from './types.js';
 import { builtinHookDefs, applyBuiltinOverride, ensureWrapperIfShellAvailable, SHELL_DEPENDENT_TOOLS } from './builtin-hooks.js';
 import type { BuiltinHookOverride } from './builtin-hooks.js';
@@ -957,5 +957,18 @@ export async function reconcileTeamHooksForConfig(
     builtinOverride: builtin,
     filterAgents,
   });
+  // Sweep the legacy <projectRoot> copy a pre-#370 CLI wrote alongside HOME for
+  // a non-self project scope. Without this, both copies stay live after upgrade
+  // and every session start fires hook-dispatch twice (two background pulls) —
+  // and the auto-migrate guard never converges. Project-owned location only
+  // (resolveLegacyProjectHookScope never returns HOME), so this cannot touch a
+  // coexisting user-scope install.
+  const legacy = resolveLegacyProjectHookScope(localConfig);
+  if (legacy) {
+    await reconcileHooksToAllTools(teamConfig.toolPaths, legacy.baseDir, [], legacy.manifestPath, {
+      removeAll: true,
+      filterAgents,
+    });
+  }
   return teamDefs;
 }

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -22,6 +22,7 @@ import {
   TEAMAI_RECALL_RULES_END,
   CultureFrontmatterSchema,
   resolveBaseDir,
+  resolveHookScope,
   getTeamaiHome,
   isRecallEnabled,
   isAgentDisabled,
@@ -1198,7 +1199,11 @@ async function autoMigrateHooksIfNeeded(): Promise<void> {
   const { autoDetectInit } = await import('./config.js');
   const { injectHooksToAllTools } = await import('./hooks.js');
   const { localConfig, teamConfig } = await autoDetectInit();
-  const baseDir = resolveBaseDir(localConfig);
+  // Reinject where hooks actually live (resolveHookScope), not resolveBaseDir.
+  // The old-format check above reads HOME; for a non-self project scope
+  // resolveBaseDir → <projectRoot>, so reinjecting there never clears HOME's
+  // legacy format and this migration would re-fire on every pull (#370).
+  const { baseDir } = resolveHookScope(localConfig);
   const disabled = localConfig.disabledAgents;
   let hookFilter = localConfig.enabledAgents;
   if (disabled && disabled.length > 0) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1270,6 +1270,39 @@ export function getManagedHooksPath(scope: Scope, projectRoot?: string): string 
 }
 
 /**
+ * Resolve where hooks are injected on disk for a config: the (baseDir,
+ * manifestPath) pair every hook injection path must share.
+ *
+ * The rule is load-bearing and was previously duplicated (and drifted) across
+ * `init`/`pull`/`bootstrap` (which used resolveBaseDir → projectRoot) and the
+ * `hooks inject` command (which used HOME, per #264). The divergence meant a
+ * project-scope `teamai init` tried to write the SessionStart hook into
+ * `<projectRoot>/.claude`, which does not exist yet on a fresh init, so the
+ * "only inject into installed tools" gate skipped every tool — leaving the
+ * project with no session-start hook and therefore no auto-pull.
+ *
+ * Canonical rule:
+ * - Non-self project scope → HOME + user manifest. `~/.claude` always exists,
+ *   so the gate passes; the dispatch runtime identifies the active project via
+ *   detectProjectConfig(stdin.cwd), so a projectRoot copy is unnecessary (#264).
+ * - Self single-repo mode → projectRoot (its resolveBaseDir). Hooks live in the
+ *   business repo's tool dirs and are committed to main so a teammate's clone
+ *   carries the session-start hook that self-heals ("clone = initialized").
+ * - User scope → HOME (its resolveBaseDir).
+ */
+export function resolveHookScope(
+  localConfig: LocalConfig,
+): { baseDir: string; manifestPath: string } {
+  if (localConfig.scope === 'project' && !isSelfMode(localConfig)) {
+    return { baseDir: getUserHome(), manifestPath: getManagedHooksPath('user') };
+  }
+  return {
+    baseDir: resolveBaseDir(localConfig),
+    manifestPath: getManagedHooksPath(localConfig.scope, localConfig.projectRoot),
+  };
+}
+
+/**
  * Get the user-level pushignore path.
  */
 export function getPushignorePath(): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1324,12 +1324,18 @@ export function resolveHookScope(
  *   shared with any user-scope install and its user manifest — a blind
  *   removeAll there would clobber genuine user-scope hooks, so we never sweep
  *   it. (The cross-scope collision itself is tracked separately.)
+ * - projectRoot that IS the home dir (`teamai init .` run in `~`, e.g. a
+ *   dotfiles repo). Then the "legacy" location and the live HOME target are the
+ *   same file, and sweeping it would delete the hooks the primary pass just
+ *   wrote. This is what makes the "never returns HOME" invariant callers rely
+ *   on actually hold.
  */
 export function resolveLegacyProjectHookScope(
   localConfig: LocalConfig,
 ): { baseDir: string; manifestPath: string } | null {
   if (localConfig.scope !== 'project' || !localConfig.projectRoot) return null;
   if (isSelfMode(localConfig)) return null;
+  if (path.resolve(localConfig.projectRoot) === path.resolve(getUserHome())) return null;
   return {
     baseDir: localConfig.projectRoot,
     manifestPath: getManagedHooksPath('project', localConfig.projectRoot),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1289,16 +1289,50 @@ export function getManagedHooksPath(scope: Scope, projectRoot?: string): string 
  *   business repo's tool dirs and are committed to main so a teammate's clone
  *   carries the session-start hook that self-heals ("clone = initialized").
  * - User scope → HOME (its resolveBaseDir).
+ *
+ * Degrades gracefully: only self mode reaches the projectRoot branch, and a
+ * self config missing `projectRoot` (optional in the schema) falls back to HOME
+ * rather than throwing — so read-only callers like `doctor` never crash on a
+ * partially-broken config.
  */
 export function resolveHookScope(
   localConfig: LocalConfig,
 ): { baseDir: string; manifestPath: string } {
-  if (localConfig.scope === 'project' && !isSelfMode(localConfig)) {
+  const selfWithRoot = isSelfMode(localConfig) && !!localConfig.projectRoot;
+  if (localConfig.scope === 'project' && !selfWithRoot) {
     return { baseDir: getUserHome(), manifestPath: getManagedHooksPath('user') };
   }
   return {
     baseDir: resolveBaseDir(localConfig),
     manifestPath: getManagedHooksPath(localConfig.scope, localConfig.projectRoot),
+  };
+}
+
+/**
+ * The legacy `<projectRoot>` hook location a pre-#370 CLI wrote to for a
+ * non-self project scope, whose hooks now live in HOME (`resolveHookScope`).
+ * Older `init`/`pull` runs wrote the SessionStart hook into
+ * `<projectRoot>/.claude` as well; left behind after upgrade it double-fires
+ * (two `hook-dispatch session-start` → two concurrent background pulls) and
+ * duplicates every team hook. Callers on the inject path (`init`/`pull`) and
+ * `hooks remove`/`uninstall` sweep it clean.
+ *
+ * Returns null when there is nothing project-owned to sweep:
+ * - user scope (only ever HOME),
+ * - project scope without a projectRoot,
+ * - self single-repo mode. Self mode's alternate location is HOME, which is
+ *   shared with any user-scope install and its user manifest — a blind
+ *   removeAll there would clobber genuine user-scope hooks, so we never sweep
+ *   it. (The cross-scope collision itself is tracked separately.)
+ */
+export function resolveLegacyProjectHookScope(
+  localConfig: LocalConfig,
+): { baseDir: string; manifestPath: string } | null {
+  if (localConfig.scope !== 'project' || !localConfig.projectRoot) return null;
+  if (isSelfMode(localConfig)) return null;
+  return {
+    baseDir: localConfig.projectRoot,
+    manifestPath: getManagedHooksPath('project', localConfig.projectRoot),
   };
 }
 

--- a/src/uninstall.ts
+++ b/src/uninstall.ts
@@ -19,9 +19,10 @@ import {
   TEAMAI_ENV_START,
   TEAMAI_ENV_END,
   getTeamaiHome,
-  getManagedHooksPath,
   managedMcpManifestPath,
   resolveBaseDir,
+  resolveHookScope,
+  resolveLegacyProjectHookScope,
   scopedToolPaths,
   type GlobalOptions,
   type TeamaiConfig,
@@ -56,8 +57,9 @@ interface UninstallOptions extends GlobalOptions {
 }
 
 interface RemovalPlan {
-  /** Tool settings files that contain teamai hooks. */
-  hookFiles: Array<{ path: string; tool: string }>;
+  /** Tool settings files that contain teamai hooks (each with the manifest that
+   *  recorded its team hooks — HOME/user or a legacy <projectRoot>/project one). */
+  hookFiles: Array<{ path: string; tool: string; manifestPath: string }>;
   /** OpenClaw-style hook dirs (<base>/.<tool>/hooks) holding teamai HOOK.md+handler.ts. */
   openclawHookDirs: Array<{ hooksDir: string; tool: string }>;
   /** OpenCode teamai plugin files (.opencode/plugin/teamai-*.ts) to delete. */
@@ -80,8 +82,6 @@ interface RemovalPlan {
   teamaiHome: string;
   /** Whether teamaiHome exists on disk. */
   teamaiHomeExists: boolean;
-  /** Managed-hooks manifest path (for team-hook cleanup). */
-  managedHooksPath: string;
   /** Whether shared resources (docs / ~/.teamai / shell profile) are part of this removal. */
   includeShared: boolean;
   /** Whether this removal targets Hermes (clears its SOUL.md block + config.yaml hook). */
@@ -92,7 +92,7 @@ interface RemovalPlan {
 
 /** Per-tool findings collected during discovery (tool-specific resources only). */
 interface ToolResources {
-  hookFiles: Array<{ path: string; tool: string }>;
+  hookFiles: Array<{ path: string; tool: string; manifestPath: string }>;
   openclawHookDirs: Array<{ hooksDir: string; tool: string }>;
   opencodeHookScopes: Array<{ baseDir: string; scope: Scope }>;
   claudeMdFiles: string[];
@@ -221,7 +221,7 @@ async function discoverToolResources(
   teamSkillNames: Set<string>,
   teamRuleNames: Set<string>,
   teamAgentNames: Set<string>,
-  managedHooksPath: string,
+  hookTargets: Array<{ baseDir: string; manifestPath: string }>,
   scope: Scope,
 ): Promise<ToolResources> {
   const res: ToolResources = {
@@ -248,11 +248,17 @@ async function discoverToolResources(
       }
     }
   } else if (toolPath.settings) {
-    const settingsPath = path.join(baseDir, toolPath.settings);
-    if (await pathExists(settingsPath)
-      && (await hasTeamaiHooks(settingsPath, tool, managedHooksPath)
-        || isEmptyHooksResidue(await readJson<Record<string, unknown>>(settingsPath)))) {
-      res.hookFiles.push({ path: settingsPath, tool });
+    // Hooks live where resolveHookScope injected them (HOME for a non-self
+    // project scope, per #370) — plus any legacy <projectRoot> copy. Scan every
+    // target and tag each match with the manifest that recorded its team hooks,
+    // so removal strips the right entries at each location.
+    for (const { baseDir: hookBaseDir, manifestPath } of hookTargets) {
+      const settingsPath = path.join(hookBaseDir, toolPath.settings);
+      if (await pathExists(settingsPath)
+        && (await hasTeamaiHooks(settingsPath, tool, manifestPath)
+          || isEmptyHooksResidue(await readJson<Record<string, unknown>>(settingsPath)))) {
+        res.hookFiles.push({ path: settingsPath, tool, manifestPath });
+      }
     }
   } else {
     // OpenClaw-style agents (no settings file) inject a HOOK.md + handler.ts
@@ -374,8 +380,15 @@ async function buildRemovalPlan(
     } catch { /* best effort */ }
   }
 
-  // Discover per-tool resources
-  const managedHooksPath = getManagedHooksPath(localConfig.scope, localConfig.projectRoot);
+  // Discover per-tool resources. Hooks are discovered at the injection target
+  // resolveHookScope reports (HOME + user manifest for a non-self project scope,
+  // #370) — the previous code scanned <projectRoot>, so uninstall silently left
+  // the SessionStart hook live in HOME forever. A legacy <projectRoot> copy from
+  // a pre-#370 CLI is swept too, tagged with its project manifest.
+  const primaryHookScope = resolveHookScope(localConfig);
+  const hookTargets = [primaryHookScope];
+  const legacyHookScope = resolveLegacyProjectHookScope(localConfig);
+  if (legacyHookScope) hookTargets.push(legacyHookScope);
   const perTool = new Map<string, ToolResources>();
   for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
     perTool.set(
@@ -387,7 +400,7 @@ async function buildRemovalPlan(
         teamSkillNames,
         teamRuleNames,
         teamAgentNames,
-        managedHooksPath,
+        hookTargets,
         localConfig.scope,
       ),
     );
@@ -425,7 +438,6 @@ async function buildRemovalPlan(
     docsDir: null,
     teamaiHome,
     teamaiHomeExists: includeShared && await pathExists(teamaiHome),
-    managedHooksPath,
     includeShared,
     hermesCleanup: toolsToMerge.includes('hermes'),
     scope: localConfig.scope,
@@ -616,10 +628,12 @@ async function teardownPlugins(): Promise<void> {
 }
 
 async function executeRemoval(plan: RemovalPlan): Promise<void> {
-  // (a) Remove hooks from tool settings (built-in A + team B via the manifest)
-  for (const { path: settingsPath, tool } of plan.hookFiles) {
+  // (a) Remove hooks from tool settings (built-in A + team B via the manifest).
+  // Each entry carries the manifest for its own location (HOME/user or a legacy
+  // <projectRoot>/project copy), so team hooks are stripped correctly at both.
+  for (const { path: settingsPath, tool, manifestPath } of plan.hookFiles) {
     try {
-      await reconcileHooks(settingsPath, tool, [], { removeAll: true, manifestPath: plan.managedHooksPath });
+      await reconcileHooks(settingsPath, tool, [], { removeAll: true, manifestPath });
     } catch (e) {
       log.warn(`Failed to remove hooks from ${settingsPath}: ${(e as Error).message}`);
     }


### PR DESCRIPTION
## Problem

Opening Claude Code in a **project-scope** install did not auto-pull team skills, and `teamai doctor` reported two checks failing even right after a successful `teamai init`:

```
✖ teamai hooks in claude settings
✖ Env variables injected in shell profile
```

### Root cause

Hook injection had **two divergent code paths** that had drifted:

- `init` / `pull` / `bootstrap` (`reconcileTeamHooksForConfig`) resolved the base dir via `resolveBaseDir` → `<projectRoot>` for project scope.
- The `hooks inject` command resolved it to **HOME** (per #264).

On a fresh project-scope `init`, `<projectRoot>/.claude` does not exist yet. The `reconcileHooksToAllTools` "only inject into installed tools" gate (`if (!await pathExists(toolRoot)) continue`) therefore skipped **every** tool, so the **SessionStart hook was never written anywhere**. That hook is what triggers the background `teamai pull` on each session start — with no hook, skills never auto-sync, and the env variables (a downstream effect of pull) never get injected either.

`doctor` compounded the confusion: it also resolved to `<projectRoot>` via `resolveBaseDir`, so it checked `<projectRoot>/.claude` for hooks that (when they do exist, e.g. after a manual `hooks inject`) actually live in `~/.claude` — always reporting them missing.

## Fix

Introduce a single source of truth, `resolveHookScope(localConfig)` in `src/types.ts`, returning the `(baseDir, manifestPath)` pair every injection path must share, and route `init`/`pull` (`hooks.ts`), the `hooks` command (`hooks-cmd.ts`), and `doctor` (`doctor.ts`) through it:

- **non-self project scope → HOME** (`~/.claude` always exists so the gate passes; the dispatch runtime resolves the active project by `cwd`, so no `<projectRoot>` copy is needed) — matches #264.
- **self single-repo mode → projectRoot** (hooks are committed to `main` and travel on clone, self-healing — "clone = initialized").
- **user scope → HOME**.

This aligns the implementation to the already-documented HOME behavior (see `docs/usage-guide.md`: settings.json hooks "live in HOME and gate on the `cwd` handed to `hook-dispatch`"). No doc changes needed — grepped to confirm nothing describes the old `<projectRoot>` behavior.

## Test Plan

All executed and passing on this branch (rebased onto `Tencent/teamai-cli@main`):

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — success
- [x] `npx vitest run` — **2408 passed (175 files)**
- [x] `hooks-reconcile-scope` + `doctor` unit tests — 15 passed. Rewrote the scope test to stub HOME to a sandbox and assert project-scope injection lands in HOME; added a **self-mode regression** locking injection to projectRoot.
- [x] **Real CLI end-to-end** (built `dist`, project-scope config, `<projectRoot>/.claude` absent to reproduce the bug):
  - `teamai hooks inject` → `✔ Updated teamai hooks in <HOME>/.claude/settings.json`; the file contains the **SessionStart** `hook-dispatch session-start` entry + the team hook; `<projectRoot>/.claude` is **not** created.
  - `teamai doctor` → `✔ teamai hooks in claude settings` (previously ✖).

## Notes

- The env-injection `doctor` check on `main` already resolves via `getTeamaiHome` (#264 follow-up); this PR keeps that intact and only unifies the **hook** base dir.