### PR TITLE
fix(votes): make upvote collection reliable for learning promotion

### DIFF
--- a/src/__tests__/hook-handlers.test.ts
+++ b/src/__tests__/hook-handlers.test.ts
@@ -11,6 +11,11 @@ const mockTrackFromParsed = vi.fn().mockResolvedValue(undefined);
 const mockTrackSlashFromParsed = vi.fn().mockResolvedValue(undefined);
 const mockContributeCheckForSession = vi.fn().mockResolvedValue({ hint: null });
 const mockTakePendingHint = vi.fn().mockResolvedValue(null);
+const mockTakePendingVotesHint = vi.fn().mockResolvedValue(undefined);
+const mockStashVotesHint = vi.fn().mockResolvedValue(undefined);
+const mockParseTranscriptForVotes = vi.fn().mockResolvedValue({ referencedDocIds: [], recalledDocIds: [] });
+const mockIncrementUpvoted = vi.fn().mockResolvedValue(undefined);
+const mockSyncVotesToTeam = vi.fn().mockResolvedValue(false);
 const mockDoUpdate = vi.fn().mockResolvedValue(undefined);
 const mockReportAndSyncFromHook = vi.fn().mockResolvedValue(null);
 
@@ -38,6 +43,8 @@ vi.mock('../contribute-check.js', () => ({
   contributeCheck: vi.fn().mockResolvedValue(undefined),
   contributeCheckForSession: mockContributeCheckForSession,
   takePendingHint: mockTakePendingHint,
+  takePendingVotesHint: mockTakePendingVotesHint,
+  stashVotesHint: mockStashVotesHint,
 }));
 
 vi.mock('../update.js', () => ({
@@ -58,6 +65,15 @@ vi.mock('../utils/logger.js', () => ({
 
 vi.mock('../local-agent.js', () => ({
   reportAndSyncFromHook: mockReportAndSyncFromHook,
+}));
+
+vi.mock('../transcript-parser.js', () => ({
+  parseTranscriptForVotes: mockParseTranscriptForVotes,
+}));
+
+vi.mock('../votes.js', () => ({
+  incrementUpvoted: mockIncrementUpvoted,
+  syncVotesToTeam: mockSyncVotesToTeam,
 }));
 
 const mockSeedProjectAgentRoot = vi.fn().mockResolvedValue(undefined);
@@ -431,6 +447,223 @@ describe('hook-handlers registry', () => {
     expect(filterHandlersForConfig(registry, { repo: { kind: 'git' } } as never).length).toBe(full);
     expect(filterHandlersForConfig(registry, { repo: {} } as never).length).toBe(full);
     expect(filterHandlersForConfig(registry, null).length).toBe(full);
+  });
+
+  // ── Change 2: votes-sync nudge — marker guard removed, nudge every time declared===0 ──
+
+  it('votes-sync nudges on every Stop when recalled>0 and declared===0 (no once-per-session guard)', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'stop' && r.handler.name === 'votes-sync',
+    )!.handler;
+
+    // recalled>0, declared===0 → should always nudge
+    mockParseTranscriptForVotes.mockResolvedValue({
+      referencedDocIds: [],
+      recalledDocIds: ['doc-a'],
+    });
+
+    const result1 = await handler.execute(
+      { session_id: 'sid-votes-1', cwd: '/x', transcript_path: '/t/transcript.jsonl' },
+      'claude',
+    );
+    expect(result1).not.toBeNull();
+
+    // Same session, same conditions — should nudge again (no marker blocks repeat)
+    const result2 = await handler.execute(
+      { session_id: 'sid-votes-1', cwd: '/x', transcript_path: '/t/transcript.jsonl' },
+      'claude',
+    );
+    expect(result2).not.toBeNull();
+  });
+
+  it('votes-sync does not nudge when recalled===0', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'stop' && r.handler.name === 'votes-sync',
+    )!.handler;
+
+    mockParseTranscriptForVotes.mockResolvedValue({
+      referencedDocIds: [],
+      recalledDocIds: [],
+    });
+
+    const result = await handler.execute(
+      { session_id: 'sid-votes-2', cwd: '/x', transcript_path: '/t/transcript.jsonl' },
+      'claude',
+    );
+    expect(result).toBeNull();
+  });
+
+  // ── upvote intersection filter: only recalled docs count ──
+
+  it('votes-sync: incrementUpvoted receives only the intersection of referenced and recalled doc-ids', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'stop' && r.handler.name === 'votes-sync',
+    )!.handler;
+
+    mockParseTranscriptForVotes.mockResolvedValue({
+      referencedDocIds: ['doc-a', 'doc-b', 'doc-c'],
+      recalledDocIds: ['doc-a', 'doc-b'],
+    });
+
+    await handler.execute(
+      { session_id: 'sid-filter-1', cwd: '/x', transcript_path: '/t/transcript.jsonl' },
+      'claude',
+    );
+
+    expect(mockIncrementUpvoted).toHaveBeenCalledOnce();
+    expect(mockIncrementUpvoted).toHaveBeenCalledWith(expect.any(String), ['doc-a', 'doc-b']);
+  });
+
+  it('votes-sync: incrementUpvoted is not called when no referenced doc-id was actually recalled', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'stop' && r.handler.name === 'votes-sync',
+    )!.handler;
+
+    mockParseTranscriptForVotes.mockResolvedValue({
+      referencedDocIds: ['doc-x'],
+      recalledDocIds: ['doc-a', 'doc-b'],
+    });
+
+    await handler.execute(
+      { session_id: 'sid-filter-2', cwd: '/x', transcript_path: '/t/transcript.jsonl' },
+      'claude',
+    );
+
+    expect(mockIncrementUpvoted).not.toHaveBeenCalled();
+  });
+
+  it('votes-sync: incrementUpvoted receives all ids when referenced and recalled are identical', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'stop' && r.handler.name === 'votes-sync',
+    )!.handler;
+
+    mockParseTranscriptForVotes.mockResolvedValue({
+      referencedDocIds: ['doc-p', 'doc-q'],
+      recalledDocIds: ['doc-p', 'doc-q'],
+    });
+
+    await handler.execute(
+      { session_id: 'sid-filter-3', cwd: '/x', transcript_path: '/t/transcript.jsonl' },
+      'claude',
+    );
+
+    expect(mockIncrementUpvoted).toHaveBeenCalledOnce();
+    expect(mockIncrementUpvoted).toHaveBeenCalledWith(expect.any(String), ['doc-p', 'doc-q']);
+  });
+
+  it('votes-sync: incrementUpvoted is not called when recalledDocIds is empty', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'stop' && r.handler.name === 'votes-sync',
+    )!.handler;
+
+    mockParseTranscriptForVotes.mockResolvedValue({
+      referencedDocIds: ['doc-a'],
+      recalledDocIds: [],
+    });
+
+    await handler.execute(
+      { session_id: 'sid-filter-empty-recalled', cwd: '/x', transcript_path: '/t/transcript.jsonl' },
+      'claude',
+    );
+
+    expect(mockIncrementUpvoted).not.toHaveBeenCalled();
+  });
+
+  // ── Change 3: votes-sync stash branch (STOP_STDOUT_UNSUPPORTED_TOOLS) ──
+
+  it('votes-sync stashes nudge via stashVotesHint for codebuddy (stdout ignored)', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'stop' && r.handler.name === 'votes-sync',
+    )!.handler;
+
+    mockParseTranscriptForVotes.mockResolvedValue({
+      referencedDocIds: [],
+      recalledDocIds: ['doc-b'],
+    });
+
+    const result = await handler.execute(
+      { session_id: 'sid-votes-stash', cwd: '/x', transcript_path: '/t/transcript.jsonl' },
+      'codebuddy',
+    );
+    // Stash path returns null (hint goes to pendingVotesHint)
+    expect(result).toBeNull();
+    expect(mockStashVotesHint).toHaveBeenCalledOnce();
+    const [calledSessionId, calledMsg] = mockStashVotesHint.mock.calls[0];
+    expect(calledSessionId).toBe('sid-votes-stash');
+    expect(calledMsg).toContain('doc-b');
+  });
+
+  it('votes-sync returns stdout nudge for claude (not a stash tool)', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'stop' && r.handler.name === 'votes-sync',
+    )!.handler;
+
+    mockParseTranscriptForVotes.mockResolvedValue({
+      referencedDocIds: [],
+      recalledDocIds: ['doc-c'],
+    });
+
+    const result = await handler.execute(
+      { session_id: 'sid-votes-stdout', cwd: '/x', transcript_path: '/t/transcript.jsonl' },
+      'claude',
+    );
+    expect(result).not.toBeNull();
+    expect(mockStashVotesHint).not.toHaveBeenCalled();
+  });
+
+  // ── Change 3: pending-hint replays and merges pendingVotesHint ──
+
+  it('pending-hint merges contribute hint and votes hint for codebuddy', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'prompt-submit' && r.handler.name === 'pending-hint',
+    )!.handler;
+
+    mockTakePendingHint.mockResolvedValueOnce('[teamai] contribute hint');
+    mockTakePendingVotesHint.mockResolvedValueOnce('[teamai] votes hint');
+
+    const result = await handler.execute({ session_id: 'sid-merge', cwd: '/x' }, 'codebuddy');
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result!);
+    const ctx = parsed.hookSpecificOutput.additionalContext;
+    expect(ctx).toContain('[teamai] contribute hint');
+    expect(ctx).toContain('[teamai] votes hint');
+  });
+
+  it('pending-hint delivers only votes hint when contribute hint is absent', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'prompt-submit' && r.handler.name === 'pending-hint',
+    )!.handler;
+
+    mockTakePendingHint.mockResolvedValueOnce(null);
+    mockTakePendingVotesHint.mockResolvedValueOnce('[teamai] votes only');
+
+    const result = await handler.execute({ session_id: 'sid-votes-only', cwd: '/x' }, 'codebuddy');
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result!);
+    expect(parsed.hookSpecificOutput.additionalContext).toBe('[teamai] votes only');
+  });
+
+  it('pending-hint returns null when both hints are absent', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'prompt-submit' && r.handler.name === 'pending-hint',
+    )!.handler;
+
+    mockTakePendingHint.mockResolvedValueOnce(null);
+    mockTakePendingVotesHint.mockResolvedValueOnce(undefined);
+
+    const result = await handler.execute({ session_id: 'sid-both-absent', cwd: '/x' }, 'codebuddy');
+    expect(result).toBeNull();
   });
 });
 

--- a/src/__tests__/transcript-parser.test.ts
+++ b/src/__tests__/transcript-parser.test.ts
@@ -228,4 +228,54 @@ describe('parseTranscriptForVotes', () => {
     const result = await parseTranscriptForVotes(filePath);
     expect(result.recalledDocIds).toEqual(['real-doc-id']);
   });
+
+  // ── 改动 1: extractReferencedDocIds 正则放宽边界测试 ──────────
+
+  it('referenced-doc-ids: case-insensitive variant is parsed (e.g. REFERENCED-DOC-IDS)', async () => {
+    const filePath = path.join(tmpDir, 'transcript.jsonl');
+    writeLine(filePath, {
+      type: 'assistant',
+      message: {
+        content: [{
+          type: 'text',
+          text: '<!-- Teamai:REFERENCED-DOC-IDS: [case-insensitive-doc] -->',
+        }],
+      },
+    });
+
+    const result = await parseTranscriptForVotes(filePath);
+    expect(result.referencedDocIds).toContain('case-insensitive-doc');
+  });
+
+  it('referenced-doc-ids: em-dash closing (—>) is parsed', async () => {
+    const filePath = path.join(tmpDir, 'transcript.jsonl');
+    writeLine(filePath, {
+      type: 'assistant',
+      message: {
+        content: [{
+          type: 'text',
+          text: '<!-- teamai:referenced-doc-ids: [em-dash-doc] —>',
+        }],
+      },
+    });
+
+    const result = await parseTranscriptForVotes(filePath);
+    expect(result.referencedDocIds).toContain('em-dash-doc');
+  });
+
+  it('referenced-doc-ids: missing closing delimiter is NOT parsed (negative case)', async () => {
+    const filePath = path.join(tmpDir, 'transcript.jsonl');
+    writeLine(filePath, {
+      type: 'assistant',
+      message: {
+        content: [{
+          type: 'text',
+          text: '<!-- teamai:referenced-doc-ids: [no-close-doc]',
+        }],
+      },
+    });
+
+    const result = await parseTranscriptForVotes(filePath);
+    expect(result.referencedDocIds).toEqual([]);
+  });
 });

--- a/src/contribute-check.ts
+++ b/src/contribute-check.ts
@@ -153,6 +153,7 @@ export async function readContributeState(sessionId: string): Promise<Contribute
           ? normalizePromptSummary(raw.promptSummary)
           : undefined,
         pendingHint: typeof raw.pendingHint === 'string' ? raw.pendingHint : undefined,
+        pendingVotesHint: typeof raw.pendingVotesHint === 'string' ? raw.pendingVotesHint : undefined,
       };
     }
     return defaultState();
@@ -699,6 +700,27 @@ export async function contributeCheck(toolArg?: string): Promise<void> {
     const { formatStopHookOutput } = await import('./utils/hook-output.js');
     process.stdout.write(formatStopHookOutput(hint, toolArg ?? 'claude'));
   }
+}
+
+/**
+ * Stash a votes-nudge hint for delivery on the next UserPromptSubmit.
+ * Used for tools (codebuddy/workbuddy) whose Stop hook ignores stdout.
+ */
+export async function stashVotesHint(sessionId: string, hintText: string): Promise<void> {
+  const state = await readContributeState(sessionId);
+  await writeContributeState(sessionId, { ...state, pendingVotesHint: hintText });
+}
+
+/**
+ * Read and clear a pending votes-nudge hint for this session, if any.
+ * Returns the hint text or null. Clearing preserves all other state.
+ */
+export async function takePendingVotesHint(sessionId: string): Promise<string | null> {
+  const state = await readContributeState(sessionId);
+  if (!state.pendingVotesHint) return null;
+  const hint = state.pendingVotesHint;
+  await writeContributeState(sessionId, { ...state, pendingVotesHint: undefined });
+  return hint;
 }
 
 /**

--- a/src/hook-handlers.ts
+++ b/src/hook-handlers.ts
@@ -211,7 +211,7 @@ const pendingHintHandler: HookHandler = {
     const { STOP_STDOUT_UNSUPPORTED_TOOLS } = await import('./utils/tool-names.js');
     if (!STOP_STDOUT_UNSUPPORTED_TOOLS.has(tool)) return null;
 
-    const { takePendingHint } = await import('./contribute-check.js');
+    const { takePendingHint, takePendingVotesHint } = await import('./contribute-check.js');
     // Must match contributeCheckHandler's derivation so Stop and UserPromptSubmit
     // resolve to the same session file. This cross-process handoff relies on
     // codebuddy/workbuddy sending a stable, consistent session_id on BOTH the
@@ -221,12 +221,16 @@ const pendingHintHandler: HookHandler = {
     // differ across the two hook processes and orphan the stash (best-effort).
     const sessionId = deriveSessionId(stdin, { includeCwd: true });
     const hint = await takePendingHint(sessionId);
-    if (!hint) return null;
+    const votesHint = await takePendingVotesHint(sessionId);
+
+    // Merge: combine both pending hints if present, newline-separated.
+    const combined = [hint, votesHint].filter(Boolean).join('\n');
+    if (!combined) return null;
 
     return JSON.stringify({
       hookSpecificOutput: {
         hookEventName: 'UserPromptSubmit',
-        additionalContext: hint,
+        additionalContext: combined,
       },
     });
   },
@@ -249,13 +253,15 @@ const votesSyncHandler: HookHandler = {
       // autoDetectInit picks project scope when present (so self-mode configs are
       // honored), falling back to user scope otherwise.
       const { localConfig } = await autoDetectInit();
-      const { VOTES_LOCAL_DIR, TEAMAI_SESSIONS_DIR } = await import('./types.js');
+      const { VOTES_LOCAL_DIR } = await import('./types.js');
       const votesDir = VOTES_LOCAL_DIR;
       const votePath = path.join(votesDir, `${localConfig.username}.yaml`);
 
-      // Record the adoptions the main conversation declared.
-      if (voteData.referencedDocIds.length > 0) {
-        await incrementUpvoted(votePath, voteData.referencedDocIds);
+      // Only count upvotes for docs actually recalled this session, to avoid crediting hallucinated/distractor doc-ids
+      const recalledSet = new Set(voteData.recalledDocIds);
+      const verifiedDocIds = voteData.referencedDocIds.filter((id) => recalledSet.has(id));
+      if (verifiedDocIds.length > 0) {
+        await incrementUpvoted(votePath, verifiedDocIds);
       }
       if (localConfig.repo.kind === 'self') {
         // Self mode: votes are report data → the teamai-reports orphan branch,
@@ -277,31 +283,20 @@ const votesSyncHandler: HookHandler = {
       }
 
       // Enforcement: recall happened but nothing was declared → nudge the model
-      // once to declare which recalled docs it actually used. The nudge makes the
+      // to declare which recalled docs it actually used. The nudge makes the
       // model continue; on the next Stop the declaration is recorded above.
+      // No once-per-session marker is needed: if the model declares on the
+      // next turn, declared.length > 0 and this branch is skipped naturally.
+      // Degradation: if the model never declares referenced-doc-ids for the
+      // entire session, every Stop triggers a nudge — this is intentional
+      // (keeps the model honest) and should not be suppressed with a marker.
       const sessionId = deriveSessionId(stdin, { includeCwd: true });
       const recalled = voteData.recalledDocIds;
       const declared = voteData.referencedDocIds;
       let nudged = false;
 
       if (recalled.length > 0 && declared.length === 0) {
-        const fsp = await import('node:fs/promises');
-        const safeId = sessionId.replace(/[^a-zA-Z0-9_.-]/g, '_');
-        const marker = path.join(TEAMAI_SESSIONS_DIR, `${safeId}-adoption-nudged`);
-        let already = false;
-        try { await fsp.access(marker); already = true; } catch { already = false; }
-        if (!already) {
-          try {
-            const { ensureDir } = await import('./utils/fs.js');
-            await ensureDir(TEAMAI_SESSIONS_DIR);
-            await fsp.writeFile(marker, '');
-            // Only nudge once we've persisted the marker, so a write failure
-            // degrades to "no nudge this Stop" rather than re-nudging every Stop.
-            nudged = true;
-          } catch {
-            // Could not persist the marker — skip the nudge this Stop; retry next.
-          }
-        }
+        nudged = true;
       }
 
       // A/B measurement (opt-in): one line per Stop.
@@ -325,9 +320,17 @@ const votesSyncHandler: HookHandler = {
 
       if (nudged) {
         const { formatStopHookOutput } = await import('./utils/hook-output.js');
+        const { STOP_STDOUT_UNSUPPORTED_TOOLS } = await import('./utils/tool-names.js');
         const msg =
           `你本次通过 teamai 召回了团队知识（候选 doc-id：${recalled.join(', ')}）。` +
           `结束前请在回复末尾声明你实际用到的条目：<!-- teamai:referenced-doc-ids: [用到的doc-id] -->；没用到就留空 []。`;
+        // For tools whose Stop stdout is ignored, stash the nudge for delivery
+        // on the next UserPromptSubmit (same cross-process mechanism as contribute).
+        if (STOP_STDOUT_UNSUPPORTED_TOOLS.has(tool ?? '')) {
+          const { stashVotesHint } = await import('./contribute-check.js');
+          await stashVotesHint(sessionId, msg);
+          return null;
+        }
         return formatStopHookOutput(msg, tool ?? 'claude');
       }
     } catch {

--- a/src/transcript-parser.ts
+++ b/src/transcript-parser.ts
@@ -115,7 +115,9 @@ function extractRecalledDocIds(text: string, out: Set<string>): void {
 }
 
 function extractReferencedDocIds(text: string, out: Set<string>): void {
-  const pattern = /<!--\s*teamai:referenced-doc-ids:\s*\[([^\]]*)\]\s*-->/g;
+  // Case-insensitive; accept --> or —> (em-dash variant) as closing delimiter.
+  // Closed delimiter is required — bare [^\]]* prevents unclosed strings from bleeding past.
+  const pattern = /<!--\s*teamai:referenced-doc-ids:\s*\[([^\]]*)\]\s*(?:-->|—>)/gi;
 
   let match: RegExpExecArray | null;
   while ((match = pattern.exec(text)) !== null) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -901,6 +901,12 @@ export interface ContributeState {
    * that deliver the hint directly through the Stop hook.
    */
   pendingHint?: string;
+  /**
+   * A votes-nudge message awaiting delivery via UserPromptSubmit (stashed when
+   * Stop stdout is unsupported). Independent of pendingHint so the two channels
+   * never collide. Cleared once injected.
+   */
+  pendingVotesHint?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #369. `upvoted_count` was structurally near-zero (a real team repo showed **1154 recalled vs 2 upvoted**), so `findPromotionCandidates` could essentially never fire. This PR fixes the **collection path** — promotion thresholds are left untouched, since the confidence/users/upvoted gates unblock on their own once upvotes accrue.

## Root cause

The `referenced-doc-ids` marker is parsed only **once per session** behind a marker-file guard that requires the stop hook to run **twice**, and the strict parser silently dropped ~25% of naturally-written markers. Most sessions therefore ended with zero upvotes recorded.

## Changes

- **transcript-parser**: case-insensitive marker regex + accept em-dash (`—>`) closer (closer still required, to avoid greedy mis-match)
- **hook-handlers**:
  - drop the once-per-session marker guard → same-turn close-out (re-nudges next stop only while still undeclared; no permanent miss)
  - stash the nudge for tools without stop-hook stdout, replayed on next `UserPromptSubmit` (via new `pendingVotesHint`)
  - **intersection filter**: only count upvotes for docs actually recalled this session, so hallucinated/distractor doc-ids can't inflate counts
- **contribute-check / types**: `pendingVotesHint` stash/replay field

## Why not lower the thresholds

Simulation on real data showed the `upvoted>=5`, `confidence>=0.90`, and `users>=2` gates are all downstream symptoms of upvote starvation. Fixing collection unblocks them without changing promotion semantics — the safest, smallest change.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — full suite green (2422 tests)
- [x] `npm run build` — tsup build succeeds
- [x] Real CLI hook end-to-end: upvote lands in votes.yaml; regex variants (uppercase / `—>`) counted, unclosed marker rejected; stash/replay works for stdout-less tools; same-session re-nudge verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)