### PR TITLE
feat(gitcode): add GitCode (gitcode.com) provider support (#361)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm install -g teamai-cli
 
 ### Team admin / solo user
 
-Create a shared-experience repo on your git host (GitHub, GitLab, CNB, TGit, or a private Git service), **grant write access to team members**, then run `teamai init https://github.com/yourorg/yourrepo`.
+Create a shared-experience repo on your git host (GitHub, GitLab, GitCode, CNB, TGit, or a private Git service), **grant write access to team members**, then run `teamai init https://github.com/yourorg/yourrepo`.
 
 > **No team repo yet?** Start from a template pre-loaded with production-ready skills, rules, and review agents. Browse the [teamai-hub](https://github.com/teamai-hub) org, click **Use this template**, then `teamai init` against your new repo.
 
@@ -75,7 +75,7 @@ Once initialized, every AI session automatically pulls the latest skills / rules
   </tbody>
 </table>
 
-**Git providers** — GitHub · GitLab · CNB · TGit · private Git service.
+**Git providers** — GitHub · GitLab · GitCode · CNB · TGit · private Git service.
 
 ### Distribution Controls
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -25,7 +25,7 @@ npm install -g teamai-cli
 
 ### 团队管理员 / 个人使用者
 
-在 Git 托管平台（GitHub、GitLab、CNB、TGit，或私有 Git 服务）创建共享经验仓库，**授予团队成员写权限**，然后运行 `teamai init https://github.com/yourorg/yourrepo`。
+在 Git 托管平台（GitHub、GitLab、GitCode、CNB、TGit，或私有 Git 服务）创建共享经验仓库，**授予团队成员写权限**，然后运行 `teamai init https://github.com/yourorg/yourrepo`。
 
 > **还没有团队仓库？** 可以从内置了成套 skills、rules、review agents 的模板起步。浏览 [teamai-hub](https://github.com/teamai-hub) org，点 **Use this template** 生成自己的仓库，再对它执行 `teamai init`。
 
@@ -75,7 +75,7 @@ teamai init https://github.com/yourorg/yourrepo --scope user
   </tbody>
 </table>
 
-**Git 托管平台** —— GitHub · GitLab · CNB · TGit · 私有 Git 服务。
+**Git 托管平台** —— GitHub · GitLab · GitCode · CNB · TGit · 私有 Git 服务。
 
 ### 分发策略
 

--- a/docs/designs/gitcode-provider.md
+++ b/docs/designs/gitcode-provider.md
@@ -1,0 +1,90 @@
+# GitCode Provider 设计方案
+
+> Issue: [#361 Support the GitCode platform](https://github.com/Tencent/teamai-cli/issues/361)
+> 目标平台：GitCode（gitcode.com，CSDN 旗下国内代码托管平台，Gitee/AtomGit 风格 v5 API）
+> 范围：仅公有云 `gitcode.com`；认证做到 init 交互式贴 token（存 `~/.netrc`）。
+
+## 1. 背景与问题
+
+`teamai init https://gitcode.com/xxx/repo.git` 报 `Unrecognized GitHub repo format`——
+`gitcode.com` 不在 provider `HOST_MAP` 中。连带 `teamai push`（自动建分支 + PR）不可用。
+
+现有 provider 抽象已成熟（github / tgit / cnb / gitlab / git），新增一个 provider 是成熟路径。
+
+## 2. 关键结论：GitCode 是 Gitee 风格，不是 GitLab 风格
+
+结构上参照 GitLab provider，但 API 方言几乎每项都不同（均已实机验证）：
+
+| 维度 | GitLab | **GitCode** |
+|---|---|---|
+| API base | `<host>/api/v4`（同域） | `https://api.gitcode.com/api/v5`（独立 API 域名） |
+| REST 认证头 | `PRIVATE-TOKEN` | `Authorization: Bearer` |
+| whoami 字段 | `username` | **`login`** |
+| 建 PR | `POST /projects/{id}/merge_requests` | `POST /repos/{owner}/{repo}/pulls` |
+| PR body | `source_branch`/`target_branch`/… | `head`/`base`/`title`/`body` |
+| PR 响应 URL | `web_url` | `html_url`（web 路径 `/pull/` 单数） |
+| 建仓 | `POST /projects` | 个人 `POST /user/repos`；组织 `POST /orgs/{org}/repos` |
+| 命名空间 | 多级 subgroup + `/-/` 路由 | 单层 user/org，GitHub 风格 `/owner/repo/pulls/1` |
+
+结论：新建独立 `src/providers/gitcode/`，以 GitLab 为骨架、按 Gitee 方言改写。
+
+### 2.1 为什么用 PAT，不用 OAuth / gitcode-cli
+
+- **OAuth**：只有 authorization code flow（需注册 app + client_secret + redirect_uri），
+  **无 device flow**，不适合公开发布的 CLI。
+- **gitcode-cli（`gc`）**：社区项目，只能 pip/源码/deb·rpm 安装，**npm 装不了**，且它自己也是 PAT。
+- **官方 MCP（gitcode-org-com/gitcode-mcp，Go）**：其 `api/*.go` 源码是权威 API 契约——
+  端点 / 字段 / 认证 / 错误码全在其中，可**几乎零 token** 还原 REST 方言（见 §5）。
+- **结论**：纯 REST + PAT。
+
+## 3. 认证设计（init 交互式贴 token）
+
+- token 解析：`GITCODE_TOKEN`（主）→ `GC_TOKEN`（别名）→ `~/.netrc` 的 gitcode.com 条目。
+- 无 token 且 TTY：提示粘贴 PAT，`GET /user` 验证，写 `~/.netrc`（0600）。非 TTY 报错。
+- 复用 `~/.netrc`（git 原生认、TGit 已有先例），不发明新存储。
+
+## 4. 文件改动
+
+新增 `src/providers/gitcode/`：`index.ts` / `gitcode-api.ts` / `repo-url.ts` / `mr-fetch.ts` / `org.ts`。
+接线：`registry.ts`（HOST_MAP + KNOWN_PROVIDERS + PROVIDERS + import）、`providers/index.ts`、
+`types.ts`（enum）、`doctor.ts`（分支）、`clone.ts`（shallowClone 分支）。
+测试：`gitcode-provider.test.ts`、`provider-fallback.test.ts` 补充、`e2e/gitcode-provider-live.test.ts`。
+
+## 5. 方言点实测结论 ✅
+
+均已用真实 `GITCODE_TOKEN` 在实机验证：
+
+1. **REST 认证**：`Authorization: Bearer`；whoami `GET /user` → `login`。
+2. **git-over-HTTPS 认证 ≠ REST 认证**：git 端点**拒绝 Bearer**（仍索要用户名），
+   仅接受 Basic `oauth2:<token>`——和 TGit 同类坑。
+3. **建 PR**：`POST /repos/{o}/{r}/pulls`，body `head`/`base`/`title`/`body`，响应 `html_url`（`/pull/` 单数）。
+4. **建仓**：`POST /user/repos`（个人）body `{name, private, auto_init}`——实测建仓成功。
+5. **fetchMR**：`GET /repos/{o}/{r}/pulls/{n}` + `/commits` + `/files`（diff 取 `patch`）。
+
+### 5.1 关键修复：团队仓 push 认证
+
+`teamai push` 的分支 push 走 `pushRepoBranch` → 裸 `git push`（无 auth 注入），依赖 clone 时持久化的凭据。
+GitLab 的 clone 用一次性 `-c http.extraHeader`（不持久化）——照搬会导致 push 报 **Access denied**（实机复现）。
+GitHub / TGit 的做法是把 token 内嵌进 remote URL（持久化到 `.git/config`）。
+
+**修复**：`gitcodeRepoClone`（团队仓 clone）内嵌 `https://oauth2:<token>@gitcode.com/...`，
+使 `git push`（分支 + PR 流程）能认证。token 只落在 `~/.teamai/team-repo` 的私有 clone 中，
+与 GitHub / TGit 一致。（`clone.ts` 的浅克隆路径非 push 目标，沿用 extraHeader。）
+
+## 6. 端到端验证（真实 CLI + 真实 GitCode 仓）
+
+- `teamai init https://gitcode.com/...`：✔ Detected provider gitcode / ✔ Authenticated / ✔ Team repo cloned /
+  ✔ Member registration pushed（init 期的 push 也通过认证）。
+- `teamai push --all`：✔ Pushed branch / ✔ **Pull Request created: `.../pull/1`**。
+- `fetchMergeRequest(.../pull/1)`：✔ 拉到 title/author/commits/diff。
+- clone：HTTPS（token 走内嵌，push 可用）+ SSH（公钥）均通过。
+- 单测：gitcode + fallback 全过；type check 通过。
+- 测试仓与临时 SSH key 已清理。
+
+**未做真机覆盖**（边缘/可选）：`listOrgRepos`（缺测试组织）、组织建仓、交互式贴 token 分支。
+
+## 7. 非目标
+
+- 自托管 GitCode 企业版（`TEAMAI_GITCODE_HOST`）。
+- OAuth 浏览器/device 登录（GitCode 无 device flow）。
+- 内嵌 gitcode-cli 依赖。

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,6 +1,6 @@
 # Git Provider 说明
 
-TeamAI CLI 通过 provider 抽象层支持多个 Git 托管平台。当前实现了五个：
+TeamAI CLI 通过 provider 抽象层支持多个 Git 托管平台。当前实现了六个：
 
 | Provider | Host            | 认证方式                            | 建议场景              |
 |----------|-----------------|--------------------------------------|----------------------|
@@ -8,6 +8,7 @@ TeamAI CLI 通过 provider 抽象层支持多个 Git 托管平台。当前实现
 | `tgit`   | git.woa.com     | `gf` CLI（自动下载）+ `~/.netrc`     | 腾讯内部团队          |
 | `cnb`    | cnb.cool        | `cnb login` 或 `CNB_TOKEN` 环境变量  | CNB（云原生构建）用户 |
 | `gitlab` | gitlab.com 或自托管实例 | `GITLAB_TOKEN` 环境变量              | GitLab / 企业自托管   |
+| `gitcode`| gitcode.com     | `GITCODE_TOKEN` 环境变量或 init 交互粘贴 | GitCode（CSDN）用户 |
 | `git`    | 任意 Git host   | 系统 Git Credential Helper 或 SSH Key | 自建 Gitea 等其他平台 |
 
 ## Provider 自动检测
@@ -24,6 +25,8 @@ https://cnb.cool/org/repo(.git)         → cnb
 git@cnb.cool:org/repo.git               → cnb
 https://gitlab.com/org/repo(.git)       → gitlab
 git@gitlab.com:org/repo.git             → gitlab
+https://gitcode.com/org/repo(.git)      → gitcode
+git@gitcode.com:org/repo.git            → gitcode
 https://git.example.com/group/repo.git  → git
 git@git.example.com:group/repo.git      → git
 ```
@@ -219,9 +222,51 @@ git@git.example.com:Group/Subgroup/repo.git
 
 GitLab Provider 不设默认 email 域（同 GitHub），使用用户的 git 全局配置。
 
+## GitCode Provider（gitcode.com）
+
+GitCode（gitcode.com，CSDN 旗下国内平台）使用 Gitee 风格的 **REST API v5**（`https://api.gitcode.com/api/v5`），不需要任何外部 CLI，只依赖一个 Personal Access Token。结构上参照 GitLab Provider，但 API 方言与 GitLab 完全不同（独立 API 域名、`Authorization: Bearer` 认证、PR 用 `head`/`base`/`title`/`body`、whoami 用 `login`）。
+
+### 认证
+
+按优先级解析 token：
+
+1. `GITCODE_TOKEN`（主）
+2. `GC_TOKEN`（别名，兼容 gitcode-cli 用户已有的环境变量）
+3. `~/.netrc` 中的 `machine gitcode.com` 条目
+
+```bash
+export GITCODE_TOKEN=xxxxxxxxxxxx
+```
+
+在 GitCode → 设置 / Settings → Access Tokens（私人令牌）生成 PAT。
+
+**交互式登录**：首次 `teamai init` 若未配置 token，会提示粘贴一次 PAT，验证通过后写入 `~/.netrc`（权限 `0600`）供后续命令与 `git push` 复用。CI / 无头环境请直接配置 `GITCODE_TOKEN`，不会触发交互。
+
+### 命名空间
+
+GitCode 命名空间为单层（用户或组织），仓库地址形如 `owner/repo`，不支持多级子组。
+
+### 支持的操作
+
+| 操作 | 实现 |
+|------|------|
+| clone | HTTPS 走 `oauth2:<token>@` 内嵌（团队仓，凭据持久化以便后续 push）或 `http.extraHeader`（浅克隆）；亦支持 SSH 公钥 |
+| createRepo | 个人 `POST /user/repos`；组织 `POST /orgs/:org/repos` |
+| createPullRequest | `POST /repos/:owner/:repo/pulls`（`head`/`base`/`title`/`body`） |
+| fetchMergeRequest | `GET /repos/:owner/:repo/pulls/:n` + commits + files；PR URL 的 host 必须为 gitcode.com，否则拒绝，避免把 token 发往未配置的 host |
+| listOrgRepos | `GET /orgs/:org/repos` 分页 |
+
+> 注：仅支持公有云 `gitcode.com`，暂不支持自托管 GitCode 企业版。
+
+**关键方言**：GitCode 的 git-over-HTTPS 端点**拒绝 `Authorization: Bearer`**，只接受 Basic `oauth2:<token>`（已实机验证）。而 REST API 用 Bearer。因此团队仓 clone 把 token 内嵌进 remote URL（`oauth2:<token>@`），使 `git push`（分支 + PR 流程）能通过认证——与 GitHub / TGit 一致。
+
+### 默认 email 域
+
+GitCode 不设默认 email 域，使用用户的 git 全局配置。
+
 ## 手动指定 Provider
 
-除了 URL 自动检测，也可以在 team 仓库的 `teamai.yaml` 中显式写 `provider: github`、`provider: tgit`、`provider: cnb`、`provider: gitlab` 或 `provider: git` 强制切换。一个典型的 `teamai.yaml`：
+除了 URL 自动检测，也可以在 team 仓库的 `teamai.yaml` 中显式写 `provider: github`、`provider: tgit`、`provider: cnb`、`provider: gitlab`、`provider: gitcode` 或 `provider: git` 强制切换。一个典型的 `teamai.yaml`：
 
 ```yaml
 team: my-team

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -76,7 +76,7 @@ teamai --version
 
 > Only one admin needs to do this — other members can skip to [Member Onboarding](#member-onboarding).
 
-Create an empty repository on GitHub, GitLab (gitlab.com or a self-hosted instance), CNB (cnb.cool), TGit (Tencent's internal Git host), or any private/self-hosted Git service (suggested naming: `TeamAi-<team-name>`), or simply run `teamai init` — if the repo doesn't exist yet, you'll be prompted to create it automatically.
+Create an empty repository on GitHub, GitLab (gitlab.com or a self-hosted instance), GitCode (gitcode.com), CNB (cnb.cool), TGit (Tencent's internal Git host), or any private/self-hosted Git service (suggested naming: `TeamAi-<team-name>`), or simply run `teamai init` — if the repo doesn't exist yet, you'll be prompted to create it automatically.
 
 ### Project Scope (default)
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -74,7 +74,7 @@ teamai --version
 
 > 只需一位管理员完成，其他成员跳到[成员接入](#成员接入)。
 
-在 GitHub、GitLab（gitlab.com 或自建实例）、CNB（cnb.cool）、TGit（腾讯工蜂），或任意私有/自建 Git 服务上创建一个空仓库（命名建议：`TeamAi-<团队名>`），或者直接执行 `teamai init`，不存在时会提示自动创建。
+在 GitHub、GitLab（gitlab.com 或自建实例）、GitCode（gitcode.com）、CNB（cnb.cool）、TGit（腾讯工蜂），或任意私有/自建 Git 服务上创建一个空仓库（命名建议：`TeamAi-<团队名>`），或者直接执行 `teamai init`，不存在时会提示自动创建。
 
 ### 项目级（Project Scope，默认）
 

--- a/src/__tests__/e2e/gitcode-provider-live.test.ts
+++ b/src/__tests__/e2e/gitcode-provider-live.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { GitCodeProvider } from '../../providers/gitcode/index.js';
+
+/**
+ * Opt-in live GitCode test. Skipped unless GITCODE_TOKEN is set.
+ *
+ * Run with:  GITCODE_TOKEN=xxx npx vitest run src/__tests__/e2e/gitcode-provider-live.test.ts
+ */
+const RUN = !!process.env.GITCODE_TOKEN;
+
+describe.skipIf(!RUN)('GitCode provider (live)', () => {
+  it('whoami returns a username', async () => {
+    const provider = new GitCodeProvider();
+    const name = await provider.authenticate();
+    expect(name).toBeTruthy();
+  });
+});

--- a/src/__tests__/gitcode-provider.test.ts
+++ b/src/__tests__/gitcode-provider.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import os from 'node:os';
+import fs from 'node:fs';
+import path from 'node:path';
+import { parseGitCodeRepoInput } from '../providers/gitcode/repo-url.js';
+import { GitCodeProvider } from '../providers/gitcode/index.js';
+import {
+  getGitCodeToken,
+  gitcodePullCreate,
+  gitcodeWhoami,
+} from '../providers/gitcode/gitcode-api.js';
+
+describe('GitCode repo-url parsing', () => {
+  it('parses short owner/repo format', () => {
+    const info = parseGitCodeRepoInput('owner/repo');
+    expect(info.owner).toBe('owner');
+    expect(info.repo).toBe('repo');
+    expect(info.httpsUrl).toBe('https://gitcode.com/owner/repo.git');
+    expect(info.projectId).toBe('owner/repo');
+  });
+
+  it('parses HTTPS URL and strips .git', () => {
+    const info = parseGitCodeRepoInput('https://gitcode.com/owner/repo.git');
+    expect(info.owner).toBe('owner');
+    expect(info.repo).toBe('repo');
+  });
+
+  it('parses SSH URL', () => {
+    const info = parseGitCodeRepoInput('git@gitcode.com:owner/repo.git');
+    expect(info.owner).toBe('owner');
+    expect(info.repo).toBe('repo');
+  });
+
+  it('ignores trailing web-route segments (Gitee-style /pulls/1)', () => {
+    const info = parseGitCodeRepoInput('https://gitcode.com/owner/repo/pulls/1');
+    expect(info.owner).toBe('owner');
+    expect(info.repo).toBe('repo');
+  });
+
+  it('throws on a single-segment input', () => {
+    expect(() => parseGitCodeRepoInput('justowner')).toThrow(/Unrecognized GitCode/);
+  });
+});
+
+describe('GitCodeProvider', () => {
+  it('has name gitcode', () => {
+    expect(new GitCodeProvider().name).toBe('gitcode');
+  });
+
+  it('getDefaultEmailDomain returns null', () => {
+    expect(new GitCodeProvider().getDefaultEmailDomain()).toBeNull();
+  });
+});
+
+describe('GitCode token resolution', () => {
+  const OLD_ENV = process.env;
+  let tmpHome: string;
+  let homedirSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.env = { ...OLD_ENV };
+    delete process.env.GITCODE_TOKEN;
+    delete process.env.GC_TOKEN;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gitcode-netrc-'));
+    homedirSpy = vi.spyOn(os, 'homedir').mockReturnValue(tmpHome);
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+    homedirSpy.mockRestore();
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it('prefers GITCODE_TOKEN env over everything', () => {
+    process.env.GITCODE_TOKEN = 'env-primary';
+    expect(getGitCodeToken()).toBe('env-primary');
+  });
+
+  it('accepts GC_TOKEN as an alias when GITCODE_TOKEN is absent', () => {
+    process.env.GC_TOKEN = 'gc-alias';
+    expect(getGitCodeToken()).toBe('gc-alias');
+  });
+
+  it('falls back to ~/.netrc when no env token is set', () => {
+    fs.writeFileSync(
+      path.join(tmpHome, '.netrc'),
+      'machine gitcode.com login oauth2 password netrc-token\n',
+    );
+    expect(getGitCodeToken()).toBe('netrc-token');
+  });
+
+  it('returns null when neither env nor netrc has a token', () => {
+    expect(getGitCodeToken()).toBeNull();
+  });
+});
+
+describe('GitCode REST calls', () => {
+  const OLD_ENV = process.env;
+  beforeEach(() => {
+    process.env = { ...OLD_ENV };
+    process.env.GITCODE_TOKEN = 'test-token';
+  });
+  afterEach(() => {
+    process.env = OLD_ENV;
+    vi.restoreAllMocks();
+  });
+
+  it('whoami reads the Gitee-style `login` field', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ login: 'octocat' }), { status: 200 }),
+    );
+    expect(await gitcodeWhoami()).toBe('octocat');
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe('https://api.gitcode.com/api/v5/user');
+    expect((init?.headers as Record<string, string>).Authorization).toBe('Bearer test-token');
+  });
+
+  it('pullCreate posts head/base/title/body and returns html_url', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ html_url: 'https://gitcode.com/o/r/pull/7', number: 7 }), {
+        status: 201,
+      }),
+    );
+    const url = await gitcodePullCreate({
+      repo: 'o/r',
+      source: 'feature',
+      target: 'main',
+      title: 'My PR',
+      description: 'body text',
+    });
+    expect(url).toBe('https://gitcode.com/o/r/pull/7');
+
+    const [reqUrl, init] = fetchMock.mock.calls[0];
+    expect(String(reqUrl)).toBe('https://api.gitcode.com/api/v5/repos/o/r/pulls');
+    expect(init?.method).toBe('POST');
+    const body = JSON.parse(init?.body as string);
+    expect(body).toMatchObject({ head: 'feature', base: 'main', title: 'My PR', body: 'body text' });
+  });
+
+  it('pullCreate falls back to a /pull/ URL when html_url is absent', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ number: 42 }), { status: 201 }),
+    );
+    const url = await gitcodePullCreate({
+      repo: 'o/r',
+      source: 'f',
+      target: 'main',
+      title: 't',
+    });
+    expect(url).toBe('https://gitcode.com/o/r/pull/42');
+  });
+
+  it('pullCreate throws on a non-ok response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('bad request', { status: 422 }),
+    );
+    await expect(
+      gitcodePullCreate({ repo: 'o/r', source: 'f', target: 'main', title: 't' }),
+    ).rejects.toThrow(/Failed to create GitCode PR: 422/);
+  });
+});

--- a/src/__tests__/gitcode-provider.test.ts
+++ b/src/__tests__/gitcode-provider.test.ts
@@ -31,6 +31,19 @@ describe('GitCode repo-url parsing', () => {
     expect(info.repo).toBe('repo');
   });
 
+  it('parses ssh:// URL with a non-default port', () => {
+    const info = parseGitCodeRepoInput('ssh://git@gitcode.com:2222/owner/repo.git');
+    expect(info.owner).toBe('owner');
+    expect(info.repo).toBe('repo');
+    expect(info.httpsUrl).toBe('https://gitcode.com/owner/repo.git');
+  });
+
+  it('parses ssh:// URL without a port', () => {
+    const info = parseGitCodeRepoInput('ssh://git@gitcode.com/owner/repo.git');
+    expect(info.owner).toBe('owner');
+    expect(info.repo).toBe('repo');
+  });
+
   it('ignores trailing web-route segments (Gitee-style /pulls/1)', () => {
     const info = parseGitCodeRepoInput('https://gitcode.com/owner/repo/pulls/1');
     expect(info.owner).toBe('owner');

--- a/src/__tests__/provider-fallback.test.ts
+++ b/src/__tests__/provider-fallback.test.ts
@@ -122,6 +122,15 @@ describe('detectProvider with package-name fallback', () => {
     expect(detectProvider('https://gitlab.com/org/repo')).toBe('gitlab');
   });
 
+  it('explicit gitcode.com URL resolves to gitcode', () => {
+    setPackageName('@tencent/teamai-cli');
+    expect(detectProvider('https://gitcode.com/org/repo')).toBe('gitcode');
+  });
+
+  it('gitcode.com SSH URL resolves to gitcode', () => {
+    expect(detectProvider('git@gitcode.com:org/repo.git')).toBe('gitcode');
+  });
+
   it('explicit github.com URL still resolves to github on tnpm build', () => {
     setPackageName('@tencent/teamai-cli');
     expect(detectProvider('https://github.com/org/repo')).toBe('github');

--- a/src/clone.ts
+++ b/src/clone.ts
@@ -218,16 +218,19 @@ export async function shallowClone(
             log.debug(`shallowClone: 无 GITLAB_TOKEN，尝试匿名 HTTPS 克隆`);
         }
     } else if (provider === 'gitcode') {
-        // GitCode: PAT 走 HTTP Basic（用户名固定 oauth2），用 http.extraHeader 注入，
-        // token 不进 URL。已实机验证：GitCode git 端点拒绝 Bearer，仅认 Basic oauth2。
-        // 公有云只有 https，故强制 http→https。
+        // GitCode: 把 PAT 以 oauth2:<token>@ 内嵌进 clone URL（而非仅用一次性
+        // http.extraHeader），让 origin remote 持久化凭据——否则后续 shallowFetch()
+        // 的普通 `git fetch` 在无 credential helper 的环境里会对私有仓报
+        // "could not read Username"。已实机验证 GitCode git 端点仅认 Basic oauth2、
+        // 拒绝 Bearer。与 tgit 分支一致。公有云只有 https，故强制 http→https。
         const token = getGitCodeToken();
-        cloneUrl = url.replace(/^http:\/\//, 'https://');
+        const httpsUrl = url.replace(/^http:\/\//, 'https://');
         if (token) {
-            extraAuthHeader = buildAuthHeader(token, 'oauth2');
+            cloneUrl = httpsUrl.replace(/^https:\/\//, `https://oauth2:${token}@`);
             cloneMethod = 'https-token';
             log.debug(`shallowClone: 使用 HTTPS+token 克隆 gitcode 仓库`);
         } else {
+            cloneUrl = httpsUrl;
             cloneMethod = 'https-anonymous';
             log.debug(`shallowClone: 无 GITCODE_TOKEN，尝试匿名 HTTPS 克隆`);
         }

--- a/src/clone.ts
+++ b/src/clone.ts
@@ -218,19 +218,17 @@ export async function shallowClone(
             log.debug(`shallowClone: 无 GITLAB_TOKEN，尝试匿名 HTTPS 克隆`);
         }
     } else if (provider === 'gitcode') {
-        // GitCode: 把 PAT 以 oauth2:<token>@ 内嵌进 clone URL（而非仅用一次性
-        // http.extraHeader），让 origin remote 持久化凭据——否则后续 shallowFetch()
-        // 的普通 `git fetch` 在无 credential helper 的环境里会对私有仓报
-        // "could not read Username"。已实机验证 GitCode git 端点仅认 Basic oauth2、
-        // 拒绝 Bearer。与 tgit 分支一致。公有云只有 https，故强制 http→https。
+        // GitCode: PAT 走 HTTP Basic（用户名固定 oauth2），用 http.extraHeader 注入，
+        // token 不进 URL、不落 .git/config。shallowFetch 会用同样的 header 复用认证
+        // （见 fetchAuthHeader），故私有仓的增量 fetch 无需 credential helper 也能成功。
+        // 已实机验证：GitCode git 端点拒绝 Bearer，仅认 Basic oauth2。公有云只有 https。
         const token = getGitCodeToken();
-        const httpsUrl = url.replace(/^http:\/\//, 'https://');
+        cloneUrl = url.replace(/^http:\/\//, 'https://');
         if (token) {
-            cloneUrl = httpsUrl.replace(/^https:\/\//, `https://oauth2:${token}@`);
+            extraAuthHeader = buildAuthHeader(token, 'oauth2');
             cloneMethod = 'https-token';
             log.debug(`shallowClone: 使用 HTTPS+token 克隆 gitcode 仓库`);
         } else {
-            cloneUrl = httpsUrl;
             cloneMethod = 'https-anonymous';
             log.debug(`shallowClone: 无 GITCODE_TOKEN，尝试匿名 HTTPS 克隆`);
         }
@@ -283,21 +281,54 @@ export async function shallowClone(
 }
 
 /**
+ * Resolve an `http.extraHeader` auth value for a follow-up `git fetch`, so the
+ * token stays out of the remote URL and out of `.git/config` (it is passed
+ * per-invocation via `-c`). Mirrors the token providers handled in shallowClone
+ * that inject via extraHeader rather than embedding creds in the URL.
+ *
+ * Returns null when the provider needs no header here: `tgit` already carries an
+ * in-URL OAuth credential from clone, and `git` / unknown hosts rely on ambient
+ * Git credentials.
+ */
+function fetchAuthHeader(provider?: string): string | null {
+    if (provider === 'github') {
+        const token = getGitHubToken();
+        return token ? buildAuthHeader(token) : null;
+    }
+    if (provider === 'gitlab') {
+        const token = getGitLabToken();
+        return token ? buildAuthHeader(token, 'oauth2') : null;
+    }
+    if (provider === 'gitcode') {
+        const token = getGitCodeToken();
+        return token ? buildAuthHeader(token, 'oauth2') : null;
+    }
+    return null;
+}
+
+/**
  * 在已有 clone 目录上执行 git fetch 并 reset 到最新 HEAD（用于 P5.3 增量；P5.1 暂不调用）。
  *
  * @param localPath  本地 clone 目录
- * @param opts       选项
+ * @param opts       选项。传入 `provider` 时，token 类 provider（github/gitlab/gitcode）
+ *                   会用 `http.extraHeader` 复用认证——私有仓无需 credential helper 即可 fetch，
+ *                   且 token 不进 URL / .git/config。
  */
 export async function shallowFetch(
     localPath: string,
-    opts?: { timeoutMs?: number },
+    opts?: { timeoutMs?: number; provider?: string },
 ): Promise<{ sha: string }> {
     const timeoutMs = opts?.timeoutMs ?? 180_000;
 
     // 获取当前分支
     const branch = await gitCmd(['rev-parse', '--abbrev-ref', 'HEAD'], localPath, timeoutMs);
 
-    await gitCmd(['fetch', '--depth=50', 'origin'], localPath, timeoutMs);
+    // `-c http.extraHeader=` 必须置于 fetch 子命令之前（git-level 选项）。
+    const authHeader = fetchAuthHeader(opts?.provider);
+    const fetchArgs = authHeader
+        ? ['-c', `http.extraHeader=${authHeader}`, 'fetch', '--depth=50', 'origin']
+        : ['fetch', '--depth=50', 'origin'];
+    await gitCmd(fetchArgs, localPath, timeoutMs);
     await gitCmd(['reset', '--hard', `origin/${branch}`], localPath, timeoutMs);
 
     const sha = await gitCmd(['rev-parse', 'HEAD'], localPath);

--- a/src/clone.ts
+++ b/src/clone.ts
@@ -4,6 +4,7 @@ import fs from 'fs-extra';
 
 import { getGitHubToken } from './providers/github/gh-cli.js';
 import { getGitLabToken } from './providers/gitlab/gitlab-api.js';
+import { getGitCodeToken } from './providers/gitcode/gitcode-api.js';
 import { tgitGitCloneUrl } from './providers/tgit/rest-auth.js';
 import { log } from './utils/logger.js';
 import { sanitizeGitUrl } from './utils/redact.js';
@@ -215,6 +216,20 @@ export async function shallowClone(
             cloneUrl = url;
             cloneMethod = 'https-anonymous';
             log.debug(`shallowClone: 无 GITLAB_TOKEN，尝试匿名 HTTPS 克隆`);
+        }
+    } else if (provider === 'gitcode') {
+        // GitCode: PAT 走 HTTP Basic（用户名固定 oauth2），用 http.extraHeader 注入，
+        // token 不进 URL。已实机验证：GitCode git 端点拒绝 Bearer，仅认 Basic oauth2。
+        // 公有云只有 https，故强制 http→https。
+        const token = getGitCodeToken();
+        cloneUrl = url.replace(/^http:\/\//, 'https://');
+        if (token) {
+            extraAuthHeader = buildAuthHeader(token, 'oauth2');
+            cloneMethod = 'https-token';
+            log.debug(`shallowClone: 使用 HTTPS+token 克隆 gitcode 仓库`);
+        } else {
+            cloneMethod = 'https-anonymous';
+            log.debug(`shallowClone: 无 GITCODE_TOKEN，尝试匿名 HTTPS 克隆`);
         }
     } else {
         // 其他 provider 依赖 Git 自身的 credential helper / ~/.netrc。

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -133,6 +133,15 @@ export async function doctor(options: GlobalOptions): Promise<void> {
       fix: 'Export GITLAB_TOKEN (a Personal Access Token with `api` scope). '
         + 'GITLAB_PRIVATE_TOKEN and GITLAB_PAT are accepted as aliases.',
     });
+  } else if (providerName === 'gitcode') {
+    // GitCode needs no CLI — only a Personal Access Token (env or ~/.netrc).
+    const { gitcodeIsAuthenticated } = await import('./providers/gitcode/index.js');
+    checks.push({
+      name: 'GitCode token is configured',
+      check: async () => gitcodeIsAuthenticated(),
+      fix: 'Export GITCODE_TOKEN (a GitCode Personal Access Token), or run `teamai init` '
+        + 'to paste one interactively. GC_TOKEN is accepted as an alias.',
+    });
   }
 
   checks.push(

--- a/src/import-repo.ts
+++ b/src/import-repo.ts
@@ -225,7 +225,7 @@ export async function importFromRepo(opts: ImportFromRepoOptions): Promise<void>
         oldSha = lastSync.sha;
         log.info(`[incremental] cache hit ${cacheDir}, syncing from ${oldSha.slice(0, 8)}`);
         try {
-            const fetchResult = await shallowFetch(cacheDir);
+            const fetchResult = await shallowFetch(cacheDir, { provider: providerName });
             cloneSha = fetchResult.sha;
             cloneBranch = 'HEAD';
             log.info(`[incremental] Fetch complete: SHA=${cloneSha.slice(0, 8)}`);

--- a/src/providers/gitcode/gitcode-api.ts
+++ b/src/providers/gitcode/gitcode-api.ts
@@ -1,0 +1,278 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { GITCODE_HOST } from './repo-url.js';
+import { sanitizeGitUrl } from '../../utils/redact.js';
+
+/**
+ * GitCode (gitcode.com) REST API client.
+ *
+ * GitCode uses a Gitee/AtomGit-style v5 REST API — NOT GitLab-style — so this
+ * provider is modelled on gitlab/ structurally but differs in every dialect
+ * detail (all verified against the live API):
+ *
+ *   - API base is a SEPARATE host: https://api.gitcode.com/api/v5
+ *   - A Personal Access Token authenticates every REST call via the
+ *     `Authorization: Bearer` header.
+ *   - whoami returns `login` (not GitLab's `username`).
+ *   - PR create is `POST /repos/{owner}/{repo}/pulls` with `head`/`base`/
+ *     `title`/`body`, response `html_url` (web path uses `/pull/` singular).
+ *
+ * Auth token resolution (highest precedence first):
+ *   1. `GITCODE_TOKEN` env var (primary)
+ *   2. `GC_TOKEN` env var (alias — matches the gitcode-cli convention)
+ *   3. `~/.netrc` entry `machine gitcode.com … password <token>`
+ */
+
+// ─── Config ──────────────────────────────────────────────
+
+const GITCODE_API_BASE = 'https://api.gitcode.com/api/v5';
+
+export function gitcodeApiBase(): string {
+  return GITCODE_API_BASE;
+}
+
+// ─── Token resolution ────────────────────────────────────
+
+/** Resolve the GitCode PAT from env, then ~/.netrc. Returns null when absent. */
+export function getGitCodeToken(): string | null {
+  for (const raw of [process.env.GITCODE_TOKEN, process.env.GC_TOKEN]) {
+    const token = raw?.trim();
+    if (token) return token;
+  }
+  return readNetrcToken();
+}
+
+function requireToken(): string {
+  const token = getGitCodeToken();
+  if (!token) {
+    throw new Error(
+      'GitCode authentication unavailable. Set GITCODE_TOKEN (a GitCode Personal ' +
+        'Access Token), or run `teamai init` to paste one interactively. GC_TOKEN is ' +
+        'accepted as an alias.',
+    );
+  }
+  return token;
+}
+
+function authHeaders(token: string): Record<string, string> {
+  return {
+    'Authorization': `Bearer ${token}`,
+    'Content-Type': 'application/json',
+    'Accept': 'application/json',
+  };
+}
+
+// ─── ~/.netrc credential storage ─────────────────────────
+//
+// Reused (not reinvented) as the credential store: git reads ~/.netrc natively
+// for HTTPS clone/push, and the TGit provider already persists tokens here.
+// Entry format: `machine gitcode.com login oauth2 password <token>`.
+
+function netrcPath(): string {
+  return path.join(os.homedir(), '.netrc');
+}
+
+/** Read the gitcode.com token from ~/.netrc, or null when absent/unreadable. */
+export function readNetrcToken(): string | null {
+  try {
+    const content = fs.readFileSync(netrcPath(), 'utf-8');
+    const match = content.match(
+      new RegExp(`machine\\s+${GITCODE_HOST.replace('.', '\\.')}\\s+.*?password\\s+(\\S+)`),
+    );
+    return match?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist the token to ~/.netrc (mode 0600). Replaces any existing gitcode.com
+ * entry so re-authenticating overwrites rather than duplicates.
+ */
+export function writeNetrcToken(token: string): void {
+  const file = netrcPath();
+  let existing = '';
+  try {
+    existing = fs.readFileSync(file, 'utf-8');
+  } catch {
+    // no existing file — start fresh
+  }
+  const filtered = existing
+    .split('\n')
+    .filter((line) => !new RegExp(`^machine\\s+${GITCODE_HOST.replace('.', '\\.')}\\b`).test(line.trim()))
+    .join('\n')
+    .replace(/\n+$/, '');
+
+  const entry = `machine ${GITCODE_HOST} login oauth2 password ${token}`;
+  const next = filtered ? `${filtered}\n${entry}\n` : `${entry}\n`;
+  fs.writeFileSync(file, next, { mode: 0o600 });
+  try {
+    fs.chmodSync(file, 0o600);
+  } catch {
+    // best-effort on platforms without chmod semantics
+  }
+}
+
+// ─── Auth ────────────────────────────────────────────────
+
+/** True when a GitCode token is configured (no network check). */
+export function gitcodeIsAuthenticated(): boolean {
+  return getGitCodeToken() !== null;
+}
+
+/** Fetch the authenticated GitCode username (`login`), or null when unavailable. */
+export async function gitcodeWhoami(): Promise<string | null> {
+  const token = getGitCodeToken();
+  if (!token) return null;
+  try {
+    const resp = await fetch(`${gitcodeApiBase()}/user`, {
+      headers: authHeaders(token),
+      redirect: 'manual',
+    });
+    if (!resp.ok) return null;
+    const data = (await resp.json()) as { login?: string };
+    return data.login ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// ─── Repo operations ─────────────────────────────────────
+
+export class GitCodeRepoNotFoundError extends Error {
+  constructor(repo: string) {
+    super(`Repo "${repo}" not found on GitCode.`);
+    this.name = 'GitCodeRepoNotFoundError';
+  }
+}
+
+/**
+ * Build the clone URL for the team repo, embedding the PAT as `oauth2:<token>@`
+ * basic-auth so the credential PERSISTS to `.git/config` and later `git push`
+ * (branch + PR flow) authenticates without a separate credential helper.
+ *
+ * This mirrors the GitHub (`x-access-token:<token>@`) and TGit (`oauth2:<token>@`)
+ * providers. GitCode's git-over-HTTPS endpoint accepts Basic `oauth2:<token>`
+ * but REJECTS `Authorization: Bearer` (verified live) — so an in-URL credential,
+ * not a Bearer header, is required. The token lives only in the private team-repo
+ * clone under ~/.teamai/team-repo.
+ */
+function cloneUrl(repo: string, token: string | null): string {
+  if (token) {
+    return `https://oauth2:${token}@${GITCODE_HOST}/${repo}.git`;
+  }
+  return `https://${GITCODE_HOST}/${repo}.git`;
+}
+
+/** Redact an embedded oauth2 token from git output before logging/throwing. */
+function redactCloneOutput(output: string): string {
+  return sanitizeGitUrl(output.replace(/oauth2:[^@]+@/g, 'oauth2:***@')).trim();
+}
+
+/**
+ * Clone a GitCode repo to localPath. The token is embedded in the remote URL so
+ * subsequent pull/push operations work (see cloneUrl).
+ */
+export function gitcodeRepoClone(repo: string, localPath: string): void {
+  const token = getGitCodeToken();
+  const result = spawnSync('git', ['clone', cloneUrl(repo, token), localPath], {
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: 120_000,
+  });
+  const allOutput = `${result.stderr ?? ''} ${result.stdout ?? ''}`;
+  if (result.status === 0) return;
+
+  if (
+    allOutput.includes('not found')
+    || allOutput.includes('does not exist')
+    || allOutput.includes('Repository not found')
+    || allOutput.includes('could not be found')
+    || /\b404\b/.test(allOutput)
+  ) {
+    throw new GitCodeRepoNotFoundError(repo);
+  }
+
+  throw new Error(`git clone failed: ${redactCloneOutput(allOutput)}`);
+}
+
+/**
+ * Create a private GitCode repo. Uses the authenticated user's namespace when
+ * `owner` matches the current user (`POST /user/repos`), otherwise creates it
+ * under an organization (`POST /orgs/{org}/repos`).
+ */
+export async function gitcodeCreateRepo(owner: string, repo: string): Promise<void> {
+  const token = requireToken();
+  const login = await gitcodeWhoami();
+
+  const isOrg = !login || login.toLowerCase() !== owner.toLowerCase();
+  const endpoint = isOrg
+    ? `${gitcodeApiBase()}/orgs/${encodeURIComponent(owner)}/repos`
+    : `${gitcodeApiBase()}/user/repos`;
+
+  const body: Record<string, unknown> = { name: repo, private: true, auto_init: true };
+
+  const resp = await fetch(endpoint, {
+    method: 'POST',
+    headers: authHeaders(token),
+    body: JSON.stringify(body),
+    redirect: 'manual',
+  });
+  if (!resp.ok) {
+    const errBody = await resp.text().catch(() => '');
+    throw new Error(`Failed to create GitCode repo: ${resp.status} ${errBody}`);
+  }
+}
+
+// ─── Pull requests ───────────────────────────────────────
+
+export interface GitCodePullCreateOptions {
+  /** Repository in "owner/repo" format */
+  repo: string;
+  /** Source branch name */
+  source: string;
+  /** Target branch name (usually 'main' or 'master') */
+  target: string;
+  /** PR title */
+  title: string;
+  /** PR description */
+  description?: string;
+  /** Working directory (unused for the REST path, kept for interface parity) */
+  cwd?: string;
+}
+
+/**
+ * Create a pull request via the GitCode REST API.
+ * `POST /repos/{owner}/{repo}/pulls` with Gitee-style body { head, base, title, body }.
+ * Returns the PR web URL (`html_url`) on success.
+ */
+export async function gitcodePullCreate(opts: GitCodePullCreateOptions): Promise<string> {
+  const token = requireToken();
+
+  const body: Record<string, unknown> = {
+    title: opts.title,
+    head: opts.source,
+    base: opts.target,
+  };
+  if (opts.description) body.body = opts.description;
+
+  const resp = await fetch(`${gitcodeApiBase()}/repos/${opts.repo}/pulls`, {
+    method: 'POST',
+    headers: authHeaders(token),
+    body: JSON.stringify(body),
+    redirect: 'manual',
+  });
+  if (!resp.ok) {
+    const errBody = await resp.text().catch(() => '');
+    throw new Error(`Failed to create GitCode PR: ${resp.status} ${errBody}`);
+  }
+
+  const pr = (await resp.json()) as { html_url?: string; number?: number };
+  if (pr.html_url) return pr.html_url;
+  // Fallback when html_url is absent: GitCode's PR web path uses `/pull/`
+  // (singular), verified against the live API — not `/pulls/`.
+  if (pr.number) return `https://${GITCODE_HOST}/${opts.repo}/pull/${pr.number}`;
+  throw new Error('GitCode PR created but response did not include html_url.');
+}

--- a/src/providers/gitcode/index.ts
+++ b/src/providers/gitcode/index.ts
@@ -1,0 +1,130 @@
+import type { GitProvider, PrCreateOptions, RepoInfo, OrgRepoInfo } from '../types.js';
+import { RepoNotFoundError } from '../types.js';
+import {
+  gitcodeIsAuthenticated,
+  gitcodeWhoami,
+  gitcodeRepoClone,
+  gitcodeCreateRepo,
+  gitcodePullCreate,
+  writeNetrcToken,
+  GitCodeRepoNotFoundError,
+} from './gitcode-api.js';
+import { gitcodeListOrgRepos } from './org.js';
+import { fetchGitCodeMR } from './mr-fetch.js';
+import { parseGitCodeRepoInput, GITCODE_HOST } from './repo-url.js';
+import type { MRData } from '../../types.js';
+import { log } from '../../utils/logger.js';
+import { askQuestion } from '../../utils/prompt.js';
+
+/**
+ * GitCode (gitcode.com) provider.
+ *
+ * Uses the GitCode Gitee-style REST API v5 directly — no external CLI is
+ * required, only a Personal Access Token. See gitcode-api.ts for the token
+ * resolution order (GITCODE_TOKEN / GC_TOKEN / ~/.netrc) and the dialect notes
+ * that distinguish it from the GitLab provider it is structurally modelled on.
+ */
+export class GitCodeProvider implements GitProvider {
+  readonly name = 'gitcode';
+
+  parseRepoInput(input: string): RepoInfo {
+    return parseGitCodeRepoInput(input);
+  }
+
+  isAuthenticated(): boolean {
+    return gitcodeIsAuthenticated();
+  }
+
+  /**
+   * Ensure the user is authenticated and return the login name.
+   *
+   * - A configured token (env or ~/.netrc) is verified via `GET /user`.
+   * - Otherwise, on a TTY, the user is prompted to paste a PAT once; a valid
+   *   token is persisted to ~/.netrc so later commands (and `git push`) reuse it.
+   * - Non-interactive (CI) with no token → a clear error.
+   */
+  async authenticate(): Promise<string> {
+    if (this.isAuthenticated()) {
+      const username = await gitcodeWhoami();
+      if (username) return username;
+      throw new Error(
+        'GitCode token is set but was rejected by the API. Check GITCODE_TOKEN / GC_TOKEN, ' +
+          'or generate a new Personal Access Token at ' +
+          `https://${GITCODE_HOST} → 设置 / Settings → Access Tokens.`,
+      );
+    }
+
+    if (!process.stdin.isTTY) {
+      throw new Error(
+        'GitCode authentication unavailable. Set the GITCODE_TOKEN environment variable ' +
+          '(a GitCode Personal Access Token). GC_TOKEN is accepted as an alias.',
+      );
+    }
+
+    log.info(
+      `Not logged in to GitCode. Create a Personal Access Token at https://${GITCODE_HOST} → ` +
+        '设置 / Settings → Access Tokens, then paste it below.',
+    );
+    const token = (await askQuestion('Paste your GitCode Personal Access Token: ')).trim();
+    if (!token) {
+      throw new Error('No token provided. GitCode authentication cancelled.');
+    }
+
+    // Make the just-pasted token visible to the verification call (and to the
+    // rest of this process, so subsequent clone/push in the same `init` run use
+    // it) before persisting.
+    process.env.GITCODE_TOKEN = token;
+    const username = await gitcodeWhoami();
+    if (!username) {
+      delete process.env.GITCODE_TOKEN;
+      throw new Error('GitCode authentication failed: the pasted token was rejected. Please try again.');
+    }
+    writeNetrcToken(token);
+    log.success('Saved GitCode credentials to ~/.netrc');
+    return username;
+  }
+
+  async ensureInstalled(): Promise<void> {
+    // No external CLI — a token is all that's needed, checked in authenticate().
+  }
+
+  cloneRepo(repo: string, localPath: string): void {
+    try {
+      gitcodeRepoClone(repo, localPath);
+    } catch (e) {
+      if (e instanceof GitCodeRepoNotFoundError) {
+        throw new RepoNotFoundError(repo);
+      }
+      throw e;
+    }
+  }
+
+  async createRepo(owner: string, repo: string): Promise<void> {
+    await gitcodeCreateRepo(owner, repo);
+  }
+
+  async createPullRequest(opts: PrCreateOptions): Promise<string> {
+    return gitcodePullCreate({
+      repo: opts.repo,
+      source: opts.source,
+      target: opts.target,
+      title: opts.title,
+      description: opts.description,
+      cwd: opts.cwd,
+    });
+  }
+
+  async fetchMergeRequest(url: string): Promise<MRData> {
+    return fetchGitCodeMR(url);
+  }
+
+  async listOrgRepos(org: string, opts?: { maxRepos?: number }): Promise<OrgRepoInfo[]> {
+    return gitcodeListOrgRepos(org, opts);
+  }
+
+  getDefaultEmailDomain(): string | null {
+    return null;
+  }
+}
+
+export { gitcodeIsAuthenticated, getGitCodeToken } from './gitcode-api.js';

--- a/src/providers/gitcode/mr-fetch.ts
+++ b/src/providers/gitcode/mr-fetch.ts
@@ -1,0 +1,125 @@
+import { type MRData } from '../../types.js';
+import { log } from '../../utils/logger.js';
+import { getGitCodeToken, gitcodeApiBase } from './gitcode-api.js';
+import { GITCODE_HOST } from './repo-url.js';
+
+/** GitCode PR URL 解析结果 */
+interface ParsedGitCodePR {
+  owner: string;
+  repo: string;
+  number: string;
+}
+
+/**
+ * 从 GitCode PR URL 解析出 owner / repo / PR number。
+ *
+ * 支持 Gitee 风格 URL：https://gitcode.com/<owner>/<repo>/(pull|pulls|merge_requests)/<number>
+ * host 必须为 gitcode.com——避免把 token 发往任意 host（SSRF / 凭据外泄）。
+ * 解析失败时抛出 Error。
+ */
+function parseGitCodePRUrl(url: string): ParsedGitCodePR {
+  const match = url.match(
+    /^https?:\/\/([^/]+)\/([^/]+)\/([^/]+)\/(?:pull|pulls|merge_requests)\/(\d+)/i,
+  );
+  if (!match) {
+    throw new Error(`Invalid GitCode PR URL: ${url}`);
+  }
+  const host = match[1].toLowerCase().replace(/^www\./, '');
+  if (host !== GITCODE_HOST) {
+    throw new Error(
+      `Refusing to fetch GitCode PR from "${match[1]}": only ${GITCODE_HOST} is supported.`,
+    );
+  }
+  return { owner: match[2], repo: match[3], number: match[4] };
+}
+
+/** GitCode REST API 返回的 PR 元信息（仅使用的字段） */
+interface GitCodePR {
+  title: string;
+  body: string | null;
+  user: { login: string };
+  merged_at?: string | null;
+}
+
+/** GitCode REST API 返回的 commit（仅使用的字段） */
+interface GitCodeCommit {
+  sha: string;
+  commit?: { message?: string };
+}
+
+function authHeaders(token: string): Record<string, string> {
+  return { 'Authorization': `Bearer ${token}`, 'Accept': 'application/json' };
+}
+
+/**
+ * 通过 GitCode REST API（api.gitcode.com/api/v5）获取 PR 的完整数据。
+ *
+ *   1. GET /repos/{o}/{r}/pulls/{n}                 元信息
+ *   2. GET /repos/{o}/{r}/pulls/{n}/commits         提交列表（失败非致命）
+ *   3. GET /repos/{o}/{r}/pulls/{n}/files           diff（截断 50KB，失败非致命）
+ *
+ * @param url - GitCode PR 完整 web URL
+ * @returns 包含标题、描述、提交列表、diff 的 MRData 对象
+ * @throws Error 当 URL 非法、未配置 token 或元信息调用失败时
+ */
+export async function fetchGitCodeMR(url: string): Promise<MRData> {
+  const { owner, repo, number } = parseGitCodePRUrl(url);
+  const token = getGitCodeToken();
+  if (!token) {
+    throw new Error('GITCODE_TOKEN is not set.');
+  }
+
+  const base = `${gitcodeApiBase()}/repos/${owner}/${repo}/pulls/${number}`;
+  const headers = authHeaders(token);
+  log.debug(`fetchGitCodeMR: ${owner}/${repo}#${number}`);
+
+  // ── 1. 元信息 ─────────────────────────────────────────────
+  const resp = await fetch(base, { headers, redirect: 'manual' });
+  if (!resp.ok) {
+    throw new Error(`GitCode API error ${resp.status}: ${await resp.text()}`);
+  }
+  const pr = (await resp.json()) as GitCodePR;
+
+  // ── 2. 提交列表（失败非致命） ─────────────────────────────
+  let commits: Array<{ hash: string; message: string }> = [];
+  try {
+    const commitsResp = await fetch(`${base}/commits?per_page=50`, { headers, redirect: 'manual' });
+    if (commitsResp.ok) {
+      const raw = (await commitsResp.json()) as GitCodeCommit[];
+      commits = raw.map((c) => ({
+        hash: c.sha,
+        message: (c.commit?.message ?? '').split('\n')[0],
+      }));
+    }
+  } catch (err) {
+    log.debug(`GitCode PR commits 获取异常，commits 将为空：${(err as Error).message}`);
+  }
+
+  // ── 3. diff（截断 50KB，失败非致命） ──────────────────────
+  let diff = '';
+  try {
+    const filesResp = await fetch(`${base}/files`, { headers, redirect: 'manual' });
+    if (filesResp.ok) {
+      const files = (await filesResp.json()) as Array<{ patch?: string; diff?: string }>;
+      diff = files
+        .map((f) => f.patch ?? f.diff ?? '')
+        .filter(Boolean)
+        .join('\n')
+        .slice(0, 50000);
+    } else {
+      log.debug(`GitCode PR diff 获取失败（${filesResp.status}），diff 将为空`);
+    }
+  } catch (err) {
+    log.debug(`GitCode PR diff 获取异常，diff 将为空：${(err as Error).message}`);
+  }
+
+  return {
+    title: pr.title,
+    description: pr.body ?? '',
+    author: pr.user?.login,
+    mergedAt: pr.merged_at ?? undefined,
+    commits,
+    diff,
+    url,
+  };
+}

--- a/src/providers/gitcode/org.ts
+++ b/src/providers/gitcode/org.ts
@@ -1,0 +1,83 @@
+import type { OrgRepoInfo } from '../types.js';
+import { getGitCodeToken, gitcodeApiBase } from './gitcode-api.js';
+import { GITCODE_HOST } from './repo-url.js';
+
+const DEFAULT_PER_PAGE = 100;
+const DEFAULT_MAX_REPOS = 200;
+
+/** GitCode API 返回的 repo 条目（仅使用的字段）。 */
+interface GitCodeRepoApiItem {
+  name: string;
+  full_name: string;
+  path?: string;
+  description?: string | null;
+  html_url?: string;
+  archived?: boolean;
+  updated_at?: string;
+  stargazers_count?: number;
+}
+
+function mapItem(item: GitCodeRepoApiItem): OrgRepoInfo {
+  const fullName = item.full_name;
+  return {
+    url: item.html_url ?? `https://${GITCODE_HOST}/${fullName}.git`,
+    fullName,
+    name: item.name,
+    description: item.description ?? undefined,
+    primaryLanguage: undefined,
+    archived: item.archived ?? false,
+    stars: item.stargazers_count,
+    pushedAt: item.updated_at,
+  };
+}
+
+/**
+ * 列出 GitCode 组织下的所有仓库（轻量元信息）。
+ *
+ * 实现：GET /api/v5/orgs/<org>/repos?per_page=100&page=N，分页至数组长度 < per_page
+ * 或累计达到 maxRepos。
+ *
+ * @param org   组织名
+ * @param opts.maxRepos  上限，默认 200
+ * @throws Error 缺 token / org 不存在 / 其他 HTTP 错误
+ */
+export async function gitcodeListOrgRepos(
+  org: string,
+  opts?: { maxRepos?: number },
+): Promise<OrgRepoInfo[]> {
+  const token = getGitCodeToken();
+  if (!token) {
+    throw new Error('GitCode token unavailable: set GITCODE_TOKEN (or GC_TOKEN).');
+  }
+
+  const maxRepos = opts?.maxRepos ?? DEFAULT_MAX_REPOS;
+  const headers = { 'Authorization': `Bearer ${token}`, 'Accept': 'application/json' };
+  const collected: OrgRepoInfo[] = [];
+  let page = 1;
+
+  while (collected.length < maxRepos) {
+    const url = `${gitcodeApiBase()}/orgs/${encodeURIComponent(org)}/repos`
+      + `?per_page=${DEFAULT_PER_PAGE}&page=${page}`;
+    const resp = await fetch(url, { headers, redirect: 'manual' });
+
+    if (resp.status === 404) {
+      throw new Error(`GitCode org ${org} not found or no access`);
+    }
+    if (!resp.ok) {
+      throw new Error(`GitCode API HTTP ${resp.status}: ${await resp.text().catch(() => '')}`);
+    }
+
+    const items = (await resp.json()) as GitCodeRepoApiItem[];
+    if (!Array.isArray(items) || items.length === 0) break;
+
+    for (const item of items) {
+      collected.push(mapItem(item));
+      if (collected.length >= maxRepos) break;
+    }
+
+    if (items.length < DEFAULT_PER_PAGE) break;
+    page++;
+  }
+
+  return collected;
+}

--- a/src/providers/gitcode/repo-url.ts
+++ b/src/providers/gitcode/repo-url.ts
@@ -21,14 +21,22 @@ export const GITCODE_HOST = 'gitcode.com';
  * two leading path segments are taken as `owner/repo`; anything after is a web
  * route and is ignored. Unlike GitLab there is no subgroup nesting and no `/-/`
  * route separator (GitCode uses GitHub/Gitee-style `/owner/repo/pulls/1`).
+ *
+ * Accepted forms: `owner/repo`, `https://gitcode.com/owner/repo(.git)`,
+ * scp-style `git@gitcode.com:owner/repo(.git)`, and `ssh://` URLs including the
+ * port-qualified form GitCode's UI hands out (`ssh://git@gitcode.com:2222/owner/repo.git`).
  */
 export function parseGitCodeRepoInput(input: string): RepoInfo {
   const trimmed = input.trim();
 
-  // Strip a leading scheme+host (HTTPS) or scp-style `git@host:` prefix, then
-  // split into path segments. The first two segments are owner/repo; the rest
-  // are web-route noise.
+  // Strip a leading scheme+host prefix, then split into path segments. The first
+  // two segments are owner/repo; the rest are web-route noise.
+  //   - `ssh://[user@]host[:port]/…`  → drop through the first slash after host
+  //     (handled before the scp rule; the `[:port]` never contains a `/`)
+  //   - `https?://host/…`             → drop scheme+host
+  //   - scp-style `git@host:…`        → drop `git@host:`
   const withoutPrefix = trimmed
+    .replace(/^ssh:\/\/[^/]+\//i, '')
     .replace(/^https?:\/\/[^/]+\//i, '')
     .replace(/^git@[^:]+:/i, '')
     .replace(/^\/+/, '');
@@ -47,7 +55,8 @@ export function parseGitCodeRepoInput(input: string): RepoInfo {
       '  Supported formats:\n' +
       '    owner/repo\n' +
       `    https://${GITCODE_HOST}/owner/repo.git\n` +
-      `    git@${GITCODE_HOST}:owner/repo.git`,
+      `    git@${GITCODE_HOST}:owner/repo.git\n` +
+      `    ssh://git@${GITCODE_HOST}:2222/owner/repo.git`,
   );
 }
 

--- a/src/providers/gitcode/repo-url.ts
+++ b/src/providers/gitcode/repo-url.ts
@@ -1,0 +1,63 @@
+import type { RepoInfo } from '../types.js';
+
+/**
+ * Git host for GitCode repos. Fixed to the public platform gitcode.com — this
+ * provider does not support self-hosted GitCode Enterprise (out of scope; see
+ * docs/designs/gitcode-provider.md §8). The REST API lives on a *separate*
+ * host (api.gitcode.com), handled in gitcode-api.ts.
+ */
+export const GITCODE_HOST = 'gitcode.com';
+
+/**
+ * Parse user input into a standardized RepoInfo structure for GitCode.
+ *
+ * Supports:
+ *   - Short format:  `owner/repo`
+ *   - HTTPS URL:     `https://gitcode.com/owner/repo(.git)`, tolerating trailing
+ *                    web-route segments (`/tree/main`, `/pulls/1`, …)
+ *   - SSH URL:       `git@gitcode.com:owner/repo(.git)`
+ *
+ * GitCode namespaces are single-level (a user or an organization), so exactly
+ * two leading path segments are taken as `owner/repo`; anything after is a web
+ * route and is ignored. Unlike GitLab there is no subgroup nesting and no `/-/`
+ * route separator (GitCode uses GitHub/Gitee-style `/owner/repo/pulls/1`).
+ */
+export function parseGitCodeRepoInput(input: string): RepoInfo {
+  const trimmed = input.trim();
+
+  // Strip a leading scheme+host (HTTPS) or scp-style `git@host:` prefix, then
+  // split into path segments. The first two segments are owner/repo; the rest
+  // are web-route noise.
+  const withoutPrefix = trimmed
+    .replace(/^https?:\/\/[^/]+\//i, '')
+    .replace(/^git@[^:]+:/i, '')
+    .replace(/^\/+/, '');
+
+  const segs = withoutPrefix.split('/').filter(Boolean);
+  if (segs.length >= 2) {
+    const owner = segs[0];
+    const repo = segs[1].replace(/\.git$/i, '');
+    if (owner && repo) {
+      return buildRepoInfo(owner, repo);
+    }
+  }
+
+  throw new Error(
+    `Unrecognized GitCode repo format: "${trimmed}"\n` +
+      '  Supported formats:\n' +
+      '    owner/repo\n' +
+      `    https://${GITCODE_HOST}/owner/repo.git\n` +
+      `    git@${GITCODE_HOST}:owner/repo.git`,
+  );
+}
+
+function buildRepoInfo(owner: string, repo: string): RepoInfo {
+  return {
+    owner,
+    repo,
+    httpsUrl: `https://${GITCODE_HOST}/${owner}/${repo}.git`,
+    // GitCode's API addresses repos by the plain `owner/repo` path (Gitee-style),
+    // not a URL-encoded id. Kept for interface parity with other providers.
+    projectId: `${owner}/${repo}`,
+  };
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -4,4 +4,5 @@ export { getProvider, getProviderFromUrl, detectProvider } from './registry.js';
 export { TGitProvider } from './tgit/index.js';
 export { GitHubProvider } from './github/index.js';
 export { GitLabProvider } from './gitlab/index.js';
+export { GitCodeProvider } from './gitcode/index.js';
 export { GenericGitProvider } from './git/index.js';

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -3,6 +3,7 @@ import { TGitProvider } from './tgit/index.js';
 import { GitHubProvider } from './github/index.js';
 import { CNBProvider } from './cnb/index.js';
 import { GitLabProvider } from './gitlab/index.js';
+import { GitCodeProvider } from './gitcode/index.js';
 import { GenericGitProvider } from './git/index.js';
 import { getCurrentPackageName } from '../package-info.js';
 
@@ -33,10 +34,11 @@ const HOST_MAP: Record<string, string> = {
   'git.woa.com': 'tgit',
   'cnb.cool': 'cnb',
   'gitlab.com': 'gitlab',
+  'gitcode.com': 'gitcode',
 };
 
 /** Providers we are willing to accept as a default override. */
-const KNOWN_PROVIDERS = new Set(['github', 'tgit', 'cnb', 'gitlab']);
+const KNOWN_PROVIDERS = new Set(['github', 'tgit', 'cnb', 'gitlab', 'gitcode']);
 
 /**
  * Decide the fallback provider used when the input URL host is unknown or
@@ -165,6 +167,7 @@ const PROVIDERS: Record<string, () => GitProvider> = {
   github: () => new GitHubProvider(),
   cnb: () => new CNBProvider(),
   gitlab: () => new GitLabProvider(),
+  gitcode: () => new GitCodeProvider(),
   git: () => new GenericGitProvider(),
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -190,7 +190,7 @@ export const TeamaiConfigSchema = z.object({
   description: z.string().default(''),
   repo: z.string(),
   /** Git hosting provider. `git` is the transport-only fallback for arbitrary hosts. */
-  provider: z.enum(['tgit', 'github', 'cnb', 'gitlab', 'git']).default('tgit'),
+  provider: z.enum(['tgit', 'github', 'cnb', 'gitlab', 'gitcode', 'git']).default('tgit'),
   /**
    * @deprecated Ignored by `teamai init` (issue #250). Local install scope is
    * decided only by CLI `--scope` / default. Kept optional for old teamai.yaml files.


### PR DESCRIPTION
## Problem

`teamai init https://gitcode.com/<owner>/<repo>.git` fails with `Unrecognized GitHub repo format`, and `teamai push` (branch + PR) is unavailable for GitCode (gitcode.com, CSDN's Chinese code-hosting platform). Closes #361.

## Solution

Add a first-class GitCode provider. GitCode uses a **Gitee-style v5 REST API** (`https://api.gitcode.com/api/v5`), not GitLab-style, so it's a new `src/providers/gitcode/` modelled structurally on the GitLab provider but with the correct dialect (all verified against the live API):

- **Auth**: PAT via `Authorization: Bearer`; token resolved from `GITCODE_TOKEN` → `GC_TOKEN` → `~/.netrc`. Interactive paste on `init`, persisted to `~/.netrc` (0600).
- **whoami** reads `login` (Gitee-style, not `username`).
- **PR create**: `POST /repos/{owner}/{repo}/pulls` with `head`/`base`/`title`/`body`, response `html_url` (`/pull/` singular).
- **createRepo**: personal `POST /user/repos`, org `POST /orgs/{org}/repos`.
- **Team-repo clone embeds `oauth2:<token>@` in the remote URL** so the branch+PR push flow authenticates — GitCode's git endpoint rejects `Authorization: Bearer` and only accepts Basic `oauth2:<token>` (verified). This mirrors GitHub/TGit.

Wiring: `registry.ts` (HOST_MAP / KNOWN_PROVIDERS / PROVIDERS), `providers/index.ts`, `types.ts` enum, `doctor.ts`, `clone.ts` (shallowClone branch). Docs updated across `providers.md`, README (both languages), usage-guide (both languages), plus a design doc.

Scope: public cloud `gitcode.com` only (no self-hosted enterprise; no OAuth — GitCode has no device flow).

## Test Plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 2459 passed (177 files), incl. new gitcode unit tests + fallback detection
- [x] **Real end-to-end (live GitCode repo)**:
  - `teamai init https://gitcode.com/...` → detects `gitcode`, authenticates, clones team repo, pushes member registration
  - `teamai push --all` → pushes branch → **creates PR** ✔
  - `fetchMergeRequest` → fetches title/author/commits/diff ✔
  - clone via HTTPS (token) and SSH (public key) ✔; `createRepo` (personal) ✔
- [ ] Not live-tested (edge/optional): `listOrgRepos`, org `createRepo`, interactive token-paste branch

<sub>🤖 Generated with [Claude Code](https://claude.com/claude-code)</sub>
