### PR TITLE
chore(release): 0.22.0-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teamai-cli",
-  "version": "0.21.0",
+  "version": "0.22.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teamai-cli",
-      "version": "0.21.0",
+      "version": "0.22.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teamai-cli",
-  "version": "0.21.0",
+  "version": "0.22.0-beta.1",
   "description": "TeamAI — the team harness for AI agents (skill sync + shared knowledge base, powered by Git)",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Bump package version to `0.22.0-beta.1`.
- Publish the prerelease through the `beta` dist-tag after pushing the release tag.
- Keep `latest` unchanged at `0.21.0`.

## Test Plan

- `npm run typecheck`
- `CI=1 npx vitest run --reporter=dot`

After the PR is merged, push `v0.22.0-beta.1` to trigger the release pipelines.