### PR TITLE
ci: migrate npm publishing to trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: npm
 
+      - name: Update npm for trusted publishing
+        run: npm install --global npm@^11.5.1
+
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
@@ -76,9 +79,7 @@ jobs:
           echo "is_prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
 
       - name: Publish
-        run: npm publish --provenance --access public --tag "${{ steps.disttag.outputs.dist_tag }}"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --tag "${{ steps.disttag.outputs.dist_tag }}"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary

- upgrade npm to a Trusted Publishing-compatible 11.x release in the release job
- remove the long-lived `NPM_TOKEN` from the publish step
- rely on GitHub Actions OIDC for npm authentication and automatic provenance
- preserve existing stable and prerelease dist-tag behavior

## Validation

- parsed `.github/workflows/release.yml` successfully as YAML
- ran `git diff --check`

## npm configuration

The npm Trusted Publisher must match `Tencent/teamai-cli` and `.github/workflows/release.yml`, with **Allow npm publish** enabled.