### PR TITLE
chore(release): 0.22.0-beta.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teamai-cli",
-  "version": "0.22.0-beta.1",
+  "version": "0.22.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teamai-cli",
-      "version": "0.22.0-beta.1",
+      "version": "0.22.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teamai-cli",
-  "version": "0.22.0-beta.1",
+  "version": "0.22.0-beta.2",
   "description": "TeamAI — the team harness for AI agents (skill sync + shared knowledge base, powered by Git)",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- bump the package version to `0.22.0-beta.2`
- keep `latest` unchanged; the release workflow will publish this version under the `beta` dist-tag

## Test plan

- `npm run typecheck`
- `CI=1 npx vitest run --reporter=dot` (177 files, 2462 tests passed)

## Release

After this PR is merged, create and push `v0.22.0-beta.2` from the resulting `main` commit to trigger npm Trusted Publishing.