### PR TITLE
fix(frontmatter): preserve malformed skill metadata

### DIFF
--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -351,7 +351,7 @@ Choose namespace [1-3] (default: 1 = common):
 
 **Updating an open PR instead of duplicating it:** If a resource is already waiting in an unmerged PR, re-running `teamai push` on it updates that existing PR in place (by force-pushing its branch) rather than opening a duplicate. Keep the resource selected to update its PR; deselect it to leave the PR untouched. Unrelated resources selected in the same run go into their own new PR. Once the PR merges (or its branch is removed from the remote), the record is cleared and the next push opens a fresh PR as usual.
 
-**Automatic YAML frontmatter completion:** When pushing, the CLI automatically checks `SKILL.md` and fills in `name`/`description` if missing — no manual upkeep required.
+**Automatic YAML frontmatter completion:** When pushing, the CLI automatically checks valid mapping-style `SKILL.md` frontmatter and fills in `name`/`description` if missing. Malformed or scalar frontmatter is left unchanged with a warning and must be fixed manually.
 
 ### Check status
 
@@ -435,6 +435,8 @@ teamai push --role pm
 > tags: [deploy, automation]
 > ---
 > ```
+>
+> Malformed YAML or a non-mapping frontmatter root is preserved unchanged and reported as a warning; fix it manually before pushing again.
 
 With role-based skills enabled, the push target directory becomes:
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -349,7 +349,7 @@ Choose namespace [1-3] (default: 1 = common):
 
 **更新已存在的 PR 而非重复创建：** 如果某个资源已在一个未合并的 PR 中等待评审，再次对它执行 `teamai push` 会就地更新那个已存在的 PR（通过 force-push 其分支），而不是新开一个重复的 PR。保持该资源被选中即更新其 PR；取消勾选则不动它。同一次运行中选中的其他无关资源会进入各自新开的 PR。一旦该 PR 合并（或其分支从远端删除），记录会被清除，下次 push 照常新开 PR。
 
-**YAML Frontmatter 自动补全：** 推送时 CLI 自动检查 `SKILL.md`，缺少 `name`/`description` 则自动补全，无需手动维护。
+**YAML Frontmatter 自动补全：** 推送时 CLI 自动检查合法的 mapping 形式 `SKILL.md` frontmatter，缺少 `name`/`description` 则自动补全。格式损坏或根节点为标量时会保留原文并告警，需要手动修复。
 
 ### 查看状态
 
@@ -433,6 +433,8 @@ teamai push --role pm
 > tags: [deploy, automation]
 > ---
 > ```
+>
+> YAML 格式损坏或 frontmatter 根节点不是 mapping 时，CLI 会保留原文并输出告警；请手动修复后再推送。
 
 启用角色化 skills 后，push 的目标目录为：
 

--- a/src/__tests__/frontmatter.test.ts
+++ b/src/__tests__/frontmatter.test.ts
@@ -72,6 +72,18 @@ describe('splitFrontmatter – round-trip', () => {
     });
 });
 
+describe('splitFrontmatter – root shape', () => {
+    it('marks scalar frontmatter as invalid without exposing it as a record', () => {
+        const result = splitFrontmatter('---\njust-a-scalar\n---\nbody');
+        expect(result.valid).toBe(false);
+        expect(result.data).toEqual({});
+    });
+
+    it('marks mapping frontmatter as valid', () => {
+        expect(splitFrontmatter('---\nname: foo\n---\nbody').valid).toBe(true);
+    });
+});
+
 describe('parseFrontmatter – no trailing newline after closing delimiter', () => {
     it('parses frontmatter at end of string with no trailing newline', () => {
         const { data, body } = parseFrontmatter('---\nname: x\n---');

--- a/src/__tests__/frontmatter.test.ts
+++ b/src/__tests__/frontmatter.test.ts
@@ -45,6 +45,12 @@ describe('parseFrontmatter – malformed YAML', () => {
         const { data } = parseFrontmatter('---\n: : :\n---\nx');
         expect(data).toEqual({});
     });
+
+    it('remains invalid when the same malformed block is parsed repeatedly', () => {
+        const input = '---\nname: original\ncustom: [\n---\nbody';
+        expect(splitFrontmatter(input).valid).toBe(false);
+        expect(splitFrontmatter(input).valid).toBe(false);
+    });
 });
 
 describe('splitFrontmatter – round-trip', () => {
@@ -81,6 +87,18 @@ describe('splitFrontmatter – root shape', () => {
 
     it('marks mapping frontmatter as valid', () => {
         expect(splitFrontmatter('---\nname: foo\n---\nbody').valid).toBe(true);
+    });
+
+    it('marks sequence and timestamp roots as invalid', () => {
+        expect(splitFrontmatter('---\n- item\n---\nbody').valid).toBe(false);
+        expect(splitFrontmatter('---\n2020-01-01\n---\nbody').valid).toBe(false);
+    });
+
+    it('does not share parsed data between identical blocks', () => {
+        const input = '---\ntrigger: shared\n---\nbody';
+        const first = splitFrontmatter(input);
+        first.data.name = 'mutated';
+        expect(splitFrontmatter(input).data).toEqual({ trigger: 'shared' });
     });
 });
 

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -851,9 +851,34 @@ describe('ensureSkillFrontmatter', () => {
   it('does not throw on scalar frontmatter', async () => {
     const skillDir = path.join(tmpDir, 'scalar');
     await fse.ensureDir(skillDir);
-    await fse.writeFile(path.join(skillDir, 'SKILL.md'), '---\njust-a-scalar\n---\n# Body\n');
+    const original = '---\njust-a-scalar\n---\n# Body\n';
+    await fse.writeFile(path.join(skillDir, 'SKILL.md'), original);
 
     await expect(ensureSkillFrontmatter(skillDir, 'scalar')).resolves.toBe(false);
+    await expect(fse.readFile(path.join(skillDir, 'SKILL.md'), 'utf8')).resolves.toBe(original);
+  });
+
+  it('preserves comments and quoting when adding a missing field', async () => {
+    const skillDir = path.join(tmpDir, 'preserve-format');
+    await fse.ensureDir(skillDir);
+    const original = '---\nname: preserve-format\n# keep me\nallowed-tools: "Bash(git:*)"\n---\n# Body\n';
+    await fse.writeFile(path.join(skillDir, 'SKILL.md'), original);
+
+    await expect(ensureSkillFrontmatter(skillDir, 'preserve-format')).resolves.toBe(true);
+    const updated = await fse.readFile(path.join(skillDir, 'SKILL.md'), 'utf8');
+    expect(updated).toContain('# keep me\nallowed-tools: "Bash(git:*)"');
+    expect(updated).toContain('description: Body\n---\n# Body\n');
+  });
+
+  it('completes byte-identical frontmatter independently for multiple skills', async () => {
+    for (const skillName of ['skill-a', 'skill-b']) {
+      const skillDir = path.join(tmpDir, skillName);
+      await fse.ensureDir(skillDir);
+      await fse.writeFile(path.join(skillDir, 'SKILL.md'), '---\ntrigger: shared\n---\n# Shared Body\n');
+      await expect(ensureSkillFrontmatter(skillDir, skillName)).resolves.toBe(true);
+      const { data } = parseFrontmatter(await fse.readFile(path.join(skillDir, 'SKILL.md'), 'utf8'));
+      expect(data).toMatchObject({ trigger: 'shared', name: skillName, description: 'Shared Body' });
+    }
   });
 
   it('does not modify SKILL.md when frontmatter already has name and description', async () => {

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -838,6 +838,24 @@ describe('ensureSkillFrontmatter', () => {
     expect(body).toContain('Does cool things.');
   });
 
+  it('does not throw or overwrite malformed frontmatter', async () => {
+    const skillDir = path.join(tmpDir, 'malformed');
+    await fse.ensureDir(skillDir);
+    const original = '---\nname: original\ncustom: [\n---\n# Body\n';
+    await fse.writeFile(path.join(skillDir, 'SKILL.md'), original);
+
+    await expect(ensureSkillFrontmatter(skillDir, 'malformed')).resolves.toBe(false);
+    await expect(fse.readFile(path.join(skillDir, 'SKILL.md'), 'utf8')).resolves.toBe(original);
+  });
+
+  it('does not throw on scalar frontmatter', async () => {
+    const skillDir = path.join(tmpDir, 'scalar');
+    await fse.ensureDir(skillDir);
+    await fse.writeFile(path.join(skillDir, 'SKILL.md'), '---\njust-a-scalar\n---\n# Body\n');
+
+    await expect(ensureSkillFrontmatter(skillDir, 'scalar')).resolves.toBe(false);
+  });
+
   it('does not modify SKILL.md when frontmatter already has name and description', async () => {
     const skillDir = path.join(tmpDir, 'complete-skill');
     await fse.ensureDir(skillDir);

--- a/src/resources/skills.ts
+++ b/src/resources/skills.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import YAML from 'yaml';
 import { ResourceHandler } from './base.js';
 import type { ResourceItem, ResourceItemStatus, TeamaiConfig, LocalConfig } from '../types.js';
 import { resolveBaseDir, getPushignorePath, isAgentDisabled, scopedToolPaths } from '../types.js';
@@ -14,6 +15,16 @@ import { splitFrontmatter, stringifyFrontmatter } from '../utils/frontmatter.js'
 /** File name used to track who has contributed (pushed) a skill. */
 const CONTRIBUTORS_FILE = 'CONTRIBUTORS';
 const SKILL_MD = 'SKILL.md';
+
+/** Add fields immediately before the closing delimiter without reformatting existing YAML. */
+function appendFrontmatterFields(raw: string, fields: Record<string, string>): string {
+  const eol = raw.includes('\r\n') ? '\r\n' : '\n';
+  const yaml = YAML.stringify(fields).trimEnd().replace(/\n/g, eol);
+  return raw.replace(
+    /(\r?\n---[ \t]*)(\r?\n|$)$/,
+    (_match, closing: string, trailing: string) => `${eol}${yaml}${closing}${trailing}`,
+  );
+}
 
 /**
  * Ensure a SKILL.md file has valid YAML frontmatter with `name` and `description`.
@@ -51,17 +62,13 @@ export async function ensureSkillFrontmatter(skillDir: string, skillName: string
 
   if (hasName && hasDescription) return false; // Already complete
 
-  if (!hasName) {
-    data['name'] = skillName;
-  }
-  if (!hasDescription) {
-    data['description'] = extractDescriptionFromContent(body, skillName);
-  }
+  const missingFields: Record<string, string> = {};
+  if (!hasName) missingFields.name = skillName;
+  if (!hasDescription) missingFields.description = extractDescriptionFromContent(body, skillName);
 
-  // Re-serialize the parsed frontmatter with the missing fields filled in. Note: if
-  // the original frontmatter had malformed YAML, splitFrontmatter yields an empty
-  // `data`, so the rebuilt block keeps only name/description and drops the bad content.
-  const newContent = stringifyFrontmatter(data, body);
+  // Preserve existing comments, quoting, key order, and line endings. Re-serializing
+  // the whole block would make an unrelated metadata repair unnecessarily lossy.
+  const newContent = appendFrontmatterFields(raw, missingFields) + body;
   await writeFile(skillMdPath, newContent);
   log.debug(`Added missing frontmatter fields to ${skillName}/SKILL.md`);
   return true;

--- a/src/resources/skills.ts
+++ b/src/resources/skills.ts
@@ -29,7 +29,7 @@ export async function ensureSkillFrontmatter(skillDir: string, skillName: string
   const content = await readFileSafe(skillMdPath);
   if (!content) return false;
 
-  const { data, body, raw } = splitFrontmatter(content);
+  const { data, body, raw, valid } = splitFrontmatter(content);
 
   if (!raw) {
     // No frontmatter at all — derive description from first heading or first non-empty line
@@ -38,6 +38,11 @@ export async function ensureSkillFrontmatter(skillDir: string, skillName: string
     await writeFile(skillMdPath, newContent);
     log.debug(`Injected YAML frontmatter into ${skillName}/SKILL.md`);
     return true;
+  }
+
+  if (!valid) {
+    log.warn(`Could not repair malformed frontmatter in ${skillName}/SKILL.md; leaving it unchanged`);
+    return false;
   }
 
   // Frontmatter exists — check for missing fields

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -4,7 +4,7 @@ import matter from 'gray-matter';
 export interface FrontmatterSplit {
   /** Parsed frontmatter fields. Empty object when absent or unparseable. */
   data: Record<string, unknown>;
-  /** Whether the frontmatter parsed to a mapping/object. */
+  /** Whether a present frontmatter block parsed to a plain YAML mapping. Meaningful only when `raw` is non-empty. */
   valid: boolean;
   /** Document body after the frontmatter block (any leading BOM removed). */
   body: string;
@@ -21,6 +21,13 @@ const FRONTMATTER_BLOCK = /^﻿?---[ \t]*\r?\n[\s\S]*?\r?\n---[ \t]*(?:\r?\n|$)/
 /** Strip a single leading UTF-8 BOM if present. */
 function stripBom(text: string): string {
     return text.charCodeAt(0) === 0xFEFF ? text.slice(1) : text;
+}
+
+/** YAML mappings parse to plain records; scalars such as timestamps may still be objects. */
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
 }
 
 /**
@@ -41,11 +48,13 @@ export function splitFrontmatter(content: string): FrontmatterSplit {
     let data: Record<string, unknown> = {};
     let valid = false;
     try {
-        const parsed = matter(raw);
-        if (parsed.data === null || typeof parsed.data !== 'object' || Array.isArray(parsed.data)) {
+        // Passing options disables gray-matter's module-level cache. Cache entries
+        // otherwise survive parse failures and share mutable `data` references.
+        const parsed = matter(raw, {});
+        if (!isPlainRecord(parsed.data)) {
             return { data: {}, valid: false, body, raw };
         }
-        data = parsed.data as Record<string, unknown>;
+        data = { ...parsed.data };
         valid = true;
     } catch {
         data = {};

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -4,6 +4,8 @@ import matter from 'gray-matter';
 export interface FrontmatterSplit {
   /** Parsed frontmatter fields. Empty object when absent or unparseable. */
   data: Record<string, unknown>;
+  /** Whether the frontmatter parsed to a mapping/object. */
+  valid: boolean;
   /** Document body after the frontmatter block (any leading BOM removed). */
   body: string;
   /** Verbatim leading frontmatter block including delimiters and trailing newline; '' when absent. */
@@ -31,19 +33,24 @@ function stripBom(text: string): string {
 export function splitFrontmatter(content: string): FrontmatterSplit {
     const match = content.match(FRONTMATTER_BLOCK);
     if (!match) {
-        return { data: {}, body: stripBom(content), raw: '' };
+        return { data: {}, valid: false, body: stripBom(content), raw: '' };
     }
     const rawFull = match[0];
     const body = content.slice(rawFull.length);
     const raw = stripBom(rawFull);
     let data: Record<string, unknown> = {};
+    let valid = false;
     try {
         const parsed = matter(raw);
-        data = (parsed.data ?? {}) as Record<string, unknown>;
+        if (parsed.data === null || typeof parsed.data !== 'object' || Array.isArray(parsed.data)) {
+            return { data: {}, valid: false, body, raw };
+        }
+        data = parsed.data as Record<string, unknown>;
+        valid = true;
     } catch {
         data = {};
     }
-    return { data, body, raw };
+    return { data, valid, body, raw };
 }
 
 /** Parse frontmatter fields and body from a document. */


### PR DESCRIPTION
Fixes the malformed frontmatter regression introduced by #378.

- Validate that parsed frontmatter is a YAML mapping before accessing or serializing fields.
- Leave malformed/scalar frontmatter unchanged instead of throwing or dropping metadata.
- Add regression coverage for malformed mapping and scalar frontmatter.

Tests: `npm test -- --run`, `npm run typecheck`