### PR TITLE
fix(votes): avoid clobbering pending contribute hints

### DIFF
--- a/src/__tests__/contribute-check.test.ts
+++ b/src/__tests__/contribute-check.test.ts
@@ -10,6 +10,7 @@ import {
   takePendingHint,
   stashVotesHint,
   takePendingVotesHint,
+  claimVotesNudge,
 } from '../contribute-check.js';
 import { appendEvent } from '../dashboard-collector.js';
 import {
@@ -71,9 +72,17 @@ describe('contributeState', () => {
 
     await stashVotesHint(sessionId, 'votes');
 
+    const sidecar = path.join(tmpDir, '.teamai', 'sessions', `${sessionId}.votes-hint.json`);
+    expect(fs.existsSync(sidecar)).toBe(true);
     expect(await takePendingVotesHint(sessionId)).toBe('votes');
+    expect(fs.existsSync(sidecar)).toBe(false);
     expect((await readContributeState(sessionId)).pendingHint).toBe('contribute');
     expect(await takePendingVotesHint(sessionId)).toBeNull();
+  });
+
+  it('claims a Cursor votes nudge only once per session', async () => {
+    expect(await claimVotesNudge('cursor-nudge')).toBe(true);
+    expect(await claimVotesNudge('cursor-nudge')).toBe(false);
   });
 
   it('returns defaults when session file does not exist', async () => {
@@ -967,5 +976,18 @@ describe('sessionId filesystem safety (L2)', () => {
     await cleanupStaleSessions(sessionsDir, sessionId);
 
     expect(fs.existsSync(filePath)).toBe(true);
+  });
+
+  it('cleanupStaleSessions removes stale votes-hint sidecars', async () => {
+    const { cleanupStaleSessions } = await import('../contribute-check.js');
+    await stashVotesHint('old-votes-session', 'votes');
+    const sessionsDir = path.join(tmpDir, '.teamai', 'sessions');
+    const sidecarPath = path.join(sessionsDir, 'old-votes-session.votes-hint.json');
+    const past = Date.now() - 25 * 60 * 60 * 1000;
+    fs.utimesSync(sidecarPath, new Date(past), new Date(past));
+
+    await cleanupStaleSessions(sessionsDir, 'current-session');
+
+    expect(fs.existsSync(sidecarPath)).toBe(false);
   });
 });

--- a/src/__tests__/contribute-check.test.ts
+++ b/src/__tests__/contribute-check.test.ts
@@ -8,6 +8,8 @@ import {
   computeSmartScore,
   contributeCheckForSession,
   takePendingHint,
+  stashVotesHint,
+  takePendingVotesHint,
 } from '../contribute-check.js';
 import { appendEvent } from '../dashboard-collector.js';
 import {
@@ -61,6 +63,17 @@ describe('contributeState', () => {
 
     const readB = await readContributeState('session-bbb');
     expect(readB.contributed).toBe(true);
+  });
+
+  it('stores vote hints independently from contribute state', async () => {
+    const sessionId = 'independent-votes-hint';
+    await writeContributeState(sessionId, { contributed: false, pendingHint: 'contribute' });
+
+    await stashVotesHint(sessionId, 'votes');
+
+    expect(await takePendingVotesHint(sessionId)).toBe('votes');
+    expect((await readContributeState(sessionId)).pendingHint).toBe('contribute');
+    expect(await takePendingVotesHint(sessionId)).toBeNull();
   });
 
   it('returns defaults when session file does not exist', async () => {

--- a/src/__tests__/contribute-check.test.ts
+++ b/src/__tests__/contribute-check.test.ts
@@ -85,6 +85,15 @@ describe('contributeState', () => {
     expect(await claimVotesNudge('cursor-nudge')).toBe(false);
   });
 
+  it('keeps a successful Cursor claim when stale cleanup fails', async () => {
+    const readdir = vi.spyOn(fs.promises, 'readdir').mockRejectedValueOnce(new Error('EMFILE'));
+
+    expect(await claimVotesNudge('cursor-cleanup-failure')).toBe(true);
+    expect(await claimVotesNudge('cursor-cleanup-failure')).toBe(false);
+
+    readdir.mockRestore();
+  });
+
   it('returns defaults when session file does not exist', async () => {
     const state = await readContributeState('nonexistent-session');
     expect(state).toEqual({ contributed: false });

--- a/src/__tests__/hook-dispatch.test.ts
+++ b/src/__tests__/hook-dispatch.test.ts
@@ -160,6 +160,35 @@ describe('hook-dispatch', () => {
 
       expect(result.output).toBeNull();
     });
+
+    it('merges additionalContext from concurrent handlers', async () => {
+      const first = createHandler('votes', JSON.stringify({
+        hookSpecificOutput: { hookEventName: 'Stop', additionalContext: 'VOTES' },
+      }));
+      const second = createHandler('contribute', JSON.stringify({
+        hookSpecificOutput: { hookEventName: 'Stop', additionalContext: 'CONTRIBUTE' },
+      }));
+      const dispatcher = createDispatcher({ handlers: [
+        { event: 'stop', matcher: '*', handler: first },
+        { event: 'stop', matcher: '*', handler: second },
+      ] });
+
+      const result = await dispatcher.dispatch('stop', '*', {}, 'claude');
+      const parsed = JSON.parse(result.output!);
+      expect(parsed.hookSpecificOutput.additionalContext).toBe('VOTES\nCONTRIBUTE');
+    });
+
+    it('merges Cursor followup messages from concurrent handlers', async () => {
+      const first = createHandler('votes', JSON.stringify({ followup_message: 'VOTES' }));
+      const second = createHandler('contribute', JSON.stringify({ followup_message: 'CONTRIBUTE' }));
+      const dispatcher = createDispatcher({ handlers: [
+        { event: 'stop', matcher: '*', handler: first },
+        { event: 'stop', matcher: '*', handler: second },
+      ] });
+
+      const result = await dispatcher.dispatch('stop', '*', {}, 'cursor');
+      expect(JSON.parse(result.output!).followup_message).toBe('VOTES\nCONTRIBUTE');
+    });
   });
 
   describe('stdin sharing', () => {

--- a/src/__tests__/hook-handlers.test.ts
+++ b/src/__tests__/hook-handlers.test.ts
@@ -11,6 +11,11 @@ const mockTrackFromParsed = vi.fn().mockResolvedValue(undefined);
 const mockTrackSlashFromParsed = vi.fn().mockResolvedValue(undefined);
 const mockContributeCheckForSession = vi.fn().mockResolvedValue({ hint: null });
 const mockTakePendingHint = vi.fn().mockResolvedValue(null);
+const mockTakePendingVotesHint = vi.fn().mockResolvedValue(undefined);
+const mockStashVotesHint = vi.fn().mockResolvedValue(undefined);
+const mockParseTranscriptForVotes = vi.fn().mockResolvedValue({ referencedDocIds: [], recalledDocIds: [] });
+const mockIncrementUpvoted = vi.fn().mockResolvedValue(undefined);
+const mockSyncVotesToTeam = vi.fn().mockResolvedValue(false);
 const mockDoUpdate = vi.fn().mockResolvedValue(undefined);
 const mockReportAndSyncFromHook = vi.fn().mockResolvedValue(null);
 
@@ -38,6 +43,8 @@ vi.mock('../contribute-check.js', () => ({
   contributeCheck: vi.fn().mockResolvedValue(undefined),
   contributeCheckForSession: mockContributeCheckForSession,
   takePendingHint: mockTakePendingHint,
+  takePendingVotesHint: mockTakePendingVotesHint,
+  stashVotesHint: mockStashVotesHint,
 }));
 
 vi.mock('../update.js', () => ({
@@ -58,6 +65,15 @@ vi.mock('../utils/logger.js', () => ({
 
 vi.mock('../local-agent.js', () => ({
   reportAndSyncFromHook: mockReportAndSyncFromHook,
+}));
+
+vi.mock('../transcript-parser.js', () => ({
+  parseTranscriptForVotes: mockParseTranscriptForVotes,
+}));
+
+vi.mock('../votes.js', () => ({
+  incrementUpvoted: mockIncrementUpvoted,
+  syncVotesToTeam: mockSyncVotesToTeam,
 }));
 
 const mockSeedProjectAgentRoot = vi.fn().mockResolvedValue(undefined);
@@ -431,6 +447,223 @@ describe('hook-handlers registry', () => {
     expect(filterHandlersForConfig(registry, { repo: { kind: 'git' } } as never).length).toBe(full);
     expect(filterHandlersForConfig(registry, { repo: {} } as never).length).toBe(full);
     expect(filterHandlersForConfig(registry, null).length).toBe(full);
+  });
+
+  // ── Change 2: votes-sync nudge — marker guard removed, nudge every time declared===0 ──
+
+  it('votes-sync nudges on every Stop when recalled>0 and declared===0 (no once-per-session guard)', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'stop' && r.handler.name === 'votes-sync',
+    )!.handler;
+
+    // recalled>0, declared===0 → should always nudge
+    mockParseTranscriptForVotes.mockResolvedValue({
+      referencedDocIds: [],
+      recalledDocIds: ['doc-a'],
+    });
+
+    const result1 = await handler.execute(
+      { session_id: 'sid-votes-1', cwd: '/x', transcript_path: '/t/transcript.jsonl' },
+      'claude',
+    );
+    expect(result1).not.toBeNull();
+
+    // Same session, same conditions — should nudge again (no marker blocks repeat)
+    const result2 = await handler.execute(
+      { session_id: 'sid-votes-1', cwd: '/x', transcript_path: '/t/transcript.jsonl' },
+      'claude',
+    );
+    expect(result2).not.toBeNull();
+  });
+
+  it('votes-sync does not nudge when recalled===0', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'stop' && r.handler.name === 'votes-sync',
+    )!.handler;
+
+    mockParseTranscriptForVotes.mockResolvedValue({
+      referencedDocIds: [],
+      recalledDocIds: [],
+    });
+
+    const result = await handler.execute(
+      { session_id: 'sid-votes-2', cwd: '/x', transcript_path: '/t/transcript.jsonl' },
+      'claude',
+    );
+    expect(result).toBeNull();
+  });
+
+  // ── upvote intersection filter: only recalled docs count ──
+
+  it('votes-sync: incrementUpvoted receives only the intersection of referenced and recalled doc-ids', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'stop' && r.handler.name === 'votes-sync',
+    )!.handler;
+
+    mockParseTranscriptForVotes.mockResolvedValue({
+      referencedDocIds: ['doc-a', 'doc-b', 'doc-c'],
+      recalledDocIds: ['doc-a', 'doc-b'],
+    });
+
+    await handler.execute(
+      { session_id: 'sid-filter-1', cwd: '/x', transcript_path: '/t/transcript.jsonl' },
+      'claude',
+    );
+
+    expect(mockIncrementUpvoted).toHaveBeenCalledOnce();
+    expect(mockIncrementUpvoted).toHaveBeenCalledWith(expect.any(String), ['doc-a', 'doc-b']);
+  });
+
+  it('votes-sync: incrementUpvoted is not called when no referenced doc-id was actually recalled', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'stop' && r.handler.name === 'votes-sync',
+    )!.handler;
+
+    mockParseTranscriptForVotes.mockResolvedValue({
+      referencedDocIds: ['doc-x'],
+      recalledDocIds: ['doc-a', 'doc-b'],
+    });
+
+    await handler.execute(
+      { session_id: 'sid-filter-2', cwd: '/x', transcript_path: '/t/transcript.jsonl' },
+      'claude',
+    );
+
+    expect(mockIncrementUpvoted).not.toHaveBeenCalled();
+  });
+
+  it('votes-sync: incrementUpvoted receives all ids when referenced and recalled are identical', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'stop' && r.handler.name === 'votes-sync',
+    )!.handler;
+
+    mockParseTranscriptForVotes.mockResolvedValue({
+      referencedDocIds: ['doc-p', 'doc-q'],
+      recalledDocIds: ['doc-p', 'doc-q'],
+    });
+
+    await handler.execute(
+      { session_id: 'sid-filter-3', cwd: '/x', transcript_path: '/t/transcript.jsonl' },
+      'claude',
+    );
+
+    expect(mockIncrementUpvoted).toHaveBeenCalledOnce();
+    expect(mockIncrementUpvoted).toHaveBeenCalledWith(expect.any(String), ['doc-p', 'doc-q']);
+  });
+
+  it('votes-sync: incrementUpvoted is not called when recalledDocIds is empty', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'stop' && r.handler.name === 'votes-sync',
+    )!.handler;
+
+    mockParseTranscriptForVotes.mockResolvedValue({
+      referencedDocIds: ['doc-a'],
+      recalledDocIds: [],
+    });
+
+    await handler.execute(
+      { session_id: 'sid-filter-empty-recalled', cwd: '/x', transcript_path: '/t/transcript.jsonl' },
+      'claude',
+    );
+
+    expect(mockIncrementUpvoted).not.toHaveBeenCalled();
+  });
+
+  // ── Change 3: votes-sync stash branch (STOP_STDOUT_UNSUPPORTED_TOOLS) ──
+
+  it('votes-sync stashes nudge via stashVotesHint for codebuddy (stdout ignored)', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'stop' && r.handler.name === 'votes-sync',
+    )!.handler;
+
+    mockParseTranscriptForVotes.mockResolvedValue({
+      referencedDocIds: [],
+      recalledDocIds: ['doc-b'],
+    });
+
+    const result = await handler.execute(
+      { session_id: 'sid-votes-stash', cwd: '/x', transcript_path: '/t/transcript.jsonl' },
+      'codebuddy',
+    );
+    // Stash path returns null (hint goes to pendingVotesHint)
+    expect(result).toBeNull();
+    expect(mockStashVotesHint).toHaveBeenCalledOnce();
+    const [calledSessionId, calledMsg] = mockStashVotesHint.mock.calls[0];
+    expect(calledSessionId).toBe('sid-votes-stash');
+    expect(calledMsg).toContain('doc-b');
+  });
+
+  it('votes-sync returns stdout nudge for claude (not a stash tool)', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'stop' && r.handler.name === 'votes-sync',
+    )!.handler;
+
+    mockParseTranscriptForVotes.mockResolvedValue({
+      referencedDocIds: [],
+      recalledDocIds: ['doc-c'],
+    });
+
+    const result = await handler.execute(
+      { session_id: 'sid-votes-stdout', cwd: '/x', transcript_path: '/t/transcript.jsonl' },
+      'claude',
+    );
+    expect(result).not.toBeNull();
+    expect(mockStashVotesHint).not.toHaveBeenCalled();
+  });
+
+  // ── Change 3: pending-hint replays and merges pendingVotesHint ──
+
+  it('pending-hint merges contribute hint and votes hint for codebuddy', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'prompt-submit' && r.handler.name === 'pending-hint',
+    )!.handler;
+
+    mockTakePendingHint.mockResolvedValueOnce('[teamai] contribute hint');
+    mockTakePendingVotesHint.mockResolvedValueOnce('[teamai] votes hint');
+
+    const result = await handler.execute({ session_id: 'sid-merge', cwd: '/x' }, 'codebuddy');
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result!);
+    const ctx = parsed.hookSpecificOutput.additionalContext;
+    expect(ctx).toContain('[teamai] contribute hint');
+    expect(ctx).toContain('[teamai] votes hint');
+  });
+
+  it('pending-hint delivers only votes hint when contribute hint is absent', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'prompt-submit' && r.handler.name === 'pending-hint',
+    )!.handler;
+
+    mockTakePendingHint.mockResolvedValueOnce(null);
+    mockTakePendingVotesHint.mockResolvedValueOnce('[teamai] votes only');
+
+    const result = await handler.execute({ session_id: 'sid-votes-only', cwd: '/x' }, 'codebuddy');
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result!);
+    expect(parsed.hookSpecificOutput.additionalContext).toBe('[teamai] votes only');
+  });
+
+  it('pending-hint returns null when both hints are absent', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'prompt-submit' && r.handler.name === 'pending-hint',
+    )!.handler;
+
+    mockTakePendingHint.mockResolvedValueOnce(null);
+    mockTakePendingVotesHint.mockResolvedValueOnce(undefined);
+
+    const result = await handler.execute({ session_id: 'sid-both-absent', cwd: '/x' }, 'codebuddy');
+    expect(result).toBeNull();
   });
 });
 

--- a/src/__tests__/hook-handlers.test.ts
+++ b/src/__tests__/hook-handlers.test.ts
@@ -11,7 +11,7 @@ const mockTrackFromParsed = vi.fn().mockResolvedValue(undefined);
 const mockTrackSlashFromParsed = vi.fn().mockResolvedValue(undefined);
 const mockContributeCheckForSession = vi.fn().mockResolvedValue({ hint: null });
 const mockTakePendingHint = vi.fn().mockResolvedValue(null);
-const mockTakePendingVotesHint = vi.fn().mockResolvedValue(undefined);
+const mockTakePendingVotesHint = vi.fn().mockResolvedValue(null);
 const mockStashVotesHint = vi.fn().mockResolvedValue(undefined);
 const mockClaimVotesNudge = vi.fn().mockResolvedValue(true);
 const mockParseTranscriptForVotes = vi.fn().mockResolvedValue({ referencedDocIds: [], recalledDocIds: [] });
@@ -704,7 +704,7 @@ describe('hook-handlers registry', () => {
     )!.handler;
 
     mockTakePendingHint.mockResolvedValueOnce(null);
-    mockTakePendingVotesHint.mockResolvedValueOnce(undefined);
+    mockTakePendingVotesHint.mockResolvedValueOnce(null);
 
     const result = await handler.execute({ session_id: 'sid-both-absent', cwd: '/x' }, 'codebuddy');
     expect(result).toBeNull();

--- a/src/__tests__/hook-handlers.test.ts
+++ b/src/__tests__/hook-handlers.test.ts
@@ -13,6 +13,7 @@ const mockContributeCheckForSession = vi.fn().mockResolvedValue({ hint: null });
 const mockTakePendingHint = vi.fn().mockResolvedValue(null);
 const mockTakePendingVotesHint = vi.fn().mockResolvedValue(undefined);
 const mockStashVotesHint = vi.fn().mockResolvedValue(undefined);
+const mockClaimVotesNudge = vi.fn().mockResolvedValue(true);
 const mockParseTranscriptForVotes = vi.fn().mockResolvedValue({ referencedDocIds: [], recalledDocIds: [] });
 const mockIncrementUpvoted = vi.fn().mockResolvedValue(undefined);
 const mockSyncVotesToTeam = vi.fn().mockResolvedValue(false);
@@ -45,6 +46,7 @@ vi.mock('../contribute-check.js', () => ({
   takePendingHint: mockTakePendingHint,
   takePendingVotesHint: mockTakePendingVotesHint,
   stashVotesHint: mockStashVotesHint,
+  claimVotesNudge: mockClaimVotesNudge,
 }));
 
 vi.mock('../update.js', () => ({
@@ -89,6 +91,8 @@ import { createDispatcher } from '../hook-dispatch.js';
 describe('hook-handlers registry', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockParseTranscriptForVotes.mockResolvedValue({ referencedDocIds: [], recalledDocIds: [] });
+    mockClaimVotesNudge.mockResolvedValue(true);
   });
 
   it('returns registrations for all expected events', () => {
@@ -592,7 +596,7 @@ describe('hook-handlers registry', () => {
       { session_id: 'sid-votes-stash', cwd: '/x', transcript_path: '/t/transcript.jsonl' },
       'codebuddy',
     );
-    // Stash path returns null (hint goes to pendingVotesHint)
+    // Stash path returns null (hint goes to the votes-hint sidecar)
     expect(result).toBeNull();
     expect(mockStashVotesHint).toHaveBeenCalledOnce();
     const [calledSessionId, calledMsg] = mockStashVotesHint.mock.calls[0];
@@ -619,7 +623,47 @@ describe('hook-handlers registry', () => {
     expect(mockStashVotesHint).not.toHaveBeenCalled();
   });
 
-  // ── Change 3: pending-hint replays and merges pendingVotesHint ──
+  it('votes-sync caps Cursor follow-up nudges to once per session', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'stop' && r.handler.name === 'votes-sync',
+    )!.handler;
+    mockParseTranscriptForVotes.mockResolvedValue({
+      referencedDocIds: [],
+      recalledDocIds: ['doc-cursor'],
+    });
+    mockClaimVotesNudge
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+
+    const stdin = { session_id: 'sid-cursor', cwd: '/x', transcript_path: '/t/transcript.jsonl' };
+    expect(await handler.execute(stdin, 'cursor')).not.toBeNull();
+    expect(await handler.execute(stdin, 'cursor')).toBeNull();
+    expect(mockClaimVotesNudge).toHaveBeenCalledTimes(2);
+  });
+
+  it('stop dispatcher preserves both votes and contribute hints', async () => {
+    mockParseTranscriptForVotes.mockResolvedValue({
+      referencedDocIds: [],
+      recalledDocIds: ['doc-a'],
+    });
+    mockContributeCheckForSession.mockResolvedValueOnce({ hint: 'CONTRIBUTE-HINT' });
+    const dispatcher = createDispatcher({ handlers: buildHandlerRegistry() });
+
+    const result = await dispatcher.dispatch(
+      'stop',
+      '*',
+      { session_id: 'sid-merged-stop', cwd: '/x', transcript_path: '/t/transcript.jsonl' },
+      'claude',
+      'foreground',
+    );
+
+    const context = JSON.parse(result.output!).hookSpecificOutput.additionalContext;
+    expect(context).toContain('doc-a');
+    expect(context).toContain('CONTRIBUTE-HINT');
+  });
+
+  // ── Change 3: pending-hint replays and merges the votes hint ──
 
   it('pending-hint merges contribute hint and votes hint for codebuddy', async () => {
     const registry = buildHandlerRegistry();

--- a/src/__tests__/transcript-parser.test.ts
+++ b/src/__tests__/transcript-parser.test.ts
@@ -158,6 +158,32 @@ describe('parseTranscriptForVotes', () => {
     expect(result.referencedDocIds).toEqual([]);
   });
 
+  it('detects recalled markers when message.content is a plain string', async () => {
+    const filePath = path.join(tmpDir, 'transcript.jsonl');
+    writeLine(filePath, {
+      type: 'user',
+      message: {
+        content: 'Tool output.<!-- teamai:recalled-doc-ids: [doc-string] -->',
+      },
+    });
+
+    const result = await parseTranscriptForVotes(filePath);
+    expect(result.recalledDocIds).toContain('doc-string');
+  });
+
+  it('detects recalled markers in top-level toolUseResult stdout', async () => {
+    const filePath = path.join(tmpDir, 'transcript.jsonl');
+    writeLine(filePath, {
+      type: 'user',
+      toolUseResult: {
+        stdout: '<!-- teamai:recalled-doc-ids: [doc-stdout] -->',
+      },
+    });
+
+    const result = await parseTranscriptForVotes(filePath);
+    expect(result.recalledDocIds).toContain('doc-stdout');
+  });
+
   it('extracts Bash recall regions from tool_result content', async () => {
     const filePath = path.join(tmpDir, 'transcript.jsonl');
     writeLine(filePath, {

--- a/src/__tests__/transcript-parser.test.ts
+++ b/src/__tests__/transcript-parser.test.ts
@@ -158,6 +158,38 @@ describe('parseTranscriptForVotes', () => {
     expect(result.referencedDocIds).toEqual([]);
   });
 
+  it('extracts Bash recall regions from tool_result content', async () => {
+    const filePath = path.join(tmpDir, 'transcript.jsonl');
+    writeLine(filePath, {
+      type: 'user',
+      message: {
+        content: [{
+          type: 'tool_result',
+          content: '--- [teamai:recall:start] ---\nFile: /path/bash-recall.md\n--- [teamai:recall:end] ---',
+        }],
+      },
+    });
+
+    const result = await parseTranscriptForVotes(filePath);
+    expect(result.recalledDocIds).toContain('bash-recall');
+  });
+
+  it('parses case-insensitive recalled markers with smart delimiters', async () => {
+    const filePath = path.join(tmpDir, 'transcript.jsonl');
+    writeLine(filePath, {
+      type: 'user',
+      message: {
+        content: [{
+          type: 'tool_result',
+          content: '<!— TeamAI:RECALLED-DOC-IDS: [smart-recall] —>',
+        }],
+      },
+    });
+
+    const result = await parseTranscriptForVotes(filePath);
+    expect(result.recalledDocIds).toContain('smart-recall');
+  });
+
   it('referenced-doc-ids in a non-assistant line is NOT counted (assistant-only guard)', async () => {
     const filePath = path.join(tmpDir, 'transcript.jsonl');
     writeLine(filePath, {
@@ -261,6 +293,22 @@ describe('parseTranscriptForVotes', () => {
 
     const result = await parseTranscriptForVotes(filePath);
     expect(result.referencedDocIds).toContain('em-dash-doc');
+  });
+
+  it('referenced-doc-ids: smart opening and closing are parsed together', async () => {
+    const filePath = path.join(tmpDir, 'transcript.jsonl');
+    writeLine(filePath, {
+      type: 'assistant',
+      message: {
+        content: [{
+          type: 'text',
+          text: '<!— teamai:referenced-doc-ids: [smart-doc] —>',
+        }],
+      },
+    });
+
+    const result = await parseTranscriptForVotes(filePath);
+    expect(result.referencedDocIds).toContain('smart-doc');
   });
 
   it('referenced-doc-ids: missing closing delimiter is NOT parsed (negative case)', async () => {

--- a/src/__tests__/transcript-parser.test.ts
+++ b/src/__tests__/transcript-parser.test.ts
@@ -228,4 +228,54 @@ describe('parseTranscriptForVotes', () => {
     const result = await parseTranscriptForVotes(filePath);
     expect(result.recalledDocIds).toEqual(['real-doc-id']);
   });
+
+  // ── 改动 1: extractReferencedDocIds 正则放宽边界测试 ──────────
+
+  it('referenced-doc-ids: case-insensitive variant is parsed (e.g. REFERENCED-DOC-IDS)', async () => {
+    const filePath = path.join(tmpDir, 'transcript.jsonl');
+    writeLine(filePath, {
+      type: 'assistant',
+      message: {
+        content: [{
+          type: 'text',
+          text: '<!-- Teamai:REFERENCED-DOC-IDS: [case-insensitive-doc] -->',
+        }],
+      },
+    });
+
+    const result = await parseTranscriptForVotes(filePath);
+    expect(result.referencedDocIds).toContain('case-insensitive-doc');
+  });
+
+  it('referenced-doc-ids: em-dash closing (—>) is parsed', async () => {
+    const filePath = path.join(tmpDir, 'transcript.jsonl');
+    writeLine(filePath, {
+      type: 'assistant',
+      message: {
+        content: [{
+          type: 'text',
+          text: '<!-- teamai:referenced-doc-ids: [em-dash-doc] —>',
+        }],
+      },
+    });
+
+    const result = await parseTranscriptForVotes(filePath);
+    expect(result.referencedDocIds).toContain('em-dash-doc');
+  });
+
+  it('referenced-doc-ids: missing closing delimiter is NOT parsed (negative case)', async () => {
+    const filePath = path.join(tmpDir, 'transcript.jsonl');
+    writeLine(filePath, {
+      type: 'assistant',
+      message: {
+        content: [{
+          type: 'text',
+          text: '<!-- teamai:referenced-doc-ids: [no-close-doc]',
+        }],
+      },
+    });
+
+    const result = await parseTranscriptForVotes(filePath);
+    expect(result.referencedDocIds).toEqual([]);
+  });
 });

--- a/src/contribute-check.ts
+++ b/src/contribute-check.ts
@@ -153,6 +153,7 @@ export async function readContributeState(sessionId: string): Promise<Contribute
           ? normalizePromptSummary(raw.promptSummary)
           : undefined,
         pendingHint: typeof raw.pendingHint === 'string' ? raw.pendingHint : undefined,
+        pendingVotesHint: typeof raw.pendingVotesHint === 'string' ? raw.pendingVotesHint : undefined,
       };
     }
     return defaultState();
@@ -699,6 +700,27 @@ export async function contributeCheck(toolArg?: string): Promise<void> {
     const { formatStopHookOutput } = await import('./utils/hook-output.js');
     process.stdout.write(formatStopHookOutput(hint, toolArg ?? 'claude'));
   }
+}
+
+/**
+ * Stash a votes-nudge hint for delivery on the next UserPromptSubmit.
+ * Used for tools (codebuddy/workbuddy) whose Stop hook ignores stdout.
+ */
+export async function stashVotesHint(sessionId: string, hintText: string): Promise<void> {
+  const state = await readContributeState(sessionId);
+  await writeContributeState(sessionId, { ...state, pendingVotesHint: hintText });
+}
+
+/**
+ * Read and clear a pending votes-nudge hint for this session, if any.
+ * Returns the hint text or null. Clearing preserves all other state.
+ */
+export async function takePendingVotesHint(sessionId: string): Promise<string | null> {
+  const state = await readContributeState(sessionId);
+  if (!state.pendingVotesHint) return null;
+  const hint = state.pendingVotesHint;
+  await writeContributeState(sessionId, { ...state, pendingVotesHint: undefined });
+  return hint;
 }
 
 /**

--- a/src/contribute-check.ts
+++ b/src/contribute-check.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { log } from './utils/logger.js';
-import { readJson, writeJson, ensureDir } from './utils/fs.js';
+import { readJson, writeJson, ensureDir, readFileSafe, writeFile } from './utils/fs.js';
 import { readEvents, aggregateSessionMetrics, scanTranscriptStop } from './dashboard-collector.js';
 import { readRecallQuality } from './recall-quality.js';
 import { deriveSessionId } from './utils/session-id.js';
@@ -123,6 +123,19 @@ function getSessionPath(sessionId: string): string {
     '.teamai',
     'sessions',
     `${sanitizeSessionId(sessionId)}.json`,
+  );
+}
+
+/**
+ * Get the sidecar used for vote nudges. Keep it separate from the contribute
+ * state JSON because the Stop handlers run concurrently and independently.
+ */
+function getPendingVotesHintPath(sessionId: string): string {
+  return path.join(
+    getUserHome(),
+    '.teamai',
+    'sessions',
+    `${sanitizeSessionId(sessionId)}.votes-hint`,
   );
 }
 
@@ -707,8 +720,11 @@ export async function contributeCheck(toolArg?: string): Promise<void> {
  * Used for tools (codebuddy/workbuddy) whose Stop hook ignores stdout.
  */
 export async function stashVotesHint(sessionId: string, hintText: string): Promise<void> {
-  const state = await readContributeState(sessionId);
-  await writeContributeState(sessionId, { ...state, pendingVotesHint: hintText });
+  try {
+    await writeFile(getPendingVotesHintPath(sessionId), hintText);
+  } catch (e) {
+    log.error(`Failed to write pending votes hint: ${(e as Error).message}`);
+  }
 }
 
 /**
@@ -716,6 +732,14 @@ export async function stashVotesHint(sessionId: string, hintText: string): Promi
  * Returns the hint text or null. Clearing preserves all other state.
  */
 export async function takePendingVotesHint(sessionId: string): Promise<string | null> {
+  const sidecarPath = getPendingVotesHintPath(sessionId);
+  const sidecarHint = await readFileSafe(sidecarPath);
+  if (sidecarHint !== null) {
+    await fs.promises.unlink(sidecarPath).catch(() => undefined);
+    return sidecarHint;
+  }
+
+  // Read legacy state written by an earlier PR 371 build, if present.
   const state = await readContributeState(sessionId);
   if (!state.pendingVotesHint) return null;
   const hint = state.pendingVotesHint;

--- a/src/contribute-check.ts
+++ b/src/contribute-check.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { log } from './utils/logger.js';
-import { readJson, writeJson, ensureDir, readFileSafe, writeFile } from './utils/fs.js';
+import { readJson, writeJson, writeJsonAtomic, ensureDir } from './utils/fs.js';
 import { readEvents, aggregateSessionMetrics, scanTranscriptStop } from './dashboard-collector.js';
 import { readRecallQuality } from './recall-quality.js';
 import { deriveSessionId } from './utils/session-id.js';
@@ -135,7 +135,16 @@ function getPendingVotesHintPath(sessionId: string): string {
     getUserHome(),
     '.teamai',
     'sessions',
-    `${sanitizeSessionId(sessionId)}.votes-hint`,
+    `${sanitizeSessionId(sessionId)}.votes-hint.json`,
+  );
+}
+
+function getVotesNudgeMarkerPath(sessionId: string): string {
+  return path.join(
+    getUserHome(),
+    '.teamai',
+    'sessions',
+    `${sanitizeSessionId(sessionId)}.votes-nudged.json`,
   );
 }
 
@@ -166,7 +175,6 @@ export async function readContributeState(sessionId: string): Promise<Contribute
           ? normalizePromptSummary(raw.promptSummary)
           : undefined,
         pendingHint: typeof raw.pendingHint === 'string' ? raw.pendingHint : undefined,
-        pendingVotesHint: typeof raw.pendingVotesHint === 'string' ? raw.pendingVotesHint : undefined,
       };
     }
     return defaultState();
@@ -721,7 +729,7 @@ export async function contributeCheck(toolArg?: string): Promise<void> {
  */
 export async function stashVotesHint(sessionId: string, hintText: string): Promise<void> {
   try {
-    await writeFile(getPendingVotesHintPath(sessionId), hintText);
+    await writeJsonAtomic(getPendingVotesHintPath(sessionId), { hintText });
   } catch (e) {
     log.error(`Failed to write pending votes hint: ${(e as Error).message}`);
   }
@@ -729,22 +737,30 @@ export async function stashVotesHint(sessionId: string, hintText: string): Promi
 
 /**
  * Read and clear a pending votes-nudge hint for this session, if any.
- * Returns the hint text or null. Clearing preserves all other state.
+ * Returns the hint text or null. The independent sidecar is atomically written
+ * so a concurrent prompt-submit never observes a truncated hint.
  */
 export async function takePendingVotesHint(sessionId: string): Promise<string | null> {
   const sidecarPath = getPendingVotesHintPath(sessionId);
-  const sidecarHint = await readFileSafe(sidecarPath);
-  if (sidecarHint !== null) {
-    await fs.promises.unlink(sidecarPath).catch(() => undefined);
-    return sidecarHint;
-  }
+  const pending = await readJson<{ hintText?: unknown }>(sidecarPath);
+  if (!pending || typeof pending.hintText !== 'string' || !pending.hintText) return null;
+  await fs.promises.unlink(sidecarPath).catch(() => undefined);
+  return pending.hintText;
+}
 
-  // Read legacy state written by an earlier PR 371 build, if present.
-  const state = await readContributeState(sessionId);
-  if (!state.pendingVotesHint) return null;
-  const hint = state.pendingVotesHint;
-  await writeContributeState(sessionId, { ...state, pendingVotesHint: undefined });
-  return hint;
+/** Atomically cap Cursor's Stop follow-up nudge to once per session. */
+export async function claimVotesNudge(sessionId: string): Promise<boolean> {
+  const markerPath = getVotesNudgeMarkerPath(sessionId);
+  try {
+    await ensureDir(path.dirname(markerPath));
+    await fs.promises.writeFile(markerPath, '{}\n', { encoding: 'utf-8', flag: 'wx' });
+    await cleanupStaleSessions(path.dirname(markerPath), sessionId);
+    return true;
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === 'EEXIST') return false;
+    log.error(`Failed to claim votes nudge: ${(e as Error).message}`);
+    return false;
+  }
 }
 
 /**

--- a/src/contribute-check.ts
+++ b/src/contribute-check.ts
@@ -754,7 +754,9 @@ export async function claimVotesNudge(sessionId: string): Promise<boolean> {
   try {
     await ensureDir(path.dirname(markerPath));
     await fs.promises.writeFile(markerPath, '{}\n', { encoding: 'utf-8', flag: 'wx' });
-    await cleanupStaleSessions(path.dirname(markerPath), sessionId);
+    // The claim is complete once the exclusive marker write succeeds. Cleanup
+    // is best-effort and must not swallow Cursor's one allowed nudge.
+    await cleanupStaleSessions(path.dirname(markerPath), sessionId).catch(() => undefined);
     return true;
   } catch (e) {
     if ((e as NodeJS.ErrnoException).code === 'EEXIST') return false;

--- a/src/hook-dispatch.ts
+++ b/src/hook-dispatch.ts
@@ -8,7 +8,7 @@
  * Design:
  *   - Handlers are pure functions: (stdin, tool) → output | null
  *   - Promise.allSettled ensures one handler crash doesn't take down others
- *   - At most one handler per event produces STDOUT output
+ *   - Compatible structured outputs are merged so concurrent hints are preserved
  */
 
 // ─── Public types ───────────────────────────────────────
@@ -43,7 +43,7 @@ export interface DispatchError {
 }
 
 export interface DispatchResult {
-  /** Combined STDOUT output (at most one handler produces output per event). */
+  /** Combined STDOUT output from all compatible output-producing handlers. */
   output: string | null;
   /** Errors from failed handlers (non-fatal — other handlers still ran). */
   errors: DispatchError[];
@@ -69,6 +69,57 @@ export interface Dispatcher {
 
 /** Default timeout: 60 seconds (matches Claude Code's default hook timeout). */
 const DEFAULT_TIMEOUT_MS = 60_000;
+
+type JsonObject = Record<string, unknown>;
+
+function asObject(value: unknown): JsonObject | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as JsonObject
+    : null;
+}
+
+/** Merge the two hook output schemas used by the supported hosts. */
+function mergeHookOutputs(outputs: string[]): string | null {
+  if (outputs.length === 0) return null;
+  if (outputs.length === 1) return outputs[0];
+
+  let parsed: JsonObject[];
+  try {
+    parsed = outputs.map((output) => {
+      const value = asObject(JSON.parse(output));
+      if (!value) throw new Error('Hook output is not an object');
+      return value;
+    });
+  } catch {
+    // Preserve the historical first-output behavior for unknown/plain schemas.
+    return outputs[0];
+  }
+
+  const followups = parsed.map((value) => value.followup_message);
+  if (followups.every((value): value is string => typeof value === 'string')) {
+    return JSON.stringify({ ...parsed[0], followup_message: followups.join('\n') });
+  }
+
+  const specificOutputs = parsed.map((value) => asObject(value.hookSpecificOutput));
+  if (specificOutputs.every((value): value is JsonObject => value !== null)) {
+    const contexts = specificOutputs.map((value) => value.additionalContext);
+    const eventNames = new Set(specificOutputs.map((value) => value.hookEventName).filter(Boolean));
+    if (
+      contexts.every((value): value is string => typeof value === 'string')
+      && eventNames.size <= 1
+    ) {
+      return JSON.stringify({
+        ...parsed[0],
+        hookSpecificOutput: {
+          ...specificOutputs[0],
+          additionalContext: contexts.join('\n'),
+        },
+      });
+    }
+  }
+
+  return outputs[0];
+}
 
 /**
  * Wrap a promise with a timeout. Rejects with a timeout error if not resolved in time.
@@ -121,7 +172,7 @@ export function createDispatcher(config: DispatcherConfig): Dispatcher {
       );
 
       // Collect results
-      let output: string | null = null;
+      const outputs: string[] = [];
       const errors: DispatchError[] = [];
 
       for (let i = 0; i < settled.length; i++) {
@@ -134,14 +185,11 @@ export function createDispatcher(config: DispatcherConfig): Dispatcher {
             error: result.reason instanceof Error ? result.reason : new Error(String(result.reason)),
           });
         } else if (result.status === 'fulfilled' && result.value != null) {
-          // First non-null output wins (at most one handler should produce output per event)
-          if (output === null) {
-            output = result.value;
-          }
+          outputs.push(result.value);
         }
       }
 
-      return { output, errors };
+      return { output: mergeHookOutputs(outputs), errors };
     },
   };
 }

--- a/src/hook-handlers.ts
+++ b/src/hook-handlers.ts
@@ -285,11 +285,9 @@ const votesSyncHandler: HookHandler = {
       // Enforcement: recall happened but nothing was declared → nudge the model
       // to declare which recalled docs it actually used. The nudge makes the
       // model continue; on the next Stop the declaration is recorded above.
-      // No once-per-session marker is needed: if the model declares on the
-      // next turn, declared.length > 0 and this branch is skipped naturally.
-      // Degradation: if the model never declares referenced-doc-ids for the
-      // entire session, every Stop triggers a nudge — this is intentional
-      // (keeps the model honest) and should not be suppressed with a marker.
+      // Most tools can retry until the model declares on the next turn. Cursor
+      // is capped below because followup_message itself forces another turn and
+      // would otherwise create an unbounded Stop loop.
       const sessionId = deriveSessionId(stdin, { includeCwd: true });
       const recalled = voteData.recalledDocIds;
       const declared = voteData.referencedDocIds;
@@ -297,6 +295,13 @@ const votesSyncHandler: HookHandler = {
 
       if (recalled.length > 0 && declared.length === 0) {
         nudged = true;
+        // Cursor's followup_message forces another model turn. Cap it to one
+        // per session so a model that never emits the declaration cannot enter
+        // an unbounded Stop → follow-up loop.
+        if ((tool ?? '').toLowerCase() === 'cursor') {
+          const { claimVotesNudge } = await import('./contribute-check.js');
+          nudged = await claimVotesNudge(sessionId);
+        }
       }
 
       // A/B measurement (opt-in): one line per Stop.

--- a/src/hook-handlers.ts
+++ b/src/hook-handlers.ts
@@ -211,7 +211,7 @@ const pendingHintHandler: HookHandler = {
     const { STOP_STDOUT_UNSUPPORTED_TOOLS } = await import('./utils/tool-names.js');
     if (!STOP_STDOUT_UNSUPPORTED_TOOLS.has(tool)) return null;
 
-    const { takePendingHint } = await import('./contribute-check.js');
+    const { takePendingHint, takePendingVotesHint } = await import('./contribute-check.js');
     // Must match contributeCheckHandler's derivation so Stop and UserPromptSubmit
     // resolve to the same session file. This cross-process handoff relies on
     // codebuddy/workbuddy sending a stable, consistent session_id on BOTH the
@@ -221,12 +221,16 @@ const pendingHintHandler: HookHandler = {
     // differ across the two hook processes and orphan the stash (best-effort).
     const sessionId = deriveSessionId(stdin, { includeCwd: true });
     const hint = await takePendingHint(sessionId);
-    if (!hint) return null;
+    const votesHint = await takePendingVotesHint(sessionId);
+
+    // Merge: combine both pending hints if present, newline-separated.
+    const combined = [hint, votesHint].filter(Boolean).join('\n');
+    if (!combined) return null;
 
     return JSON.stringify({
       hookSpecificOutput: {
         hookEventName: 'UserPromptSubmit',
-        additionalContext: hint,
+        additionalContext: combined,
       },
     });
   },
@@ -249,13 +253,15 @@ const votesSyncHandler: HookHandler = {
       // autoDetectInit picks project scope when present (so self-mode configs are
       // honored), falling back to user scope otherwise.
       const { localConfig } = await autoDetectInit();
-      const { VOTES_LOCAL_DIR, TEAMAI_SESSIONS_DIR } = await import('./types.js');
+      const { VOTES_LOCAL_DIR } = await import('./types.js');
       const votesDir = VOTES_LOCAL_DIR;
       const votePath = path.join(votesDir, `${localConfig.username}.yaml`);
 
-      // Record the adoptions the main conversation declared.
-      if (voteData.referencedDocIds.length > 0) {
-        await incrementUpvoted(votePath, voteData.referencedDocIds);
+      // Only count upvotes for docs actually recalled this session, to avoid crediting hallucinated/distractor doc-ids
+      const recalledSet = new Set(voteData.recalledDocIds);
+      const verifiedDocIds = voteData.referencedDocIds.filter((id) => recalledSet.has(id));
+      if (verifiedDocIds.length > 0) {
+        await incrementUpvoted(votePath, verifiedDocIds);
       }
       if (localConfig.repo.kind === 'self') {
         // Self mode: votes are report data → the teamai-reports orphan branch,
@@ -277,31 +283,20 @@ const votesSyncHandler: HookHandler = {
       }
 
       // Enforcement: recall happened but nothing was declared → nudge the model
-      // once to declare which recalled docs it actually used. The nudge makes the
+      // to declare which recalled docs it actually used. The nudge makes the
       // model continue; on the next Stop the declaration is recorded above.
+      // No once-per-session marker is needed: if the model declares on the
+      // next turn, declared.length > 0 and this branch is skipped naturally.
+      // Degradation: if the model never declares referenced-doc-ids for the
+      // entire session, every Stop triggers a nudge — this is intentional
+      // (keeps the model honest) and should not be suppressed with a marker.
       const sessionId = deriveSessionId(stdin, { includeCwd: true });
       const recalled = voteData.recalledDocIds;
       const declared = voteData.referencedDocIds;
       let nudged = false;
 
       if (recalled.length > 0 && declared.length === 0) {
-        const fsp = await import('node:fs/promises');
-        const safeId = sessionId.replace(/[^a-zA-Z0-9_.-]/g, '_');
-        const marker = path.join(TEAMAI_SESSIONS_DIR, `${safeId}-adoption-nudged`);
-        let already = false;
-        try { await fsp.access(marker); already = true; } catch { already = false; }
-        if (!already) {
-          try {
-            const { ensureDir } = await import('./utils/fs.js');
-            await ensureDir(TEAMAI_SESSIONS_DIR);
-            await fsp.writeFile(marker, '');
-            // Only nudge once we've persisted the marker, so a write failure
-            // degrades to "no nudge this Stop" rather than re-nudging every Stop.
-            nudged = true;
-          } catch {
-            // Could not persist the marker — skip the nudge this Stop; retry next.
-          }
-        }
+        nudged = true;
       }
 
       // A/B measurement (opt-in): one line per Stop.
@@ -325,9 +320,17 @@ const votesSyncHandler: HookHandler = {
 
       if (nudged) {
         const { formatStopHookOutput } = await import('./utils/hook-output.js');
+        const { STOP_STDOUT_UNSUPPORTED_TOOLS } = await import('./utils/tool-names.js');
         const msg =
           `你本次通过 teamai 召回了团队知识（候选 doc-id：${recalled.join(', ')}）。` +
           `结束前请在回复末尾声明你实际用到的条目：<!-- teamai:referenced-doc-ids: [用到的doc-id] -->；没用到就留空 []。`;
+        // For tools whose Stop stdout is ignored, stash the nudge for delivery
+        // on the next UserPromptSubmit (same cross-process mechanism as contribute).
+        if (STOP_STDOUT_UNSUPPORTED_TOOLS.has(tool ?? '')) {
+          const { stashVotesHint } = await import('./contribute-check.js');
+          await stashVotesHint(sessionId, msg);
+          return null;
+        }
         return formatStopHookOutput(msg, tool ?? 'claude');
       }
     } catch {

--- a/src/transcript-parser.ts
+++ b/src/transcript-parser.ts
@@ -115,7 +115,9 @@ function extractRecalledDocIds(text: string, out: Set<string>): void {
 }
 
 function extractReferencedDocIds(text: string, out: Set<string>): void {
-  const pattern = /<!--\s*teamai:referenced-doc-ids:\s*\[([^\]]*)\]\s*-->/g;
+  // Case-insensitive; accept --> or —> (em-dash variant) as closing delimiter.
+  // Closed delimiter is required — bare [^\]]* prevents unclosed strings from bleeding past.
+  const pattern = /<!--\s*teamai:referenced-doc-ids:\s*\[([^\]]*)\]\s*(?:-->|—>)/gi;
 
   let match: RegExpExecArray | null;
   while ((match = pattern.exec(text)) !== null) {

--- a/src/transcript-parser.ts
+++ b/src/transcript-parser.ts
@@ -32,13 +32,6 @@ export async function parseTranscriptForVotes(transcriptPath: string): Promise<T
     const trimmed = line.trim();
     if (!trimmed) continue;
 
-    // The teamai-recall subagent emits `<!-- teamai:recalled-doc-ids: [...] -->`;
-    // in the subagent path it lands in the main transcript as a tool_result (not
-    // an assistant text block), so scan every raw line regardless of role.
-    extractRecalledDocIdsFromComment(trimmed, recalledSet);
-
-    if (!trimmed.includes('"assistant"')) continue;
-
     let entry: Record<string, unknown>;
     try {
       entry = JSON.parse(trimmed) as Record<string, unknown>;
@@ -46,13 +39,17 @@ export async function parseTranscriptForVotes(transcriptPath: string): Promise<T
       continue;
     }
 
-    if (entry['type'] !== 'assistant') continue;
-
     const message = entry['message'] as Record<string, unknown> | undefined;
     if (!message || !Array.isArray(message['content'])) continue;
 
     for (const block of message['content'] as Array<Record<string, unknown>>) {
-      if (block['type'] !== 'text') continue;
+      // Subagent and Bash recall output lands in a tool_result. Scan its decoded
+      // content recursively because some hosts represent it as nested blocks.
+      if (block['type'] === 'tool_result') {
+        extractRecalledDocIdsFromValue(block['content'], recalledSet);
+      }
+
+      if (entry['type'] !== 'assistant' || block['type'] !== 'text') continue;
       const text = block['text'];
       if (typeof text !== 'string') continue;
 
@@ -77,12 +74,29 @@ function isValidDocId(docId: string): boolean {
 }
 
 function extractRecalledDocIdsFromComment(text: string, out: Set<string>): void {
-  const pattern = /<!--\s*teamai:recalled-doc-ids:\s*\[([^\]]*)\]\s*-->/g;
+  const pattern = /(?:<!--|<!—)\s*teamai:recalled-doc-ids:\s*\[([^\]]*)\]\s*(?:-->|—>)/gi;
   let match: RegExpExecArray | null;
   while ((match = pattern.exec(text)) !== null) {
     for (const item of match[1].split(',')) {
       const docId = item.trim().replace(/^['"]|['"]$/g, '');
       if (isValidDocId(docId)) out.add(docId);
+    }
+  }
+}
+
+function extractRecalledDocIdsFromValue(value: unknown, out: Set<string>): void {
+  if (typeof value === 'string') {
+    extractRecalledDocIdsFromComment(value, out);
+    extractRecalledDocIds(value, out);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) extractRecalledDocIdsFromValue(item, out);
+    return;
+  }
+  if (value !== null && typeof value === 'object') {
+    for (const item of Object.values(value as Record<string, unknown>)) {
+      extractRecalledDocIdsFromValue(item, out);
     }
   }
 }
@@ -115,9 +129,9 @@ function extractRecalledDocIds(text: string, out: Set<string>): void {
 }
 
 function extractReferencedDocIds(text: string, out: Set<string>): void {
-  // Case-insensitive; accept --> or —> (em-dash variant) as closing delimiter.
+  // Case-insensitive; accept smart-punctuation variants of both delimiters.
   // Closed delimiter is required — bare [^\]]* prevents unclosed strings from bleeding past.
-  const pattern = /<!--\s*teamai:referenced-doc-ids:\s*\[([^\]]*)\]\s*(?:-->|—>)/gi;
+  const pattern = /(?:<!--|<!—)\s*teamai:referenced-doc-ids:\s*\[([^\]]*)\]\s*(?:-->|—>)/gi;
 
   let match: RegExpExecArray | null;
   while ((match = pattern.exec(text)) !== null) {

--- a/src/transcript-parser.ts
+++ b/src/transcript-parser.ts
@@ -32,6 +32,12 @@ export async function parseTranscriptForVotes(transcriptPath: string): Promise<T
     const trimmed = line.trim();
     if (!trimmed) continue;
 
+    // Host transcript schemas vary. Keep a raw-line fallback for recalled
+    // markers that may live outside message.content (for example a plain
+    // content string or top-level toolUseResult.stdout). Parsed scans below
+    // additionally handle multiline recall regions after JSON decoding.
+    extractRecalledDocIdsFromComment(trimmed, recalledSet);
+
     let entry: Record<string, unknown>;
     try {
       entry = JSON.parse(trimmed) as Record<string, unknown>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -580,10 +580,9 @@ export const SKILL_NAME_REGEX = /^[a-zA-Z0-9_\-:.]{1,200}$/;
 export const TEAMAI_USAGE_PATH = `${TEAMAI_HOME}/usage.jsonl`;
 export const TEAMAI_KNOWN_SKILLS_PATH = `${TEAMAI_HOME}/known-skills.json`;
 export const TEAMAI_PUSHIGNORE_PATH = `${TEAMAI_HOME}/pushignore`;
-export const TEAMAI_SESSIONS_DIR = `${TEAMAI_HOME}/sessions`;
 /**
  * Local monthly session logs (`teamai session save`). Kept in a dedicated dir —
- * not TEAMAI_SESSIONS_DIR, which holds per-session contribute-state `.json`.
+ * not the sessions directory, which holds per-session contribute-state `.json`.
  */
 export const SESSION_LOGS_LOCAL_DIR = `${TEAMAI_HOME}/session-logs`;
 
@@ -901,12 +900,6 @@ export interface ContributeState {
    * that deliver the hint directly through the Stop hook.
    */
   pendingHint?: string;
-  /**
-   * A votes-nudge message awaiting delivery via UserPromptSubmit (stashed when
-   * Stop stdout is unsupported). Independent of pendingHint so the two channels
-   * never collide. Cleared once injected.
-   */
-  pendingVotesHint?: string;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -901,6 +901,12 @@ export interface ContributeState {
    * that deliver the hint directly through the Stop hook.
    */
   pendingHint?: string;
+  /**
+   * A votes-nudge message awaiting delivery via UserPromptSubmit (stashed when
+   * Stop stdout is unsupported). Independent of pendingHint so the two channels
+   * never collide. Cleared once injected.
+   */
+  pendingVotesHint?: string;
 }
 
 /**


### PR DESCRIPTION
Depends on #371 and should be merged after it.

When the Stop handlers for contribute-check and votes-sync run concurrently, both previously read-modified-wrote the same session JSON, allowing the votes hint write to erase pendingHint.

This stores votes hints in a separate session sidecar file and keeps backward-compatible reads for state written by earlier #371 builds.

Tests: 105 relevant tests passed; typecheck passed.