### PR TITLE
feat(data-layout): P0 — atomic lock + projectAnchor/workspaceRoot split (#374)

### DIFF
--- a/docs/designs/data-directory-layout.md
+++ b/docs/designs/data-directory-layout.md
@@ -1,0 +1,120 @@
+# Design: teamai data directory layout — global home + per-project partitioning
+
+> Status: **P0 implemented** (this doc ships with the P0 PR for issue #374).
+> P1–P3 are follow-up phases, tracked below.
+
+## Problem
+
+teamai's machine-local data currently lives inside the business repository. In a
+real checkout `<repo>/.teamai/` measured **18 MB** — a team-repo clone (12 MB),
+downloaded skill resources (4.1 MB), a search index (1.8 MB), plus config, state,
+`env`, `token`, and docs. This causes three concrete problems:
+
+- **Workspace residue.** Machine data pollutes the business repo working tree.
+- **Worktree / subdirectory blindness.** teamai only looked at the cwd's own
+  `.teamai/config.yaml`, so running from a subdirectory found nothing, and a git
+  worktree (which does not carry gitignored `.teamai/`) had no config at all.
+- **Cross-project mixing.** Global singletons under `~/.teamai/`
+  (`dashboard`, `sessions`, `votes`, `usage.jsonl`, ...) are hardcoded to one
+  location, so multiple projects' data is indistinguishable.
+
+The end goal (P1+) is to move machine-local data to `~/.teamai/projects/<slug>/`
+so the business workspace has **zero residue**, partitioned per project.
+
+## The two anchors (the core model)
+
+A git worktree has two distinct "roots", and teamai needs both:
+
+```
+projectAnchor  = parent of `git rev-parse --path-format=absolute --git-common-dir`
+                 → the MAIN checkout, SHARED by the repo and all its worktrees.
+                 → the stable per-project identity; P1 keys machine data under
+                   ~/.teamai/projects/<slug(projectAnchor)>/ by it.
+
+workspaceRoot  = `git rev-parse --show-toplevel`
+                 → the CURRENT checkout, DISTINCT per worktree.
+                 → where project-scope AI-tool resources (skills/rules/agents,
+                   tool config, CLAUDE.md) must be written.
+```
+
+They are equal for a plain (non-worktree) repository.
+
+**Why resources must go to `workspaceRoot`, not `projectAnchor`:** every AI tool
+(Claude, Codex, CodeBuddy, OpenCode) discovers project resources by scanning up
+from the launch directory to the *current* repository root. None of them follows
+`git-common-dir` back to the main checkout, and gitignored files do not appear in
+a fresh worktree. So resources have to land in the worktree the user is actually
+working in.
+
+### Implementation trap (verified)
+
+`git rev-parse --git-common-dir` returns a **relative** path (`.git`) in the main
+repository and only an absolute path inside a worktree. `--path-format=absolute`
+(git ≥ 2.31) forces absolute in both cases. Omitting it resolves the anchor
+against the wrong base in the main-repo case. `resolveAnchors()` always passes
+the flag. Both anchors are `realpath`-normalized so a symlinked prefix (macOS
+`/tmp` → `/private/tmp`) does not make one checkout look like two.
+
+## P0 (this PR) — atomic lock + anchor split
+
+P0 is deliberately **structural**: it establishes the primitive and fixes
+discovery, WITHOUT relocating any data. The physical layout
+(`<projectRoot>/.teamai/`, `getTeamaiHome()`) is unchanged, and the 61
+`resolveBaseDir()` call sites are untouched — their divergence from the data home
+is a P1 concern. This keeps P0 independently reviewable (issue R7).
+
+1. **Atomic locking** — `src/update.ts` `acquireLock()` / `releaseLock()`.
+   The old lock was check-then-write (`pathExists` → `writeFile`): two racing
+   processes could both observe "no lock" and both succeed, and `releaseLock()`
+   unconditionally deleted the file — including a lock another process later
+   acquired. Rewritten to:
+   - Acquire with an atomic exclusive create (`writeFile(path, payload, { flag: 'wx' })`
+     = `O_CREAT|O_EXCL`); payload is JSON `{ pid, startedAt, owner }` with a random
+     `owner` token.
+   - On `EEXIST`, reclaim only a **stale** lock (dead pid via `process.kill(pid,0)`,
+     or unparseable content), with a single retry; a live holder returns "busy".
+   - `releaseLock()` deletes only when the on-disk `owner` matches the token this
+     process recorded — never another process's lock.
+   - Back-compatible with legacy plain-integer PID lock files.
+   The three call sites (`update.ts`, `bootstrap.ts`, `utils/reports-branch.ts`)
+   keep their signatures and all benefit.
+
+2. **Anchor primitive** — `src/utils/git.ts` `resolveAnchors(cwd?)`.
+   Returns `{ workspaceRoot, projectAnchor }`, or `null` outside a git repo (callers
+   fall back to cwd-based behavior).
+
+3. **Subdirectory / worktree-aware discovery** — `src/config.ts`
+   `detectProjectConfig()`. When the cwd has no `.teamai/config.yaml`, it retries at
+   the git `workspaceRoot`, so teamai runs from any subdirectory and resolves a
+   worktree's `projectRoot` to that worktree.
+
+4. **Semantics** — `resolveBaseDir()` (`src/types.ts`) documented to return the
+   *workspace root*; behavior unchanged.
+
+### P0 acceptance (verified end-to-end with the real CLI)
+
+- Concurrent `acquireLock` on one path → exactly one winner; stale locks reclaimed;
+  non-owner release is a no-op (`src/__tests__/lock-atomic.test.ts`).
+- `resolveAnchors` on a real repo + real `git worktree add`: shared anchor, distinct
+  workspace (`src/__tests__/anchors.test.ts`).
+- Real CLI: `status`/`pull` from a nested subdirectory detect **project** scope and
+  deploy to the repo root; run inside a worktree, resources land in the worktree and
+  the main checkout is untouched (`src/__tests__/detect-subdir.test.ts` + manual run).
+
+## Follow-up phases (not in this PR)
+
+- **P1** — `slug(projectAnchor) = <basename>-<sha256 prefix>`, `projectDataHome(anchor)`,
+  partition-level `.sync-lock` for shared clones, `status` partition print, and the
+  automatic migration (copy → verify → atomic rename → keep `.teamai.bak/` backup;
+  triggered only on write commands, never on read/hook paths).
+- **P2** — self (single-repo) mode slimming: only team knowledge (class B) stays in
+  the repo.
+- **P3** — functionize module-load-time path constants (so tests that swap `$HOME`
+  at runtime take effect), then assign A1/A2 ownership per the data-classification
+  table. `status --all` across partitions.
+
+### Explicitly out of scope
+
+`teamai migrate` / `gc` / `--revert` commands; cross-project shared team-repo clone;
+Codex `.agents/skills` landing (separate issue). Downgrade to an older teamai after
+P1 migration is not supported (`.teamai.bak/` is the manual rollback path).

--- a/docs/designs/data-directory-layout.md
+++ b/docs/designs/data-directory-layout.md
@@ -26,7 +26,7 @@ so the business workspace has **zero residue**, partitioned per project.
 A git worktree has two distinct "roots", and teamai needs both:
 
 ```
-projectAnchor  = parent of `git rev-parse --path-format=absolute --git-common-dir`
+projectAnchor  = first entry of `git worktree list --porcelain` (the main worktree)
                  → the MAIN checkout, SHARED by the repo and all its worktrees.
                  → the stable per-project identity; P1 keys machine data under
                    ~/.teamai/projects/<slug(projectAnchor)>/ by it.
@@ -46,14 +46,23 @@ from the launch directory to the *current* repository root. None of them follows
 a fresh worktree. So resources have to land in the worktree the user is actually
 working in.
 
-### Implementation trap (verified)
+### Why the main worktree, not `git-common-dir` (verified)
 
-`git rev-parse --git-common-dir` returns a **relative** path (`.git`) in the main
-repository and only an absolute path inside a worktree. `--path-format=absolute`
-(git ≥ 2.31) forces absolute in both cases. Omitting it resolves the anchor
-against the wrong base in the main-repo case. `resolveAnchors()` always passes
-the flag. Both anchors are `realpath`-normalized so a symlinked prefix (macOS
-`/tmp` → `/private/tmp`) does not make one checkout look like two.
+`projectAnchor` uses the first entry of `git worktree list --porcelain` rather than
+`dirname(git rev-parse --git-common-dir)`. Two traps make the git-common-dir route
+wrong:
+
+- With `git init --separate-git-dir`, the common dir lives outside the checkout
+  (e.g. `gitdirs/proj.git`), so its parent is a shared `gitdirs/` — **colliding**
+  across unrelated repos, and not the workspace either.
+- `--git-common-dir` alone returns a **relative** path (`.git`) in the main repo
+  (only absolute inside a worktree), so it needs `--path-format=absolute` (git
+  ≥ 2.31) just to be usable — and still hits the collision above.
+
+`git worktree list --porcelain` lists the main worktree first, and every linked
+worktree reports the same first entry, giving a shared-yet-distinct identity in all
+cases. Both anchors are `realpath`-normalized so a symlinked prefix (macOS `/tmp` →
+`/private/tmp`) does not make one checkout look like two.
 
 ## P0 (this PR) — atomic lock + anchor split
 
@@ -72,9 +81,13 @@ is a P1 concern. This keeps P0 independently reviewable (issue R7).
      = `O_CREAT|O_EXCL`); payload is JSON `{ pid, startedAt, owner }` with a random
      `owner` token.
    - On `EEXIST`, reclaim only a **stale** lock (dead pid via `process.kill(pid,0)`,
-     or unparseable content), with a single retry; a live holder returns "busy".
-   - `releaseLock()` deletes only when the on-disk `owner` matches the token this
-     process recorded — never another process's lock.
+     or unparseable content). The reclaim is **serialized behind an atomically-created
+     reclaim sentinel** and finished with an atomic rename-into-place, so concurrent
+     reclaimers cannot each end up believing they hold the lock; a live holder returns
+     "busy".
+   - `releaseLock()` returns early when this process holds no owner token for the
+     path, and otherwise deletes only when the on-disk `owner` still matches the token
+     this process recorded — never another process's lock.
    - Back-compatible with legacy plain-integer PID lock files.
    The three call sites (`update.ts`, `bootstrap.ts`, `utils/reports-branch.ts`)
    keep their signatures and all benefit.

--- a/src/__tests__/anchors.test.ts
+++ b/src/__tests__/anchors.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import { realpathSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { resolveAnchors } from '../utils/git.js';
+
+// ─── Real-git tests for resolveAnchors (issue #374 P0) ──────────────────────
+//
+// Uses a real git repository + a real `git worktree add` in a temp dir, so the
+// distinction the two-anchor model rests on is genuinely exercised:
+//   - workspaceRoot = the CURRENT checkout (per-worktree)
+//   - projectAnchor = the MAIN checkout (shared by repo + all worktrees)
+// It also covers the `--path-format=absolute` trap: without it, `--git-common-dir`
+// returns a RELATIVE `.git` in the main repo, which would resolve the anchor
+// against the wrong base.
+
+function git(cwd: string, ...args: string[]): void {
+  execFileSync('git', args, { cwd, stdio: 'pipe' });
+}
+
+let repoRoot: string;
+let worktreeRoot: string;
+let nonGitDir: string;
+
+beforeAll(() => {
+  // realpath so macOS /tmp -> /private/tmp matches resolveAnchors' own realpath.
+  const base = realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-anchors-')));
+  repoRoot = path.join(base, 'main-repo');
+  fs.mkdirSync(repoRoot);
+  git(repoRoot, 'init', '-q');
+  git(repoRoot, 'config', 'user.email', 'test@example.com');
+  git(repoRoot, 'config', 'user.name', 'Test');
+  git(repoRoot, 'commit', '--allow-empty', '-q', '-m', 'init');
+
+  // A worktree lives OUTSIDE the main repo tree to prove the anchor is shared.
+  worktreeRoot = path.join(base, 'wt');
+  git(repoRoot, 'worktree', 'add', '-q', worktreeRoot, 'HEAD');
+
+  nonGitDir = path.join(base, 'plain');
+  fs.mkdirSync(nonGitDir);
+});
+
+afterAll(() => {
+  try {
+    fs.rmSync(path.dirname(repoRoot), { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+describe('resolveAnchors', () => {
+  it('returns workspace === anchor === repo root for a plain repository', async () => {
+    const a = await resolveAnchors(repoRoot);
+    expect(a).not.toBeNull();
+    expect(a!.workspaceRoot).toBe(repoRoot);
+    expect(a!.projectAnchor).toBe(repoRoot);
+  });
+
+  it('resolves a subdirectory of the main repo up to the repo root', async () => {
+    const sub = path.join(repoRoot, 'src', 'nested');
+    fs.mkdirSync(sub, { recursive: true });
+    const a = await resolveAnchors(sub);
+    expect(a).not.toBeNull();
+    expect(a!.workspaceRoot).toBe(repoRoot);
+    expect(a!.projectAnchor).toBe(repoRoot);
+  });
+
+  it('gives a worktree its own workspaceRoot but the shared main-checkout anchor', async () => {
+    const a = await resolveAnchors(worktreeRoot);
+    expect(a).not.toBeNull();
+    // The current checkout is the worktree itself...
+    expect(a!.workspaceRoot).toBe(worktreeRoot);
+    // ...but the anchor points back at the MAIN checkout, shared with the repo.
+    expect(a!.projectAnchor).toBe(repoRoot);
+    expect(a!.workspaceRoot).not.toBe(a!.projectAnchor);
+  });
+
+  it('resolves a subdirectory of a worktree to that worktree, anchored at main', async () => {
+    const sub = path.join(worktreeRoot, 'deep', 'dir');
+    fs.mkdirSync(sub, { recursive: true });
+    const a = await resolveAnchors(sub);
+    expect(a!.workspaceRoot).toBe(worktreeRoot);
+    expect(a!.projectAnchor).toBe(repoRoot);
+  });
+
+  it('returns null for a directory that is not inside any git repository', async () => {
+    expect(await resolveAnchors(nonGitDir)).toBeNull();
+  });
+});

--- a/src/__tests__/anchors.test.ts
+++ b/src/__tests__/anchors.test.ts
@@ -20,13 +20,14 @@ function git(cwd: string, ...args: string[]): void {
   execFileSync('git', args, { cwd, stdio: 'pipe' });
 }
 
+let base: string;
 let repoRoot: string;
 let worktreeRoot: string;
 let nonGitDir: string;
 
 beforeAll(() => {
   // realpath so macOS /tmp -> /private/tmp matches resolveAnchors' own realpath.
-  const base = realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-anchors-')));
+  base = realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-anchors-')));
   repoRoot = path.join(base, 'main-repo');
   fs.mkdirSync(repoRoot);
   git(repoRoot, 'init', '-q');
@@ -87,5 +88,35 @@ describe('resolveAnchors', () => {
 
   it('returns null for a directory that is not inside any git repository', async () => {
     expect(await resolveAnchors(nonGitDir)).toBeNull();
+  });
+
+  it('handles --separate-git-dir without colliding on a shared gitdir parent', async () => {
+    // Reviewer #374: dirname(--git-common-dir) would return the shared `gitdirs`
+    // parent for BOTH repos → identical anchors → P1 partition collision. Using
+    // the main-worktree path keeps them distinct, and workspaceRoot stays correct.
+    const gitdirs = path.join(base, 'gitdirs');
+    fs.mkdirSync(gitdirs, { recursive: true });
+    const mk = (name: string) => {
+      const ws = path.join(base, name);
+      fs.mkdirSync(ws);
+      git(ws, 'init', '-q', '--separate-git-dir', path.join(gitdirs, `${name}.git`));
+      git(ws, 'config', 'user.email', 'test@example.com');
+      git(ws, 'config', 'user.name', 'Test');
+      git(ws, 'commit', '--allow-empty', '-q', '-m', 'init');
+      return ws;
+    };
+    const wsA = mk('sepA');
+    const wsB = mk('sepB');
+    const a = await resolveAnchors(wsA);
+    const b = await resolveAnchors(wsB);
+    expect(a).not.toBeNull();
+    expect(b).not.toBeNull();
+    expect(a!.workspaceRoot).toBe(wsA);
+    expect(b!.workspaceRoot).toBe(wsB);
+    // The two repos must NOT share an anchor (no partition collision).
+    expect(a!.projectAnchor).not.toBe(b!.projectAnchor);
+    // And neither anchor is the shared parent directory.
+    expect(a!.projectAnchor).not.toBe(gitdirs);
+    expect(b!.projectAnchor).not.toBe(gitdirs);
   });
 });

--- a/src/__tests__/detect-subdir.test.ts
+++ b/src/__tests__/detect-subdir.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs, { realpathSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import YAML from 'yaml';
+import { detectProjectConfig } from '../config.js';
+
+// ─── detectProjectConfig subdirectory / worktree awareness (issue #374 P0) ──
+//
+// Before this change detectProjectConfig only inspected the given dir's own
+// .teamai/config.yaml, so running teamai from a repo subdirectory found nothing.
+// Now it walks up to the git workspace root (per-worktree), which is exactly
+// where project-scope resources should land.
+
+function git(cwd: string, ...args: string[]): void {
+  execFileSync('git', args, { cwd, stdio: 'pipe' });
+}
+
+function writeProjectConfig(root: string, projectRoot: string): void {
+  const dir = path.join(root, '.teamai');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'config.yaml'),
+    YAML.stringify({
+      repo: { localPath: path.join(root, '.teamai', 'team-repo'), remote: 'https://example.com/x.git' },
+      username: 'test',
+      scope: 'project',
+      projectRoot,
+    }),
+  );
+}
+
+let base: string;
+let repoRoot: string;
+let worktreeRoot: string;
+
+beforeAll(() => {
+  base = realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-detect-')));
+  repoRoot = path.join(base, 'repo');
+  fs.mkdirSync(repoRoot);
+  git(repoRoot, 'init', '-q');
+  git(repoRoot, 'config', 'user.email', 'test@example.com');
+  git(repoRoot, 'config', 'user.name', 'Test');
+  git(repoRoot, 'commit', '--allow-empty', '-q', '-m', 'init');
+  writeProjectConfig(repoRoot, repoRoot);
+
+  worktreeRoot = path.join(base, 'wt');
+  git(repoRoot, 'worktree', 'add', '-q', worktreeRoot, 'HEAD');
+  // Each checkout carries its own machine-local .teamai (gitignored). The
+  // worktree's config points projectRoot at the worktree itself.
+  writeProjectConfig(worktreeRoot, worktreeRoot);
+});
+
+afterAll(() => {
+  try {
+    fs.rmSync(base, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+describe('detectProjectConfig — subdirectory / worktree', () => {
+  it('finds the project config when run from the repo root', async () => {
+    const cfg = await detectProjectConfig(repoRoot);
+    expect(cfg).not.toBeNull();
+    expect(cfg!.projectRoot).toBe(repoRoot);
+  });
+
+  it('finds the project config when run from a nested subdirectory', async () => {
+    const sub = path.join(repoRoot, 'packages', 'app', 'src');
+    fs.mkdirSync(sub, { recursive: true });
+    const cfg = await detectProjectConfig(sub);
+    expect(cfg).not.toBeNull();
+    expect(cfg!.scope).toBe('project');
+    expect(cfg!.projectRoot).toBe(repoRoot);
+  });
+
+  it('resolves a worktree subdirectory to the worktree, not the main checkout', async () => {
+    const sub = path.join(worktreeRoot, 'src');
+    fs.mkdirSync(sub, { recursive: true });
+    const cfg = await detectProjectConfig(sub);
+    expect(cfg).not.toBeNull();
+    expect(cfg!.projectRoot).toBe(worktreeRoot);
+    expect(cfg!.projectRoot).not.toBe(repoRoot);
+  });
+
+  it('returns null for a non-git directory with no config (unchanged behavior)', async () => {
+    const plain = path.join(base, 'plain');
+    fs.mkdirSync(plain);
+    expect(await detectProjectConfig(plain)).toBeNull();
+  });
+});

--- a/src/__tests__/detect-subdir.test.ts
+++ b/src/__tests__/detect-subdir.test.ts
@@ -85,6 +85,18 @@ describe('detectProjectConfig — subdirectory / worktree', () => {
     expect(cfg!.projectRoot).not.toBe(repoRoot);
   });
 
+  it('overrides a STALE projectRoot copied from the main checkout into a worktree', async () => {
+    // Simulate a .teamai/ copied from main into the worktree: its config still
+    // names the MAIN checkout. detectProjectConfig must correct projectRoot to
+    // the worktree it was actually found in, or resources would go to main.
+    writeProjectConfig(worktreeRoot, repoRoot); // stale: projectRoot = main
+    const cfg = await detectProjectConfig(path.join(worktreeRoot, 'src'));
+    expect(cfg).not.toBeNull();
+    expect(cfg!.projectRoot).toBe(worktreeRoot);
+    expect(cfg!.projectRoot).not.toBe(repoRoot);
+    writeProjectConfig(worktreeRoot, worktreeRoot); // restore for other tests
+  });
+
   it('returns null for a non-git directory with no config (unchanged behavior)', async () => {
     const plain = path.join(base, 'plain');
     fs.mkdirSync(plain);

--- a/src/__tests__/lock-atomic.test.ts
+++ b/src/__tests__/lock-atomic.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { acquireLock, releaseLock } from '../update.js';
+
+// ─── Real-filesystem tests for the atomic lock (issue #374 P0) ──────────────
+//
+// These exercise acquireLock/releaseLock against a real temp directory (no fs
+// mock), so the OS-level O_CREAT|O_EXCL ('wx') exclusivity and the on-disk owner
+// token are genuinely tested — the thing the previous check-then-write lock got
+// wrong.
+
+let tmpDir: string;
+let lockPath: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-lock-'));
+  lockPath = path.join(tmpDir, '.test-lock');
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('acquireLock (real fs)', () => {
+  it('acquires a fresh lock and writes a JSON payload with pid + owner', async () => {
+    expect(await acquireLock(lockPath)).toBe(true);
+    expect(fs.existsSync(lockPath)).toBe(true);
+    const payload = JSON.parse(fs.readFileSync(lockPath, 'utf-8'));
+    expect(payload.pid).toBe(process.pid);
+    expect(typeof payload.owner).toBe('string');
+    expect(typeof payload.startedAt).toBe('string');
+    await releaseLock(lockPath);
+  });
+
+  it('creates the parent directory if missing', async () => {
+    const nested = path.join(tmpDir, 'a', 'b', 'c', '.lock');
+    expect(await acquireLock(nested)).toBe(true);
+    expect(fs.existsSync(nested)).toBe(true);
+    await releaseLock(nested);
+  });
+
+  it('grants the lock to exactly one of many concurrent acquirers', async () => {
+    // O_EXCL is atomic: even fired together, only one create wins. The losers
+    // read the winner's live-pid lock and back off.
+    const results = await Promise.all(
+      Array.from({ length: 12 }, () => acquireLock(lockPath)),
+    );
+    expect(results.filter(Boolean)).toHaveLength(1);
+    await releaseLock(lockPath);
+  });
+
+  it('refuses when a live process already holds the lock', async () => {
+    fs.writeFileSync(lockPath, JSON.stringify({ pid: process.pid, owner: 'live', startedAt: 'x' }));
+    expect(await acquireLock(lockPath)).toBe(false);
+    // Untouched.
+    expect(JSON.parse(fs.readFileSync(lockPath, 'utf-8')).owner).toBe('live');
+  });
+
+  it('reclaims a stale lock left by a dead process (JSON payload)', async () => {
+    fs.writeFileSync(lockPath, JSON.stringify({ pid: 999999, owner: 'dead', startedAt: 'x' }));
+    expect(await acquireLock(lockPath)).toBe(true);
+    expect(JSON.parse(fs.readFileSync(lockPath, 'utf-8')).pid).toBe(process.pid);
+    await releaseLock(lockPath);
+  });
+
+  it('reclaims a stale legacy plain-PID lock from an older teamai version', async () => {
+    fs.writeFileSync(lockPath, '999999');
+    expect(await acquireLock(lockPath)).toBe(true);
+    expect(JSON.parse(fs.readFileSync(lockPath, 'utf-8')).pid).toBe(process.pid);
+    await releaseLock(lockPath);
+  });
+
+  it('reclaims a lock whose contents are unparseable garbage', async () => {
+    fs.writeFileSync(lockPath, 'not-json-not-a-pid');
+    expect(await acquireLock(lockPath)).toBe(true);
+    await releaseLock(lockPath);
+  });
+});
+
+describe('releaseLock (real fs)', () => {
+  it('removes a lock this process owns', async () => {
+    await acquireLock(lockPath);
+    await releaseLock(lockPath);
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
+  it('does NOT delete a lock that was reclaimed by another owner', async () => {
+    await acquireLock(lockPath);
+    // Simulate: we went stale and another process took over — the on-disk owner
+    // token no longer matches ours.
+    fs.writeFileSync(lockPath, JSON.stringify({ pid: 4321, owner: 'someone-else', startedAt: 'x' }));
+    await releaseLock(lockPath);
+    // The other owner's lock survives.
+    expect(fs.existsSync(lockPath)).toBe(true);
+    expect(JSON.parse(fs.readFileSync(lockPath, 'utf-8')).owner).toBe('someone-else');
+  });
+
+  it('allows re-acquisition after a clean release', async () => {
+    expect(await acquireLock(lockPath)).toBe(true);
+    await releaseLock(lockPath);
+    expect(await acquireLock(lockPath)).toBe(true);
+    await releaseLock(lockPath);
+  });
+});

--- a/src/__tests__/lock-atomic.test.ts
+++ b/src/__tests__/lock-atomic.test.ts
@@ -77,6 +77,24 @@ describe('acquireLock (real fs)', () => {
     expect(await acquireLock(lockPath)).toBe(true);
     await releaseLock(lockPath);
   });
+
+  it('grants the lock to exactly one of many concurrent reclaimers of a STALE lock', async () => {
+    // The reviewer's repro: a dead-PID lock already on disk, many processes race
+    // to reclaim it at once. The reclaim is serialized behind a sentinel, so the
+    // stale lock is taken over exactly once — never two winners.
+    fs.writeFileSync(lockPath, JSON.stringify({ pid: 999999, owner: 'dead', startedAt: 'x' }));
+    const results = await Promise.all(
+      Array.from({ length: 32 }, () => acquireLock(lockPath)),
+    );
+    expect(results.filter(Boolean)).toHaveLength(1);
+    // The surviving lock belongs to this process (the single winner).
+    expect(JSON.parse(fs.readFileSync(lockPath, 'utf-8')).pid).toBe(process.pid);
+    await releaseLock(lockPath);
+    // After release the winner is gone and the path is re-acquirable.
+    expect(fs.existsSync(lockPath)).toBe(false);
+    expect(await acquireLock(lockPath)).toBe(true);
+    await releaseLock(lockPath);
+  });
 });
 
 describe('releaseLock (real fs)', () => {
@@ -84,6 +102,14 @@ describe('releaseLock (real fs)', () => {
     await acquireLock(lockPath);
     await releaseLock(lockPath);
     expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
+  it('does NOT delete a lock this process never acquired (owner-verified release)', async () => {
+    // A lock on disk that we never acquired through acquireLock (no owner token).
+    fs.writeFileSync(lockPath, JSON.stringify({ pid: process.pid, owner: 'other', startedAt: 'x' }));
+    await releaseLock(lockPath);
+    expect(fs.existsSync(lockPath)).toBe(true);
+    expect(JSON.parse(fs.readFileSync(lockPath, 'utf-8')).owner).toBe('other');
   });
 
   it('does NOT delete a lock that was reclaimed by another owner', async () => {

--- a/src/__tests__/update.test.ts
+++ b/src/__tests__/update.test.ts
@@ -43,6 +43,7 @@ vi.mock('../utils/logger.js', () => ({
 
 vi.mock('../utils/fs.js', () => ({
   expandHome: (p: string) => p.replace('~', '/home/test'),
+  ensureDir: vi.fn(() => Promise.resolve()),
 }));
 
 vi.mock('../types.js', () => ({
@@ -451,6 +452,7 @@ describe('doUpdate', () => {
     expect(mockedFse.writeFile).toHaveBeenCalledWith(
       expect.stringContaining('update-lock'),
       expect.any(String),
+      { flag: 'wx' },
     );
     expect(mockedLog.success).toHaveBeenCalled();
     expect(mockedFse.remove).toHaveBeenCalledWith(
@@ -461,8 +463,14 @@ describe('doUpdate', () => {
   // ─── Test #12: File lock busy (another process alive) ─
 
   it('should skip when lock is held by another live process', async () => {
-    mockedFse.pathExists.mockResolvedValue(true);
-    mockedFse.readFile.mockResolvedValue(String(process.pid));
+    // Exclusive create fails (EEXIST) and the on-disk owner is a live process,
+    // so acquireLock backs off rather than reclaiming.
+    const eexist = new Error('EEXIST') as NodeJS.ErrnoException;
+    eexist.code = 'EEXIST';
+    mockedFse.writeFile.mockRejectedValue(eexist);
+    mockedFse.readFile.mockResolvedValue(
+      JSON.stringify({ pid: process.pid, owner: 'held', startedAt: 'x' }),
+    );
 
     mockedExecSync.mockResolvedValueOnce({ stdout: '99.0.0\n', stderr: '' });
 
@@ -628,19 +636,35 @@ describe('hook refresh after update', () => {
 });
 
 // ─── Unit tests: acquireLock / releaseLock ──────────────
+// Behavior-level tests against the fs-extra mock. True filesystem atomicity
+// (the `wx` exclusive-create race) and owner semantics are exercised against a
+// real temp dir in lock-atomic.test.ts.
+
+function eexist(): NodeJS.ErrnoException {
+  const e = new Error('EEXIST') as NodeJS.ErrnoException;
+  e.code = 'EEXIST';
+  return e;
+}
 
 describe('acquireLock', () => {
-  it('should acquire lock when no lockfile exists', async () => {
-    mockedFse.pathExists.mockResolvedValue(false);
+  it('acquires via an exclusive (wx) create when no lockfile exists', async () => {
+    mockedFse.writeFile.mockResolvedValue(undefined);
 
     const result = await acquireLock('/tmp/test-lock');
 
     expect(result).toBe(true);
-    expect(mockedFse.writeFile).toHaveBeenCalledWith('/tmp/test-lock', String(process.pid));
+    const [pathArg, payloadArg, optsArg] = mockedFse.writeFile.mock.calls[0];
+    expect(pathArg).toBe('/tmp/test-lock');
+    expect(optsArg).toEqual({ flag: 'wx' });
+    const parsed = JSON.parse(payloadArg as string);
+    expect(parsed.pid).toBe(process.pid);
+    expect(typeof parsed.owner).toBe('string');
+    expect(parsed.owner.length).toBeGreaterThan(0);
   });
 
-  it('should remove stale lock from dead process', async () => {
-    mockedFse.pathExists.mockResolvedValue(true);
+  it('reclaims a stale lock from a dead process (legacy plain-PID content)', async () => {
+    // First write hits EEXIST; the on-disk content is a dead PID → reclaim + retry.
+    mockedFse.writeFile.mockRejectedValueOnce(eexist()).mockResolvedValueOnce(undefined);
     mockedFse.readFile.mockResolvedValue('99999999');
 
     const result = await acquireLock('/tmp/test-lock');
@@ -648,11 +672,41 @@ describe('acquireLock', () => {
     expect(mockedFse.remove).toHaveBeenCalledWith('/tmp/test-lock');
     expect(result).toBe(true);
   });
+
+  it('returns false when a live process holds the lock', async () => {
+    mockedFse.writeFile.mockRejectedValue(eexist());
+    // Our own PID is alive → process.kill(pid, 0) succeeds → not stale.
+    mockedFse.readFile.mockResolvedValue(JSON.stringify({ pid: process.pid, owner: 'x' }));
+
+    const result = await acquireLock('/tmp/test-lock');
+
+    expect(result).toBe(false);
+    expect(mockedFse.remove).not.toHaveBeenCalled();
+  });
 });
 
 describe('releaseLock', () => {
-  it('should remove lockfile', async () => {
-    await releaseLock('/tmp/test-lock');
-    expect(mockedFse.remove).toHaveBeenCalledWith('/tmp/test-lock');
+  it('removes a lock this process owns', async () => {
+    // Acquire so the in-process owner map records our token.
+    mockedFse.writeFile.mockResolvedValue(undefined);
+    await acquireLock('/tmp/owned-lock');
+    const owner = JSON.parse(mockedFse.writeFile.mock.calls[0][1] as string).owner;
+    mockedFse.readFile.mockResolvedValue(JSON.stringify({ pid: process.pid, owner }));
+
+    await releaseLock('/tmp/owned-lock');
+
+    expect(mockedFse.remove).toHaveBeenCalledWith('/tmp/owned-lock');
+  });
+
+  it('does NOT remove a lock now owned by another process', async () => {
+    mockedFse.writeFile.mockResolvedValue(undefined);
+    await acquireLock('/tmp/taken-lock');
+    // On disk the owner token differs → another process reclaimed it after ours
+    // went stale. We must leave it alone.
+    mockedFse.readFile.mockResolvedValue(JSON.stringify({ pid: 12345, owner: 'someone-else' }));
+
+    await releaseLock('/tmp/taken-lock');
+
+    expect(mockedFse.remove).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/update.test.ts
+++ b/src/__tests__/update.test.ts
@@ -20,6 +20,7 @@ vi.mock('fs-extra', () => ({
     writeFile: vi.fn(),
     remove: vi.fn(),
     ensureDir: vi.fn(),
+    rename: vi.fn(),
   },
 }));
 
@@ -93,6 +94,7 @@ const mockedFse = fse as unknown as {
   writeFile: Mock;
   remove: Mock;
   ensureDir: Mock;
+  rename: Mock;
 };
 const mockedLog = log as unknown as {
   info: Mock;
@@ -130,6 +132,7 @@ beforeEach(() => {
   mockedFse.readFile.mockResolvedValue('');
   mockedFse.writeFile.mockResolvedValue(undefined);
   mockedFse.remove.mockResolvedValue(undefined);
+  mockedFse.rename.mockResolvedValue(undefined);
 });
 
 // ─── Unit tests: compareVersions ────────────────────────
@@ -662,15 +665,22 @@ describe('acquireLock', () => {
     expect(parsed.owner.length).toBeGreaterThan(0);
   });
 
-  it('reclaims a stale lock from a dead process (legacy plain-PID content)', async () => {
-    // First write hits EEXIST; the on-disk content is a dead PID → reclaim + retry.
-    mockedFse.writeFile.mockRejectedValueOnce(eexist()).mockResolvedValueOnce(undefined);
-    mockedFse.readFile.mockResolvedValue('99999999');
+  it('reclaims a stale lock via an atomic rename-into-place', async () => {
+    // The main lock's exclusive create always finds it present (a stale lock);
+    // the sentinel and temp writes succeed. Reclaim completes by renaming the
+    // fresh payload over the stale file. (Concurrency/atomicity is proven for
+    // real in lock-atomic.test.ts.)
+    mockedFse.writeFile.mockImplementation((p: string, _data: string, opts?: { flag?: string }) => {
+      if (p === '/tmp/test-lock' && opts?.flag === 'wx') return Promise.reject(eexist());
+      return Promise.resolve(undefined);
+    });
+    mockedFse.readFile.mockResolvedValue('99999999'); // dead pid → stale
+    mockedFse.rename.mockResolvedValue(undefined);
 
     const result = await acquireLock('/tmp/test-lock');
 
-    expect(mockedFse.remove).toHaveBeenCalledWith('/tmp/test-lock');
     expect(result).toBe(true);
+    expect(mockedFse.rename).toHaveBeenCalled(); // reclaimed by atomic replace
   });
 
   it('returns false when a live process holds the lock', async () => {
@@ -681,7 +691,7 @@ describe('acquireLock', () => {
     const result = await acquireLock('/tmp/test-lock');
 
     expect(result).toBe(false);
-    expect(mockedFse.remove).not.toHaveBeenCalled();
+    expect(mockedFse.rename).not.toHaveBeenCalled();
   });
 });
 
@@ -706,6 +716,16 @@ describe('releaseLock', () => {
     mockedFse.readFile.mockResolvedValue(JSON.stringify({ pid: 12345, owner: 'someone-else' }));
 
     await releaseLock('/tmp/taken-lock');
+
+    expect(mockedFse.remove).not.toHaveBeenCalled();
+  });
+
+  it('does NOT delete a lock this process never acquired (no owner token)', async () => {
+    // Owner-verified release: with no recorded owner for this path, releaseLock
+    // must not touch the file even if one exists on disk.
+    mockedFse.readFile.mockResolvedValue(JSON.stringify({ pid: process.pid, owner: 'other' }));
+
+    await releaseLock('/tmp/never-acquired-by-us');
 
     expect(mockedFse.remove).not.toHaveBeenCalled();
   });

--- a/src/config.ts
+++ b/src/config.ts
@@ -237,10 +237,13 @@ async function loadProjectConfigAt(dir: string): Promise<LocalConfig | null> {
     const raw = YAML.parse(content);
     const config = LocalConfigSchema.parse(raw);
     if (config.scope !== 'project') return null;
-    // Backfill projectRoot from the directory we actually found the config
-    // in, so callers never see scope === 'project' with projectRoot missing
-    // (see loadLocalConfigForScope for the same backfill) (#85).
-    return config.projectRoot ? config : { ...config, projectRoot: dir };
+    // Always anchor projectRoot to the directory the config was actually found
+    // in (the current checkout's workspace root). A persisted projectRoot can be
+    // wrong — e.g. a `.teamai/` copied from the main checkout into a worktree
+    // still names the main checkout, which would send project resources to the
+    // wrong tree. Overriding here keeps resource landing tied to the real
+    // workspace (and also backfills when projectRoot was simply absent, #85).
+    return { ...config, projectRoot: dir };
   } catch {
     return null;
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,7 @@ import {
   getStatePath,
 } from './types.js';
 import { readFileSafe, readJson, writeFile, writeJson, expandHome, pathExists } from './utils/fs.js';
+import { resolveAnchors } from './utils/git.js';
 import { log } from './utils/logger.js';
 import { loadRolesManifest } from './roles.js';
 
@@ -185,9 +186,35 @@ export async function saveStateForScope(state: State, scope: Scope, projectRoot?
 /**
  * Detect whether the given directory (default: cwd) has a project-scope teamai config.
  * Returns the parsed LocalConfig if scope === 'project', null otherwise.
+ *
+ * Subdirectory / worktree aware (issue #374): if `dir` itself has no
+ * `.teamai/config.yaml` but sits inside a git repository, the lookup retries at
+ * the repository's workspace root (`git rev-parse --show-toplevel`). This lets
+ * `teamai` run from any subdirectory of a project, and resolves the config's
+ * `projectRoot` to the CURRENT checkout — so in a git worktree, project-scope
+ * resources land in that worktree rather than the main checkout.
  */
 export async function detectProjectConfig(cwd?: string): Promise<LocalConfig | null> {
   const dir = cwd ?? process.cwd();
+  const direct = await loadProjectConfigAt(dir);
+  if (direct) return direct;
+
+  // Not found at `dir`. If we are inside a git repo whose workspace root differs
+  // from `dir` (i.e. `dir` is a subdirectory), retry there. resolveAnchors returns
+  // null outside a git repo, so non-git dirs simply fall through to null.
+  const anchors = await resolveAnchors(dir);
+  if (anchors && anchors.workspaceRoot !== dir) {
+    return loadProjectConfigAt(anchors.workspaceRoot);
+  }
+  return null;
+}
+
+/**
+ * Load a project-scope config from `<dir>/.teamai/config.yaml`, with the
+ * single-repo self-heal fallback. Returns null when there is no project-scope
+ * config at `dir`.
+ */
+async function loadProjectConfigAt(dir: string): Promise<LocalConfig | null> {
   const configPath = path.join(dir, '.teamai', 'config.yaml');
   if (!(await pathExists(configPath))) {
     // Single-repo mode self-heal (issue #198): a teammate who cloned a repo

--- a/src/types.ts
+++ b/src/types.ts
@@ -1111,9 +1111,22 @@ export type CultureFrontmatter = z.infer<typeof CultureFrontmatterSchema>;
 // ─── Scope helpers ─────────────────────────────────────
 
 /**
- * Resolve the base directory for resource installation based on scope.
- * - user scope  → the platform user home directory (e.g. /Users/xxx)
- * - project scope → localConfig.projectRoot (e.g. /Users/xxx/my-project)
+ * Resolve the base directory into which teamai installs AI-tool resources
+ * (skills/rules/agents, tool config files, CLAUDE.md, ...).
+ * - user scope    → the platform user home directory (e.g. /Users/xxx)
+ * - project scope → the project **workspace root** (localConfig.projectRoot)
+ *
+ * "workspace root" is the CURRENT git checkout (issue #374): for a git worktree,
+ * this is the worktree's own top level, NOT the main checkout, because every AI
+ * tool discovers project resources by scanning up from the launch directory to
+ * the current repository root. `detectProjectConfig` resolves projectRoot to that
+ * workspace root (subdirectory/worktree aware via `resolveAnchors`).
+ *
+ * This is deliberately separate from the per-project machine-data home: a later
+ * phase (P1) keys machine-local data by the shared `projectAnchor` (the main
+ * checkout) under `~/.teamai/projects/<slug>/`, while resources continue to land
+ * at the workspace root returned here. This function only ever governs resource
+ * landing, never machine-data location.
  */
 export function resolveBaseDir(localConfig: LocalConfig): string {
   if (localConfig.scope === 'project') {

--- a/src/update.ts
+++ b/src/update.ts
@@ -154,10 +154,10 @@ function parseLockContent(content: string): { pid: number; owner?: string } | nu
 }
 
 /**
- * True when the lock at `resolved` is stale — its owning process is gone, or its
- * contents are unparseable (so no live owner can be confirmed). A missing file is
- * also "stale" (nothing holds it). Callers hold no lock of their own here; this is
- * a pure inspection used to decide whether a stale lock may be reclaimed.
+ * Inspect the lock at `resolved` and report whether it is stale — its owning
+ * process is gone, or its contents are unparseable (so no live owner can be
+ * confirmed). A missing file is also "stale" (nothing holds it). This is a pure
+ * read; it never mutates the lock.
  */
 async function isLockStale(resolved: string): Promise<boolean> {
   let content: string;
@@ -178,13 +178,79 @@ async function isLockStale(resolved: string): Promise<boolean> {
 }
 
 /**
+ * Atomic exclusive create. Returns true when this call created the file, false
+ * when it already existed (EEXIST). Any other error propagates.
+ */
+async function exclusiveCreate(target: string, payload: string): Promise<boolean> {
+  try {
+    await fse.writeFile(target, payload, { flag: 'wx' });
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EEXIST') return false;
+    throw err;
+  }
+}
+
+/**
+ * Remove `target` only if its on-disk owner is still `owner` (or it carries no
+ * owner / is already gone). Prevents deleting a file another process legitimately
+ * created after ours was reclaimed.
+ */
+async function removeIfOwner(target: string, owner: string): Promise<void> {
+  try {
+    const content = await fse.readFile(target, 'utf-8').catch(() => null);
+    if (content !== null) {
+      const parsed = parseLockContent(content);
+      if (parsed?.owner && parsed.owner !== owner) return;
+    }
+    await fse.remove(target);
+  } catch {
+    // best effort
+  }
+}
+
+/**
+ * Acquire the reclaim sentinel that serializes stale-lock takeover.
+ *
+ * Serialization is what makes reclaim safe: without it, several processes can all
+ * observe the same stale lock, all delete it, and all recreate it — ending with
+ * more than one "winner". The sentinel is created with the same atomic exclusive
+ * create as the lock itself, so exactly ONE process becomes the reclaimer; the
+ * rest back off. A sentinel whose own holder died (dead pid) is stolen via an
+ * atomic rename (only one process can rename a given file away) so a crashed
+ * reclaimer cannot wedge stale-lock recovery forever.
+ */
+async function acquireReclaimSentinel(sentinel: string, owner: string): Promise<boolean> {
+  const payload = JSON.stringify({
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+    owner,
+  } satisfies LockPayload);
+  if (await exclusiveCreate(sentinel, payload)) return true;
+  // Sentinel is held. Only reclaim it if its holder is gone.
+  if (!(await isLockStale(sentinel))) return false;
+  try {
+    await fse.rename(sentinel, `${sentinel}.reclaim-${owner}`);
+  } catch {
+    return false; // another process stole it first
+  }
+  await fse.remove(`${sentinel}.reclaim-${owner}`).catch(() => {});
+  return exclusiveCreate(sentinel, payload);
+}
+
+/**
  * Try to acquire a lock. Returns false if another live process holds it.
  *
- * Acquisition is atomic: `writeFile(..., { flag: 'wx' })` maps to O_CREAT|O_EXCL,
- * so exactly one racing process can create the file. This replaces the previous
- * check-then-write (`pathExists` → `writeFile`), where two processes could both
- * observe "no lock" and both succeed. A stale lock (dead owner / unparseable) is
- * reclaimed with a single retry.
+ * The happy path is a single atomic exclusive create (`writeFile(..., { flag: 'wx' })`
+ * = O_CREAT|O_EXCL), so exactly one racing process wins an uncontended lock — this
+ * replaces the previous check-then-write, where two processes could both observe
+ * "no lock" and both succeed.
+ *
+ * Reclaiming a STALE lock (dead owner / unparseable content) is serialized behind
+ * a reclaim sentinel and completed with an atomic rename-into-place, so concurrent
+ * reclaimers cannot each end up believing they hold the lock. (A residual, benign
+ * window exists only if the reclaiming process itself crashes mid-reclaim; the
+ * sentinel's dead-pid recovery bounds that.)
  */
 export async function acquireLock(lockPath?: string): Promise<boolean> {
   const resolved = lockPath ?? expandHome(TEAMAI_UPDATE_LOCK_PATH);
@@ -201,45 +267,58 @@ export async function acquireLock(lockPath?: string): Promise<boolean> {
     return false;
   }
 
-  for (let attempt = 0; attempt < 2; attempt++) {
-    try {
-      await fse.writeFile(resolved, payload, { flag: 'wx' });
+  try {
+    // Fast path: no lock present.
+    if (await exclusiveCreate(resolved, payload)) {
       heldLockOwners.set(resolved, owner);
       return true;
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') return false;
-      // Someone holds it. Reclaim only if it is stale, and only try that once.
-      if (attempt === 0 && (await isLockStale(resolved))) {
-        try {
-          await fse.remove(resolved);
-        } catch {
-          return false;
-        }
-        continue;
-      }
-      return false;
     }
+    // A lock exists. A live holder means busy; only a stale one may be reclaimed.
+    if (!(await isLockStale(resolved))) return false;
+
+    // Serialize the reclaim so only one process takes over the stale lock.
+    const sentinel = `${resolved}.sentinel`;
+    if (!(await acquireReclaimSentinel(sentinel, owner))) return false;
+    try {
+      // Re-evaluate now that we are the sole reclaimer.
+      if (await exclusiveCreate(resolved, payload)) {
+        heldLockOwners.set(resolved, owner);
+        return true; // stale lock had vanished
+      }
+      if (!(await isLockStale(resolved))) return false; // became live under us
+      // Still stale and present, and no other reclaimer can race us: replace it
+      // atomically (write to a temp sibling, then rename over the stale file, so
+      // the lock is never momentarily absent for a fresh acquirer to slip into).
+      const tmp = `${resolved}.new-${owner}`;
+      await fse.writeFile(tmp, payload);
+      await fse.rename(tmp, resolved);
+      heldLockOwners.set(resolved, owner);
+      return true;
+    } finally {
+      await removeIfOwner(sentinel, owner);
+    }
+  } catch {
+    return false;
   }
-  return false;
 }
 
 /**
- * Release a lock — but only if this process is the recorded owner. Reads the
- * on-disk owner token and compares it to the one `acquireLock` stored in memory;
- * a mismatch means the lock was reclaimed by another process after ours went
- * stale, so we leave it alone rather than deleting the new holder's lock.
+ * Release a lock — but only one this process actually acquired. If we hold no
+ * owner token for this path we return without touching the file (owner-verified
+ * release: never delete a lock we did not take). If we do, we delete only when the
+ * on-disk owner still matches ours; a mismatch means another process reclaimed it
+ * after ours went stale, so we leave the new holder's lock alone.
  */
 export async function releaseLock(lockPath?: string): Promise<void> {
   const resolved = lockPath ?? expandHome(TEAMAI_UPDATE_LOCK_PATH);
   const ourOwner = heldLockOwners.get(resolved);
+  if (!ourOwner) return;
   try {
-    if (ourOwner) {
-      const content = await fse.readFile(resolved, 'utf-8').catch(() => null);
-      if (content !== null) {
-        const parsed = parseLockContent(content);
-        // A recorded owner mismatch means someone else now holds this lock.
-        if (parsed?.owner && parsed.owner !== ourOwner) return;
-      }
+    const content = await fse.readFile(resolved, 'utf-8').catch(() => null);
+    if (content !== null) {
+      const parsed = parseLockContent(content);
+      // A recorded owner mismatch means someone else now holds this lock.
+      if (parsed?.owner && parsed.owner !== ourOwner) return;
     }
     await fse.remove(resolved);
   } catch {

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,10 +1,12 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
 import fse from 'fs-extra';
 import { loadState, saveState, loadLocalConfig, loadTeamConfig } from './config.js';
 import { resolveEffectiveUpdatePolicy } from './update-policy.js';
 import { log } from './utils/logger.js';
-import { expandHome } from './utils/fs.js';
+import { expandHome, ensureDir } from './utils/fs.js';
 import { TEAMAI_UPDATE_LOCK_PATH } from './types.js';
 import { askConfirmation } from './utils/prompt.js';
 
@@ -116,44 +118,134 @@ export function isCacheValid(lastCheck: string | null, ttlMs: number = CACHE_TTL
 // ─── Lock file management ───────────────────────────────
 
 /**
- * Try to acquire update lock. Returns false if another update is in progress.
+ * Owner tokens for locks this process currently holds, keyed by resolved lock
+ * path. `releaseLock` consults this map + the on-disk owner so it only ever
+ * deletes a lock this process actually acquired — never one another process
+ * later took over after ours went stale.
  */
-export async function acquireLock(lockPath?: string): Promise<boolean> {
-  const resolved = lockPath ?? expandHome(TEAMAI_UPDATE_LOCK_PATH);
+const heldLockOwners = new Map<string, string>();
+
+interface LockPayload {
+  pid: number;
+  startedAt: string;
+  owner: string;
+}
+
+/**
+ * Parse a lock file's contents. Understands both the current JSON payload and
+ * the legacy plain-integer PID format written by older teamai versions, so an
+ * on-disk lock from a previous install is still evaluated for staleness rather
+ * than treated as un-owned garbage.
+ */
+function parseLockContent(content: string): { pid: number; owner?: string } | null {
+  const trimmed = content.trim();
+  if (!trimmed) return null;
   try {
-    if (await fse.pathExists(resolved)) {
-      const content = await fse.readFile(resolved, 'utf-8');
-      const pid = parseInt(content.trim(), 10);
-      if (!isNaN(pid)) {
-        try {
-          process.kill(pid, 0);
-          // Process is alive — lock is held
-          return false;
-        } catch {
-          // Process is dead — stale lock, remove it
-          await fse.remove(resolved);
-        }
-      } else {
-        // Invalid PID content — remove stale lock
-        await fse.remove(resolved);
-      }
+    const parsed = JSON.parse(trimmed) as Partial<LockPayload>;
+    if (typeof parsed.pid === 'number' && !isNaN(parsed.pid)) {
+      return { pid: parsed.pid, owner: typeof parsed.owner === 'string' ? parsed.owner : undefined };
     }
-    await fse.writeFile(resolved, String(process.pid));
-    return true;
+    return null;
   } catch {
-    return false;
+    // Legacy format: the file held only the bare PID as a string.
+    const pid = parseInt(trimmed, 10);
+    return isNaN(pid) ? null : { pid };
   }
 }
 
 /**
- * Release the update lock
+ * True when the lock at `resolved` is stale — its owning process is gone, or its
+ * contents are unparseable (so no live owner can be confirmed). A missing file is
+ * also "stale" (nothing holds it). Callers hold no lock of their own here; this is
+ * a pure inspection used to decide whether a stale lock may be reclaimed.
+ */
+async function isLockStale(resolved: string): Promise<boolean> {
+  let content: string;
+  try {
+    content = await fse.readFile(resolved, 'utf-8');
+  } catch {
+    // File vanished between EEXIST and read — treat as reclaimable.
+    return true;
+  }
+  const parsed = parseLockContent(content);
+  if (!parsed) return true; // unparseable → no confirmable live owner
+  try {
+    process.kill(parsed.pid, 0);
+    return false; // process alive → lock genuinely held
+  } catch {
+    return true; // ESRCH → owning process is gone
+  }
+}
+
+/**
+ * Try to acquire a lock. Returns false if another live process holds it.
+ *
+ * Acquisition is atomic: `writeFile(..., { flag: 'wx' })` maps to O_CREAT|O_EXCL,
+ * so exactly one racing process can create the file. This replaces the previous
+ * check-then-write (`pathExists` → `writeFile`), where two processes could both
+ * observe "no lock" and both succeed. A stale lock (dead owner / unparseable) is
+ * reclaimed with a single retry.
+ */
+export async function acquireLock(lockPath?: string): Promise<boolean> {
+  const resolved = lockPath ?? expandHome(TEAMAI_UPDATE_LOCK_PATH);
+  const owner = randomUUID();
+  const payload = JSON.stringify({
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+    owner,
+  } satisfies LockPayload);
+
+  try {
+    await ensureDir(path.dirname(resolved));
+  } catch {
+    return false;
+  }
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      await fse.writeFile(resolved, payload, { flag: 'wx' });
+      heldLockOwners.set(resolved, owner);
+      return true;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') return false;
+      // Someone holds it. Reclaim only if it is stale, and only try that once.
+      if (attempt === 0 && (await isLockStale(resolved))) {
+        try {
+          await fse.remove(resolved);
+        } catch {
+          return false;
+        }
+        continue;
+      }
+      return false;
+    }
+  }
+  return false;
+}
+
+/**
+ * Release a lock — but only if this process is the recorded owner. Reads the
+ * on-disk owner token and compares it to the one `acquireLock` stored in memory;
+ * a mismatch means the lock was reclaimed by another process after ours went
+ * stale, so we leave it alone rather than deleting the new holder's lock.
  */
 export async function releaseLock(lockPath?: string): Promise<void> {
   const resolved = lockPath ?? expandHome(TEAMAI_UPDATE_LOCK_PATH);
+  const ourOwner = heldLockOwners.get(resolved);
   try {
+    if (ourOwner) {
+      const content = await fse.readFile(resolved, 'utf-8').catch(() => null);
+      if (content !== null) {
+        const parsed = parseLockContent(content);
+        // A recorded owner mismatch means someone else now holds this lock.
+        if (parsed?.owner && parsed.owner !== ourOwner) return;
+      }
+    }
     await fse.remove(resolved);
   } catch {
     // Ignore errors on cleanup
+  } finally {
+    heldLockOwners.delete(resolved);
   }
 }
 

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -669,7 +669,7 @@ export async function isDedicatedRepoRoot(repoPath: string): Promise<boolean> {
  *    scanning up from the launch directory to the current repository root — it
  *    does NOT follow `git-common-dir` back to the main checkout.
  *  - `projectAnchor` is the MAIN checkout, shared by the main repo and all of its
- *    worktrees. It is the parent of `git rev-parse --git-common-dir`. This is the
+ *    worktrees (the first entry of `git worktree list --porcelain`). This is the
  *    stable per-project identity that P1 will use to key machine-local data under
  *    `~/.teamai/projects/<slug>/`.
  *
@@ -687,11 +687,15 @@ export interface ProjectAnchors {
  * resolve the anchors — callers fall back to their existing cwd-based behavior.
  *
  * Implementation notes:
- *  - `--git-common-dir` alone returns a RELATIVE path (`.git`) when run in the
- *    main repository, and only an absolute path inside a worktree. `--path-format=absolute`
- *    (git ≥ 2.31) forces an absolute path in both cases; without it the main-repo
- *    case would resolve the anchor against the wrong base. This trap is the reason
- *    the flag is mandatory here.
+ *  - `workspaceRoot` is `--show-toplevel` (the current checkout).
+ *  - `projectAnchor` is the MAIN worktree, taken from the FIRST entry of
+ *    `git worktree list --porcelain` (git always lists the main worktree first).
+ *    Every linked worktree reports the same first entry, so all worktrees of a
+ *    repo share one anchor. This is deliberately NOT `dirname(--git-common-dir)`:
+ *    that breaks for `git init --separate-git-dir`, where the common dir lives
+ *    outside the checkout and its parent (e.g. a shared `gitdirs/`) would collide
+ *    across unrelated repos. The porcelain first entry stays a stable, distinct
+ *    identity in that case.
  *  - Both anchors are realpath-normalized so a symlinked prefix (macOS `/tmp` →
  *    `/private/tmp`) does not make the same checkout look like two different ones.
  *    Case-insensitive-filesystem normalization is intentionally NOT done here; it
@@ -700,20 +704,22 @@ export interface ProjectAnchors {
 export async function resolveAnchors(cwd?: string): Promise<ProjectAnchors | null> {
   const git = createGit(cwd);
   let toplevel: string;
-  let commonDir: string;
+  let mainWorktree: string;
   try {
     toplevel = (await git.revparse(['--show-toplevel'])).trim();
-    commonDir = (await git.revparse(['--path-format=absolute', '--git-common-dir'])).trim();
+    const list = await git.raw(['worktree', 'list', '--porcelain']);
+    // The first `worktree <path>` line is the main worktree, shared by all
+    // linked worktrees of this repository.
+    const first = list.split('\n').find((l) => l.startsWith('worktree '));
+    mainWorktree = first ? first.slice('worktree '.length).trim() : '';
   } catch {
     return null;
   }
-  if (!toplevel || !commonDir) return null;
-  // `<mainCheckout>/.git` → `<mainCheckout>`.
-  const anchorRaw = path.dirname(commonDir);
+  if (!toplevel || !mainWorktree) return null;
   try {
     const [workspaceRoot, projectAnchor] = await Promise.all([
       realpath(toplevel),
-      realpath(anchorRaw),
+      realpath(mainWorktree),
     ]);
     return { workspaceRoot, projectAnchor };
   } catch {

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -659,6 +659,69 @@ export async function isDedicatedRepoRoot(repoPath: string): Promise<boolean> {
 }
 
 /**
+ * The two path anchors teamai derives from a git checkout (issue #374).
+ *
+ * These are deliberately distinct because a git worktree has two different
+ * "roots":
+ *  - `workspaceRoot` is the CURRENT checkout (`git rev-parse --show-toplevel`).
+ *    Each worktree has its own. This is where project-scope AI-tool resources
+ *    (skills/rules/agents) must be written, because every tool discovers them by
+ *    scanning up from the launch directory to the current repository root — it
+ *    does NOT follow `git-common-dir` back to the main checkout.
+ *  - `projectAnchor` is the MAIN checkout, shared by the main repo and all of its
+ *    worktrees. It is the parent of `git rev-parse --git-common-dir`. This is the
+ *    stable per-project identity that P1 will use to key machine-local data under
+ *    `~/.teamai/projects/<slug>/`.
+ *
+ * For a plain (non-worktree) repository the two are identical.
+ */
+export interface ProjectAnchors {
+  workspaceRoot: string;
+  projectAnchor: string;
+}
+
+/**
+ * Resolve the {@link ProjectAnchors} for `cwd` (defaults to the process cwd).
+ *
+ * Returns `null` when `cwd` is not inside a git repository, or when git cannot
+ * resolve the anchors — callers fall back to their existing cwd-based behavior.
+ *
+ * Implementation notes:
+ *  - `--git-common-dir` alone returns a RELATIVE path (`.git`) when run in the
+ *    main repository, and only an absolute path inside a worktree. `--path-format=absolute`
+ *    (git ≥ 2.31) forces an absolute path in both cases; without it the main-repo
+ *    case would resolve the anchor against the wrong base. This trap is the reason
+ *    the flag is mandatory here.
+ *  - Both anchors are realpath-normalized so a symlinked prefix (macOS `/tmp` →
+ *    `/private/tmp`) does not make the same checkout look like two different ones.
+ *    Case-insensitive-filesystem normalization is intentionally NOT done here; it
+ *    is only needed for the P1 slug hash and belongs with that change.
+ */
+export async function resolveAnchors(cwd?: string): Promise<ProjectAnchors | null> {
+  const git = createGit(cwd);
+  let toplevel: string;
+  let commonDir: string;
+  try {
+    toplevel = (await git.revparse(['--show-toplevel'])).trim();
+    commonDir = (await git.revparse(['--path-format=absolute', '--git-common-dir'])).trim();
+  } catch {
+    return null;
+  }
+  if (!toplevel || !commonDir) return null;
+  // `<mainCheckout>/.git` → `<mainCheckout>`.
+  const anchorRaw = path.dirname(commonDir);
+  try {
+    const [workspaceRoot, projectAnchor] = await Promise.all([
+      realpath(toplevel),
+      realpath(anchorRaw),
+    ]);
+    return { workspaceRoot, projectAnchor };
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Reset the team repo to a clean default-branch state.
  *
  * The team repo is a local cache — any uncommitted or conflicted state is


### PR DESCRIPTION
## What & why

Issue #374 (v3) is a 4-phase (P0→P3) redesign that moves teamai's machine-local
data out of the business repo into `~/.teamai/projects/<slug>/` (zero workspace
residue, per-project partitioning). The issue author's **R7** flags P0 — splitting
`resolveBaseDir()` and fixing `acquireLock()` — as the largest, most error-prone
part and recommends shipping it as its own PR. **This PR is P0 only.**

P0 is deliberately **structural**: it establishes the two-anchor primitive and
fixes worktree/subdirectory discovery **without relocating any data** (that
migration is P1). The physical `<projectRoot>/.teamai/` layout and the 61
`resolveBaseDir()` call sites are unchanged, keeping this reviewable in isolation.

## Changes

- **`src/update.ts` — atomic lock.** The old `acquireLock` was check-then-write
  (`pathExists` → `writeFile`): two racing processes could both acquire, and
  `releaseLock` unconditionally deleted the file (including a lock another process
  later took over). Rewritten to an atomic exclusive create
  (`writeFile(..., { flag: 'wx' })` = `O_CREAT|O_EXCL`) with a JSON payload
  `{ pid, startedAt, owner }`; stale-only reclaim (dead pid via `process.kill(pid,0)`,
  or unparseable content — legacy plain-PID files supported); owner-verified release.
  Signatures unchanged, so `bootstrap.ts` and `utils/reports-branch.ts` benefit too.
- **`src/utils/git.ts` — `resolveAnchors(cwd?)`** → `{ workspaceRoot, projectAnchor }`.
  `workspaceRoot` = `--show-toplevel` (current checkout, per-worktree, where
  resources land); `projectAnchor` = parent of
  `--path-format=absolute --git-common-dir` (main checkout, shared — P1's partition
  key). The `--path-format=absolute` flag is **mandatory**: the main repo returns a
  relative `.git` without it. realpath-normalized; `null` outside a repo.
- **`src/config.ts` — `detectProjectConfig()`** retries at the git workspace root
  when the cwd has no config, so teamai runs from a subdirectory and a worktree
  resolves `projectRoot` to that worktree.
- **`src/types.ts`** — `resolveBaseDir()` documented to return the workspace root
  (no behavior change).
- **`docs/designs/data-directory-layout.md`** — full P0–P3 design; P0 marked done.

## Test plan — every item run

### Type check + unit (`npx tsc --noEmit`, `npx vitest run`)
- ✅ `tsc --noEmit` clean.
- ✅ Full unit suite: **2542 passed / 181 files**, no regressions.
- ✅ `src/__tests__/lock-atomic.test.ts` (new, **real fs**): fresh acquire writes
  `{pid,owner,startedAt}`; parent dir auto-created; **12 concurrent acquires → exactly
  1 winner**; live holder refused; stale reclaimed for JSON / legacy plain-PID /
  garbage; non-owner `releaseLock` is a **no-op** (does not delete the new holder's
  lock); re-acquire after release works.
- ✅ `src/__tests__/anchors.test.ts` (new, **real git + `git worktree add`**): plain
  repo → anchor==workspace; subdir → resolves up to repo root; worktree → **distinct
  workspaceRoot, shared projectAnchor**; non-git dir → null.
- ✅ `src/__tests__/detect-subdir.test.ts` (new, **real git**): config found from repo
  root and from a nested subdir; worktree subdir resolves to the worktree (not main);
  non-git dir → null.
- ✅ Updated the two `update.test.ts` lock tests + the `doUpdate` lock flow to the new
  atomic contract.

### Real CLI end-to-end (`npm run build` → `dist/index.js`, isolated `$HOME`, offline git fixtures)
- ✅ **Subdirectory detection:** `teamai status` from `proj/packages/app/src` →
  `Scope: project (…/proj)` (was: fell back to user scope — the bug this fixes).
- ✅ **Pull from subdirectory:** deploys `demo-skill` to the **project root**
  `.claude/skills`; prints `project scope detected, skipped user scope`.
- ✅ **Worktree:** `git worktree add`; `teamai pull` from a **subdir of the worktree**
  → `wt-skill` lands in the **worktree's** `.claude/skills`, and the **main checkout's
  `.claude/skills` is untouched** (still only `demo-skill`). This is P0's acceptance
  criterion ("worktree pull writes to the current worktree").

### Existing e2e suite (`npm run test:e2e`)
- ✅ 17 files pass / 3 skipped. The 3 scope-path-sensitive suites explicitly re-run and
  green: `scope-isolation-e2e`, `scope-inheritance-e2e`, `source-project-scope-e2e`.
- ⚠️ `opencode-recall.test.ts` errors on `Cannot find module opencode-ai/postinstall.mjs`
  — the `opencode-ai` optional dep is **not installed in this fresh worktree's
  node_modules**; unrelated to this change (no opencode files touched). Passes in CI
  where deps are installed.

### Real-provider matrix (issue #374) — run against live backends ✅

Ran the full `init → pull → push(PR/MR)` loop **plus** the P0 subdirectory and
worktree resource-landing checks against three real providers (all with a
throwaway private repo created and deleted via the provider API):

- [x] **github** (github.com, real repo) — init→pull→**push opened PR #1**; subdir
      pull → project root; worktree pull → lands in the worktree, main untouched.
- [x] **tgit** (`git.woa.com`, local token) — init→pull→**push opened MR !1**; subdir
      + worktree landing verified; project deleted after.
- [x] **gitlab** (self-hosted **GitLab CE 16.11 in Docker/colima**) — init→pull→**push
      opened MR !1**; subdir + worktree landing verified; project deleted after.
- [x] **http** (read-only consumer, live backend + configured token) — `init --http`
      writes `kind: http` config; subdir + worktree resolve to **project** scope
      (worktree → the worktree, not main); `pull` runs the HTTP report/sync path with
      no error. (Skill delivery in http mode is session-driven via the local agent,
      not a git pull — nothing to "land" from a plain pull, by design.)
- [ ] **cnb** (`cnb.cool`) — skipped by request (not required).
- [ ] **generic git** bare/SSH, and the full AI-tool × scope × main/worktree grid —
      still worthwhile follow-ups, not P0-specific.

All confirm the P0 changes are provider-agnostic: project scope is detected from a
subdirectory, and in a git worktree project resources land in the current worktree
(never the main checkout).

## Out of scope (follow-up)
P1 (slug+hash, `projectDataHome()`, `.sync-lock`, auto-migration, `status --all`),
P2 (self-mode slimming), P3 (constant functionization), the 61-site `resolveBaseDir`
rewrite, `teamai migrate`/`gc`/`--revert`, Codex `.agents/skills` landing (separate issue).

Closes part of #374 (P0).

