### PR TITLE
fix(viz): left-align Top Recalled labels so titles aren't clipped

### DIFF
--- a/src/viz-render.ts
+++ b/src/viz-render.ts
@@ -57,9 +57,9 @@ function renderBarChart(items: Array<{ label: string; value: number; badge: stri
     const barW = Math.max(2, Math.round((item.value / maxVal) * BAR_AREA));
     const textY = y + BAR_H / 2 + 5;
     const labelEl =
-      `<text x="${LABEL_W - 4}" y="${textY}" text-anchor="end"` +
+      `<text x="0" y="${textY}"` +
       ` style="${mono};font-size:12px;fill:var(--text2)">` +
-      `${escapeHtml(trunc(item.label, 32))}</text>`;
+      `${escapeHtml(trunc(item.label, 30))}</text>`;
     const barEl =
       `<rect x="${LABEL_W}" y="${y}" width="${barW}" height="${BAR_H}"` +
       ` style="fill:var(--accent);opacity:0.9" rx="4"/>`;


### PR DESCRIPTION
## Summary

Follow-up to #368 (already merged): fix a display glitch in the KB Health report's **Top Recalled Entries** chart.

The bar-chart row labels were right-anchored (`text-anchor="end"`) inside a ~216px column and truncated to 32 chars. A longer entry title rendered wider than the column, so with right-anchoring its **beginning overflowed past the SVG's left edge and was clipped** — the reader saw only the middle/tail of the title, which looked misaligned.

## Fix

Left-align the labels (`x="0"`, default anchor) and trim to 30 chars, so every title reads from the beginning and its left edge lines up with the section heading. Bars/values/badges columns are unchanged.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/__tests__/viz.test.ts` — 12 tests green
- [x] `npm run build` — success
- [x] Rendered a report with long/short titles and confirmed each label now shows from the start, left-aligned under the heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)
