### PR TITLE
chore(release): 0.22.0-beta.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teamai-cli",
-  "version": "0.22.0-beta.4",
+  "version": "0.22.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teamai-cli",
-      "version": "0.22.0-beta.4",
+      "version": "0.22.0-beta.5",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teamai-cli",
-  "version": "0.22.0-beta.4",
+  "version": "0.22.0-beta.5",
   "description": "TeamAI — the team harness for AI agents (skill sync + shared knowledge base, powered by Git)",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- bump the package version to `0.22.0-beta.5` (includes #387 P0 data-layout anchors and #389 viz label align)
- keep `latest` unchanged; the release workflow will publish this version under the `beta` dist-tag

## Test plan

- [x] `npm run typecheck`
- [x] `CI=1 npx vitest run --reporter=dot` (182 files, 2559 tests passed)

## Release

After this PR is merged, create and push `v0.22.0-beta.5` from the resulting `main` commit to trigger npm Trusted Publishing. Do **not** publish with `--tag latest`.


Made with [Cursor](https://cursor.com)