### PR TITLE
fix(local-agent): stop re-prompting ClawPro binding in every git worktree

### DIFF
--- a/src/__tests__/local-agent.test.ts
+++ b/src/__tests__/local-agent.test.ts
@@ -174,6 +174,32 @@ describe('local-agent: bindCurrentProject --skip', () => {
     expect(binding.projectName).toBe('__skipped__');
     expect(binding.boundAt).toBeTruthy();
   });
+
+  it('skips the whole project (main + all worktrees) when run from a worktree', async () => {
+    await setupConfig();
+    const mainDir = path.join(tmpDir, 'main-repo');
+    const worktreeDir = path.join(tmpDir, 'linked-wt');
+    await fse.ensureDir(mainDir);
+    const { execFileSync } = await import('node:child_process');
+    const git = (args: string[], cwd: string) => execFileSync('git', args, { cwd, stdio: 'ignore' });
+    git(['init'], mainDir);
+    git(['config', 'user.email', 'test@example.com'], mainDir);
+    git(['config', 'user.name', 'test'], mainDir);
+    git(['commit', '--allow-empty', '-m', 'init'], mainDir);
+    git(['worktree', 'add', worktreeDir], mainDir);
+
+    const { bindCurrentProject } = await import('../local-agent.js');
+    // Skip from *inside the worktree*.
+    await bindCurrentProject({ skip: true, cwd: worktreeDir });
+
+    const config = await fse.readJson(path.join(tmpDir, '.teamai', 'local-agent', 'config.json'));
+    const realMain = fse.realpathSync(mainDir);
+    const realWt = fse.realpathSync(worktreeDir);
+    // The skip decision is recorded on BOTH the main checkout (the shared
+    // projectAnchor — so sibling worktrees inherit it) and this worktree.
+    expect(config.workspaceBindings[realMain]?.projectName).toBe('__skipped__');
+    expect(config.workspaceBindings[realWt]?.projectName).toBe('__skipped__');
+  });
 });
 
 describe('local-agent: emitBindingHint via reportAndSyncLocalAgent', () => {
@@ -488,6 +514,64 @@ describe('local-agent: emitBindingHint via reportAndSyncLocalAgent', () => {
     const ctx = parsed.hookSpecificOutput.additionalContext as string;
     expect(ctx).toContain('当前工作区尚未绑定项目');
     expect(ctx).toContain('teamai bind-project');
+  });
+});
+
+describe('local-agent: worktree binding inheritance', () => {
+  it('inherits the main checkout binding without re-prompting in a worktree', async () => {
+    process.env.TEAMAI_BIND_PROMPT_ENABLED = '1';
+    const mainDir = path.join(tmpDir, 'main-repo');
+    const worktreeDir = path.join(tmpDir, 'linked-wt');
+    await fse.ensureDir(mainDir);
+    const { execFileSync } = await import('node:child_process');
+    const git = (args: string[], cwd: string) => execFileSync('git', args, { cwd, stdio: 'ignore' });
+    git(['init'], mainDir);
+    git(['config', 'user.email', 'test@example.com'], mainDir);
+    git(['config', 'user.name', 'test'], mainDir);
+    git(['commit', '--allow-empty', '-m', 'init'], mainDir);
+    git(['worktree', 'add', worktreeDir], mainDir);
+
+    const realMain = fse.realpathSync(mainDir);
+    const realWt = fse.realpathSync(worktreeDir);
+    // Only the MAIN checkout is bound.
+    await setupConfig({
+      [realMain]: { projectId: 42, projectName: 'gamma', boundAt: '2026-01-01T00:00:00.000Z' },
+    });
+
+    // Projects are available — so a real prompt WOULD fire if inheritance failed.
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/api/projects/mine')) {
+        return new Response(JSON.stringify({ ok: true, projects: [{ id: 42, name: 'gamma' }] }));
+      }
+      return new Response(JSON.stringify({ ok: true }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const stdoutChunks: string[] = [];
+    const origWrite = process.stdout.write;
+    process.stdout.write = ((chunk: string | Buffer) => {
+      stdoutChunks.push(typeof chunk === 'string' ? chunk : chunk.toString());
+      return true;
+    }) as typeof process.stdout.write;
+
+    try {
+      const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+      await reportAndSyncLocalAgent({
+        cwd: worktreeDir,
+        tool: 'claude',
+        event: { type: 'prompt_submit', timestamp: new Date().toISOString(), sessionId: 'test-session', tool: 'claude' },
+      });
+    } finally {
+      process.stdout.write = origWrite;
+    }
+
+    // No binding prompt/hint in the worktree.
+    expect(stdoutChunks.join('')).not.toContain('hookSpecificOutput');
+    // The worktree inherited the main checkout's project_id (so its resources
+    // are reported/delivered), while resources still land in the worktree itself.
+    const config = await fse.readJson(path.join(tmpDir, '.teamai', 'local-agent', 'config.json'));
+    expect(config.workspaceBindings[realWt]?.projectId).toBe(42);
+    expect(config.workspaceBindings[realWt]?.projectName).toBe('gamma');
   });
 });
 

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -65,6 +65,7 @@ import {
   type TeamaiConfig,
 } from './types.js';
 import { getUserHome } from './utils/home.js';
+import { resolveAnchors } from './utils/git.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -933,6 +934,71 @@ async function promptForProjectBinding(
   return projects[index - 1];
 }
 
+/**
+ * Persist a ClawPro binding decision for the current checkout.
+ *
+ * Binding is a per-project decision, so it is recorded on the `projectAnchor`
+ * (the main checkout, shared by a repo and all of its git worktrees — issue
+ * #374 / #387). It is ALSO stamped on the current `workspaceRoot` so this
+ * checkout is reported with the project_id immediately and its resources land
+ * in the current worktree (#387's workspaceRoot model — every AI tool discovers
+ * resources by scanning up from the launch dir, never via git-common-dir). For a
+ * plain repo the two anchors coincide and this writes a single entry. Falls back
+ * to `resolvedPath` when `cwd` is not inside a git repo.
+ *
+ * Existing fields (e.g. a stamped `ideType`) on any touched entry are preserved.
+ */
+async function persistWorkspaceBinding(
+  config: LocalAgentConfig,
+  cwd: string | undefined,
+  resolvedPath: string,
+  projectId: number,
+  projectName: string,
+): Promise<void> {
+  const anchors = await resolveAnchors(cwd);
+  const keys = new Set<string>([resolvedPath]);
+  if (anchors) {
+    keys.add(anchors.projectAnchor);
+    keys.add(anchors.workspaceRoot);
+  }
+  const boundAt = new Date().toISOString();
+  for (const key of keys) {
+    config.workspaceBindings[key] = {
+      ...(config.workspaceBindings[key] ?? {}),
+      projectId,
+      projectName,
+      boundAt,
+    };
+  }
+  await saveLocalAgentConfig(config);
+}
+
+/**
+ * If the current checkout is an unbound git worktree whose main checkout
+ * (`projectAnchor`) is already bound or skipped, copy that decision onto the
+ * current `workspaceRoot` and report success — so a repo is never re-prompted
+ * for binding once per new worktree (a `--skip` on the main checkout silences
+ * all of them too). Returns true when the worktree inherited a binding.
+ */
+async function inheritWorktreeBinding(
+  config: LocalAgentConfig,
+  cwd: string | undefined,
+  resolvedPath: string,
+): Promise<boolean> {
+  const anchors = await resolveAnchors(cwd);
+  if (!anchors || anchors.projectAnchor === anchors.workspaceRoot) return false;
+  const anchorBinding = config.workspaceBindings[anchors.projectAnchor];
+  if (!anchorBinding) return false;
+  config.workspaceBindings[resolvedPath] = {
+    ...(config.workspaceBindings[resolvedPath] ?? {}),
+    projectId: anchorBinding.projectId,
+    projectName: anchorBinding.projectName,
+    boundAt: new Date().toISOString(),
+  };
+  await saveLocalAgentConfig(config);
+  return true;
+}
+
 export async function bindWorkspaceToProject(
   workspacePath: string,
   projectId?: number,
@@ -953,8 +1019,9 @@ export async function bindWorkspaceToProject(
     projectName: project.name,
     boundAt: new Date().toISOString(),
   };
-  config.workspaceBindings[workspacePath] = binding;
-  await saveLocalAgentConfig(config);
+  // Record on the projectAnchor (shared across the repo's worktrees) and the
+  // current workspaceRoot; workspacePath is already the resolved checkout root.
+  await persistWorkspaceBinding(config, workspacePath, workspacePath, project.id, project.name);
   log.success(`已将工作区绑定到项目：${project.name} [id=${project.id}]`);
   return binding;
 }
@@ -963,8 +1030,11 @@ async function ensureWorkspaceBinding(
   config: LocalAgentConfig,
   workspacePath: string,
   sessionId?: string,
+  cwd?: string,
 ): Promise<void> {
   if (config.workspaceBindings[workspacePath]) return;
+  // A worktree inherits its main checkout's binding/skip decision — never prompt.
+  if (await inheritWorktreeBinding(config, cwd, workspacePath)) return;
 
   const markerKey = sessionId || `ppid-${process.ppid}`;
   const hintMarker = path.join(os.tmpdir(), `teamai-bind-session-${markerKey}`);
@@ -983,12 +1053,7 @@ async function ensureWorkspaceBinding(
 
   const project = await promptForProjectBinding(workspacePath, projects);
   if (project) {
-    config.workspaceBindings[workspacePath] = {
-      projectId: project.id,
-      projectName: project.name,
-      boundAt: new Date().toISOString(),
-    };
-    await saveLocalAgentConfig(config);
+    await persistWorkspaceBinding(config, cwd, workspacePath, project.id, project.name);
     return;
   }
 
@@ -1026,8 +1091,11 @@ async function emitBindingHint(
   config: LocalAgentConfig,
   workspacePath: string,
   sessionId?: string,
+  cwd?: string,
 ): Promise<void> {
   if (config.workspaceBindings[workspacePath]) return;
+  // A worktree inherits its main checkout's binding/skip decision — never hint.
+  if (await inheritWorktreeBinding(config, cwd, workspacePath)) return;
 
   // Only hint once per session — use a temp marker file keyed by sessionId
   const markerKey = sessionId || `ppid-${process.ppid}`;
@@ -2407,10 +2475,10 @@ export async function reportAndSyncLocalAgent(context: LocalAgentContext): Promi
     if (workspacePath) {
       const sid = context.event?.sessionId;
       if (context.event?.type === 'session_start') {
-        await ensureWorkspaceBinding(config, workspacePath, sid);
+        await ensureWorkspaceBinding(config, workspacePath, sid, context.cwd);
       }
       if (context.event?.type === 'prompt_submit') {
-        await emitBindingHint(config, workspacePath, sid);
+        await emitBindingHint(config, workspacePath, sid, context.cwd);
       }
     }
   }
@@ -2739,8 +2807,9 @@ export async function bindCurrentProject(options?: { projectId?: number; skip?: 
     if (!config) {
       throw new Error('Local agent not initialized. Run `teamai init --http` first.');
     }
-    config.workspaceBindings[workspacePath] = { projectId: 0, projectName: '__skipped__', boundAt: new Date().toISOString() };
-    await saveLocalAgentConfig(config);
+    // Skip the whole project (main checkout + all its worktrees), not just this
+    // one checkout, so sibling worktrees are not re-prompted.
+    await persistWorkspaceBinding(config, options?.cwd ?? process.cwd(), workspacePath, 0, '__skipped__');
     log.info(`已跳过绑定，以后不再提示此工作区。`);
     return;
   }


### PR DESCRIPTION
## What & why

Entering a git **worktree** repeatedly re-triggers the ClawPro project-binding
prompt ("当前工作区未绑定 ClawPro 项目…"), and choosing *不绑定（跳过）* does
not stop it for the next worktree.

**Root cause.** `local-agent.ts::resolveWorkspacePath()` keys the workspace
binding off `git rev-parse --show-toplevel`, which for a *linked worktree* is
that worktree's **own unique path** (a per-task dir, often with a random
suffix). So every new worktree of the same repo is an unseen key in
`workspaceBindings` → re-prompted; and the `__skipped__` marker only silences
that one worktree path.

`#387` (issue #374 P0) added the exact primitive needed here — `resolveAnchors()`
returning `{ workspaceRoot, projectAnchor }` — but deliberately did **not**
touch the local-agent binding prompt, so the bug persists after #387.

## Approach — align with the #387 anchor model

Binding is a **per-project** decision, so it belongs on the shared
`projectAnchor` (the main checkout, shared by a repo and all its worktrees).
Resource landing stays **per-worktree** on `workspaceRoot` (every AI tool
discovers resources by scanning up from the launch dir — it never follows
`git-common-dir` back to the main checkout), so `resolveWorkspacePath()` is
left unchanged.

- **`persistWorkspaceBinding()`** — manual `bind-project`, `--skip`, and an
  accepted auto-prompt now write the decision to **both** the `projectAnchor`
  and the current `workspaceRoot` (a plain repo collapses to one entry).
  Existing fields (e.g. a stamped `ideType`) are preserved.
- **`inheritWorktreeBinding()`** — before prompting, an unbound worktree whose
  main checkout is already bound/skipped **inherits** that decision onto its
  own `workspaceRoot` and returns: no prompt, the correct `project_id` on
  report, and resources still land in the worktree (never the main checkout).

Reuses `#387`'s `resolveAnchors` (which uses `git worktree list --porcelain`,
robust for `--separate-git-dir`) rather than a bespoke `dirname(--git-common-dir)`.

## Changes

- `src/local-agent.ts` — add `persistWorkspaceBinding` + `inheritWorktreeBinding`;
  route `bindWorkspaceToProject`, `ensureWorkspaceBinding`, `emitBindingHint`
  and `bindCurrentProject --skip` through them; thread `cwd` into the two prompt
  functions.
- `src/__tests__/local-agent.test.ts` — 2 new tests (real `git worktree add`).

## Test plan — every item run

- ✅ `npx tsc --noEmit` — no new errors in `local-agent` (pre-existing
  `wiki-engine` missing-dep errors only, unrelated).
- ✅ Full unit suite: **182 files / 2561 tests pass**, incl. 2 new worktree tests
  (real `git worktree add` + real `bindCurrentProject` / `reportAndSyncLocalAgent`):
  - `--skip` from inside a worktree writes `__skipped__` to **both** main and worktree.
  - main-bound repo → a fresh worktree inherits `project_id` with **no** prompt.
- ✅ `npm run build`.
- ✅ **Real built CLI E2E** (isolated `$HOME`, real repo + `git worktree add`,
  local fake endpoint):
  - `node dist/index.js bind-project --skip` from a worktree → main + worktree both `__skipped__`.
  - main bound → `hook-dispatch session-start` from the worktree → **no** binding
    prompt on stdout, worktree entry inherits `projectId=42`.

No user-facing docs describe this behavior (grep confirmed), so none needed.