### PR TITLE
feat(local-agent): sync and report ClawPro model configs

### DIFF
--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -848,6 +848,43 @@ When using `teamai init --http <baseUrl>`, the endpoint must implement the follo
 }
 ```
 
+The backend may push an **`apply_model_config`** task whose `cmd` is JSON. Both
+the documented candidate-set shape and the legacy single-model shape are accepted.
+`{"models":[...]}` is a full snapshot; a direct model object is an incremental upsert:
+
+```jsonc
+{ "id": 16, "type": "apply_model_config",
+  "cmd": "{\"models\":[{\"provider\":\"openai\",\"model_id\":\"gpt-4o\",\"name\":\"GPT-4o\",\"base_url\":\"https://proxy.example.com/v1\",\"api_key\":\"<ProxyToken>\",\"max_tokens\":4096,\"context_window\":128000}]}" }
+```
+
+The candidate set is merged into CodeBuddy's user-level `~/.codebuddy/models.json`;
+user-owned entries with the same model ID are preserved. For Claude, teamai writes an
+explicit profile at `~/.claude/teamai-models.json` and also adds the gateway environment
+to `~/.claude/settings.json` when it has no conflicting user-owned Anthropic gateway
+configuration. These files are mode `0600`. A successful write is acknowledged with
+`type: "apply_model_config"`; malformed payloads are acknowledged as `failed`. Unknown
+future task types are silently skipped for protocol compatibility.
+
+The reverse direction is reported through the existing `report` call: the models the
+current tool can use are sent as `user_level.models`. The server requires both
+`provider` and `model_id`, so entries that cannot supply them are dropped instead of
+being reported incomplete. Like skills and rules, the field is omitted entirely when
+no model is configured, because a present array is treated as a full snapshot. Only
+CodeBuddy (`~/.codebuddy/models.json`) and Claude (the `ANTHROPIC_CUSTOM_MODEL_OPTION`
+gateway in `~/.claude/settings.json`) expose a discoverable model config; other tools
+report nothing. `source` is `enterprise` for models still matching what teamai
+delivered and `local` for user-owned ones. A Claude gateway configured by the user
+reports `provider: "anthropic"`. **`api_key` is never reported back** — the ProxyToken
+stays on disk.
+
+```jsonc
+{ "agent_type": "codebuddy", "local_agent_id": "...",
+  "user_level": { "models": [
+    { "provider": "openai", "model_id": "my-local-gpt", "name": "My Local GPT", "source": "local" },
+    { "provider": "tokenhub", "model_id": "gpt-4o", "name": "GPT-4o", "source": "enterprise" }
+  ] } }
+```
+
 The backend may also push an **`uninstall_teamai`** command to remove the local agent. It carries a `cmd` (a single `teamai` subcommand) that runs once on the client, with the result reported back through the same ack channel:
 
 ```json

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -850,7 +850,8 @@ When using `teamai init --http <baseUrl>`, the endpoint must implement the follo
 
 The backend may push an **`apply_model_config`** task whose `cmd` is JSON. Both
 the documented candidate-set shape and the legacy single-model shape are accepted.
-`{"models":[...]}` is a full snapshot; a direct model object is an incremental upsert:
+`{"models":[...]}` is a full snapshot; a direct model object is an incremental upsert.
+`max_tokens` is optional (CodeBuddy `maxOutputTokens`); omitted or `0` defaults to `4096`. Claude does not use it.
 
 ```jsonc
 { "id": 16, "type": "apply_model_config",

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -866,22 +866,20 @@ configuration. These files are mode `0600`. A successful write is acknowledged w
 `type: "apply_model_config"`; malformed payloads are acknowledged as `failed`. Unknown
 future task types are silently skipped for protocol compatibility.
 
-The reverse direction is reported through the existing `report` call: the models the
-current tool can use are sent as `user_level.models`. The server requires both
-`provider` and `model_id`, so entries that cannot supply them are dropped instead of
-being reported incomplete. Like skills and rules, the field is omitted entirely when
-no model is configured, because a present array is treated as a full snapshot. Only
-CodeBuddy (`~/.codebuddy/models.json`) and Claude (the `ANTHROPIC_CUSTOM_MODEL_OPTION`
-gateway in `~/.claude/settings.json`) expose a discoverable model config; other tools
-report nothing. `source` is `enterprise` for models still matching what teamai
-delivered and `local` for user-owned ones. A Claude gateway configured by the user
-reports `provider: "anthropic"`. **`api_key` is never reported back** — the ProxyToken
-stays on disk.
+The reverse direction is reported through the existing `report` call: models that
+TeamAI delivered and that still match on disk are sent as `user_level.models`.
+User-owned models are omitted because the backend cannot resolve them. The server
+requires both `provider` and `model_id`. Like skills and rules, the field is omitted
+entirely when nothing qualifies, because a present array is treated as a full
+snapshot. Only CodeBuddy (`~/.codebuddy/models.json`) and Claude (the
+`ANTHROPIC_CUSTOM_MODEL_OPTION` gateway in `~/.claude/settings.json`) expose a
+discoverable model config; other tools report nothing. Reported entries always use
+`source: "enterprise"`. **`api_key` is never reported back** — the ProxyToken stays
+on disk.
 
 ```jsonc
 { "agent_type": "codebuddy", "local_agent_id": "...",
   "user_level": { "models": [
-    { "provider": "openai", "model_id": "my-local-gpt", "name": "My Local GPT", "source": "local" },
     { "provider": "tokenhub", "model_id": "gpt-4o", "name": "GPT-4o", "source": "enterprise" }
   ] } }
 ```

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -858,16 +858,20 @@ the documented candidate-set shape and the legacy single-model shape are accepte
   "cmd": "{\"models\":[{\"provider\":\"openai\",\"model_id\":\"gpt-4o\",\"name\":\"GPT-4o\",\"base_url\":\"https://proxy.example.com/v1\",\"api_key\":\"<ProxyToken>\",\"max_tokens\":4096,\"context_window\":128000}]}" }
 ```
 
-The candidate set is merged into CodeBuddy's user-level `~/.codebuddy/models.json`;
-user-owned entries with the same model ID are preserved. For Claude, teamai writes an
-explicit profile at `~/.claude/teamai-models.json` and also adds the gateway environment
-to `~/.claude/settings.json` when it has no conflicting user-owned Anthropic gateway
-configuration. These files are mode `0600`. A successful write is acknowledged with
+The candidate set is applied only to the agent that reported the task. CodeBuddy uses
+its user-level `~/.codebuddy/models.json`; user-owned entries with the same model ID
+are preserved. Claude gets an explicit profile at `~/.claude/teamai-models.json` and
+also receives the gateway environment in `~/.claude/settings.json` when it has no
+conflicting user-owned Anthropic gateway configuration. Unsupported agents acknowledge
+the task as failed instead of writing another agent's config. Symlinked user config
+files remain symlinks. These files are mode `0600`. A successful write is acknowledged with
 `type: "apply_model_config"`; malformed payloads are acknowledged as `failed`. Unknown
 future task types are silently skipped for protocol compatibility.
 
 The reverse direction is reported through the existing `report` call: models that
-TeamAI delivered and that still match on disk are sent as `user_level.models`.
+TeamAI recorded in its model manifest and can still identify by model ID and provider
+on disk are sent as `user_level.models`. Normal agent-added metadata does not suppress
+the report. A successful apply triggers this report immediately in the same sync run.
 User-owned models are omitted because the backend cannot resolve them. The server
 requires both `provider` and `model_id`. Like skills and rules, the field is omitted
 entirely when nothing qualifies, because a present array is treated as a full

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -848,6 +848,7 @@ cat ~/.claude/CLAUDE.md
 
 后端可下发 **`apply_model_config`** 任务，其 `cmd` 为 JSON。客户端同时兼容设计文档中的候选集结构和
 旧版单模型结构：`{"models":[...]}` 按完整快照处理，直接模型对象按增量 upsert 处理。
+`max_tokens` 可选（对应 CodeBuddy 的 `maxOutputTokens`）；缺省或 `0` 时默认 `4096`。Claude 不使用该字段。
 
 ```jsonc
 { "id": 16, "type": "apply_model_config",

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -861,19 +861,17 @@ cat ~/.claude/CLAUDE.md
 settings。以上含凭证文件权限均为 `0600`。落盘成功后以 `type: "apply_model_config"` 回执；
 非法 payload 回执 `failed`。未来未知任务类型会静默跳过，以保持协议向后兼容。
 
-反向的模型上报走已有的 `report` 接口：当前工具可用的模型放在 `user_level.models` 中。
-服务端要求 `provider` 与 `model_id` 同时存在，因此凑不出这两个字段的条目会被丢弃，而不是
-以不完整的形式上报。与 skills/rules 一致，没有任何模型配置时该字段整体省略——因为存在的
-数组会被当作全量快照。只有 CodeBuddy（`~/.codebuddy/models.json`）和 Claude
+反向的模型上报走已有的 `report` 接口：仅上报 TeamAI 下发且磁盘内容仍匹配的模型，放在
+`user_level.models` 中。用户自有模型不上报，因为后台无法识别。服务端要求 `provider` 与
+`model_id` 同时存在。与 skills/rules 一致，没有任何符合条件的模型时该字段整体省略——因为
+存在的数组会被当作全量快照。只有 CodeBuddy（`~/.codebuddy/models.json`）和 Claude
 （`~/.claude/settings.json` 里的 `ANTHROPIC_CUSTOM_MODEL_OPTION` 网关）有可发现的模型配置，
-其余工具不上报。`source` 对仍与 teamai 下发内容一致的模型取 `enterprise`，用户自有的取
-`local`；用户自行配置的 Claude 网关上报为 `provider: "anthropic"`。
+其余工具不上报。上报条目的 `source` 固定为 `enterprise`。
 **`api_key` 不会被回传** —— ProxyToken 只留在本地磁盘。
 
 ```jsonc
 { "agent_type": "codebuddy", "local_agent_id": "...",
   "user_level": { "models": [
-    { "provider": "openai", "model_id": "my-local-gpt", "name": "My Local GPT", "source": "local" },
     { "provider": "tokenhub", "model_id": "gpt-4o", "name": "GPT-4o", "source": "enterprise" }
   ] } }
 ```

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -846,6 +846,37 @@ cat ~/.claude/CLAUDE.md
 }
 ```
 
+后端可下发 **`apply_model_config`** 任务，其 `cmd` 为 JSON。客户端同时兼容设计文档中的候选集结构和
+旧版单模型结构：`{"models":[...]}` 按完整快照处理，直接模型对象按增量 upsert 处理。
+
+```jsonc
+{ "id": 16, "type": "apply_model_config",
+  "cmd": "{\"models\":[{\"provider\":\"openai\",\"model_id\":\"gpt-4o\",\"name\":\"GPT-4o\",\"base_url\":\"https://proxy.example.com/v1\",\"api_key\":\"<ProxyToken>\",\"max_tokens\":4096,\"context_window\":128000}]}" }
+```
+
+候选集会合并到 CodeBuddy 用户级 `~/.codebuddy/models.json`；若同一模型 ID 已由用户配置，则保留
+用户条目。Claude 侧会生成独立配置 `~/.claude/teamai-models.json`；仅当
+`~/.claude/settings.json` 中不存在冲突的用户 Anthropic 网关配置时，才把网关环境变量写入默认
+settings。以上含凭证文件权限均为 `0600`。落盘成功后以 `type: "apply_model_config"` 回执；
+非法 payload 回执 `failed`。未来未知任务类型会静默跳过，以保持协议向后兼容。
+
+反向的模型上报走已有的 `report` 接口：当前工具可用的模型放在 `user_level.models` 中。
+服务端要求 `provider` 与 `model_id` 同时存在，因此凑不出这两个字段的条目会被丢弃，而不是
+以不完整的形式上报。与 skills/rules 一致，没有任何模型配置时该字段整体省略——因为存在的
+数组会被当作全量快照。只有 CodeBuddy（`~/.codebuddy/models.json`）和 Claude
+（`~/.claude/settings.json` 里的 `ANTHROPIC_CUSTOM_MODEL_OPTION` 网关）有可发现的模型配置，
+其余工具不上报。`source` 对仍与 teamai 下发内容一致的模型取 `enterprise`，用户自有的取
+`local`；用户自行配置的 Claude 网关上报为 `provider: "anthropic"`。
+**`api_key` 不会被回传** —— ProxyToken 只留在本地磁盘。
+
+```jsonc
+{ "agent_type": "codebuddy", "local_agent_id": "...",
+  "user_level": { "models": [
+    { "provider": "openai", "model_id": "my-local-gpt", "name": "My Local GPT", "source": "local" },
+    { "provider": "tokenhub", "model_id": "gpt-4o", "name": "GPT-4o", "source": "enterprise" }
+  ] } }
+```
+
 后端也可下发 **`uninstall_teamai`** 命令来移除本地 agent。它携带一个 `cmd`（一条 `teamai` 子命令），让客户端执行一次，执行结果经同一 ack 通道回报：
 
 ```json

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -855,14 +855,18 @@ cat ~/.claude/CLAUDE.md
   "cmd": "{\"models\":[{\"provider\":\"openai\",\"model_id\":\"gpt-4o\",\"name\":\"GPT-4o\",\"base_url\":\"https://proxy.example.com/v1\",\"api_key\":\"<ProxyToken>\",\"max_tokens\":4096,\"context_window\":128000}]}" }
 ```
 
-候选集会合并到 CodeBuddy 用户级 `~/.codebuddy/models.json`；若同一模型 ID 已由用户配置，则保留
-用户条目。Claude 侧会生成独立配置 `~/.claude/teamai-models.json`；仅当
-`~/.claude/settings.json` 中不存在冲突的用户 Anthropic 网关配置时，才把网关环境变量写入默认
-settings。以上含凭证文件权限均为 `0600`。落盘成功后以 `type: "apply_model_config"` 回执；
+候选集只会写入当前上报任务的 agent。CodeBuddy 使用用户级 `~/.codebuddy/models.json`；若同一
+模型 ID 已由用户配置，则保留用户条目。Claude 侧会生成独立配置
+`~/.claude/teamai-models.json`；仅当 `~/.claude/settings.json` 中不存在冲突的用户 Anthropic
+网关配置时，才把网关环境变量写入默认 settings。不支持的 agent 会回执失败，不会误写其他
+agent 的配置。用户配置文件是符号链接时会保留链接。以上含凭证文件权限均为 `0600`。落盘成功后以
+`type: "apply_model_config"` 回执；
 非法 payload 回执 `failed`。未来未知任务类型会静默跳过，以保持协议向后兼容。
 
-反向的模型上报走已有的 `report` 接口：仅上报 TeamAI 下发且磁盘内容仍匹配的模型，放在
-`user_level.models` 中。用户自有模型不上报，因为后台无法识别。服务端要求 `provider` 与
+反向的模型上报走已有的 `report` 接口：仅上报 TeamAI manifest 已记录、且磁盘上的模型 ID 和
+provider 仍可识别的模型，放在 `user_level.models` 中。agent 正常补充元数据不会导致漏报；
+模型落盘成功后会在同一次 sync 中立即补一次 report，无需等待下一次 session。用户自有模型不上报，
+因为后台无法识别。服务端要求 `provider` 与
 `model_id` 同时存在。与 skills/rules 一致，没有任何符合条件的模型时该字段整体省略——因为
 存在的数组会被当作全量快照。只有 CodeBuddy（`~/.codebuddy/models.json`）和 Claude
 （`~/.claude/settings.json` 里的 `ANTHROPIC_CUSTOM_MODEL_OPTION` 网关）有可发现的模型配置，

--- a/src/__tests__/local-agent-model-config.test.ts
+++ b/src/__tests__/local-agent-model-config.test.ts
@@ -1,0 +1,355 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import fse from 'fs-extra';
+
+vi.mock('../utils/logger.js', () => ({
+  log: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+let home: string;
+let originalHome: string | undefined;
+
+beforeEach(async () => {
+  home = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-model-config-'));
+  originalHome = process.env.HOME;
+  process.env.HOME = home;
+  await fse.outputJson(path.join(home, '.teamai/local-agent/config.json'), {
+    endpoint: 'https://clawpro.example.com',
+    token: 'reporter-token',
+    localAgentId: '0123456789abcdef',
+    createdAt: '2026-09-02T00:00:00.000Z',
+    workspaceBindings: {},
+  });
+});
+
+afterEach(async () => {
+  process.env.HOME = originalHome;
+  vi.restoreAllMocks();
+  await fse.remove(home);
+});
+
+function stubSync(command: Record<string, unknown>) {
+  const acks: Array<Record<string, unknown>> = [];
+  vi.stubGlobal('fetch', vi.fn(async (input: string | URL, init?: { body?: string }) => {
+    const url = String(input);
+    if (url.includes('/local-agent/sync')) {
+      return new Response(JSON.stringify({ ok: true, version: 'v2', cmds: [command] }));
+    }
+    if (url.includes('/commands/ack')) {
+      acks.push(JSON.parse(init?.body ?? '{}'));
+    }
+    return new Response(JSON.stringify({ ok: true }));
+  }));
+  return acks;
+}
+
+const deliveredModel = {
+  provider: 'tokenhub',
+  model_id: 'deepseek-v3-0324',
+  name: 'DeepSeek V3 0324',
+  base_url: 'https://proxy.example.com/v1',
+  api_key: 'proxy-token',
+  max_tokens: 5555,
+  context_window: 128000,
+};
+
+describe('local-agent: apply_model_config', () => {
+  it('persists a direct model payload for CodeBuddy and Claude, then acks with the task type', async () => {
+    await fse.outputJson(path.join(home, '.codebuddy/models.json'), {
+      models: [{ id: 'personal-model', name: 'Personal' }],
+      availableModels: ['personal-model'],
+    });
+    const acks = stubSync({
+      id: 16,
+      type: 'apply_model_config',
+      cmd: JSON.stringify(deliveredModel),
+      scope: '',
+    });
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ tool: 'codebuddy', status: 'running' });
+
+    const codebuddy = await fse.readJson(path.join(home, '.codebuddy/models.json'));
+    expect(codebuddy.models).toEqual([
+      { id: 'personal-model', name: 'Personal' },
+      {
+        id: 'deepseek-v3-0324',
+        name: 'DeepSeek V3 0324',
+        vendor: 'tokenhub',
+        apiKey: 'proxy-token',
+        maxInputTokens: 128000,
+        maxOutputTokens: 5555,
+        url: 'https://proxy.example.com/v1/chat/completions',
+        supportsToolCall: true,
+      },
+    ]);
+    expect(codebuddy.availableModels).toEqual(['personal-model', 'deepseek-v3-0324']);
+
+    const claude = await fse.readJson(path.join(home, '.claude/settings.json'));
+    expect(claude.env).toMatchObject({
+      ANTHROPIC_BASE_URL: 'https://proxy.example.com',
+      ANTHROPIC_AUTH_TOKEN: 'proxy-token',
+      ANTHROPIC_CUSTOM_MODEL_OPTION: 'deepseek-v3-0324',
+      ANTHROPIC_CUSTOM_MODEL_OPTION_NAME: 'DeepSeek V3 0324',
+    });
+    const claudeProfile = await fse.readJson(path.join(home, '.claude/teamai-models.json'));
+    expect(claudeProfile.env).toEqual(claude.env);
+
+    expect(acks).toContainEqual(expect.objectContaining({
+      id: 16,
+      type: 'apply_model_config',
+      status: 'success',
+    }));
+    expect((await fs.promises.stat(path.join(home, '.codebuddy/models.json'))).mode & 0o777).toBe(0o600);
+    expect((await fs.promises.stat(path.join(home, '.claude/teamai-models.json'))).mode & 0o777).toBe(0o600);
+  });
+
+  it('accepts the documented models wrapper and preserves conflicting user models and Claude gateway settings', async () => {
+    await fse.outputJson(path.join(home, '.codebuddy/models.json'), {
+      models: [{ id: deliveredModel.model_id, name: 'User-owned model', url: 'https://user.example.com/chat' }],
+    });
+    await fse.outputJson(path.join(home, '.claude/settings.json'), {
+      env: { ANTHROPIC_BASE_URL: 'https://user-gateway.example.com' },
+      model: 'sonnet',
+    });
+    const acks = stubSync({
+      id: 17,
+      type: 'apply_model_config',
+      cmd: JSON.stringify({ models: [deliveredModel] }),
+    });
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ tool: 'codebuddy', status: 'running' });
+
+    const codebuddy = await fse.readJson(path.join(home, '.codebuddy/models.json'));
+    expect(codebuddy.models).toEqual([
+      { id: deliveredModel.model_id, name: 'User-owned model', url: 'https://user.example.com/chat' },
+    ]);
+    const claude = await fse.readJson(path.join(home, '.claude/settings.json'));
+    expect(claude).toEqual({
+      env: { ANTHROPIC_BASE_URL: 'https://user-gateway.example.com' },
+      model: 'sonnet',
+    });
+    expect(await fse.pathExists(path.join(home, '.claude/teamai-models.json'))).toBe(true);
+    expect(acks[0]?.status).toBe('success');
+  });
+
+  it('keeps an empty CodeBuddy availableModels list unrestricted', async () => {
+    await fse.outputJson(path.join(home, '.codebuddy/models.json'), {
+      models: [],
+      availableModels: [],
+    });
+    stubSync({
+      id: 22,
+      type: 'apply_model_config',
+      cmd: JSON.stringify(deliveredModel),
+    });
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ tool: 'codebuddy', status: 'running' });
+
+    const codebuddy = await fse.readJson(path.join(home, '.codebuddy/models.json'));
+    expect(codebuddy.availableModels).toEqual([]);
+  });
+
+  it('treats direct model tasks as incremental upserts', async () => {
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    stubSync({
+      id: 23,
+      type: 'apply_model_config',
+      cmd: JSON.stringify(deliveredModel),
+    });
+    await reportAndSyncLocalAgent({ tool: 'codebuddy', status: 'running' });
+
+    stubSync({
+      id: 24,
+      type: 'apply_model_config',
+      cmd: JSON.stringify({
+        ...deliveredModel,
+        model_id: 'second-model',
+        name: 'Second Model',
+        max_tokens: '4096',
+        context_window: '64000',
+      }),
+    });
+    await reportAndSyncLocalAgent({ tool: 'codebuddy', status: 'running' });
+
+    const codebuddy = await fse.readJson(path.join(home, '.codebuddy/models.json'));
+    expect(codebuddy.models.map((model: { id: string }) => model.id)).toEqual([
+      'deepseek-v3-0324',
+      'second-model',
+    ]);
+    expect(codebuddy.models[1]).toMatchObject({
+      maxInputTokens: 64000,
+      maxOutputTokens: 4096,
+    });
+  });
+
+  it('reconciles models previously managed by TeamAI without deleting user edits', async () => {
+    const firstAcks = stubSync({
+      id: 18,
+      type: 'apply_model_config',
+      cmd: JSON.stringify({ models: [deliveredModel] }),
+    });
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ tool: 'codebuddy', status: 'running' });
+    expect(firstAcks[0]?.status).toBe('success');
+
+    const configPath = path.join(home, '.codebuddy/models.json');
+    const edited = await fse.readJson(configPath);
+    edited.models[0].name = 'User took ownership';
+    await fse.writeJson(configPath, edited);
+
+    const secondAcks = stubSync({
+      id: 19,
+      type: 'apply_model_config',
+      cmd: JSON.stringify({ models: [] }),
+    });
+    await reportAndSyncLocalAgent({ tool: 'codebuddy', status: 'running' });
+
+    const after = await fse.readJson(configPath);
+    expect(after.models).toEqual([expect.objectContaining({ name: 'User took ownership' })]);
+    expect(secondAcks[0]?.status).toBe('success');
+  });
+
+  it('retains CodeBuddy ownership when Claude reconciliation fails', async () => {
+    await fse.outputJson(path.join(home, '.claude/settings.json'), { env: 'invalid' });
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    const firstAcks = stubSync({
+      id: 25,
+      type: 'apply_model_config',
+      cmd: JSON.stringify(deliveredModel),
+    });
+    await reportAndSyncLocalAgent({ tool: 'codebuddy', status: 'running' });
+    expect(firstAcks[0]?.status).toBe('failed');
+
+    await fse.outputJson(path.join(home, '.claude/settings.json'), {});
+    const secondAcks = stubSync({
+      id: 26,
+      type: 'apply_model_config',
+      cmd: JSON.stringify({ ...deliveredModel, name: 'Updated by TeamAI' }),
+    });
+    await reportAndSyncLocalAgent({ tool: 'codebuddy', status: 'running' });
+
+    const codebuddy = await fse.readJson(path.join(home, '.codebuddy/models.json'));
+    expect(codebuddy.models).toEqual([
+      expect.objectContaining({ id: deliveredModel.model_id, name: 'Updated by TeamAI' }),
+    ]);
+    expect(secondAcks[0]?.status).toBe('success');
+  });
+
+  it('acks failed for malformed model config without writing tool files', async () => {
+    const acks = stubSync({
+      id: 20,
+      type: 'apply_model_config',
+      cmd: JSON.stringify({ models: [{ ...deliveredModel, model_id: '' }] }),
+    });
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ tool: 'codebuddy', status: 'running' });
+
+    expect(acks).toContainEqual(expect.objectContaining({
+      id: 20,
+      type: 'apply_model_config',
+      status: 'failed',
+      error: expect.stringMatching(/model_id/i),
+    }));
+    expect(await fse.pathExists(path.join(home, '.codebuddy/models.json'))).toBe(false);
+    expect(await fse.pathExists(path.join(home, '.claude/teamai-models.json'))).toBe(false);
+  });
+
+  it('silently skips unknown task types without acknowledging failure', async () => {
+    const acks = stubSync({ id: 21, type: 'future_model_task', cmd: '{}' });
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ tool: 'codebuddy', status: 'running' });
+
+    expect(acks).toEqual([]);
+  });
+});
+
+describe('local-agent: report local model inventory', () => {
+  async function reportedModels(tool: string): Promise<Array<Record<string, unknown>> | undefined> {
+    const { buildReportPayload, loadLocalAgentConfig } = await import('../local-agent.js');
+    const config = await loadLocalAgentConfig();
+    const payload = (await buildReportPayload(config!, { tool })) as {
+      user_level: { models?: Array<Record<string, unknown>> };
+    };
+    return payload.user_level.models;
+  }
+
+  it('omits models entirely when the tool has no model config on disk', async () => {
+    expect(await reportedModels('codebuddy')).toBeUndefined();
+  });
+
+  it('reports CodeBuddy models, deriving provider from vendor and source from the manifest', async () => {
+    await fse.outputJson(path.join(home, '.codebuddy/models.json'), {
+      models: [{ id: 'user-model', name: 'User Model', vendor: 'openai' }],
+    });
+    stubSync({ id: 30, type: 'apply_model_config', cmd: JSON.stringify(deliveredModel) });
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ tool: 'codebuddy', status: 'running' });
+
+    expect(await reportedModels('codebuddy')).toEqual([
+      { provider: 'openai', model_id: 'user-model', name: 'User Model', source: 'local' },
+      {
+        provider: 'tokenhub',
+        model_id: 'deepseek-v3-0324',
+        name: 'DeepSeek V3 0324',
+        source: 'enterprise',
+      },
+    ]);
+  });
+
+  it('skips CodeBuddy entries missing the backend-required provider or model id', async () => {
+    await fse.outputJson(path.join(home, '.codebuddy/models.json'), {
+      models: [
+        { id: 'no-vendor', name: 'No Vendor' },
+        { vendor: 'openai', name: 'No Id' },
+        { id: 'ok', vendor: 'openai', name: 'OK' },
+      ],
+    });
+
+    expect(await reportedModels('codebuddy')).toEqual([
+      { provider: 'openai', model_id: 'ok', name: 'OK', source: 'local' },
+    ]);
+  });
+
+  it('reports the Claude gateway model with the delivered provider restored', async () => {
+    stubSync({ id: 31, type: 'apply_model_config', cmd: JSON.stringify(deliveredModel) });
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ tool: 'claude', status: 'running' });
+
+    expect(await reportedModels('claude')).toEqual([
+      {
+        provider: 'tokenhub',
+        model_id: 'deepseek-v3-0324',
+        name: 'DeepSeek V3 0324',
+        source: 'enterprise',
+      },
+    ]);
+  });
+
+  it('reports a user-configured Claude gateway as a local anthropic model', async () => {
+    await fse.outputJson(path.join(home, '.claude/settings.json'), {
+      env: {
+        ANTHROPIC_BASE_URL: 'https://gateway.example.com',
+        ANTHROPIC_CUSTOM_MODEL_OPTION: 'my-own-model',
+      },
+    });
+
+    expect(await reportedModels('claude')).toEqual([
+      { provider: 'anthropic', model_id: 'my-own-model', source: 'local' },
+    ]);
+  });
+});

--- a/src/__tests__/local-agent-model-config.test.ts
+++ b/src/__tests__/local-agent-model-config.test.ts
@@ -319,7 +319,7 @@ describe('local-agent: report local model inventory', () => {
     expect(await reportedModels('codebuddy')).toBeUndefined();
   });
 
-  it('reports CodeBuddy models, deriving provider from vendor and source from the manifest', async () => {
+  it('reports only CodeBuddy models still matching a TeamAI delivery', async () => {
     await fse.outputJson(path.join(home, '.codebuddy/models.json'), {
       models: [{ id: 'user-model', name: 'User Model', vendor: 'openai' }],
     });
@@ -329,7 +329,6 @@ describe('local-agent: report local model inventory', () => {
     await reportAndSyncLocalAgent({ tool: 'codebuddy', status: 'running' });
 
     expect(await reportedModels('codebuddy')).toEqual([
-      { provider: 'openai', model_id: 'user-model', name: 'User Model', source: 'local' },
       {
         provider: 'tokenhub',
         model_id: 'deepseek-v3-0324',
@@ -339,18 +338,12 @@ describe('local-agent: report local model inventory', () => {
     ]);
   });
 
-  it('skips CodeBuddy entries missing the backend-required provider or model id', async () => {
+  it('omits user-owned CodeBuddy models the backend did not deliver', async () => {
     await fse.outputJson(path.join(home, '.codebuddy/models.json'), {
-      models: [
-        { id: 'no-vendor', name: 'No Vendor' },
-        { vendor: 'openai', name: 'No Id' },
-        { id: 'ok', vendor: 'openai', name: 'OK' },
-      ],
+      models: [{ id: 'ok', vendor: 'openai', name: 'OK' }],
     });
 
-    expect(await reportedModels('codebuddy')).toEqual([
-      { provider: 'openai', model_id: 'ok', name: 'OK', source: 'local' },
-    ]);
+    expect(await reportedModels('codebuddy')).toBeUndefined();
   });
 
   it('reports the Claude gateway model with the delivered provider restored', async () => {
@@ -369,7 +362,7 @@ describe('local-agent: report local model inventory', () => {
     ]);
   });
 
-  it('reports a user-configured Claude gateway as a local anthropic model', async () => {
+  it('does not report a user-configured Claude gateway', async () => {
     await fse.outputJson(path.join(home, '.claude/settings.json'), {
       env: {
         ANTHROPIC_BASE_URL: 'https://gateway.example.com',
@@ -377,8 +370,6 @@ describe('local-agent: report local model inventory', () => {
       },
     });
 
-    expect(await reportedModels('claude')).toEqual([
-      { provider: 'anthropic', model_id: 'my-own-model', source: 'local' },
-    ]);
+    expect(await reportedModels('claude')).toBeUndefined();
   });
 });

--- a/src/__tests__/local-agent-model-config.test.ts
+++ b/src/__tests__/local-agent-model-config.test.ts
@@ -246,6 +246,35 @@ describe('local-agent: apply_model_config', () => {
     expect(secondAcks[0]?.status).toBe('success');
   });
 
+  it('defaults max_tokens to 4096 when the backend omits it or sends a Go zero value', async () => {
+    const acks = stubSync({
+      id: 25,
+      type: 'apply_model_config',
+      cmd: JSON.stringify({
+        provider: 'tencentcodingplan',
+        model_id: 'kimi-k2.5',
+        name: 'kimi-k2.5',
+        base_url: 'https://proxy.example.com/v1',
+        api_key: 'proxy-token',
+        max_tokens: 0,
+        context_window: 128000,
+      }),
+    });
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ tool: 'codebuddy', status: 'running' });
+
+    expect(acks[0]?.status).toBe('success');
+    const codebuddy = await fse.readJson(path.join(home, '.codebuddy/models.json'));
+    expect(codebuddy.models).toEqual([
+      expect.objectContaining({
+        id: 'kimi-k2.5',
+        maxOutputTokens: 4096,
+        maxInputTokens: 128000,
+      }),
+    ]);
+  });
+
   it('acks failed for malformed model config without writing tool files', async () => {
     const acks = stubSync({
       id: 20,

--- a/src/__tests__/local-agent-model-config.test.ts
+++ b/src/__tests__/local-agent-model-config.test.ts
@@ -62,7 +62,7 @@ const deliveredModel = {
 };
 
 describe('local-agent: apply_model_config', () => {
-  it('persists a direct model payload for CodeBuddy and Claude, then acks with the task type', async () => {
+  it('persists a direct model payload for CodeBuddy, then acks with the task type', async () => {
     await fse.outputJson(path.join(home, '.codebuddy/models.json'), {
       models: [{ id: 'personal-model', name: 'Personal' }],
       availableModels: ['personal-model'],
@@ -93,15 +93,8 @@ describe('local-agent: apply_model_config', () => {
     ]);
     expect(codebuddy.availableModels).toEqual(['personal-model', 'deepseek-v3-0324']);
 
-    const claude = await fse.readJson(path.join(home, '.claude/settings.json'));
-    expect(claude.env).toMatchObject({
-      ANTHROPIC_BASE_URL: 'https://proxy.example.com',
-      ANTHROPIC_AUTH_TOKEN: 'proxy-token',
-      ANTHROPIC_CUSTOM_MODEL_OPTION: 'deepseek-v3-0324',
-      ANTHROPIC_CUSTOM_MODEL_OPTION_NAME: 'DeepSeek V3 0324',
-    });
-    const claudeProfile = await fse.readJson(path.join(home, '.claude/teamai-models.json'));
-    expect(claudeProfile.env).toEqual(claude.env);
+    expect(await fse.pathExists(path.join(home, '.claude/settings.json'))).toBe(false);
+    expect(await fse.pathExists(path.join(home, '.claude/teamai-models.json'))).toBe(false);
 
     expect(acks).toContainEqual(expect.objectContaining({
       id: 16,
@@ -109,7 +102,6 @@ describe('local-agent: apply_model_config', () => {
       status: 'success',
     }));
     expect((await fs.promises.stat(path.join(home, '.codebuddy/models.json'))).mode & 0o777).toBe(0o600);
-    expect((await fs.promises.stat(path.join(home, '.claude/teamai-models.json'))).mode & 0o777).toBe(0o600);
   });
 
   it('accepts the documented models wrapper and preserves conflicting user models and Claude gateway settings', async () => {
@@ -138,7 +130,7 @@ describe('local-agent: apply_model_config', () => {
       env: { ANTHROPIC_BASE_URL: 'https://user-gateway.example.com' },
       model: 'sonnet',
     });
-    expect(await fse.pathExists(path.join(home, '.claude/teamai-models.json'))).toBe(true);
+    expect(await fse.pathExists(path.join(home, '.claude/teamai-models.json'))).toBe(false);
     expect(acks[0]?.status).toBe('success');
   });
 
@@ -220,7 +212,7 @@ describe('local-agent: apply_model_config', () => {
     expect(secondAcks[0]?.status).toBe('success');
   });
 
-  it('retains CodeBuddy ownership when Claude reconciliation fails', async () => {
+  it('does not inspect unrelated Claude settings when applying a CodeBuddy model', async () => {
     await fse.outputJson(path.join(home, '.claude/settings.json'), { env: 'invalid' });
     const { reportAndSyncLocalAgent } = await import('../local-agent.js');
     const firstAcks = stubSync({
@@ -229,7 +221,7 @@ describe('local-agent: apply_model_config', () => {
       cmd: JSON.stringify(deliveredModel),
     });
     await reportAndSyncLocalAgent({ tool: 'codebuddy', status: 'running' });
-    expect(firstAcks[0]?.status).toBe('failed');
+    expect(firstAcks[0]?.status).toBe('success');
 
     await fse.outputJson(path.join(home, '.claude/settings.json'), {});
     const secondAcks = stubSync({
@@ -303,6 +295,122 @@ describe('local-agent: apply_model_config', () => {
 
     expect(acks).toEqual([]);
   });
+
+  it('reports an applied model immediately without waiting for the next session', async () => {
+    const reports: Array<Record<string, unknown>> = [];
+    const command = {
+      id: 26,
+      type: 'apply_model_config',
+      cmd: JSON.stringify(deliveredModel),
+    };
+    vi.stubGlobal('fetch', vi.fn(async (input: string | URL, init?: { body?: string }) => {
+      const url = String(input);
+      if (url.includes('/local-agent/report')) {
+        reports.push(JSON.parse(init?.body ?? '{}'));
+      }
+      if (url.includes('/local-agent/sync')) {
+        return new Response(JSON.stringify({ ok: true, version: 'v2', cmds: [command] }));
+      }
+      return new Response(JSON.stringify({ ok: true }));
+    }));
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ tool: 'codebuddy', status: 'running' });
+
+    expect(reports).toHaveLength(2);
+    expect((reports[1]?.user_level as { models?: unknown[] }).models).toEqual([
+      {
+        provider: 'tokenhub',
+        model_id: 'deepseek-v3-0324',
+        name: 'DeepSeek V3 0324',
+        source: 'enterprise',
+      },
+    ]);
+  });
+
+  it('fails apply_model_config for an unsupported reporting agent', async () => {
+    const acks = stubSync({
+      id: 27,
+      type: 'apply_model_config',
+      cmd: JSON.stringify(deliveredModel),
+    });
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ tool: 'workbuddy', status: 'running' });
+
+    expect(acks[0]).toMatchObject({
+      id: 27,
+      type: 'apply_model_config',
+      status: 'failed',
+      error: expect.stringMatching(/unsupported agent/i),
+    });
+    expect(await fse.pathExists(path.join(home, '.codebuddy/models.json'))).toBe(false);
+    expect(await fse.pathExists(path.join(home, '.claude/settings.json'))).toBe(false);
+  });
+
+  it('preserves a symlinked CodeBuddy models file', async () => {
+    const target = path.join(home, 'dotfiles', 'codebuddy-models.json');
+    const link = path.join(home, '.codebuddy', 'models.json');
+    await fse.outputJson(target, { models: [] });
+    await fse.ensureDir(path.dirname(link));
+    await fse.symlink(target, link);
+    const acks = stubSync({
+      id: 28,
+      type: 'apply_model_config',
+      cmd: JSON.stringify(deliveredModel),
+    });
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ tool: 'codebuddy', status: 'running' });
+
+    expect(acks[0]?.status).toBe('success');
+    expect((await fse.lstat(link)).isSymbolicLink()).toBe(true);
+    expect((await fse.readJson(target)).models[0].id).toBe('deepseek-v3-0324');
+  });
+
+  it('preserves a symlinked Claude settings file', async () => {
+    const target = path.join(home, 'dotfiles', 'claude-settings.json');
+    const link = path.join(home, '.claude', 'settings.json');
+    await fse.outputJson(target, { env: {} });
+    await fse.ensureDir(path.dirname(link));
+    await fse.symlink(target, link);
+    const acks = stubSync({
+      id: 29,
+      type: 'apply_model_config',
+      cmd: JSON.stringify(deliveredModel),
+    });
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ tool: 'claude', status: 'running' });
+
+    expect(acks[0]?.status).toBe('success');
+    expect((await fse.lstat(link)).isSymbolicLink()).toBe(true);
+    expect((await fse.readJson(target)).env.ANTHROPIC_CUSTOM_MODEL_OPTION).toBe('deepseek-v3-0324');
+  });
+
+  it('preserves the whole Claude gateway when one managed field was user-edited', async () => {
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    stubSync({
+      id: 30,
+      type: 'apply_model_config',
+      cmd: JSON.stringify(deliveredModel),
+    });
+    await reportAndSyncLocalAgent({ tool: 'claude', status: 'running' });
+
+    const settingsPath = path.join(home, '.claude', 'settings.json');
+    const edited = await fse.readJson(settingsPath);
+    edited.env.ANTHROPIC_BASE_URL = 'https://user.example.com';
+    await fse.writeJson(settingsPath, edited);
+    stubSync({
+      id: 31,
+      type: 'apply_model_config',
+      cmd: JSON.stringify({ models: [] }),
+    });
+
+    await reportAndSyncLocalAgent({ tool: 'claude', status: 'running' });
+
+    expect((await fse.readJson(settingsPath)).env).toEqual(edited.env);
+  });
 });
 
 describe('local-agent: report local model inventory', () => {
@@ -344,6 +452,59 @@ describe('local-agent: report local model inventory', () => {
     });
 
     expect(await reportedModels('codebuddy')).toBeUndefined();
+  });
+
+  it('still reports a delivered CodeBuddy model after CodeBuddy adds metadata', async () => {
+    stubSync({ id: 32, type: 'apply_model_config', cmd: JSON.stringify(deliveredModel) });
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ tool: 'codebuddy', status: 'running' });
+
+    const configPath = path.join(home, '.codebuddy', 'models.json');
+    const config = await fse.readJson(configPath);
+    config.models[0].supportsImages = false;
+    await fse.writeJson(configPath, config);
+
+    expect(await reportedModels('codebuddy')).toEqual([
+      {
+        provider: 'tokenhub',
+        model_id: 'deepseek-v3-0324',
+        name: 'DeepSeek V3 0324',
+        source: 'enterprise',
+      },
+    ]);
+  });
+
+  it('keeps CodeBuddy report ownership after Claude receives a different full snapshot', async () => {
+    stubSync({
+      id: 33,
+      type: 'apply_model_config',
+      cmd: JSON.stringify({ models: [deliveredModel] }),
+    });
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ tool: 'codebuddy', status: 'running' });
+
+    stubSync({
+      id: 34,
+      type: 'apply_model_config',
+      cmd: JSON.stringify({
+        models: [{
+          ...deliveredModel,
+          provider: 'openai',
+          model_id: 'gpt-4o',
+          name: 'GPT-4o',
+        }],
+      }),
+    });
+    await reportAndSyncLocalAgent({ tool: 'claude', status: 'running' });
+
+    expect(await reportedModels('codebuddy')).toEqual([
+      {
+        provider: 'tokenhub',
+        model_id: 'deepseek-v3-0324',
+        name: 'DeepSeek V3 0324',
+        source: 'enterprise',
+      },
+    ]);
   });
 
   it('reports the Claude gateway model with the delivered provider restored', async () => {

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -71,6 +71,7 @@ const execFileAsync = promisify(execFile);
 const LOCAL_AGENT_DIR = 'local-agent';
 const CONFIG_FILE = 'config.json';
 const MANIFEST_FILE = 'manifest.json';
+const MODEL_MANIFEST_FILE = 'model-manifest.json';
 const REPORTER_ERROR_LOG = 'reporter/errors.jsonl';
 
 /**
@@ -225,6 +226,27 @@ interface LocalAgentCommand {
   };
 }
 
+interface DeliveredModel {
+  provider: string;
+  model_id: string;
+  name: string;
+  base_url: string;
+  api_key: string;
+  max_tokens?: number;
+  context_window?: number;
+}
+
+interface ModelConfigManifest {
+  codebuddy?: Record<string, string>;
+  claudeEnv?: Record<string, string>;
+  /**
+   * model_id → provider for every model this reporter has applied. Claude
+   * stores its gateway as plain ANTHROPIC_* env vars that carry no provider,
+   * so this is the only way to report back the provider the server sent.
+   */
+  providers?: Record<string, string>;
+}
+
 /**
  * Whether a sync command is recognized-but-unimplemented and must be skipped
  * before dispatch. Matches both the known unimplemented type strings and any
@@ -259,6 +281,10 @@ function getConfigPath(): string {
 
 function getManifestPath(): string {
   return path.join(getLocalAgentHome(), MANIFEST_FILE);
+}
+
+function getModelManifestPath(): string {
+  return path.join(getLocalAgentHome(), MODEL_MANIFEST_FILE);
 }
 
 function getErrorLogPath(): string {
@@ -1212,6 +1238,71 @@ async function scanMcpFromManifest(
   return results.sort((a, b) => a.slug.localeCompare(b.slug));
 }
 
+interface ReportedModel {
+  provider: string;
+  model_id: string;
+  name?: string;
+  source: string;
+}
+
+/**
+ * Scan the models a tool can currently use, as configured on disk. The server
+ * requires both `provider` and `model_id`, so entries that cannot supply them
+ * are dropped rather than reported as incomplete. `source` is derived from the
+ * model manifest, mirroring how skills/rules classify enterprise vs local.
+ *
+ * Only CodeBuddy and Claude keep a discoverable model config; every other tool
+ * reports nothing.
+ */
+async function scanModelsFromDisk(tool: string): Promise<ReportedModel[]> {
+  const manifest = (await readJson<ModelConfigManifest>(getModelManifestPath())) ?? {};
+  const providers = manifest.providers ?? {};
+
+  if (tool === 'codebuddy' || tool === 'codebuddy-internal') {
+    const doc = await readJson<{ models?: unknown }>(
+      path.join(getUserHome(), '.codebuddy', 'models.json'),
+    );
+    const entries = Array.isArray(doc?.models) ? doc.models : [];
+    const owned = manifest.codebuddy ?? {};
+    const results: ReportedModel[] = [];
+    for (const entry of entries) {
+      if (typeof entry !== 'object' || entry === null) continue;
+      const { id, vendor, name } = entry as Record<string, unknown>;
+      if (typeof id !== 'string' || !id) continue;
+      if (typeof vendor !== 'string' || !vendor) continue;
+      results.push({
+        provider: vendor,
+        model_id: id,
+        ...(typeof name === 'string' && name ? { name } : {}),
+        source: owned[id] !== undefined && entryHash(entry) === owned[id] ? 'enterprise' : 'local',
+      });
+    }
+    return results;
+  }
+
+  if (tool === 'claude' || tool === 'claude-internal') {
+    const settings = await readJson<{ env?: unknown }>(
+      path.join(getUserHome(), '.claude', 'settings.json'),
+    );
+    const env = settings?.env;
+    if (typeof env !== 'object' || env === null || Array.isArray(env)) return [];
+    const { ANTHROPIC_CUSTOM_MODEL_OPTION: modelId, ANTHROPIC_CUSTOM_MODEL_OPTION_NAME: name } =
+      env as Record<string, unknown>;
+    if (typeof modelId !== 'string' || !modelId) return [];
+    const managed = manifest.claudeEnv?.ANTHROPIC_CUSTOM_MODEL_OPTION;
+    return [{
+      // A gateway configured by the user carries no provider; it speaks the
+      // Anthropic protocol, so report it as such.
+      provider: providers[modelId] ?? 'anthropic',
+      model_id: modelId,
+      ...(typeof name === 'string' && name ? { name } : {}),
+      source: managed !== undefined && entryHash(modelId) === managed ? 'enterprise' : 'local',
+    }];
+  }
+
+  return [];
+}
+
 /**
  * Remove workspace bindings whose directory no longer exists on disk.
  *
@@ -1323,6 +1414,10 @@ export async function buildReportPayload(
   if (userScope.rules.length > 0) userLevel.rules = userScope.rules;
   const userMcps = await scanMcpFromManifest('user');
   if (userMcps.length > 0) userLevel.mcps = userMcps;
+  // Omitted when empty for the same full-sync reason as skills/rules: the
+  // server treats a present array as a snapshot, so [] would wipe the models.
+  const userModels = await scanModelsFromDisk(tool);
+  if (userModels.length > 0) userLevel.models = userModels;
 
   const payload: Record<string, unknown> = {
     agent_type: normalizeAgentType(tool),
@@ -1887,6 +1982,251 @@ async function ackCommand(
   });
 }
 
+function requireModelString(
+  value: unknown,
+  field: keyof Pick<DeliveredModel, 'provider' | 'model_id' | 'name' | 'base_url' | 'api_key'>,
+): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error(`apply_model_config: ${field} must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function optionalPositiveInteger(value: unknown, field: 'max_tokens' | 'context_window'): number | undefined {
+  if (value === undefined || value === null) return undefined;
+  const normalized = typeof value === 'string' && /^\d+$/.test(value)
+    ? Number(value)
+    : value;
+  if (!Number.isSafeInteger(normalized) || (normalized as number) <= 0) {
+    throw new Error(`apply_model_config: ${field} must be a positive integer`);
+  }
+  return normalized as number;
+}
+
+function parseDeliveredModels(raw: string | undefined): { models: DeliveredModel[]; fullSnapshot: boolean } {
+  if (!raw) throw new Error('apply_model_config: missing cmd');
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error('apply_model_config: cmd must be valid JSON');
+  }
+  const fullSnapshot = (
+    typeof parsed === 'object' &&
+    parsed !== null &&
+    'models' in parsed
+  );
+  const values = fullSnapshot ? (parsed as { models?: unknown }).models : [parsed];
+  if (!Array.isArray(values)) {
+    throw new Error('apply_model_config: models must be an array');
+  }
+
+  const seen = new Set<string>();
+  const models = values.map((value) => {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+      throw new Error('apply_model_config: each model must be an object');
+    }
+    const input = value as Record<string, unknown>;
+    const model: DeliveredModel = {
+      provider: requireModelString(input.provider, 'provider'),
+      model_id: requireModelString(input.model_id, 'model_id'),
+      name: requireModelString(input.name, 'name'),
+      base_url: requireModelString(input.base_url, 'base_url'),
+      api_key: requireModelString(input.api_key, 'api_key'),
+      max_tokens: optionalPositiveInteger(input.max_tokens, 'max_tokens'),
+      context_window: optionalPositiveInteger(input.context_window, 'context_window'),
+    };
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(model.base_url);
+    } catch {
+      throw new Error('apply_model_config: base_url must be a valid URL');
+    }
+    if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+      throw new Error('apply_model_config: base_url must use http or https');
+    }
+    if (seen.has(model.model_id)) {
+      throw new Error(`apply_model_config: duplicate model_id "${model.model_id}"`);
+    }
+    seen.add(model.model_id);
+    return model;
+  });
+  return { models, fullSnapshot };
+}
+
+function codebuddyModelEntry(model: DeliveredModel): Record<string, unknown> {
+  const baseUrl = model.base_url.replace(/\/+$/, '');
+  return {
+    id: model.model_id,
+    name: model.name,
+    vendor: model.provider,
+    apiKey: model.api_key,
+    ...(model.context_window === undefined ? {} : { maxInputTokens: model.context_window }),
+    ...(model.max_tokens === undefined ? {} : { maxOutputTokens: model.max_tokens }),
+    url: baseUrl.endsWith('/chat/completions') ? baseUrl : `${baseUrl}/chat/completions`,
+    supportsToolCall: true,
+  };
+}
+
+async function readJsonObject(filePath: string): Promise<Record<string, unknown>> {
+  const source = await readFileSafe(filePath);
+  if (source === null) return {};
+  try {
+    const parsed = JSON.parse(source);
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      throw new Error('root must be an object');
+    }
+    return parsed as Record<string, unknown>;
+  } catch (error) {
+    throw new Error(`apply_model_config: cannot parse ${filePath}: ${(error as Error).message}`);
+  }
+}
+
+async function reconcileCodebuddyModels(
+  models: DeliveredModel[],
+  fullSnapshot: boolean,
+  manifest: ModelConfigManifest,
+): Promise<void> {
+  const targetFile = path.join(getUserHome(), '.codebuddy', 'models.json');
+  const doc = await readJsonObject(targetFile);
+  const existing = doc.models === undefined ? [] : doc.models;
+  if (!Array.isArray(existing)) {
+    throw new Error(`apply_model_config: models must be an array in ${targetFile}`);
+  }
+
+  const previouslyManaged = manifest.codebuddy ?? {};
+  const nextManaged: Record<string, string> = fullSnapshot ? {} : { ...previouslyManaged };
+  const incomingIds = new Set(models.map((model) => model.model_id));
+  const removedManaged = new Set<string>();
+  const preserved: unknown[] = [];
+  const occupiedIds = new Set<string>();
+  for (const entry of existing) {
+    const id = typeof entry === 'object' && entry !== null && typeof (entry as { id?: unknown }).id === 'string'
+      ? (entry as { id: string }).id
+      : undefined;
+    if (id && previouslyManaged[id] && entryHash(entry) === previouslyManaged[id]) {
+      if (fullSnapshot || incomingIds.has(id)) {
+        removedManaged.add(id);
+        continue;
+      }
+      preserved.push(entry);
+      occupiedIds.add(id);
+      continue;
+    }
+    preserved.push(entry);
+    if (id) occupiedIds.add(id);
+    if (id && previouslyManaged[id]) delete nextManaged[id];
+  }
+
+  for (const model of models) {
+    if (occupiedIds.has(model.model_id)) continue;
+    const entry = codebuddyModelEntry(model);
+    preserved.push(entry);
+    nextManaged[model.model_id] = entryHash(entry);
+  }
+  doc.models = preserved;
+
+  if (Array.isArray(doc.availableModels) && doc.availableModels.length > 0) {
+    const available = doc.availableModels.filter(
+      (id): id is string => typeof id === 'string' && !removedManaged.has(id),
+    );
+    for (const id of Object.keys(nextManaged)) {
+      if (!available.includes(id)) available.push(id);
+    }
+    doc.availableModels = available;
+  }
+
+  await writeJsonAtomic(targetFile, doc);
+  await fs.promises.chmod(targetFile, 0o600);
+  manifest.codebuddy = nextManaged;
+}
+
+function claudeEnvForModel(model: DeliveredModel): Record<string, string> {
+  const baseUrl = model.base_url.replace(/\/+$/, '').replace(/\/v1$/, '');
+  return {
+    ANTHROPIC_BASE_URL: baseUrl,
+    ANTHROPIC_AUTH_TOKEN: model.api_key,
+    ANTHROPIC_CUSTOM_MODEL_OPTION: model.model_id,
+    ANTHROPIC_CUSTOM_MODEL_OPTION_NAME: model.name,
+  };
+}
+
+async function reconcileClaudeModels(
+  models: DeliveredModel[],
+  manifest: ModelConfigManifest,
+): Promise<void> {
+  const settingsPath = path.join(getUserHome(), '.claude', 'settings.json');
+  const profilePath = path.join(getUserHome(), '.claude', 'teamai-models.json');
+  const previousHashes = manifest.claudeEnv ?? {};
+  const settings = await readJsonObject(settingsPath);
+  const rawEnv = settings.env === undefined ? {} : settings.env;
+  if (typeof rawEnv !== 'object' || rawEnv === null || Array.isArray(rawEnv)) {
+    throw new Error(`apply_model_config: env must be an object in ${settingsPath}`);
+  }
+  const env = { ...(rawEnv as Record<string, unknown>) };
+
+  if (models.length === 0) {
+    for (const [key, hash] of Object.entries(previousHashes)) {
+      if (entryHash(env[key]) === hash) delete env[key];
+    }
+    settings.env = env;
+    if (Object.keys(previousHashes).length > 0) {
+      await writeJsonAtomic(settingsPath, settings);
+      await fs.promises.chmod(settingsPath, 0o600);
+    }
+    await remove(profilePath);
+    manifest.claudeEnv = {};
+    return;
+  }
+
+  // Claude supports one active custom gateway in settings. The first model
+  // seeds that gateway; other candidates remain discoverable from its
+  // /v1/models endpoint when the gateway implements model discovery.
+  const desired = claudeEnvForModel(models[0]);
+  await writeJsonAtomic(profilePath, { env: desired });
+  await fs.promises.chmod(profilePath, 0o600);
+
+  const conflictKeys = new Set([
+    ...Object.keys(desired),
+    'ANTHROPIC_API_KEY',
+  ]);
+  const canManage = [...conflictKeys].every((key) => (
+    env[key] === undefined ||
+    (previousHashes[key] !== undefined && entryHash(env[key]) === previousHashes[key])
+  ));
+  if (!canManage) {
+    manifest.claudeEnv = {};
+    return;
+  }
+
+  for (const [key, hash] of Object.entries(previousHashes)) {
+    if (entryHash(env[key]) === hash) delete env[key];
+  }
+  Object.assign(env, desired);
+  settings.env = env;
+  await writeJsonAtomic(settingsPath, settings);
+  await fs.promises.chmod(settingsPath, 0o600);
+  manifest.claudeEnv = Object.fromEntries(
+    Object.entries(desired).map(([key, value]) => [key, entryHash(value)]),
+  );
+}
+
+async function applyModelConfig(command: LocalAgentCommand): Promise<void> {
+  const { models, fullSnapshot } = parseDeliveredModels(command.cmd);
+  const manifest = (await readJson<ModelConfigManifest>(getModelManifestPath())) ?? {};
+  manifest.providers = {
+    ...(fullSnapshot ? {} : manifest.providers),
+    ...Object.fromEntries(models.map((model) => [model.model_id, model.provider])),
+  };
+  await reconcileCodebuddyModels(models, fullSnapshot, manifest);
+  // Persist CodeBuddy ownership before touching Claude. If Claude settings are
+  // malformed and the task is retried, the already-written CodeBuddy entries
+  // must still be recognized as managed rather than mistaken for user config.
+  await writeJsonAtomic(getModelManifestPath(), manifest);
+  await reconcileClaudeModels(models, manifest);
+  await writeJsonAtomic(getModelManifestPath(), manifest);
+}
+
 /**
  * Tokenize a restricted `teamai` command string into an argv array.
  *
@@ -2327,6 +2667,10 @@ async function executeCommand(
   command: LocalAgentCommand,
   context: LocalAgentContext,
 ): Promise<string | undefined> {
+  if (command.type === 'apply_model_config') {
+    await applyModelConfig(command);
+    return;
+  }
   // uninstall_teamai (clawpro three-phase: cmd = "teamai uninstall --force
   // --agent <tool>") executes its `cmd` string as a restricted teamai subcommand.
   if (command.type === 'uninstall_teamai') {
@@ -2369,7 +2713,18 @@ async function processCommands(
 ): Promise<void> {
   const tag = localAgentTag(context);
   for (const command of commands) {
-    if (isUnimplementedCommand(command)) {
+    // Keep these special types aligned with executeCommand's direct branches.
+    // Resource commands are recognized generically by commandKind/action;
+    // everything else is a future protocol extension and must be skipped.
+    if (isUnimplementedCommand(command) || (
+      command.type !== 'apply_model_config' &&
+      command.type !== 'uninstall_teamai' &&
+      command.type !== 'install_hook_rule' &&
+      command.type !== 'uninstall_hook_rule' &&
+      command.type !== 'install_mcp' &&
+      command.type !== 'uninstall_mcp' &&
+      (!commandKind(command) || !commandAction(command))
+    )) {
       log.debug(`${tag} skipping unimplemented command ${command.id} (${command.type})`);
       continue;
     }
@@ -2473,6 +2828,7 @@ export async function reportAndSyncLocalAgent(context: LocalAgentContext): Promi
       tag,
       'sync',
       { method: 'POST', body: JSON.stringify(syncPayload) },
+      { redactResponseLog: true },
     );
     // Prefer the unified cmds[] (source of truth). Fall back to the legacy
     // commands[] for older backends that do not yet emit cmds. An empty cmds[]

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -1252,7 +1252,8 @@ interface ReportedModel {
  * model manifest, mirroring how skills/rules classify enterprise vs local.
  *
  * Only CodeBuddy and Claude keep a discoverable model config; every other tool
- * reports nothing.
+ * reports nothing. User-owned models are omitted: the backend cannot resolve
+ * them, so only entries still matching a TeamAI delivery are reported.
  */
 async function scanModelsFromDisk(tool: string): Promise<ReportedModel[]> {
   const manifest = (await readJson<ModelConfigManifest>(getModelManifestPath())) ?? {};
@@ -1270,11 +1271,12 @@ async function scanModelsFromDisk(tool: string): Promise<ReportedModel[]> {
       const { id, vendor, name } = entry as Record<string, unknown>;
       if (typeof id !== 'string' || !id) continue;
       if (typeof vendor !== 'string' || !vendor) continue;
+      if (owned[id] === undefined || entryHash(entry) !== owned[id]) continue;
       results.push({
         provider: vendor,
         model_id: id,
         ...(typeof name === 'string' && name ? { name } : {}),
-        source: owned[id] !== undefined && entryHash(entry) === owned[id] ? 'enterprise' : 'local',
+        source: 'enterprise',
       });
     }
     return results;
@@ -1290,13 +1292,14 @@ async function scanModelsFromDisk(tool: string): Promise<ReportedModel[]> {
       env as Record<string, unknown>;
     if (typeof modelId !== 'string' || !modelId) return [];
     const managed = manifest.claudeEnv?.ANTHROPIC_CUSTOM_MODEL_OPTION;
+    if (managed === undefined || entryHash(modelId) !== managed) return [];
+    const provider = providers[modelId];
+    if (!provider) return [];
     return [{
-      // A gateway configured by the user carries no provider; it speaks the
-      // Anthropic protocol, so report it as such.
-      provider: providers[modelId] ?? 'anthropic',
+      provider,
       model_id: modelId,
       ...(typeof name === 'string' && name ? { name } : {}),
-      source: managed !== undefined && entryHash(modelId) === managed ? 'enterprise' : 'local',
+      source: 'enterprise',
     }];
   }
 

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -1992,14 +1992,19 @@ function requireModelString(
   return value.trim();
 }
 
+/** CodeBuddy maxOutputTokens when the backend omits max_tokens or sends 0 (Go zero value). */
+const DEFAULT_MAX_TOKENS = 4096;
+
 function optionalPositiveInteger(value: unknown, field: 'max_tokens' | 'context_window'): number | undefined {
-  if (value === undefined || value === null) return undefined;
+  if (value === undefined || value === null || value === '') return undefined;
   const normalized = typeof value === 'string' && /^\d+$/.test(value)
     ? Number(value)
     : value;
-  if (!Number.isSafeInteger(normalized) || (normalized as number) <= 0) {
+  if (!Number.isSafeInteger(normalized) || (normalized as number) < 0) {
     throw new Error(`apply_model_config: ${field} must be a positive integer`);
   }
+  // 0 is the Go zero value for an unset int, not a real output/context cap.
+  if ((normalized as number) === 0) return undefined;
   return normalized as number;
 }
 
@@ -2033,7 +2038,7 @@ function parseDeliveredModels(raw: string | undefined): { models: DeliveredModel
       name: requireModelString(input.name, 'name'),
       base_url: requireModelString(input.base_url, 'base_url'),
       api_key: requireModelString(input.api_key, 'api_key'),
-      max_tokens: optionalPositiveInteger(input.max_tokens, 'max_tokens'),
+      max_tokens: optionalPositiveInteger(input.max_tokens, 'max_tokens') ?? DEFAULT_MAX_TOKENS,
       context_window: optionalPositiveInteger(input.context_window, 'context_window'),
     };
     let parsedUrl: URL;

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -245,6 +245,14 @@ interface ModelConfigManifest {
    * so this is the only way to report back the provider the server sent.
    */
   providers?: Record<string, string>;
+  providersByAgent?: Record<string, Record<string, string>>;
+}
+
+function modelAgentKind(tool: string | undefined): 'codebuddy' | 'claude' | undefined {
+  const normalized = normalizeAgentType(tool ?? '');
+  if (normalized === 'codebuddy' || normalized === 'codebuddy-internal') return 'codebuddy';
+  if (normalized === 'claude') return 'claude';
+  return undefined;
 }
 
 /**
@@ -1257,9 +1265,10 @@ interface ReportedModel {
  */
 async function scanModelsFromDisk(tool: string): Promise<ReportedModel[]> {
   const manifest = (await readJson<ModelConfigManifest>(getModelManifestPath())) ?? {};
-  const providers = manifest.providers ?? {};
+  const agentKind = modelAgentKind(tool);
+  const providers = (agentKind && manifest.providersByAgent?.[agentKind]) ?? manifest.providers ?? {};
 
-  if (tool === 'codebuddy' || tool === 'codebuddy-internal') {
+  if (agentKind === 'codebuddy') {
     const doc = await readJson<{ models?: unknown }>(
       path.join(getUserHome(), '.codebuddy', 'models.json'),
     );
@@ -1271,7 +1280,10 @@ async function scanModelsFromDisk(tool: string): Promise<ReportedModel[]> {
       const { id, vendor, name } = entry as Record<string, unknown>;
       if (typeof id !== 'string' || !id) continue;
       if (typeof vendor !== 'string' || !vendor) continue;
-      if (owned[id] === undefined || entryHash(entry) !== owned[id]) continue;
+      // CodeBuddy may normalize a model entry by adding capability metadata.
+      // The manifest's model id is the durable proof that TeamAI delivered it;
+      // requiring an exact object hash would incorrectly hide such entries.
+      if (owned[id] === undefined || providers[id] !== vendor) continue;
       results.push({
         provider: vendor,
         model_id: id,
@@ -1282,7 +1294,7 @@ async function scanModelsFromDisk(tool: string): Promise<ReportedModel[]> {
     return results;
   }
 
-  if (tool === 'claude' || tool === 'claude-internal') {
+  if (agentKind === 'claude') {
     const settings = await readJson<{ env?: unknown }>(
       path.join(getUserHome(), '.claude', 'settings.json'),
     );
@@ -2090,6 +2102,21 @@ async function readJsonObject(filePath: string): Promise<Record<string, unknown>
   }
 }
 
+/** Atomically update a model dotfile without replacing a user-managed symlink. */
+async function writeModelJson(filePath: string, data: unknown): Promise<void> {
+  let targetPath = filePath;
+  try {
+    if ((await fs.promises.lstat(filePath)).isSymbolicLink()) {
+      targetPath = await fs.promises.realpath(filePath);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+  // Set the temp file's mode before the atomic rename. A post-rename chmod
+  // would introduce a symlink-following TOCTOU window.
+  await writeJsonAtomic(targetPath, data, { mode: 0o600 });
+}
+
 async function reconcileCodebuddyModels(
   models: DeliveredModel[],
   fullSnapshot: boolean,
@@ -2144,8 +2171,7 @@ async function reconcileCodebuddyModels(
     doc.availableModels = available;
   }
 
-  await writeJsonAtomic(targetFile, doc);
-  await fs.promises.chmod(targetFile, 0o600);
+  await writeModelJson(targetFile, doc);
   manifest.codebuddy = nextManaged;
 }
 
@@ -2174,13 +2200,13 @@ async function reconcileClaudeModels(
   const env = { ...(rawEnv as Record<string, unknown>) };
 
   if (models.length === 0) {
-    for (const [key, hash] of Object.entries(previousHashes)) {
-      if (entryHash(env[key]) === hash) delete env[key];
-    }
-    settings.env = env;
-    if (Object.keys(previousHashes).length > 0) {
-      await writeJsonAtomic(settingsPath, settings);
-      await fs.promises.chmod(settingsPath, 0o600);
+    const canRemoveGateway = Object.entries(previousHashes).every(
+      ([key, hash]) => entryHash(env[key]) === hash,
+    );
+    if (canRemoveGateway && Object.keys(previousHashes).length > 0) {
+      for (const key of Object.keys(previousHashes)) delete env[key];
+      settings.env = env;
+      await writeModelJson(settingsPath, settings);
     }
     await remove(profilePath);
     manifest.claudeEnv = {};
@@ -2191,8 +2217,7 @@ async function reconcileClaudeModels(
   // seeds that gateway; other candidates remain discoverable from its
   // /v1/models endpoint when the gateway implements model discovery.
   const desired = claudeEnvForModel(models[0]);
-  await writeJsonAtomic(profilePath, { env: desired });
-  await fs.promises.chmod(profilePath, 0o600);
+  await writeModelJson(profilePath, { env: desired });
 
   const conflictKeys = new Set([
     ...Object.keys(desired),
@@ -2212,26 +2237,33 @@ async function reconcileClaudeModels(
   }
   Object.assign(env, desired);
   settings.env = env;
-  await writeJsonAtomic(settingsPath, settings);
-  await fs.promises.chmod(settingsPath, 0o600);
+  await writeModelJson(settingsPath, settings);
   manifest.claudeEnv = Object.fromEntries(
     Object.entries(desired).map(([key, value]) => [key, entryHash(value)]),
   );
 }
 
-async function applyModelConfig(command: LocalAgentCommand): Promise<void> {
+async function applyModelConfig(command: LocalAgentCommand, tool: string | undefined): Promise<void> {
   const { models, fullSnapshot } = parseDeliveredModels(command.cmd);
   const manifest = (await readJson<ModelConfigManifest>(getModelManifestPath())) ?? {};
-  manifest.providers = {
-    ...(fullSnapshot ? {} : manifest.providers),
+  const agentKind = modelAgentKind(tool);
+  if (!agentKind) {
+    throw new Error(`apply_model_config: unsupported agent "${tool ?? ''}"`);
+  }
+  const previousProviders = manifest.providersByAgent?.[agentKind] ?? manifest.providers ?? {};
+  const providers = {
+    ...(fullSnapshot ? {} : previousProviders),
     ...Object.fromEntries(models.map((model) => [model.model_id, model.provider])),
   };
-  await reconcileCodebuddyModels(models, fullSnapshot, manifest);
-  // Persist CodeBuddy ownership before touching Claude. If Claude settings are
-  // malformed and the task is retried, the already-written CodeBuddy entries
-  // must still be recognized as managed rather than mistaken for user config.
-  await writeJsonAtomic(getModelManifestPath(), manifest);
-  await reconcileClaudeModels(models, manifest);
+  manifest.providersByAgent = {
+    ...manifest.providersByAgent,
+    [agentKind]: providers,
+  };
+  if (agentKind === 'codebuddy') {
+    await reconcileCodebuddyModels(models, fullSnapshot, manifest);
+  } else {
+    await reconcileClaudeModels(models, manifest);
+  }
   await writeJsonAtomic(getModelManifestPath(), manifest);
 }
 
@@ -2676,7 +2708,7 @@ async function executeCommand(
   context: LocalAgentContext,
 ): Promise<string | undefined> {
   if (command.type === 'apply_model_config') {
-    await applyModelConfig(command);
+    await applyModelConfig(command, context.tool);
     return;
   }
   // uninstall_teamai (clawpro three-phase: cmd = "teamai uninstall --force
@@ -2718,8 +2750,9 @@ async function processCommands(
   config: LocalAgentConfig,
   commands: LocalAgentCommand[],
   context: LocalAgentContext,
-): Promise<void> {
+): Promise<boolean> {
   const tag = localAgentTag(context);
+  let modelConfigApplied = false;
   for (const command of commands) {
     // Keep these special types aligned with executeCommand's direct branches.
     // Resource commands are recognized generically by commandKind/action;
@@ -2739,11 +2772,12 @@ async function processCommands(
     try {
       const version = await executeCommand(config, command, context);
       await ackCommand(config, tag, command, 'success', version);
+      if (command.type === 'apply_model_config') modelConfigApplied = true;
       log.debug(`${tag} command ${command.id} (${command.type ?? ''}) succeeded`);
       // Uninstall succeeded — skip remaining commands; the hook process exits naturally.
       if (command.type === 'uninstall_teamai') {
         log.debug(`${tag} uninstall_teamai completed — remaining commands skipped`);
-        return;
+        return modelConfigApplied;
       }
     } catch (e) {
       const error = (e as Error).message;
@@ -2755,6 +2789,7 @@ async function processCommands(
       }
     }
   }
+  return modelConfigApplied;
 }
 
 export async function reportAndSyncLocalAgent(context: LocalAgentContext): Promise<boolean> {
@@ -2849,7 +2884,15 @@ export async function reportAndSyncLocalAgent(context: LocalAgentContext): Promi
     const commands = cmds && cmds.length > 0 ? cmds : (syncResponse.commands ?? []);
     if (commands.length > 0) {
       log.debug(`${tag} sync returned ${commands.length} command(s): ${commands.map((c) => `${c.type}#${c.id}`).join(', ')}`);
-      await processCommands(config, commands, context);
+      const modelConfigApplied = await processCommands(config, commands, context);
+      if (modelConfigApplied && !skipReport) {
+        const reportPayload = await buildReportPayload(config, context);
+        await localAgentFetch(config, tag, 'report', {
+          method: 'POST',
+          body: JSON.stringify(reportPayload),
+        });
+        log.debug(`${tag} model config report OK`);
+      }
     }
     log.debug(`${tag} sync OK (${commands.length} command(s))`);
   } catch (e) {

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -86,16 +86,23 @@ export async function writeJson(filePath: string, data: unknown): Promise<void> 
  *
  * @param filePath - Destination path (may use ~).
  * @param data - JSON-serializable value.
+ * @param options.mode - Force permission bits instead of preserving the target.
  */
-export async function writeJsonAtomic(filePath: string, data: unknown): Promise<void> {
+export async function writeJsonAtomic(
+  filePath: string,
+  data: unknown,
+  options?: { mode?: number },
+): Promise<void> {
   const expanded = expandHome(filePath);
   await fse.ensureDir(path.dirname(expanded));
   const content = JSON.stringify(data, null, 2) + '\n';
-  let mode = 0o600;
-  try {
-    mode = (await fse.stat(expanded)).mode & 0o777;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  let mode = options?.mode ?? 0o600;
+  if (options?.mode === undefined) {
+    try {
+      mode = (await fse.stat(expanded)).mode & 0o777;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
   }
   const tmp = `${expanded}.${process.pid}.${crypto.randomBytes(6).toString('hex')}.tmp`;
   try {


### PR DESCRIPTION
## Summary
- Consume `apply_model_config` tasks from `/api/local-agent/sync`, persist the candidate set only into the reporting CodeBuddy or Claude agent, and ack with `type: "apply_model_config"`. Unsupported agents fail the task; user-owned models and symlinked config files are preserved; credential files are `0600`; sync responses are redacted.
- Immediately report a successfully applied model in the same sync run on `POST /api/local-agent/report` as `user_level.models`. Only models recorded in TeamAI's per-agent manifest are reported; user-owned models and `api_key` are never sent. CodeBuddy-added capability metadata no longer suppresses a delivered model.
- Keep provider ownership isolated between CodeBuddy and Claude full snapshots, and preserve the whole Claude gateway when any managed field was user-edited.
- Closes #294. TAPD: `--story=1020422209136345350`.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run` (183 files, 2580 tests; 21 focused model-config cases)
- [x] `npm run build`
- [x] Built-CLI E2E with a stub backend: `report → sync(apply_model_config) → ack(success) → immediate report`; Kimi is reported as `enterprise`, remains reportable after CodeBuddy adds metadata, and ProxyToken is absent from report/ack traffic
- [x] Built-CLI E2E against the ClawPro test endpoint: `user_level.models=[{provider:"tencentcodingplan",model_id:"kimi-k2.5",source:"enterprise"}]` accepted with HTTP 200 for `local_agent_id=0123456789abcdef`
- [x] Symlink regression tests for CodeBuddy models and Claude settings; unsupported-agent failure; atomic Claude gateway removal; cross-agent full-snapshot ownership isolation
- [x] Code and security re-review: no remaining findings