### PR TITLE
fix: auto-discover KNOWN_AGENTS for resource injection during pull

### DIFF
--- a/src/__tests__/builtin-agents.test.ts
+++ b/src/__tests__/builtin-agents.test.ts
@@ -143,6 +143,9 @@ describe('deployBuiltinAgents', () => {
   });
 
   it('skips targets without a native agent renderer and warns how to proceed', async () => {
+    // Remove known tool roots so auto-discovery doesn't deploy to them
+    await fse.remove(path.join(homeDir, '.claude'));
+    await fse.remove(path.join(homeDir, '.codebuddy'));
     await fse.ensureDir(path.join(homeDir, '.unknown-tool', 'agents'));
     const teamConfig = buildTeamConfig({
       'unknown-tool': { agents: '.unknown-tool/agents' },
@@ -174,8 +177,9 @@ describe('deployBuiltinAgents', () => {
   });
 
   it('silently skips when the built-in agents directory does not exist', async () => {
-    // Point HOME at a fresh dir; even if the package agents/ dir exists in
-    // workspace, no tool roots are present, so deployment count is 0.
+    // Remove known tool roots so auto-discovery produces no targets either.
+    await fse.remove(path.join(homeDir, '.claude'));
+    await fse.remove(path.join(homeDir, '.codebuddy'));
     const teamConfig = buildTeamConfig({});
     const deployed = await deployBuiltinAgents(teamConfig, localConfig);
     expect(deployed).toBe(0);

--- a/src/__tests__/builtin-rules.test.ts
+++ b/src/__tests__/builtin-rules.test.ts
@@ -129,6 +129,33 @@ describe('builtin-rules', () => {
             const deployed = await deployBuiltinRules(teamConfig);
             expect(deployed).toBe(1);
         });
+
+        it('does not overwrite a personal teamai-recall in an auto-discovered tool dir', async () => {
+            // cursor auto-discovered (not in toolPaths); a personal teamai-recall.mdc pre-exists.
+            const cursorRulesDir = path.join(tmpDir, '.cursor', 'rules');
+            fs.mkdirSync(cursorRulesDir, { recursive: true });
+            fs.writeFileSync(path.join(cursorRulesDir, 'teamai-recall.mdc'), 'PERSONAL RECALL CONTENT');
+            fs.mkdirSync(path.join(tmpDir, '.claude', 'rules'), { recursive: true });
+
+            const teamConfig = {
+                team: 'test', description: '', repo: 'https://git.woa.com/test/repo.git',
+                provider: 'tgit', reviewers: [],
+                sharing: { skills: {}, rules: { enforced: [] }, docs: { localDir: '' }, env: { injectShellProfile: true } },
+                toolPaths: { claude: { rules: '.claude/rules' } },
+            } as any;
+            const localConfig = {
+                repo: { localPath: path.join(tmpDir, 'repo'), remote: 'r' },
+                username: 'u', additionalRoles: [], scope: 'user',
+            } as any;
+
+            const { deployBuiltinRules } = await import('../builtin-rules.js');
+            await deployBuiltinRules(teamConfig, localConfig);
+
+            // Personal cursor rule preserved; claude (team-managed) still got the built-in.
+            expect(fs.readFileSync(path.join(cursorRulesDir, 'teamai-recall.mdc'), 'utf-8'))
+                .toBe('PERSONAL RECALL CONTENT');
+            expect(fs.existsSync(path.join(tmpDir, '.claude', 'rules', 'teamai-recall.md'))).toBe(true);
+        });
     });
 
     describe('BUILTIN_RULE_NAMES', () => {

--- a/src/__tests__/effective-tool-paths.test.ts
+++ b/src/__tests__/effective-tool-paths.test.ts
@@ -120,4 +120,25 @@ describe('effectiveToolPaths', () => {
     // Only claude was in teamConfig.toolPaths
     expect(Object.keys(result)).toEqual(['claude']);
   });
+
+  it('auto-discovers opencode in user scope via ~/.config/opencode', async () => {
+    await fse.ensureDir(path.join(homeDir, '.config', 'opencode'));
+    const teamConfig = buildTeamConfig({});
+    const result = await effectiveToolPaths(teamConfig, localConfig);
+
+    expect(result['opencode']).toBeDefined();
+    // User-scope paths should have userScope override applied
+    expect(result['opencode'].skills).toBe('.config/opencode/skills');
+    expect(result['opencode'].rules).toBe('.config/opencode/rules');
+  });
+
+  it('does not discover opencode via ~/.opencode in user scope when only ~/.config/opencode exists', async () => {
+    // Only ~/.config/opencode exists (no ~/.opencode)
+    await fse.ensureDir(path.join(homeDir, '.config', 'opencode'));
+    const teamConfig = buildTeamConfig({});
+    const result = await effectiveToolPaths(teamConfig, localConfig);
+
+    // Should still be discovered via the userScope path
+    expect(result['opencode']).toBeDefined();
+  });
 });

--- a/src/__tests__/effective-tool-paths.test.ts
+++ b/src/__tests__/effective-tool-paths.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import os from 'node:os';
+import fse from 'fs-extra';
+
+vi.mock('../utils/logger.js', () => ({
+  log: { info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), dim: vi.fn() },
+}));
+
+import { effectiveToolPaths, DEFAULT_TOOL_PATHS, scopedToolPaths } from '../types.js';
+import type { TeamaiConfig, LocalConfig } from '../types.js';
+
+function buildTeamConfig(toolPaths: TeamaiConfig['toolPaths']): TeamaiConfig {
+  return {
+    team: 'test',
+    description: '',
+    repo: 'https://example.com/test/repo.git',
+    provider: 'tgit' as const,
+    reviewers: [],
+    sharing: {
+      skills: {},
+      rules: { enforced: [] },
+      docs: { localDir: '' },
+      env: { injectShellProfile: true },
+    },
+    toolPaths,
+  } as TeamaiConfig;
+}
+
+describe('effectiveToolPaths', () => {
+  let tmpDir: string;
+  let homeDir: string;
+  let localConfig: LocalConfig;
+
+  beforeEach(async () => {
+    tmpDir = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-effective-tp-'));
+    homeDir = path.join(tmpDir, 'home');
+    await fse.ensureDir(homeDir);
+    vi.stubEnv('HOME', homeDir);
+
+    localConfig = {
+      repo: { localPath: path.join(tmpDir, 'team-repo'), remote: 'r' },
+      username: 'testuser',
+      additionalRoles: [],
+      scope: 'user',
+    };
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await fse.remove(tmpDir);
+  });
+
+  it('auto-discovers installed .tclaude with verified paths from DEFAULT_TOOL_PATHS', async () => {
+    await fse.ensureDir(path.join(homeDir, '.tclaude'));
+    const teamConfig = buildTeamConfig({ claude: DEFAULT_TOOL_PATHS['claude'] });
+    const result = await effectiveToolPaths(teamConfig, localConfig);
+
+    expect(result['tclaude']).toBeDefined();
+    expect(result['tclaude'].skills).toBe('.tclaude/skills');
+    expect(result['tclaude'].rules).toBe('.tclaude/rules');
+    expect(result['tclaude'].claudemd).toBe('.tclaude/CLAUDE.md');
+    expect(result['tclaude'].agents).toBe('.tclaude/agents');
+  });
+
+  it('auto-discovers installed .gemini with skills-only (no DEFAULT_TOOL_PATHS entry)', async () => {
+    await fse.ensureDir(path.join(homeDir, '.gemini'));
+    const teamConfig = buildTeamConfig({ claude: DEFAULT_TOOL_PATHS['claude'] });
+    const result = await effectiveToolPaths(teamConfig, localConfig);
+
+    expect(result['gemini']).toBeDefined();
+    expect(result['gemini'].skills).toBe('.gemini/skills');
+    // No verified rules/agents/claudemd for gemini — should be absent
+    expect(result['gemini'].rules).toBeUndefined();
+    expect(result['gemini'].agents).toBeUndefined();
+    expect(result['gemini'].claudemd).toBeUndefined();
+  });
+
+  it('does not override explicitly configured toolPaths with auto-discovery', async () => {
+    await fse.ensureDir(path.join(homeDir, '.claude'));
+    const customPaths = { skills: '.claude/custom-skills', rules: '.claude/custom-rules' };
+    const teamConfig = buildTeamConfig({ claude: customPaths });
+    const result = await effectiveToolPaths(teamConfig, localConfig);
+
+    // Team-configured paths take precedence
+    expect(result['claude'].skills).toBe('.claude/custom-skills');
+    expect(result['claude'].rules).toBe('.claude/custom-rules');
+  });
+
+  it('skips agents that are not installed', async () => {
+    // No .tclaude directory exists
+    const teamConfig = buildTeamConfig({ claude: DEFAULT_TOOL_PATHS['claude'] });
+    const result = await effectiveToolPaths(teamConfig, localConfig);
+
+    expect(result['tclaude']).toBeUndefined();
+  });
+
+  it('respects disabledAgents', async () => {
+    await fse.ensureDir(path.join(homeDir, '.tclaude'));
+    const teamConfig = buildTeamConfig({ claude: DEFAULT_TOOL_PATHS['claude'] });
+    const configWithDisabled = { ...localConfig, disabledAgents: ['tclaude'] };
+    const result = await effectiveToolPaths(teamConfig, configWithDisabled);
+
+    expect(result['tclaude']).toBeUndefined();
+  });
+
+  it('preserves codebuddy CODEBUDDY.md (not CLAUDE.md) from registry', async () => {
+    await fse.ensureDir(path.join(homeDir, '.codebuddy'));
+    const teamConfig = buildTeamConfig({});
+    const result = await effectiveToolPaths(teamConfig, localConfig);
+
+    expect(result['codebuddy']).toBeDefined();
+    expect(result['codebuddy'].claudemd).toBe('.codebuddy/CODEBUDDY.md');
+  });
+
+  it('scopedToolPaths is unaffected — returns only teamConfig.toolPaths', () => {
+    const teamConfig = buildTeamConfig({ claude: DEFAULT_TOOL_PATHS['claude'] });
+    const result = scopedToolPaths(teamConfig, localConfig);
+
+    // Only claude was in teamConfig.toolPaths
+    expect(Object.keys(result)).toEqual(['claude']);
+  });
+});

--- a/src/__tests__/pull-tombstone.test.ts
+++ b/src/__tests__/pull-tombstone.test.ts
@@ -457,6 +457,22 @@ describe('pull role-aware sync and cleanup', () => {
       .toBe('PERSONAL RULE CONTENT');
   });
 
+  it('does not delete a personal .md when writing .mdc in an auto-discovered cursor dir (P1 cursor)', async () => {
+    // cursor is a .mdc tool, auto-discovered (not in toolPaths). A personal
+    // safety.md exists with NO safety.mdc — the old-layout .md cleanup must not
+    // delete it just because the .mdc write target was free.
+    await fse.ensureDir(path.join(homeDir, '.cursor', 'rules'));
+    await fse.writeFile(path.join(homeDir, '.cursor', 'rules', 'safety.md'), 'PERSONAL RULE CONTENT');
+    await fse.writeFile(path.join(repoPath, 'rules', 'safety.md'), 'TEAM RULE CONTENT');
+
+    await pull({ force: true });
+
+    // The personal .md in the auto-discovered cursor dir is preserved.
+    expect(await fse.pathExists(path.join(homeDir, '.cursor/rules', 'safety.md'))).toBe(true);
+    expect(await fse.readFile(path.join(homeDir, '.cursor/rules', 'safety.md'), 'utf-8'))
+      .toBe('PERSONAL RULE CONTENT');
+  });
+
   it('cleans up stale skills after role change (full pull cycle)', async () => {
     // Setup: create skills in all namespaces
     await fse.ensureDir(path.join(repoPath, 'skills', 'common', 'shared-skill'));

--- a/src/__tests__/pull-tombstone.test.ts
+++ b/src/__tests__/pull-tombstone.test.ts
@@ -510,6 +510,32 @@ describe('pull role-aware sync and cleanup', () => {
       .toBe('PERSONAL GHOST');
   });
 
+  it('withdrawing a cursor rule does NOT delete a personal same-name .md beside the teamai .mdc (P1 ext-scoped)', async () => {
+    // cursor auto-discovered; personal safety.md (no .mdc) pre-exists.
+    await fse.ensureDir(path.join(homeDir, '.cursor', 'rules'));
+    await fse.writeFile(path.join(homeDir, '.cursor', 'rules', 'safety.md'), 'PERSONAL RULE CONTENT');
+    await fse.writeFile(path.join(repoPath, 'rules', 'safety.md'), 'TEAM RULE CONTENT');
+
+    // First pull: teamai writes safety.mdc into cursor and records ownership of
+    // safety.mdc (NOT safety.md). Personal safety.md is left intact.
+    await pull({ force: true });
+    expect(await fse.pathExists(path.join(homeDir, '.cursor/rules', 'safety.mdc'))).toBe(true);
+    expect(await fse.readFile(path.join(homeDir, '.cursor/rules', 'safety.md'), 'utf-8'))
+      .toBe('PERSONAL RULE CONTENT');
+
+    // Team recalls the rule.
+    await fse.remove(path.join(repoPath, 'rules', 'safety.md'));
+    await fse.writeFile(path.join(repoPath, 'rules', '.removed'), 'safety\n');
+
+    // Second pull: the teamai-deployed safety.mdc is withdrawn, but the personal
+    // safety.md must survive — its filename was never in the ownership record.
+    await pull({ force: true });
+    expect(await fse.pathExists(path.join(homeDir, '.cursor/rules', 'safety.mdc'))).toBe(false);
+    expect(await fse.pathExists(path.join(homeDir, '.cursor/rules', 'safety.md'))).toBe(true);
+    expect(await fse.readFile(path.join(homeDir, '.cursor/rules', 'safety.md'), 'utf-8'))
+      .toBe('PERSONAL RULE CONTENT');
+  });
+
   it('cleans up stale skills after role change (full pull cycle)', async () => {
     // Setup: create skills in all namespaces
     await fse.ensureDir(path.join(repoPath, 'skills', 'common', 'shared-skill'));

--- a/src/__tests__/pull-tombstone.test.ts
+++ b/src/__tests__/pull-tombstone.test.ts
@@ -352,6 +352,73 @@ describe('pull role-aware sync and cleanup', () => {
     )).rejects.toThrow(/Duplicate skill "shared-skill"/);
   });
 
+  it('does not delete a personal skill in an auto-discovered dir during role cleanup (P1-1)', async () => {
+    // team config only manages claude; gemini is installed but NOT in toolPaths
+    await fse.ensureDir(path.join(homeDir, '.gemini', 'skills', 'pm-skill'));
+    await fse.writeFile(
+      path.join(homeDir, '.gemini', 'skills', 'pm-skill', 'SKILL.md'),
+      'PERSONAL PM NEVER SYNCED',
+    );
+
+    const teamConfig: TeamaiConfig = {
+      team: 'test',
+      description: '',
+      repo: 'https://git.woa.com/test/repo.git',
+      provider: 'tgit',
+      reviewers: [],
+      sharing: {
+        skills: {},
+        rules: { enforced: [] },
+        docs: { localDir: '' },
+        env: { injectShellProfile: true },
+      },
+      // Only claude is team-managed; gemini is installed but NOT listed here.
+      toolPaths: {
+        claude: { skills: '.claude/skills', rules: '.claude/rules' },
+      },
+    };
+    const localConfig: LocalConfig = {
+      repo: { localPath: repoPath, remote: 'https://git.woa.com/test/repo.git' },
+      username: 'testuser',
+      updatePolicy: 'auto',
+      primaryRole: 'hai',
+      additionalRoles: [],
+      resourceProfileVersion: 1,
+      scope: 'user',
+    };
+
+    await cleanupInactiveNamespaceSkills(
+      teamConfig,
+      localConfig,
+      new Set(['shared-skill', 'hai-skill']),
+      new Set(['pm-skill']),
+    );
+
+    // The personal skill in the auto-discovered (non-team-managed) dir survives.
+    expect(await fse.pathExists(path.join(homeDir, '.gemini/skills', 'pm-skill', 'SKILL.md'))).toBe(true);
+    expect(await fse.readFile(path.join(homeDir, '.gemini/skills', 'pm-skill', 'SKILL.md'), 'utf-8'))
+      .toBe('PERSONAL PM NEVER SYNCED');
+  });
+
+  it('does not overwrite a personal same-named skill in an auto-discovered dir on pull (P1-2)', async () => {
+    // team ships skills/hai/hai-skill; user has a personal ~/.gemini/skills/hai-skill
+    await fse.ensureDir(path.join(repoPath, 'skills', 'hai', 'hai-skill'));
+    await fse.writeFile(path.join(repoPath, 'skills', 'hai', 'hai-skill', 'SKILL.md'), 'TEAM CONTENT');
+    await fse.ensureDir(path.join(homeDir, '.gemini', 'skills', 'hai-skill'));
+    await fse.writeFile(
+      path.join(homeDir, '.gemini', 'skills', 'hai-skill', 'SKILL.md'),
+      'PERSONAL UNIQUE CONTENT',
+    );
+
+    await pull({});
+
+    // claude (team-managed) receives the team skill…
+    expect(await fse.pathExists(path.join(homeDir, '.claude/skills', 'hai-skill', 'SKILL.md'))).toBe(true);
+    // …but the personal skill in the auto-discovered gemini dir is NOT clobbered.
+    expect(await fse.readFile(path.join(homeDir, '.gemini/skills', 'hai-skill', 'SKILL.md'), 'utf-8'))
+      .toBe('PERSONAL UNIQUE CONTENT');
+  });
+
   it('cleans up stale skills after role change (full pull cycle)', async () => {
     // Setup: create skills in all namespaces
     await fse.ensureDir(path.join(repoPath, 'skills', 'common', 'shared-skill'));

--- a/src/__tests__/pull-tombstone.test.ts
+++ b/src/__tests__/pull-tombstone.test.ts
@@ -473,6 +473,43 @@ describe('pull role-aware sync and cleanup', () => {
       .toBe('PERSONAL RULE CONTENT');
   });
 
+  it('withdraws a teamai-deployed skill from an auto-discovered dir on tombstone (P2 withdrawal)', async () => {
+    await fse.ensureDir(path.join(homeDir, '.gemini', 'skills'));
+    await fse.ensureDir(path.join(repoPath, 'skills', 'hai', 'withdrawn'));
+    await fse.writeFile(
+      path.join(repoPath, 'skills', 'hai', 'withdrawn', 'SKILL.md'),
+      '---\nname: withdrawn\ndescription: to be recalled\n---\nDANGEROUS INSTRUCTION\n',
+    );
+
+    // First pull: teamai deploys `withdrawn` into the auto-discovered gemini dir
+    // and records ownership.
+    await pull({ force: true });
+    expect(await fse.pathExists(path.join(homeDir, '.gemini/skills', 'withdrawn', 'SKILL.md'))).toBe(true);
+
+    // Team recalls it: remove from repo and tombstone it.
+    await fse.remove(path.join(repoPath, 'skills', 'hai', 'withdrawn'));
+    await fse.writeFile(path.join(repoPath, 'skills', '.removed'), 'withdrawn\n');
+
+    // Second pull: the recalled skill must be withdrawn from the auto-discovered
+    // gemini dir too (it was teamai-deployed / tracked), not just from claude.
+    await pull({ force: true });
+    expect(await fse.pathExists(path.join(homeDir, '.gemini/skills', 'withdrawn'))).toBe(false);
+    expect(await fse.pathExists(path.join(homeDir, '.claude/skills', 'withdrawn'))).toBe(false);
+  });
+
+  it('does NOT delete a personal same-named skill from an auto-discovered dir on tombstone (P2 personal-safe)', async () => {
+    // A personal skill teamai never deployed (no ownership record) that shares a
+    // name with a tombstoned team skill must survive.
+    await fse.ensureDir(path.join(homeDir, '.gemini', 'skills', 'ghost'));
+    await fse.writeFile(path.join(homeDir, '.gemini', 'skills', 'ghost', 'SKILL.md'), 'PERSONAL GHOST');
+    await fse.writeFile(path.join(repoPath, 'skills', '.removed'), 'ghost\n');
+
+    await pull({ force: true });
+
+    expect(await fse.readFile(path.join(homeDir, '.gemini/skills', 'ghost', 'SKILL.md'), 'utf-8'))
+      .toBe('PERSONAL GHOST');
+  });
+
   it('cleans up stale skills after role change (full pull cycle)', async () => {
     // Setup: create skills in all namespaces
     await fse.ensureDir(path.join(repoPath, 'skills', 'common', 'shared-skill'));

--- a/src/__tests__/pull-tombstone.test.ts
+++ b/src/__tests__/pull-tombstone.test.ts
@@ -419,6 +419,44 @@ describe('pull role-aware sync and cleanup', () => {
       .toBe('PERSONAL UNIQUE CONTENT');
   });
 
+  it('still delivers team skill updates to an auto-discovered dir teamai deployed to (P2)', async () => {
+    // gemini installed (dir exists) but has NO pre-existing hai-skill.
+    await fse.ensureDir(path.join(homeDir, '.gemini', 'skills'));
+    await fse.ensureDir(path.join(repoPath, 'skills', 'hai', 'hai-skill'));
+    const v1 = '---\nname: hai-skill\ndescription: does a thing\n---\nTEAM CONTENT\n';
+    await fse.writeFile(path.join(repoPath, 'skills', 'hai', 'hai-skill', 'SKILL.md'), v1);
+
+    // First pull: teamai deploys the skill into the auto-discovered gemini dir
+    // and records ownership in state.
+    await pull({ force: true });
+    expect(await fse.readFile(path.join(homeDir, '.gemini/skills', 'hai-skill', 'SKILL.md'), 'utf-8'))
+      .toBe(v1);
+
+    // Team updates the skill body.
+    const v2 = '---\nname: hai-skill\ndescription: does a thing\n---\nTEAM VERSION TWO\n';
+    await fse.writeFile(path.join(repoPath, 'skills', 'hai', 'hai-skill', 'SKILL.md'), v2);
+
+    // Second pull: because teamai owns this deployment (tracked), the update
+    // reaches gemini — it is NOT mistaken for a personal skill.
+    await pull({ force: true });
+    expect(await fse.readFile(path.join(homeDir, '.gemini/skills', 'hai-skill', 'SKILL.md'), 'utf-8'))
+      .toBe(v2);
+  });
+
+  it('does not overwrite a personal same-named rule in an auto-discovered dir on pull (P1 rules)', async () => {
+    await fse.ensureDir(path.join(homeDir, '.gemini', 'rules'));
+    await fse.writeFile(path.join(homeDir, '.gemini', 'rules', 'safety.md'), 'PERSONAL RULE CONTENT');
+    await fse.writeFile(path.join(repoPath, 'rules', 'safety.md'), 'TEAM RULE CONTENT');
+
+    await pull({ force: true });
+
+    // claude (team-managed) receives the team rule…
+    expect(await fse.pathExists(path.join(homeDir, '.claude/rules', 'safety.md'))).toBe(true);
+    // …but the personal rule in the auto-discovered gemini dir is NOT clobbered.
+    expect(await fse.readFile(path.join(homeDir, '.gemini/rules', 'safety.md'), 'utf-8'))
+      .toBe('PERSONAL RULE CONTENT');
+  });
+
   it('cleans up stale skills after role change (full pull cycle)', async () => {
     // Setup: create skills in all namespaces
     await fse.ensureDir(path.join(repoPath, 'skills', 'common', 'shared-skill'));

--- a/src/__tests__/self-mode-agents.test.ts
+++ b/src/__tests__/self-mode-agents.test.ts
@@ -69,8 +69,8 @@ describe('detectHomeInstalledAgents', () => {
     expect(await detectHomeInstalledAgents(['cursor'])).toEqual(['cursor']);
   });
 
-  it('SELF_MODE_AGENT_CHOICES includes JoyCode among the common coding agents', () => {
-    expect([...SELF_MODE_AGENT_CHOICES]).toEqual(['claude', 'codex', 'cursor', 'joycode', 'codebuddy', 'workbuddy']);
+  it('SELF_MODE_AGENT_CHOICES is the common coding agents including tclaude/tcodex/joycode', () => {
+    expect([...SELF_MODE_AGENT_CHOICES]).toEqual(['claude', 'tclaude', 'codex', 'tcodex', 'cursor', 'joycode', 'codebuddy', 'workbuddy']);
   });
 });
 
@@ -157,24 +157,27 @@ describe('resolveSelfModeSelection (interactive picker: option 1 = Auto)', () =>
   });
 
   it('a specific tool maps by (index - 1) into the choices list', () => {
-    // index 2 → SELF_MODE_AGENT_CHOICES[1] = codex
-    expect(resolveSelfModeSelection([2], detected)).toEqual(['codex']);
-    // index 4 → SELF_MODE_AGENT_CHOICES[3] = joycode
-    expect(resolveSelfModeSelection([4], detected)).toEqual(['joycode']);
+    // choices: [0]claude [1]tclaude [2]codex [3]tcodex [4]cursor [5]joycode [6]codebuddy [7]workbuddy
+    // index 3 → SELF_MODE_AGENT_CHOICES[2] = codex
+    expect(resolveSelfModeSelection([3], detected)).toEqual(['codex']);
+    // index 6 → SELF_MODE_AGENT_CHOICES[5] = joycode
+    expect(resolveSelfModeSelection([6], detected)).toEqual(['joycode']);
   });
 
   it('multiple specific tools preserve choice order', () => {
-    // indices 5 (codebuddy) + 2 (codex) → order follows the input
-    expect(resolveSelfModeSelection([5, 2], detected)).toEqual(['codebuddy', 'codex']);
+    // indices 7 (codebuddy) + 3 (codex) → order follows the input
+    expect(resolveSelfModeSelection([7, 3], detected)).toEqual(['codebuddy', 'codex']);
   });
 
   it('Auto + a specific tool merges detected first, then extras, deduped', () => {
-    // Auto → [claude, codex]; index 3 → cursor. codex already present, not dup.
-    expect(resolveSelfModeSelection([0, 3, 2], detected)).toEqual(['claude', 'codex', 'cursor']);
+    // Auto → [claude, codex]; index 5 → cursor. codex already present, not dup.
+    expect(resolveSelfModeSelection([0, 5, 3], detected)).toEqual(['claude', 'codex', 'cursor']);
   });
 
   it('"all" (every index incl. Auto) yields the full choice set once', () => {
-    const allIndices = [0, 1, 2, 3, 4, 5, 6]; // Auto + 6 tools
-    expect(resolveSelfModeSelection(allIndices, detected)).toEqual([...SELF_MODE_AGENT_CHOICES]);
+    const allIndices = [0, 1, 2, 3, 4, 5, 6, 7, 8]; // Auto + 8 tools
+    const result = resolveSelfModeSelection(allIndices, detected);
+    expect(new Set(result)).toEqual(new Set(SELF_MODE_AGENT_CHOICES));
+    expect(result.length).toBe(SELF_MODE_AGENT_CHOICES.length);
   });
 });

--- a/src/__tests__/self-mode-prompt.test.ts
+++ b/src/__tests__/self-mode-prompt.test.ts
@@ -61,18 +61,18 @@ describe('promptForSelfModeAgents — interactive Auto option', () => {
     expect(result).toEqual(['claude', 'codex']);
   });
 
-  it('picking a specific tool (index 3 = Cursor) returns just that tool', async () => {
-    vi.mocked(askSelection).mockResolvedValueOnce([3]); // 1=Auto,2=claude,3=codex... wait: index maps -1
+  it('picking a specific tool (index 5 = Cursor) returns just that tool', async () => {
+    vi.mocked(askSelection).mockResolvedValueOnce([5]);
     const result = await promptForSelfModeAgents({});
-    // resolveSelfModeSelection: index 3 → SELF_MODE_AGENT_CHOICES[2] = cursor
+    // resolveSelfModeSelection: index 5 → SELF_MODE_AGENT_CHOICES[4] = cursor
     expect(result).toEqual(['cursor']);
   });
 
-  it('offers exactly 7 options (Auto + 6 tools)', async () => {
+  it('offers exactly 9 options (Auto + 8 tools)', async () => {
     vi.mocked(askSelection).mockResolvedValueOnce([0]);
     await promptForSelfModeAgents({});
     const [, itemCount] = vi.mocked(askSelection).mock.calls[0];
-    expect(itemCount).toBe(7);
+    expect(itemCount).toBe(9);
   });
 
   it('renders "none detected" when HOME has no known tools, and Auto → claude', async () => {

--- a/src/__tests__/skip-uninstalled-tools.test.ts
+++ b/src/__tests__/skip-uninstalled-tools.test.ts
@@ -7,6 +7,10 @@ vi.mock('../config.js', () => ({
   requireInit: vi.fn(),
   loadState: vi.fn(),
   saveState: vi.fn(),
+  // Ownership record lookup for auto-discovered built-in skill deployment.
+  // Empty record → a pre-existing personal skill is untracked → preserved.
+  loadStateForScope: vi.fn().mockResolvedValue({ autoDiscoveredManaged: [] }),
+  saveStateForScope: vi.fn(),
 }));
 
 vi.mock('../utils/git.js', () => ({
@@ -489,6 +493,50 @@ describe('deployBuiltinSkills — skip uninstalled tools', () => {
     expect(await fse.pathExists(path.join(skillDir, 'SKILL.md'))).toBe(true);
     expect(await fse.pathExists(path.join(skillDir, 'references/methodology/phase0-collection.md'))).toBe(true);
     expect(await fse.pathExists(path.join(skillDir, 'scripts/scan_repo.py'))).toBe(true);
+  });
+
+  it('does not overwrite a personal built-in-named skill in an auto-discovered dir', async () => {
+    const { deployBuiltinSkills } = await import('../builtin-skills.js');
+
+    // gemini installed (auto-discovered) but NOT in toolPaths; a personal skill
+    // occupies a built-in name with unique content.
+    await fse.ensureDir(path.join(homeDir, '.gemini', 'skills', 'team-wiki-codebase'));
+    await fse.writeFile(
+      path.join(homeDir, '.gemini', 'skills', 'team-wiki-codebase', 'SKILL.md'),
+      'PERSONAL WIKI CONTENT',
+    );
+
+    const teamConfig = {
+      team: 'test',
+      description: '',
+      repo: 'https://git.woa.com/test/repo.git',
+      provider: 'tgit' as const,
+      reviewers: [],
+      sharing: {
+        skills: {},
+        rules: { enforced: [] },
+        docs: { localDir: '' },
+        env: { injectShellProfile: true },
+      },
+      toolPaths: {
+        claude: { skills: '.claude/skills' },
+      },
+    };
+    const localConfig = {
+      repo: { localPath: path.join(tmpDir, 'repo'), remote: 'https://git.woa.com/test/repo.git' },
+      username: 'testuser',
+      updatePolicy: 'auto' as const,
+      additionalRoles: [],
+      scope: 'user' as const,
+    };
+
+    await deployBuiltinSkills(teamConfig, localConfig);
+
+    // Personal skill in the auto-discovered gemini dir is preserved…
+    expect(await fse.readFile(path.join(homeDir, '.gemini/skills/team-wiki-codebase/SKILL.md'), 'utf-8'))
+      .toBe('PERSONAL WIKI CONTENT');
+    // …while claude (team-managed) still receives the real built-in skill.
+    expect(await fse.pathExists(path.join(homeDir, '.claude/skills/team-wiki-codebase/SKILL.md'))).toBe(true);
   });
 
   it('deploys built-in skills to OpenCode user scope under .config/opencode/skills', async () => {

--- a/src/builtin-agents.ts
+++ b/src/builtin-agents.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { ensureDir, pathExists, readFileSafe, writeFile, remove, listFiles } from './utils/fs.js';
 import { log } from './utils/logger.js';
 import type { TeamaiConfig, LocalConfig } from './types.js';
-import { resolveBaseDir, isAgentDisabled, scopedToolPaths } from './types.js';
+import { resolveBaseDir, isAgentDisabled, scopedToolPaths, effectiveToolPaths } from './types.js';
 import { ResourceHandler } from './resources/base.js';
 import { getUserHome } from './utils/home.js';
 import { ALL_SUPPORTED_TOOLS, renderForTool, reverseFromClaude } from './resources/agent-format.js';
@@ -117,7 +117,7 @@ export async function deployBuiltinAgents(
   const baseDir = localConfig ? resolveBaseDir(localConfig) : getUserHome();
   let deployed = 0;
 
-  for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig ?? {}))) {
+  for (const [tool, toolPath] of Object.entries(localConfig ? await effectiveToolPaths(teamConfig, localConfig) : scopedToolPaths(teamConfig, localConfig ?? {}))) {
     if (!toolPath.agents) {
       log.debug(`Skipping built-in agent deployment for ${tool}: no agents path`);
       continue;

--- a/src/builtin-agents.ts
+++ b/src/builtin-agents.ts
@@ -9,6 +9,8 @@ import { ResourceHandler } from './resources/base.js';
 import { getUserHome } from './utils/home.js';
 import { ALL_SUPPORTED_TOOLS, renderForTool, reverseFromClaude } from './resources/agent-format.js';
 import type { ToolName } from './resources/agent-format.js';
+import { loadStateForScope, saveStateForScope } from './config.js';
+import { ownershipKey, mayWriteAutoDiscovered, markAutoDiscovered } from './resources/auto-discovered-ownership.js';
 
 // ─── Built-in agents deployment ──────────────────────────
 //
@@ -117,6 +119,12 @@ export async function deployBuiltinAgents(
   const baseDir = localConfig ? resolveBaseDir(localConfig) : getUserHome();
   let deployed = 0;
 
+  // Built-in agents deploy into auto-discovered dirs too; protect personal
+  // same-named agents the same way built-in skills/rules do.
+  const scopedKeys = new Set(Object.keys(scopedToolPaths(teamConfig, localConfig ?? {})));
+  let state: Awaited<ReturnType<typeof loadStateForScope>> | null = null;
+  let stateDirty = false;
+
   for (const [tool, toolPath] of Object.entries(localConfig ? await effectiveToolPaths(teamConfig, localConfig) : scopedToolPaths(teamConfig, localConfig ?? {}))) {
     if (!toolPath.agents) {
       log.debug(`Skipping built-in agent deployment for ${tool}: no agents path`);
@@ -136,6 +144,7 @@ export async function deployBuiltinAgents(
     }
 
     const targetAgentsDir = path.join(baseDir, toolPath.agents);
+    const autoDiscovered = !!localConfig && !scopedKeys.has(tool);
     try {
       await ensureDir(targetAgentsDir);
     } catch (e) {
@@ -155,18 +164,39 @@ export async function deployBuiltinAgents(
         }
         const rendered = renderForTool(parsed.spec, tool as ToolName);
         const stem = path.basename(file, '.md');
-        // Clean up any same-stem sibling with a different extension before
-        // writing the (possibly new) native extension — e.g. an upgrade that
-        // switches a tool from .md to .toml must not leave the stale .md behind
-        // (it would be invalid TOML for Codex, or invalid frontmatter for Claude).
-        await removeStaleAgentSiblings(targetAgentsDir, stem, rendered.ext);
         const dest = path.join(targetAgentsDir, `${stem}${rendered.ext}`);
+
+        // Auto-discovered: only overwrite an agent teamai deployed itself, and
+        // never touch same-stem siblings there (they may be personal files).
+        const key = ownershipKey(tool, 'agents', `${stem}${rendered.ext}`);
+        if (autoDiscovered) {
+          if (state === null) state = await loadStateForScope(localConfig!);
+          if (!await mayWriteAutoDiscovered(dest, key, state)) {
+            log.warn(`Preserving personal agent ${stem} in ${tool} (${dest}): not deployed by teamai, not overwriting.`);
+            continue;
+          }
+        } else {
+          // Clean up any same-stem sibling with a different extension before
+          // writing the (possibly new) native extension — e.g. an upgrade that
+          // switches a tool from .md to .toml must not leave the stale .md behind
+          // (it would be invalid TOML for Codex, or invalid frontmatter for Claude).
+          await removeStaleAgentSiblings(targetAgentsDir, stem, rendered.ext);
+        }
+
         await writeFile(dest, rendered.content);
+        if (autoDiscovered && state !== null) {
+          markAutoDiscovered(key, state);
+          stateDirty = true;
+        }
         deployed++;
       } catch (e) {
         log.warn(`Failed to deploy built-in agent ${file} to ${tool}: ${(e as Error).message}`);
       }
     }
+  }
+
+  if (stateDirty && state !== null && localConfig) {
+    await saveStateForScope(state, localConfig);
   }
 
   return deployed;

--- a/src/builtin-rules.ts
+++ b/src/builtin-rules.ts
@@ -5,7 +5,7 @@ import { ResourceHandler } from './resources/base.js';
 import { ruleFileExtensionForTool, usesCursorMdcRules } from './resources/rule-format.js';
 import { teamRuleToCursorMdc } from './resources/cursor-mdc.js';
 import type { TeamaiConfig, LocalConfig } from './types.js';
-import { resolveBaseDir, isAgentDisabled, scopedToolPaths } from './types.js';
+import { resolveBaseDir, isAgentDisabled, scopedToolPaths, effectiveToolPaths } from './types.js';
 import fs from 'node:fs/promises';
 import { getUserHome } from './utils/home.js';
 
@@ -58,7 +58,7 @@ export async function deployBuiltinRules(
         { name: 'teamai-recall', content: TEAMAI_RECALL_RULE_CONTENT },
     ].filter(r => !(options?.skipRecall && r.name === 'teamai-recall'));
 
-    for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig ?? {}))) {
+    for (const [tool, toolPath] of Object.entries(localConfig ? await effectiveToolPaths(teamConfig, localConfig) : scopedToolPaths(teamConfig, localConfig ?? {}))) {
         if (!toolPath.rules) continue;
 
         // Skip tools that are not installed

--- a/src/builtin-rules.ts
+++ b/src/builtin-rules.ts
@@ -8,6 +8,8 @@ import type { TeamaiConfig, LocalConfig } from './types.js';
 import { resolveBaseDir, isAgentDisabled, scopedToolPaths, effectiveToolPaths } from './types.js';
 import fs from 'node:fs/promises';
 import { getUserHome } from './utils/home.js';
+import { loadStateForScope, saveStateForScope } from './config.js';
+import { ownershipKey, mayWriteAutoDiscovered, markAutoDiscovered } from './resources/auto-discovered-ownership.js';
 
 // ─── Built-in rules deployment ──────────────────────────
 //
@@ -58,6 +60,13 @@ export async function deployBuiltinRules(
         { name: 'teamai-recall', content: TEAMAI_RECALL_RULE_CONTENT },
     ].filter(r => !(options?.skipRecall && r.name === 'teamai-recall'));
 
+    // Built-in rules deploy into auto-discovered tool dirs too; apply the same
+    // ownership protection as built-in skills so a personal same-named rule
+    // (e.g. a hand-written teamai-recall.mdc) is never silently overwritten.
+    const scopedKeys = new Set(Object.keys(scopedToolPaths(teamConfig, localConfig ?? {})));
+    let state: Awaited<ReturnType<typeof loadStateForScope>> | null = null;
+    let stateDirty = false;
+
     for (const [tool, toolPath] of Object.entries(localConfig ? await effectiveToolPaths(teamConfig, localConfig) : scopedToolPaths(teamConfig, localConfig ?? {}))) {
         if (!toolPath.rules) continue;
 
@@ -71,6 +80,10 @@ export async function deployBuiltinRules(
         const rulesDir = path.join(baseDir, toolPath.rules);
         if (!await pathExists(rulesDir)) continue;
 
+        // In an auto-discovered dir, a same-named file may be personal. Ownership
+        // is only consultable with a localConfig (state is scope-bound).
+        const autoDiscovered = !!localConfig && !scopedKeys.has(tool);
+
         try {
             await ensureDir(rulesDir);
 
@@ -79,14 +92,30 @@ export async function deployBuiltinRules(
             const ext = ruleFileExtensionForTool(tool);
             for (const rule of builtinRules) {
                 const destFile = path.join(rulesDir, `${rule.name}${ext}`);
+
+                // Auto-discovered: only overwrite a rule teamai deployed itself.
+                const key = ownershipKey(tool, 'rules', `${rule.name}${ext}`);
+                if (autoDiscovered) {
+                    if (state === null) state = await loadStateForScope(localConfig!);
+                    if (!await mayWriteAutoDiscovered(destFile, key, state)) {
+                        log.warn(`Preserving personal rule ${rule.name} in ${tool} (${destFile}): not deployed by teamai, not overwriting.`);
+                        continue;
+                    }
+                }
+
                 const content = usesCursorMdcRules(tool)
                     ? teamRuleToCursorMdc(rule.content)
                     : rule.content;
                 await writeFile(destFile, content);
                 log.debug(`Deployed built-in rule ${rule.name} → ${tool}`);
+                if (autoDiscovered && state !== null) {
+                    markAutoDiscovered(key, state);
+                    stateDirty = true;
+                }
 
                 // Drop the `.md` copy an older layout left in an `.mdc` rules dir.
-                if (ext !== '.md') {
+                // Never in an auto-discovered dir — that `.md` may be personal.
+                if (ext !== '.md' && !autoDiscovered) {
                     try {
                         await fs.unlink(path.join(rulesDir, `${rule.name}.md`));
                         log.debug(`Removed legacy .md built-in rule ${rule.name} from ${tool}`);
@@ -96,15 +125,18 @@ export async function deployBuiltinRules(
                 }
             }
 
-            // Clean up legacy rules no longer deployed (both extensions)
-            for (const legacyName of LEGACY_RULE_NAMES) {
-                for (const legacyExt of new Set<string>([ext, '.md'])) {
-                    const legacyFile = path.join(rulesDir, `${legacyName}${legacyExt}`);
-                    try {
-                        await fs.unlink(legacyFile);
-                        log.debug(`Removed legacy built-in rule ${legacyName} from ${tool}`);
-                    } catch {
-                        // File doesn't exist — that's fine
+            // Clean up legacy rules no longer deployed (both extensions). Skip in
+            // auto-discovered dirs: a same-named file there may be personal.
+            if (!autoDiscovered) {
+                for (const legacyName of LEGACY_RULE_NAMES) {
+                    for (const legacyExt of new Set<string>([ext, '.md'])) {
+                        const legacyFile = path.join(rulesDir, `${legacyName}${legacyExt}`);
+                        try {
+                            await fs.unlink(legacyFile);
+                            log.debug(`Removed legacy built-in rule ${legacyName} from ${tool}`);
+                        } catch {
+                            // File doesn't exist — that's fine
+                        }
                     }
                 }
             }
@@ -113,6 +145,10 @@ export async function deployBuiltinRules(
         } catch (e) {
             log.error(`Failed to deploy built-in rules to ${tool}: ${(e as Error).message}`);
         }
+    }
+
+    if (stateDirty && state !== null && localConfig) {
+        await saveStateForScope(state, localConfig);
     }
 
     return deployed;

--- a/src/builtin-skills.ts
+++ b/src/builtin-skills.ts
@@ -5,7 +5,7 @@ import fse from 'fs-extra';
 import { pathExists } from './utils/fs.js';
 import { log } from './utils/logger.js';
 import type { TeamaiConfig, LocalConfig } from './types.js';
-import { resolveBaseDir, isAgentDisabled, scopedToolPaths } from './types.js';
+import { resolveBaseDir, isAgentDisabled, scopedToolPaths, effectiveToolPaths } from './types.js';
 import { ResourceHandler } from './resources/base.js';
 import { ensureSkillFrontmatter } from './resources/skills.js';
 import { getUserHome } from './utils/home.js';
@@ -107,7 +107,7 @@ export async function deployBuiltinSkills(teamConfig: TeamaiConfig, localConfig?
   const baseDir = localConfig ? resolveBaseDir(localConfig) : getUserHome();
   let deployed = 0;
 
-  for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig ?? {}))) {
+  for (const [tool, toolPath] of Object.entries(localConfig ? await effectiveToolPaths(teamConfig, localConfig) : scopedToolPaths(teamConfig, localConfig ?? {}))) {
     if (!toolPath.skills) continue;
 
     // Skip tools that are not installed

--- a/src/builtin-skills.ts
+++ b/src/builtin-skills.ts
@@ -9,6 +9,8 @@ import { resolveBaseDir, isAgentDisabled, scopedToolPaths, effectiveToolPaths } 
 import { ResourceHandler } from './resources/base.js';
 import { ensureSkillFrontmatter } from './resources/skills.js';
 import { getUserHome } from './utils/home.js';
+import { loadStateForScope, saveStateForScope } from './config.js';
+import { ownershipKey, mayWriteAutoDiscovered, markAutoDiscovered } from './resources/auto-discovered-ownership.js';
 
 // ─── Built-in skills deployment ──────────────────────────
 //
@@ -107,6 +109,15 @@ export async function deployBuiltinSkills(teamConfig: TeamaiConfig, localConfig?
   const baseDir = localConfig ? resolveBaseDir(localConfig) : getUserHome();
   let deployed = 0;
 
+  // Built-in skills deploy into auto-discovered tool dirs too, so they need the
+  // same personal-resource protection as team resources: in a non-team-managed
+  // tool dir, only overwrite a same-named skill teamai deployed itself (tracked
+  // in state.autoDiscoveredManaged). Ownership is only consultable with a
+  // localConfig (state is scope-bound); without one, keep the legacy behavior.
+  const scopedKeys = new Set(Object.keys(scopedToolPaths(teamConfig, localConfig ?? {})));
+  let state: Awaited<ReturnType<typeof loadStateForScope>> | null = null;
+  let stateDirty = false;
+
   for (const [tool, toolPath] of Object.entries(localConfig ? await effectiveToolPaths(teamConfig, localConfig) : scopedToolPaths(teamConfig, localConfig ?? {}))) {
     if (!toolPath.skills) continue;
 
@@ -118,10 +129,20 @@ export async function deployBuiltinSkills(teamConfig: TeamaiConfig, localConfig?
     if (localConfig && isAgentDisabled(localConfig, tool)) continue;
 
     const targetSkillsDir = path.join(baseDir, toolPath.skills);
+    const autoDiscovered = !!localConfig && !scopedKeys.has(tool);
 
     for (const skillName of skillNames) {
       const srcDir = path.join(builtinDir, skillName);
       const destDir = path.join(targetSkillsDir, skillName);
+
+      const key = ownershipKey(tool, 'skills', skillName);
+      if (autoDiscovered) {
+        if (state === null) state = await loadStateForScope(localConfig!);
+        if (!await mayWriteAutoDiscovered(destDir, key, state)) {
+          log.warn(`Preserving personal skill ${skillName} in ${tool} (${destDir}): not deployed by teamai, not overwriting.`);
+          continue;
+        }
+      }
 
       try {
         await copyBuiltinSkillDir(srcDir, destDir);
@@ -129,11 +150,19 @@ export async function deployBuiltinSkills(teamConfig: TeamaiConfig, localConfig?
         // Ensure SKILL.md has proper YAML frontmatter (name + description)
         await ensureSkillFrontmatter(destDir, skillName);
 
+        if (autoDiscovered && state !== null) {
+          markAutoDiscovered(key, state);
+          stateDirty = true;
+        }
         deployed++;
       } catch (e) {
         log.error(`Failed to deploy built-in skill ${skillName} to ${toolPath.skills}: ${(e as Error).message}`);
       }
     }
+  }
+
+  if (stateDirty && state !== null && localConfig) {
+    await saveStateForScope(state, localConfig);
   }
 
   return deployed;

--- a/src/known-agents.ts
+++ b/src/known-agents.ts
@@ -11,7 +11,7 @@ import { getUserHome } from './utils/home.js';
  * against the user's HOME in non-interactive contexts. Order is the display order.
  * Kept small on purpose — the common coding agents, not the full KNOWN_AGENTS list.
  */
-export const SELF_MODE_AGENT_CHOICES = ['claude', 'codex', 'cursor', 'joycode', 'codebuddy', 'workbuddy'] as const;
+export const SELF_MODE_AGENT_CHOICES = ['claude', 'tclaude', 'codex', 'tcodex', 'cursor', 'joycode', 'codebuddy', 'workbuddy'] as const;
 
 /**
  * Normalize the `--agent` option into a deduplicated id list.

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -606,7 +606,10 @@ async function pullForScope(
       const tombstones = await handler.readTombstones(localConfig);
       if (tombstones.size === 0) continue;
 
-      for (const [tool, toolPath] of Object.entries(await effectiveToolPaths(freshConfig, localConfig))) {
+      // Tombstone cleanup only touches team-managed tools (scopedToolPaths),
+      // not auto-discovered ones — a personal skill in ~/.gemini/skills/ that
+      // happens to share a name with a tombstoned team skill must not be deleted.
+      for (const [tool, toolPath] of Object.entries(scopedToolPaths(freshConfig, localConfig))) {
         const dir = toolPath[toolPathField];
         if (!dir) continue;
         if (!await ResourceHandler.isToolInstalled(dir, baseDir)) continue;
@@ -642,10 +645,11 @@ async function pullForScope(
   }
 
   // Step 3b: Clean up local skills not in the desired union set (role + tags)
+  // Only in team-managed tools — auto-discovered dirs may have personal skills.
   if (!options.dryRun && desiredSkillNames && knownRepoSkillNames) {
     const baseDir = resolveBaseDir(localConfig);
 
-    for (const [tool, toolPath] of Object.entries(await effectiveToolPaths(freshConfig, localConfig))) {
+    for (const [tool, toolPath] of Object.entries(scopedToolPaths(freshConfig, localConfig))) {
       if (isAgentDisabled(localConfig, tool)) continue;
       if (!toolPath.skills) continue;
       if (!await ResourceHandler.isToolInstalled(toolPath.skills, baseDir)) continue;

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -29,6 +29,7 @@ import {
   isAgentDisabled,
   scopedToolPaths,
   SYNC_LOCK_FILENAME,
+  effectiveToolPaths,
 } from './types.js';
 import type { CultureFrontmatter } from './types.js';
 import { loadRolesManifest, resolveRoleResourceNamespaces, type ResourceNamespaces } from './roles.js';
@@ -225,7 +226,7 @@ export async function cleanupInactiveNamespaceSkills(
 ): Promise<void> {
   const baseDir = resolveBaseDir(localConfig);
 
-  for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
+  for (const [tool, toolPath] of Object.entries(await effectiveToolPaths(teamConfig, localConfig))) {
     if (isAgentDisabled(localConfig, tool)) continue;
     if (!toolPath.skills) continue;
     if (!await ResourceHandler.isToolInstalled(toolPath.skills, baseDir)) continue;
@@ -259,7 +260,7 @@ async function getExistingLocalNames(
 
   if (type === 'skills') {
     // Check the first installed tool's skills directory
-    for (const [_tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
+    for (const [_tool, toolPath] of Object.entries(await effectiveToolPaths(teamConfig, localConfig))) {
       if (!toolPath.skills) continue;
       const skillsDir = path.join(baseDir, toolPath.skills);
       if (!await pathExists(skillsDir)) continue;
@@ -327,7 +328,7 @@ async function getInstalledResourceTargets(
   const baseDir = resolveBaseDir(localConfig);
   const targets: string[] = [];
 
-  for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
+  for (const [tool, toolPath] of Object.entries(await effectiveToolPaths(teamConfig, localConfig))) {
     if (isAgentDisabled(localConfig, tool)) continue;
 
     const resourcePaths = [toolPath.skills, toolPath.rules, toolPath.agents]
@@ -605,7 +606,7 @@ async function pullForScope(
       const tombstones = await handler.readTombstones(localConfig);
       if (tombstones.size === 0) continue;
 
-      for (const [tool, toolPath] of Object.entries(scopedToolPaths(freshConfig, localConfig))) {
+      for (const [tool, toolPath] of Object.entries(await effectiveToolPaths(freshConfig, localConfig))) {
         const dir = toolPath[toolPathField];
         if (!dir) continue;
         if (!await ResourceHandler.isToolInstalled(dir, baseDir)) continue;
@@ -644,7 +645,7 @@ async function pullForScope(
   if (!options.dryRun && desiredSkillNames && knownRepoSkillNames) {
     const baseDir = resolveBaseDir(localConfig);
 
-    for (const [tool, toolPath] of Object.entries(scopedToolPaths(freshConfig, localConfig))) {
+    for (const [tool, toolPath] of Object.entries(await effectiveToolPaths(freshConfig, localConfig))) {
       if (isAgentDisabled(localConfig, tool)) continue;
       if (!toolPath.skills) continue;
       if (!await ResourceHandler.isToolInstalled(toolPath.skills, baseDir)) continue;
@@ -776,7 +777,7 @@ async function pullForScope(
           const compiled = compileCulture(cultureContent);
           if (compiled) {
             const baseDir = resolveBaseDir(localConfig);
-            for (const [tool, toolPath] of Object.entries(scopedToolPaths(freshConfig, localConfig))) {
+            for (const [tool, toolPath] of Object.entries(await effectiveToolPaths(freshConfig, localConfig))) {
               if (isAgentDisabled(localConfig, tool)) continue;
               if (!toolPath.claudemd) continue;
               if (toolPath.rules && !await ResourceHandler.isToolInstalled(toolPath.rules, baseDir)) continue;
@@ -807,7 +808,7 @@ async function pullForScope(
         const compiled = compileClaudemd(claudemdContents);
         if (compiled) {
           const baseDir = resolveBaseDir(localConfig);
-          for (const [tool, toolPath] of Object.entries(scopedToolPaths(freshConfig, localConfig))) {
+          for (const [tool, toolPath] of Object.entries(await effectiveToolPaths(freshConfig, localConfig))) {
             if (isAgentDisabled(localConfig, tool)) continue;
             if (!toolPath.claudemd) continue;
             if (toolPath.rules && !await ResourceHandler.isToolInstalled(toolPath.rules, baseDir)) continue;
@@ -1055,7 +1056,7 @@ export async function injectRecallBlockIntoTools(
         const baseDir = resolveBaseDir(localConfig);
         const recallBlock = compileRecallRulesBlock();
         let injected = 0;
-        for (const [tool, toolPath] of Object.entries(scopedToolPaths(config, localConfig))) {
+        for (const [tool, toolPath] of Object.entries(await effectiveToolPaths(config, localConfig))) {
             if (isAgentDisabled(localConfig, tool)) continue;
             if (!toolPath.claudemd || !toolPath.agents) continue;
             if (!await ResourceHandler.isToolInstalled(toolPath.agents, baseDir)) continue;

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -226,7 +226,11 @@ export async function cleanupInactiveNamespaceSkills(
 ): Promise<void> {
   const baseDir = resolveBaseDir(localConfig);
 
-  for (const [tool, toolPath] of Object.entries(await effectiveToolPaths(teamConfig, localConfig))) {
+  // Role cleanup DELETES local skills, so it must only touch team-managed
+  // tools (scopedToolPaths), never auto-discovered dirs — a personal skill in
+  // e.g. ~/.gemini/skills that shares a name with an inactive-namespace team
+  // skill must not be deleted. Mirrors the tombstone/stale cleanup scoping.
+  for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
     if (isAgentDisabled(localConfig, tool)) continue;
     if (!toolPath.skills) continue;
     if (!await ResourceHandler.isToolInstalled(toolPath.skills, baseDir)) continue;

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -8,6 +8,7 @@ import { log, spinner } from './utils/logger.js';
 import { pathExists, remove, listFiles, listDirs, readFileSafe } from './utils/fs.js';
 import { injectClaudeMdSection } from './utils/claudemd.js';
 import { getHandler, RulesHandler, DocsHandler, EnvHandler } from './resources/index.js';
+import { ownershipKey, isAutoDiscoveredTracked, unmarkAutoDiscovered } from './resources/auto-discovered-ownership.js';
 import { ResourceHandler } from './resources/base.js';
 import { ruleFileExtensionForTool } from './resources/rule-format.js';
 import { loadTagsConfig, filterByTags } from './utils/tags.js';
@@ -605,6 +606,13 @@ async function pullForScope(
     ];
 
     const baseDir = resolveBaseDir(localConfig);
+    const scopedTombstoneTools = scopedToolPaths(freshConfig, localConfig);
+    const scopedTombstoneKeys = new Set(Object.keys(scopedTombstoneTools));
+    // Ownership record: needed to clean tombstoned resources from AUTO-DISCOVERED
+    // dirs, but only those teamai deployed itself (never a personal same-named
+    // file). Loaded/saved lazily, load-modify-save like the final revision save.
+    let tombstoneState: Awaited<ReturnType<typeof loadStateForScope>> | null = null;
+    let tombstoneStateDirty = false;
     for (const { type, ext, toolPathField } of tombstoneTypes) {
       const handler = getHandler(type);
       const tombstones = await handler.readTombstones(localConfig);
@@ -613,7 +621,7 @@ async function pullForScope(
       // Tombstone cleanup only touches team-managed tools (scopedToolPaths),
       // not auto-discovered ones — a personal skill in ~/.gemini/skills/ that
       // happens to share a name with a tombstoned team skill must not be deleted.
-      for (const [tool, toolPath] of Object.entries(scopedToolPaths(freshConfig, localConfig))) {
+      for (const [tool, toolPath] of Object.entries(scopedTombstoneTools)) {
         const dir = toolPath[toolPathField];
         if (!dir) continue;
         if (!await ResourceHandler.isToolInstalled(dir, baseDir)) continue;
@@ -636,6 +644,41 @@ async function pullForScope(
           }
         }
       }
+
+      // Auto-discovered tools: a team resource teamai deployed there (tracked in
+      // the ownership record) MUST also be withdrawn when the team tombstones it
+      // — otherwise a recalled (possibly dangerous) resource lingers and can
+      // still be loaded. Untracked same-named files are personal — never touched.
+      for (const [tool, toolPath] of Object.entries(await effectiveToolPaths(freshConfig, localConfig))) {
+        if (scopedTombstoneKeys.has(tool)) continue; // team-managed handled above
+        const dir = toolPath[toolPathField];
+        if (!dir) continue;
+        if (!await ResourceHandler.isToolInstalled(dir, baseDir)) continue;
+        if (isAgentDisabled(localConfig, tool)) continue;
+
+        const extensions = type === 'rules'
+          ? [...new Set([ruleFileExtensionForTool(tool), '.md'])]
+          : [ext];
+
+        for (const name of tombstones) {
+          const key = ownershipKey(tool, type, name);
+          if (tombstoneState === null) tombstoneState = await loadStateForScope(localConfig);
+          if (!isAutoDiscoveredTracked(key, tombstoneState)) continue; // personal — keep
+          for (const extension of extensions) {
+            const localPath = path.join(baseDir, dir, extension ? `${name}${extension}` : name);
+            if (await pathExists(localPath)) {
+              await remove(localPath);
+              log.debug(`[${scopeLabel}] Cleaned up tombstoned teamai-deployed ${type} ${name} from auto-discovered ${dir}`);
+            }
+          }
+          unmarkAutoDiscovered(key, tombstoneState);
+          tombstoneStateDirty = true;
+        }
+      }
+    }
+
+    if (tombstoneStateDirty && tombstoneState !== null) {
+      await saveStateForScope(tombstoneState, localConfig);
     }
 
     if (roleContext) {

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -661,18 +661,22 @@ async function pullForScope(
           : [ext];
 
         for (const name of tombstones) {
-          const key = ownershipKey(tool, type, name);
           if (tombstoneState === null) tombstoneState = await loadStateForScope(localConfig);
-          if (!isAutoDiscoveredTracked(key, tombstoneState)) continue; // personal — keep
+          // Authorize deletion PER FILE: the ownership record is keyed by the
+          // exact deployed filename (incl. extension), so a `.mdc` teamai
+          // deployed never authorizes deleting a personal `.md` beside it.
           for (const extension of extensions) {
-            const localPath = path.join(baseDir, dir, extension ? `${name}${extension}` : name);
+            const filename = extension ? `${name}${extension}` : name;
+            const key = ownershipKey(tool, type, filename);
+            if (!isAutoDiscoveredTracked(key, tombstoneState)) continue; // personal or absent — keep
+            const localPath = path.join(baseDir, dir, filename);
             if (await pathExists(localPath)) {
               await remove(localPath);
-              log.debug(`[${scopeLabel}] Cleaned up tombstoned teamai-deployed ${type} ${name} from auto-discovered ${dir}`);
+              log.debug(`[${scopeLabel}] Cleaned up tombstoned teamai-deployed ${type} ${filename} from auto-discovered ${dir}`);
             }
+            unmarkAutoDiscovered(key, tombstoneState);
+            tombstoneStateDirty = true;
           }
-          unmarkAutoDiscovered(key, tombstoneState);
-          tombstoneStateDirty = true;
         }
       }
     }

--- a/src/resources/agents.ts
+++ b/src/resources/agents.ts
@@ -7,6 +7,8 @@ import { listFiles, pathExists, copyFile, ensureDir, remove, fileContentEqual, g
 import { log } from '../utils/logger.js';
 import { resolveBaseDir, isAgentDisabled, isSelfMode, scopedToolPaths, effectiveToolPaths } from '../types.js';
 import { BUILTIN_AGENT_NAMES } from '../builtin-agents.js';
+import { loadStateForScope, saveStateForScope } from '../config.js';
+import { ownershipKey, mayWriteAutoDiscovered, markAutoDiscovered } from './auto-discovered-ownership.js';
 import {
   parseAgentYaml,
   serializeAgentYaml,
@@ -372,6 +374,11 @@ export class AgentsHandler extends ResourceHandler {
 
     const targets = spec.targets ?? ALL_SUPPORTED_TOOLS;
     const scoped = await effectiveToolPaths(teamConfig, localConfig);
+    // Auto-discovered tools may hold personal agents; teamai only overwrites a
+    // same-named agent there if it deployed that agent itself.
+    const scopedKeys = new Set(Object.keys(scopedToolPaths(teamConfig, localConfig)));
+    let state: Awaited<ReturnType<typeof loadStateForScope>> | null = null;
+    let stateDirty = false;
 
     for (const tool of targets) {
       const toolPath = scoped[tool];
@@ -390,11 +397,29 @@ export class AgentsHandler extends ResourceHandler {
         await ensureDir(destDir);
         const { ext, content: rendered } = renderForTool(spec, tool);
         const dest = path.join(destDir, `${item.name}${ext}`);
+
+        const key = ownershipKey(tool, 'agents', item.name);
+        if (!scopedKeys.has(tool)) {
+          if (state === null) state = await loadStateForScope(localConfig);
+          if (!await mayWriteAutoDiscovered(dest, key, state)) {
+            log.warn(`Preserving personal agent ${item.name} in ${tool} (${dest}): not deployed by teamai, not overwriting.`);
+            continue;
+          }
+        }
+
         await writeFile(dest, rendered);
         log.debug(`Rendered agent ${item.name} → ${tool} (${ext})`);
+        if (!scopedKeys.has(tool) && state !== null) {
+          markAutoDiscovered(key, state);
+          stateDirty = true;
+        }
       } catch (e) {
         log.warn(`Failed to sync agent ${item.name} to ${tool}: ${(e as Error).message}`);
       }
+    }
+
+    if (stateDirty && state !== null) {
+      await saveStateForScope(state, localConfig);
     }
   }
 
@@ -447,6 +472,11 @@ export class AgentsHandler extends ResourceHandler {
     localConfig: LocalConfig,
   ): Promise<void> {
     const legacyTools = new Set(['claude', 'claude-internal', 'tclaude', 'codebuddy', 'joycode']);
+    // Auto-discovered tools may hold personal agents; teamai only overwrites a
+    // same-named agent there if it deployed that agent itself.
+    const scopedKeys = new Set(Object.keys(scopedToolPaths(teamConfig, localConfig)));
+    let state: Awaited<ReturnType<typeof loadStateForScope>> | null = null;
+    let stateDirty = false;
 
     for (const [tool, toolPath] of Object.entries(await effectiveToolPaths(teamConfig, localConfig))) {
       if (!legacyTools.has(tool)) continue;
@@ -464,11 +494,29 @@ export class AgentsHandler extends ResourceHandler {
       try {
         await ensureDir(destDir);
         const dest = path.join(destDir, `${item.name}.md`);
+
+        const key = ownershipKey(tool, 'agents', item.name);
+        if (!scopedKeys.has(tool)) {
+          if (state === null) state = await loadStateForScope(localConfig);
+          if (!await mayWriteAutoDiscovered(dest, key, state)) {
+            log.warn(`Preserving personal agent ${item.name} in ${tool} (${dest}): not deployed by teamai, not overwriting.`);
+            continue;
+          }
+        }
+
         await copyFile(item.sourcePath, dest);
         log.debug(`Synced legacy agent ${item.name} → ${tool}`);
+        if (!scopedKeys.has(tool) && state !== null) {
+          markAutoDiscovered(key, state);
+          stateDirty = true;
+        }
       } catch (e) {
         log.warn(`Failed to sync legacy agent ${item.name} to ${tool}: ${(e as Error).message}`);
       }
+    }
+
+    if (stateDirty && state !== null) {
+      await saveStateForScope(state, localConfig);
     }
   }
 }

--- a/src/resources/agents.ts
+++ b/src/resources/agents.ts
@@ -5,7 +5,7 @@ import { ResourceHandler } from './base.js';
 import type { ResourceItem, ResourceItemStatus, TeamaiConfig, LocalConfig } from '../types.js';
 import { listFiles, pathExists, copyFile, ensureDir, remove, fileContentEqual, getFileMtime, writeFile, readFileSafe } from '../utils/fs.js';
 import { log } from '../utils/logger.js';
-import { resolveBaseDir, isAgentDisabled, isSelfMode, scopedToolPaths } from '../types.js';
+import { resolveBaseDir, isAgentDisabled, isSelfMode, scopedToolPaths, effectiveToolPaths } from '../types.js';
 import { BUILTIN_AGENT_NAMES } from '../builtin-agents.js';
 import {
   parseAgentYaml,
@@ -371,7 +371,7 @@ export class AgentsHandler extends ResourceHandler {
     spec = parseResult.spec;
 
     const targets = spec.targets ?? ALL_SUPPORTED_TOOLS;
-    const scoped = scopedToolPaths(teamConfig, localConfig);
+    const scoped = await effectiveToolPaths(teamConfig, localConfig);
 
     for (const tool of targets) {
       const toolPath = scoped[tool];
@@ -448,7 +448,7 @@ export class AgentsHandler extends ResourceHandler {
   ): Promise<void> {
     const legacyTools = new Set(['claude', 'claude-internal', 'tclaude', 'codebuddy', 'joycode']);
 
-    for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
+    for (const [tool, toolPath] of Object.entries(await effectiveToolPaths(teamConfig, localConfig))) {
       if (!legacyTools.has(tool)) continue;
       if (!toolPath.agents) {
         log.debug(`Skipping legacy agent sync for ${tool}: no agents path configured`);

--- a/src/resources/agents.ts
+++ b/src/resources/agents.ts
@@ -398,7 +398,7 @@ export class AgentsHandler extends ResourceHandler {
         const { ext, content: rendered } = renderForTool(spec, tool);
         const dest = path.join(destDir, `${item.name}${ext}`);
 
-        const key = ownershipKey(tool, 'agents', item.name);
+        const key = ownershipKey(tool, 'agents', path.basename(dest));
         if (!scopedKeys.has(tool)) {
           if (state === null) state = await loadStateForScope(localConfig);
           if (!await mayWriteAutoDiscovered(dest, key, state)) {
@@ -495,7 +495,7 @@ export class AgentsHandler extends ResourceHandler {
         await ensureDir(destDir);
         const dest = path.join(destDir, `${item.name}.md`);
 
-        const key = ownershipKey(tool, 'agents', item.name);
+        const key = ownershipKey(tool, 'agents', path.basename(dest));
         if (!scopedKeys.has(tool)) {
           if (state === null) state = await loadStateForScope(localConfig);
           if (!await mayWriteAutoDiscovered(dest, key, state)) {

--- a/src/resources/auto-discovered-ownership.ts
+++ b/src/resources/auto-discovered-ownership.ts
@@ -15,9 +15,18 @@ import { pathExists } from '../utils/fs.js';
  * persists it (load-modify-save), mirroring how coAuthorManaged is handled.
  */
 
-/** Stable key for one deployed resource in one tool. */
-export function ownershipKey(tool: string, type: ResourceType, name: string): string {
-  return `${tool}:${type}:${name}`;
+/**
+ * Stable key for one deployed FILE in one tool.
+ *
+ * `id` must identify the exact on-disk artifact, INCLUDING its extension where
+ * one applies (e.g. a cursor rule is `safety.mdc`, a Codex agent `x.toml`).
+ * Skills are directories, so their id is just the skill name. Encoding the
+ * extension is essential: teamai may deploy `safety.mdc` while a personal
+ * `safety.md` sits beside it — a key without the extension would authorize
+ * deleting the personal `.md` during withdrawal.
+ */
+export function ownershipKey(tool: string, type: ResourceType, id: string): string {
+  return `${tool}:${type}:${id}`;
 }
 
 /**

--- a/src/resources/auto-discovered-ownership.ts
+++ b/src/resources/auto-discovered-ownership.ts
@@ -1,0 +1,47 @@
+import type { State, ResourceType } from '../types.js';
+import { pathExists } from '../utils/fs.js';
+
+/**
+ * Ownership tracking for resources teamai deploys into AUTO-DISCOVERED tool dirs
+ * (installed on disk but absent from the team's `toolPaths`).
+ *
+ * The problem: on a second pull after a team update, the local copy is the OLD
+ * team version, which no longer equals the NEW team source — indistinguishable
+ * by content from a personal resource that merely shares a name. So we cannot
+ * decide "safe to overwrite" from content alone; we record what teamai itself
+ * deployed (`state.autoDiscoveredManaged`) and consult that record.
+ *
+ * These helpers operate on a State object the caller has loaded; the caller
+ * persists it (load-modify-save), mirroring how coAuthorManaged is handled.
+ */
+
+/** Stable key for one deployed resource in one tool. */
+export function ownershipKey(tool: string, type: ResourceType, name: string): string {
+  return `${tool}:${type}:${name}`;
+}
+
+/**
+ * Decide whether pull may write `dest` in an auto-discovered tool dir.
+ *
+ * - destination absent            → write (nothing to clobber)
+ * - destination present + tracked → write (teamai deployed it; deliver updates)
+ * - destination present + untracked → DO NOT write (personal resource; preserve)
+ */
+export async function mayWriteAutoDiscovered(
+  dest: string,
+  key: string,
+  state: State,
+): Promise<boolean> {
+  if (!await pathExists(dest)) return true;
+  const tracked = state.autoDiscoveredManaged ?? [];
+  return tracked.includes(key);
+}
+
+/** Record that teamai deployed `key` into an auto-discovered dir (idempotent). */
+export function markAutoDiscovered(key: string, state: State): void {
+  const tracked = state.autoDiscoveredManaged ?? [];
+  if (!tracked.includes(key)) {
+    tracked.push(key);
+    state.autoDiscoveredManaged = tracked;
+  }
+}

--- a/src/resources/auto-discovered-ownership.ts
+++ b/src/resources/auto-discovered-ownership.ts
@@ -45,3 +45,19 @@ export function markAutoDiscovered(key: string, state: State): void {
     state.autoDiscoveredManaged = tracked;
   }
 }
+
+/** True if teamai's record says it deployed `key` into an auto-discovered dir. */
+export function isAutoDiscoveredTracked(key: string, state: State): boolean {
+  return (state.autoDiscoveredManaged ?? []).includes(key);
+}
+
+/** Drop `key` from the ownership record (e.g. after a tombstone cleanup). */
+export function unmarkAutoDiscovered(key: string, state: State): void {
+  const tracked = state.autoDiscoveredManaged;
+  if (!tracked) return;
+  const idx = tracked.indexOf(key);
+  if (idx !== -1) {
+    tracked.splice(idx, 1);
+    state.autoDiscoveredManaged = tracked;
+  }
+}

--- a/src/resources/rules.ts
+++ b/src/resources/rules.ts
@@ -3,7 +3,7 @@ import { ResourceHandler } from './base.js';
 import type { ResourceItem, ResourceItemStatus, TeamaiConfig, LocalConfig } from '../types.js';
 import { listFilesRecursive, pathExists, copyFile, ensureDir, remove, fileContentEqual, getFileMtime, listDirs, readFileSafe, writeFile } from '../utils/fs.js';
 import { log } from '../utils/logger.js';
-import { TEAMAI_RULES_START, TEAMAI_RULES_END, resolveBaseDir, isAgentDisabled, scopedToolPaths } from '../types.js';
+import { TEAMAI_RULES_START, TEAMAI_RULES_END, resolveBaseDir, isAgentDisabled, scopedToolPaths, effectiveToolPaths } from '../types.js';
 import { EXCLUDED_RULE_NAMES } from '../builtin-rules.js';
 import { teamRuleToCursorMdc, mergeCursorBodyIntoTeamMd, cursorMdcBodyEqualsTeamMd } from './cursor-mdc.js';
 import {
@@ -47,7 +47,7 @@ export class RulesHandler extends ResourceHandler {
     };
 
     // Scan each tool's rules/ directory (recursively)
-    for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
+    for (const [tool, toolPath] of Object.entries(await effectiveToolPaths(teamConfig, localConfig))) {
       const rulesPath = toolPath.rules;
       if (!rulesPath) continue;
       const rulesDir = path.join(resolveBaseDir(localConfig), rulesPath);
@@ -165,7 +165,7 @@ export class RulesHandler extends ResourceHandler {
    */
   async pullItem(item: ResourceItem, teamConfig: TeamaiConfig, localConfig: LocalConfig): Promise<void> {
     const baseDir = resolveBaseDir(localConfig);
-    for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
+    for (const [tool, toolPath] of Object.entries(await effectiveToolPaths(teamConfig, localConfig))) {
       if (isAgentDisabled(localConfig, tool)) continue;
       if (!toolPath.rules) continue;
 
@@ -219,7 +219,7 @@ export class RulesHandler extends ResourceHandler {
     // Remove from each tool's rules directory. `.mdc` tools may have an older
     // teamai layout wrote `.md` there, so both are removed — otherwise `remove`
     // would report success while leaving the rule on disk.
-    for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
+    for (const [tool, toolPath] of Object.entries(await effectiveToolPaths(teamConfig, localConfig))) {
       if (!toolPath.rules) continue;
       const extensions = new Set<string>([ruleFileExtensionForTool(tool), '.md']);
       for (const extension of extensions) {
@@ -288,7 +288,7 @@ export class RulesHandler extends ResourceHandler {
     const teamRuleNames = new Set(rules.map((r) => r.name));
     const tombstones = await this.readTombstones(localConfig);
     const baseDir = resolveBaseDir(localConfig);
-    for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
+    for (const [tool, toolPath] of Object.entries(await effectiveToolPaths(teamConfig, localConfig))) {
       if (!toolPath.rules) continue;
       if (!await ResourceHandler.isToolInstalled(toolPath.rules, baseDir)) continue;
 
@@ -331,7 +331,7 @@ export class RulesHandler extends ResourceHandler {
     }
 
     // 2. Remove legacy rules section from CLAUDE.md (no longer injected)
-    for (const [, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
+    for (const [, toolPath] of Object.entries(await effectiveToolPaths(teamConfig, localConfig))) {
       if (!toolPath.claudemd) continue;
       const claudeMdPath = path.join(baseDir, toolPath.claudemd);
       try {
@@ -367,7 +367,7 @@ export class RulesHandler extends ResourceHandler {
     present: boolean,
   ): Promise<void> {
     if (isAgentDisabled(localConfig, 'opencode')) return;
-    const scoped = scopedToolPaths(teamConfig, localConfig);
+    const scoped = await effectiveToolPaths(teamConfig, localConfig);
     const paths = scoped['opencode'];
     if (!paths?.rules) return;
 

--- a/src/resources/rules.ts
+++ b/src/resources/rules.ts
@@ -190,8 +190,9 @@ export class RulesHandler extends ResourceHandler {
 
       // Auto-discovered (non-team-managed) tool: only write if teamai deployed
       // this rule before or nothing is there; a pre-existing untracked rule is
-      // personal — preserve it with a visible notice.
-      const key = ownershipKey(tool, 'rules', item.name);
+      // personal — preserve it with a visible notice. Key by the actual filename
+      // (with extension) so a personal `.md` is never authorized by a `.mdc` record.
+      const key = ownershipKey(tool, 'rules', path.basename(dest));
       if (!scopedKeys.has(tool)) {
         if (state === null) state = await loadStateForScope(localConfig);
         if (!await mayWriteAutoDiscovered(dest, key, state)) {

--- a/src/resources/rules.ts
+++ b/src/resources/rules.ts
@@ -5,6 +5,8 @@ import { listFilesRecursive, pathExists, copyFile, ensureDir, remove, fileConten
 import { log } from '../utils/logger.js';
 import { TEAMAI_RULES_START, TEAMAI_RULES_END, resolveBaseDir, isAgentDisabled, scopedToolPaths, effectiveToolPaths } from '../types.js';
 import { EXCLUDED_RULE_NAMES } from '../builtin-rules.js';
+import { loadStateForScope, saveStateForScope } from '../config.js';
+import { ownershipKey, mayWriteAutoDiscovered, markAutoDiscovered } from './auto-discovered-ownership.js';
 import { teamRuleToCursorMdc, mergeCursorBodyIntoTeamMd, cursorMdcBodyEqualsTeamMd } from './cursor-mdc.js';
 import {
   ruleFileExtensionForTool,
@@ -165,6 +167,13 @@ export class RulesHandler extends ResourceHandler {
    */
   async pullItem(item: ResourceItem, teamConfig: TeamaiConfig, localConfig: LocalConfig): Promise<void> {
     const baseDir = resolveBaseDir(localConfig);
+    // Auto-discovered tools may hold personal rules; teamai only overwrites a
+    // same-named rule there if it deployed that rule itself (tracked in
+    // state.autoDiscoveredManaged), otherwise it is preserved.
+    const scopedKeys = new Set(Object.keys(scopedToolPaths(teamConfig, localConfig)));
+    let state: Awaited<ReturnType<typeof loadStateForScope>> | null = null;
+    let stateDirty = false;
+
     for (const [tool, toolPath] of Object.entries(await effectiveToolPaths(teamConfig, localConfig))) {
       if (isAgentDisabled(localConfig, tool)) continue;
       if (!toolPath.rules) continue;
@@ -178,6 +187,19 @@ export class RulesHandler extends ResourceHandler {
       const destDir = path.join(baseDir, toolPath.rules);
       await ensureDir(destDir);
       const dest = path.join(destDir, `${item.name}${ruleFileExtensionForTool(tool)}`);
+
+      // Auto-discovered (non-team-managed) tool: only write if teamai deployed
+      // this rule before or nothing is there; a pre-existing untracked rule is
+      // personal — preserve it with a visible notice.
+      const key = ownershipKey(tool, 'rules', item.name);
+      if (!scopedKeys.has(tool)) {
+        if (state === null) state = await loadStateForScope(localConfig);
+        if (!await mayWriteAutoDiscovered(dest, key, state)) {
+          log.warn(`Preserving personal rule ${item.name} in ${tool} (${dest}): not deployed by teamai, not overwriting.`);
+          continue;
+        }
+      }
+
       try {
         if (usesCursorMdcRules(tool)) {
           // Cursor-compatible tools need `.mdc` with derived frontmatter.
@@ -193,9 +215,17 @@ export class RulesHandler extends ResourceHandler {
           await copyFile(item.sourcePath, dest);
         }
         log.debug(`Synced rule ${item.name} → ${tool}`);
+        if (!scopedKeys.has(tool) && state !== null) {
+          markAutoDiscovered(key, state);
+          stateDirty = true;
+        }
       } catch (e) {
         log.warn(`Failed to sync rule ${item.name} to ${tool}: ${(e as Error).message}`);
       }
+    }
+
+    if (stateDirty && state !== null) {
+      await saveStateForScope(state, localConfig);
     }
   }
 

--- a/src/resources/rules.ts
+++ b/src/resources/rules.ts
@@ -209,8 +209,13 @@ export class RulesHandler extends ResourceHandler {
             throw new Error(`Cannot read rule source ${item.sourcePath}`);
           }
           await writeFile(dest, teamRuleToCursorMdc(raw));
-          // Drop the `.md` copy left by an older layout; these tools do not read it.
-          await remove(path.join(destDir, `${item.name}.md`));
+          // Drop the `.md` copy left by an older layout; these tools do not read
+          // it. Only for team-managed tools: in an auto-discovered dir a same-named
+          // `.md` may be a personal file (no `.mdc` existed to gate the write), so
+          // never delete it there.
+          if (scopedKeys.has(tool)) {
+            await remove(path.join(destDir, `${item.name}.md`));
+          }
         } else {
           await copyFile(item.sourcePath, dest);
         }

--- a/src/resources/rules.ts
+++ b/src/resources/rules.ts
@@ -285,10 +285,11 @@ export class RulesHandler extends ResourceHandler {
     }
 
     // 1.5. Clean up stale local rule files not present in team repo
+    // Only in team-managed tools — auto-discovered tools may have personal rules.
     const teamRuleNames = new Set(rules.map((r) => r.name));
     const tombstones = await this.readTombstones(localConfig);
     const baseDir = resolveBaseDir(localConfig);
-    for (const [tool, toolPath] of Object.entries(await effectiveToolPaths(teamConfig, localConfig))) {
+    for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
       if (!toolPath.rules) continue;
       if (!await ResourceHandler.isToolInstalled(toolPath.rules, baseDir)) continue;
 

--- a/src/resources/rules.ts
+++ b/src/resources/rules.ts
@@ -46,8 +46,8 @@ export class RulesHandler extends ResourceHandler {
       return content;
     };
 
-    // Scan each tool's rules/ directory (recursively)
-    for (const [tool, toolPath] of Object.entries(await effectiveToolPaths(teamConfig, localConfig))) {
+    // Scan each tool's rules/ directory (push stays within team-managed tools)
+    for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
       const rulesPath = toolPath.rules;
       if (!rulesPath) continue;
       const rulesDir = path.join(resolveBaseDir(localConfig), rulesPath);
@@ -219,7 +219,7 @@ export class RulesHandler extends ResourceHandler {
     // Remove from each tool's rules directory. `.mdc` tools may have an older
     // teamai layout wrote `.md` there, so both are removed — otherwise `remove`
     // would report success while leaving the rule on disk.
-    for (const [tool, toolPath] of Object.entries(await effectiveToolPaths(teamConfig, localConfig))) {
+    for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
       if (!toolPath.rules) continue;
       const extensions = new Set<string>([ruleFileExtensionForTool(tool), '.md']);
       for (const extension of extensions) {

--- a/src/resources/skills.ts
+++ b/src/resources/skills.ts
@@ -302,8 +302,8 @@ export class SkillsHandler extends ResourceHandler {
     // Collect the best candidate for each skill name across all tool directories
     const candidates = new Map<string, { sourcePath: string; mtime: number; status: ResourceItemStatus; namespace?: string }>();
 
-    // Scan each tool's skills directory
-    for (const [_tool, toolPath] of Object.entries(await effectiveToolPaths(teamConfig, localConfig))) {
+    // Scan each tool's skills directory (push stays within team-managed tools)
+    for (const [_tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
       if (!toolPath.skills) continue;
       const skillsDir = path.join(resolveBaseDir(localConfig), toolPath.skills);
       if (!await pathExists(skillsDir)) continue;
@@ -499,8 +499,8 @@ export class SkillsHandler extends ResourceHandler {
     // Record tombstone so the resource won't be re-pushed
     await this.addTombstone(name, localConfig);
 
-    // Remove from each tool's skills directory
-    for (const [tool, toolPath] of Object.entries(await effectiveToolPaths(teamConfig, localConfig))) {
+    // Remove only from team-managed tools (not auto-discovered ones)
+    for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
       if (!toolPath.skills) continue;
       let skillDir: string;
       if (tool === 'openclaw') {

--- a/src/resources/skills.ts
+++ b/src/resources/skills.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import YAML from 'yaml';
 import { ResourceHandler } from './base.js';
 import type { ResourceItem, ResourceItemStatus, TeamaiConfig, LocalConfig } from '../types.js';
-import { resolveBaseDir, getPushignorePath, isAgentDisabled, scopedToolPaths } from '../types.js';
+import { resolveBaseDir, getPushignorePath, isAgentDisabled, scopedToolPaths, effectiveToolPaths } from '../types.js';
 import { listDirs, pathExists, copyDir, remove, dirTeamSubsetEqual, getDirLatestMtime, readFileSafe, writeFile } from '../utils/fs.js';
 import { log } from '../utils/logger.js';
 import { BUILTIN_SKILL_NAMES } from '../builtin-skills.js';
@@ -303,7 +303,7 @@ export class SkillsHandler extends ResourceHandler {
     const candidates = new Map<string, { sourcePath: string; mtime: number; status: ResourceItemStatus; namespace?: string }>();
 
     // Scan each tool's skills directory
-    for (const [_tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
+    for (const [_tool, toolPath] of Object.entries(await effectiveToolPaths(teamConfig, localConfig))) {
       if (!toolPath.skills) continue;
       const skillsDir = path.join(resolveBaseDir(localConfig), toolPath.skills);
       if (!await pathExists(skillsDir)) continue;
@@ -439,7 +439,7 @@ export class SkillsHandler extends ResourceHandler {
   async pullItem(item: ResourceItem, teamConfig: TeamaiConfig, localConfig: LocalConfig): Promise<void> {
     const baseDir = resolveBaseDir(localConfig);
 
-    for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
+    for (const [tool, toolPath] of Object.entries(await effectiveToolPaths(teamConfig, localConfig))) {
       if (isAgentDisabled(localConfig, tool)) continue;
       if (!toolPath.skills) continue;
 
@@ -500,7 +500,7 @@ export class SkillsHandler extends ResourceHandler {
     await this.addTombstone(name, localConfig);
 
     // Remove from each tool's skills directory
-    for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
+    for (const [tool, toolPath] of Object.entries(await effectiveToolPaths(teamConfig, localConfig))) {
       if (!toolPath.skills) continue;
       let skillDir: string;
       if (tool === 'openclaw') {

--- a/src/resources/skills.ts
+++ b/src/resources/skills.ts
@@ -11,6 +11,8 @@ import { getHermesHome } from '../hermes-home.js';
 import { loadRolesManifest, resolveRoleResourceNamespaces } from '../roles.js';
 import { assertWithinRoot } from '../utils/path-safety.js';
 import { splitFrontmatter, stringifyFrontmatter } from '../utils/frontmatter.js';
+import { loadStateForScope, saveStateForScope } from '../config.js';
+import { ownershipKey, mayWriteAutoDiscovered, markAutoDiscovered } from './auto-discovered-ownership.js';
 
 /** File name used to track who has contributed (pushed) a skill. */
 const CONTRIBUTORS_FILE = 'CONTRIBUTORS';
@@ -439,10 +441,13 @@ export class SkillsHandler extends ResourceHandler {
   async pullItem(item: ResourceItem, teamConfig: TeamaiConfig, localConfig: LocalConfig): Promise<void> {
     const baseDir = resolveBaseDir(localConfig);
     // Tools present only via auto-discovery (installed on disk but not in the
-    // team's toolPaths) may hold personal skills. On first takeover we must not
-    // overwrite a pre-existing same-named skill there — only team-managed tools
-    // (scopedToolPaths) may overwrite.
+    // team's toolPaths) may hold personal skills. teamai only overwrites a
+    // pre-existing same-named skill there if it deployed that skill itself
+    // (tracked in state.autoDiscoveredManaged); otherwise it is preserved.
     const scopedKeys = new Set(Object.keys(scopedToolPaths(teamConfig, localConfig)));
+    // Lazily loaded/saved only when an auto-discovered tool is actually involved.
+    let state: Awaited<ReturnType<typeof loadStateForScope>> | null = null;
+    let stateDirty = false;
 
     for (const [tool, toolPath] of Object.entries(await effectiveToolPaths(teamConfig, localConfig))) {
       if (isAgentDisabled(localConfig, tool)) continue;
@@ -466,20 +471,33 @@ export class SkillsHandler extends ResourceHandler {
         dest = path.join(baseDir, toolPath.skills, item.name);
       }
 
-      // Auto-discovered (non-team-managed) tool with a pre-existing same-named
-      // skill: skip rather than clobber a personal skill on first takeover.
-      if (!scopedKeys.has(tool) && await pathExists(dest)) {
-        log.debug(`Skipping skill ${item.name} for auto-discovered ${tool}: destination exists (not overwriting personal skill)`);
-        continue;
+      // Auto-discovered (non-team-managed) tool: only write if teamai deployed
+      // this skill before (tracked) or nothing is there. A pre-existing untracked
+      // skill is personal — preserve it with a visible notice.
+      const key = ownershipKey(tool, 'skills', item.name);
+      if (!scopedKeys.has(tool)) {
+        if (state === null) state = await loadStateForScope(localConfig);
+        if (!await mayWriteAutoDiscovered(dest, key, state)) {
+          log.warn(`Preserving personal skill ${item.name} in ${tool} (${dest}): not deployed by teamai, not overwriting.`);
+          continue;
+        }
       }
 
       try {
         await copyDir(item.sourcePath, dest);
         await ensureSkillFrontmatter(dest, item.name);
         log.debug(`Synced skill ${item.name} → ${tool}`);
+        if (!scopedKeys.has(tool) && state !== null) {
+          markAutoDiscovered(key, state);
+          stateDirty = true;
+        }
       } catch (e) {
         log.warn(`Failed to sync skill ${item.name} to ${tool}: ${(e as Error).message}`);
       }
+    }
+
+    if (stateDirty && state !== null) {
+      await saveStateForScope(state, localConfig);
     }
   }
 

--- a/src/resources/skills.ts
+++ b/src/resources/skills.ts
@@ -438,6 +438,11 @@ export class SkillsHandler extends ResourceHandler {
    */
   async pullItem(item: ResourceItem, teamConfig: TeamaiConfig, localConfig: LocalConfig): Promise<void> {
     const baseDir = resolveBaseDir(localConfig);
+    // Tools present only via auto-discovery (installed on disk but not in the
+    // team's toolPaths) may hold personal skills. On first takeover we must not
+    // overwrite a pre-existing same-named skill there — only team-managed tools
+    // (scopedToolPaths) may overwrite.
+    const scopedKeys = new Set(Object.keys(scopedToolPaths(teamConfig, localConfig)));
 
     for (const [tool, toolPath] of Object.entries(await effectiveToolPaths(teamConfig, localConfig))) {
       if (isAgentDisabled(localConfig, tool)) continue;
@@ -459,6 +464,13 @@ export class SkillsHandler extends ResourceHandler {
           continue;
         }
         dest = path.join(baseDir, toolPath.skills, item.name);
+      }
+
+      // Auto-discovered (non-team-managed) tool with a pre-existing same-named
+      // skill: skip rather than clobber a personal skill on first takeover.
+      if (!scopedKeys.has(tool) && await pathExists(dest)) {
+        log.debug(`Skipping skill ${item.name} for auto-discovered ${tool}: destination exists (not overwriting personal skill)`);
+        continue;
       }
 
       try {

--- a/src/types.ts
+++ b/src/types.ts
@@ -185,6 +185,48 @@ export const SOURCE_PULL_TTL_MS = 24 * 60 * 60 * 1000;
 
 export const TEAMAI_SOURCES_DIR = path.join(getUserHome(), '.teamai', 'sources');
 
+/**
+ * Verified tool-path registry. Each entry has been checked against the actual
+ * tool's directory layout. Auto-discovery looks up paths here rather than
+ * guessing from `skillsPath`, so only declared resource types are synced.
+ */
+export const DEFAULT_TOOL_PATHS: Record<string, z.infer<typeof ToolPathsSchema>> = {
+  claude: { skills: '.claude/skills', rules: '.claude/rules', settings: '.claude/settings.json', claudemd: '.claude/CLAUDE.md', agents: '.claude/agents', mcp: '.claude.json', mcpProject: '.mcp.json' },
+  codex: { skills: '.codex/skills', rules: '.codex/rules', settings: '.codex/hooks.json', agents: '.codex/agents', mcp: '.codex/config.toml' },
+  'codex-internal': { skills: '.codex-internal/skills', rules: '.codex-internal/rules', settings: '.codex-internal/hooks.json', agents: '.codex-internal/agents' },
+  'claude-internal': { skills: '.claude-internal/skills', rules: '.claude-internal/rules', settings: '.claude-internal/settings.json', claudemd: '.claude-internal/CLAUDE.md', agents: '.claude-internal/agents' },
+  tclaude: { skills: '.tclaude/skills', rules: '.tclaude/rules', settings: '.tclaude/settings.json', claudemd: '.tclaude/CLAUDE.md', agents: '.tclaude/agents', mcp: '.tclaude/.claude.json' },
+  tcodex: { skills: '.tcodex/skills', rules: '.tcodex/rules', settings: '.tcodex/hooks.json', agents: '.tcodex/agents' },
+  cursor: { skills: '.cursor/skills', rules: '.cursor/rules', settings: '.cursor/hooks.json', agents: '.cursor/agents', mcp: '.cursor/mcp.json', mcpProject: '.cursor/mcp.json' },
+  // JoyCode: skills, rules (.mdc), and subagents are synced to .joycode/.
+  // JoyCode currently does not provide a lifecycle hooks system or startup
+  // adapter, so it intentionally has no `settings` path. Hook reconciliation
+  // skips JoyCode cleanly without generating ghost files; users must sync
+  // manually via `teamai pull`.
+  joycode: { skills: '.joycode/skills', rules: '.joycode/rules', agents: '.joycode/agents' },
+  qoder: {
+    skills: '.qoder/skills',
+    rules: '.qoder/rules',
+    settings: '.qoder/settings.json',
+    agents: '.qoder/agents',
+    mcp: '.qoder/settings.json',
+    mcpProject: '.qoder/settings.json',
+  },
+  codebuddy: { skills: '.codebuddy/skills', rules: '.codebuddy/rules', settings: '.codebuddy/settings.json', claudemd: '.codebuddy/CODEBUDDY.md', agents: '.codebuddy/agents', mcp: '.codebuddy/mcp.json', mcpProject: '.codebuddy/mcp.json' },
+  openclaw: { skills: '.openclaw/skills', rules: '.openclaw/rules', claudemd: '.openclaw/workspace/AGENTS.md' },
+  hermes: { skills: '.hermes/skills', claudemd: 'AGENTS.md' },
+  dsh: { skills: '.dsh/skills' },
+  workbuddy: { skills: '.workbuddy/skills', rules: '.workbuddy/rules', settings: '.workbuddy/settings.json', claudemd: 'AGENTS.md', mcp: '.workbuddy/mcp.json', mcpProject: '.workbuddy/mcp.json' },
+  opencode: {
+    skills: '.opencode/skills',
+    rules: '.opencode/rules',
+    agents: '.opencode/agents',
+    mcp: '.config/opencode/opencode.json',
+    mcpProject: 'opencode.json',
+    userScope: { skills: '.config/opencode/skills', rules: '.config/opencode/rules', agents: '.config/opencode/agents' },
+  },
+};
+
 export const TeamaiConfigSchema = z.object({
   team: z.string(),
   description: z.string().default(''),
@@ -214,59 +256,7 @@ export const TeamaiConfigSchema = z.object({
    * can override via `updatePolicy` in local config. Undefined = team has no
    * opinion (preserves legacy behavior). */
   autoUpdate: z.boolean().optional(),
-  // MCP paths are only set for tools whose config location has been verified.
-  // Tools left without `mcp` are skipped by MCP sync rather than guessed at, so a
-  // wrong guess can never create a junk config file on a user's machine.
-  toolPaths: z.record(z.string(), ToolPathsSchema).default({
-    claude: { skills: '.claude/skills', rules: '.claude/rules', settings: '.claude/settings.json', claudemd: '.claude/CLAUDE.md', agents: '.claude/agents', mcp: '.claude.json', mcpProject: '.mcp.json' },
-    codex: { skills: '.codex/skills', rules: '.codex/rules', settings: '.codex/hooks.json', agents: '.codex/agents', mcp: '.codex/config.toml' },
-    'codex-internal': { skills: '.codex-internal/skills', rules: '.codex-internal/rules', settings: '.codex-internal/hooks.json', agents: '.codex-internal/agents' },
-    'claude-internal': { skills: '.claude-internal/skills', rules: '.claude-internal/rules', settings: '.claude-internal/settings.json', claudemd: '.claude-internal/CLAUDE.md', agents: '.claude-internal/agents' },
-    // tclaude ships Claude Code with `customUserDataDir: .tclaude`, which
-    // relocates the whole user data dir — so its MCP file is
-    // ~/.tclaude/.claude.json, not ~/.tclaude.json. No mcpProject: project scope
-    // for the Claude family is <root>/.mcp.json, which the `claude` target
-    // already writes and tclaude reads from the same location.
-    tclaude: { skills: '.tclaude/skills', rules: '.tclaude/rules', settings: '.tclaude/settings.json', claudemd: '.tclaude/CLAUDE.md', agents: '.tclaude/agents', mcp: '.tclaude/.claude.json' },
-    tcodex: { skills: '.tcodex/skills', rules: '.tcodex/rules', settings: '.tcodex/hooks.json', agents: '.tcodex/agents' },
-    cursor: { skills: '.cursor/skills', rules: '.cursor/rules', settings: '.cursor/hooks.json', agents: '.cursor/agents', mcp: '.cursor/mcp.json', mcpProject: '.cursor/mcp.json' },
-    // JoyCode: skills, rules (.mdc), and subagents are synced to .joycode/.
-    // JoyCode currently does not provide a lifecycle hooks system or startup
-    // adapter, so it intentionally has no `settings` path. Hook reconciliation
-    // skips JoyCode cleanly without generating ghost files; users must sync
-    // manually via `teamai pull`.
-    joycode: { skills: '.joycode/skills', rules: '.joycode/rules', agents: '.joycode/agents' },
-    qoder: {
-      skills: '.qoder/skills',
-      rules: '.qoder/rules',
-      settings: '.qoder/settings.json',
-      agents: '.qoder/agents',
-      mcp: '.qoder/settings.json',
-      mcpProject: '.qoder/settings.json',
-    },
-    codebuddy: { skills: '.codebuddy/skills', rules: '.codebuddy/rules', settings: '.codebuddy/settings.json', claudemd: '.codebuddy/CODEBUDDY.md', agents: '.codebuddy/agents', mcp: '.codebuddy/mcp.json', mcpProject: '.codebuddy/mcp.json' },
-    openclaw: { skills: '.openclaw/skills', rules: '.openclaw/rules', claudemd: '.openclaw/workspace/AGENTS.md' },
-    hermes: { skills: '.hermes/skills', claudemd: 'AGENTS.md' },
-    // DeepSeek Harness: skills synced to ~/.dsh/skills, which its skill-filesystem
-    // provider scans as user-dsh root (rank 400). dsh discovers both directory
-    // bundles (<name>/SKILL.md) and flat Markdown files there natively.
-    dsh: { skills: '.dsh/skills' },
-    workbuddy: { skills: '.workbuddy/skills', rules: '.workbuddy/rules', settings: '.workbuddy/settings.json', claudemd: 'AGENTS.md', mcp: '.workbuddy/mcp.json', mcpProject: '.workbuddy/mcp.json' },
-    // OpenCode reads project config from <root>/.opencode/ but user config from
-    // ~/.config/opencode/ — a different prefix, hence userScope. Skills are also
-    // read natively from .claude/skills, but we write .opencode/skills so an
-    // OpenCode-only user (no Claude) still gets them. Rules land in .opencode/rules
-    // but must be activated via the `instructions` glob in opencode.json (OpenCode
-    // does not auto-scan a rules dir). MCP shares opencode.json under the `mcp` key.
-    opencode: {
-      skills: '.opencode/skills',
-      rules: '.opencode/rules',
-      agents: '.opencode/agents',
-      mcp: '.config/opencode/opencode.json',
-      mcpProject: 'opencode.json',
-      userScope: { skills: '.config/opencode/skills', rules: '.config/opencode/rules', agents: '.config/opencode/agents' },
-    },
-  }),
+  toolPaths: z.record(z.string(), ToolPathsSchema).default(DEFAULT_TOOL_PATHS),
 });
 
 export type TeamaiConfig = z.infer<typeof TeamaiConfigSchema>;
@@ -1216,20 +1206,6 @@ export function scopedToolPaths(
 }
 
 /**
- * Derive convention-based tool paths from a KNOWN_AGENTS skillsPath.
- * e.g. '.tclaude/skills' → { skills: '.tclaude/skills', rules: '.tclaude/rules', agents: '.tclaude/agents', claudemd: '.tclaude/CLAUDE.md' }
- */
-function deriveToolPaths(skillsPath: string): z.infer<typeof ToolPathsSchema> {
-  const root = skillsPath.split('/')[0]; // e.g. '.tclaude'
-  return {
-    skills: skillsPath,
-    rules: `${root}/rules`,
-    agents: `${root}/agents`,
-    claudemd: `${root}/CLAUDE.md`,
-  };
-}
-
-/**
  * Merge scopedToolPaths with KNOWN_AGENTS auto-discovery.
  *
  * scopedToolPaths only returns tools explicitly listed in teamai.yaml toolPaths.
@@ -1237,6 +1213,13 @@ function deriveToolPaths(skillsPath: string): z.infer<typeof ToolPathsSchema> {
  * exists on disk but is missing from the explicit config — so a tool like tclaude
  * that is installed (has ~/.tclaude or <project>/.tclaude) gets resources injected
  * even when the team's teamai.yaml does not list it.
+ *
+ * Resource paths come from DEFAULT_TOOL_PATHS (verified per-tool layouts), not
+ * convention-based derivation. Agents without a DEFAULT_TOOL_PATHS entry receive
+ * only their skills path — no rules/agents/claudemd are guessed.
+ *
+ * Intended for pull/sync paths only. push and remove should use scopedToolPaths()
+ * to stay within the team-managed boundary.
  */
 export async function effectiveToolPaths(
   teamConfig: TeamaiConfig,
@@ -1255,7 +1238,8 @@ export async function effectiveToolPaths(
     if (!rootSegment) continue;
     const rootPath = path.join(baseDir, rootSegment);
     if (await pathExists(rootPath)) {
-      merged[agent.id] = deriveToolPaths(agent.skillsPath);
+      const registered = DEFAULT_TOOL_PATHS[agent.id];
+      merged[agent.id] = registered ?? { skills: agent.skillsPath };
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -403,6 +403,15 @@ export const StateSchema = z.object({
    * literals stay valid; the reconciler treats absent as an empty map.
    */
   coAuthorManaged: z.record(z.string(), z.boolean()).optional(),
+  /**
+   * Resources teamai has deployed into AUTO-DISCOVERED tool dirs (installed on
+   * disk but not in the team's toolPaths). Keyed `<tool>:<resourceType>:<name>`.
+   * Lets pull tell a teamai deployment (safe to overwrite with team updates)
+   * from a personal same-named resource (preserve, never clobber). A key absent
+   * here + a pre-existing destination = personal resource. Optional so historical
+   * state.json and hand-built State literals stay valid (treated as empty).
+   */
+  autoDiscoveredManaged: z.array(z.string()).optional(),
   lastUpdateCheck: z.string().nullable().default(null),
   availableUpdate: z.string().nullable().default(null),
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1228,18 +1228,45 @@ export async function effectiveToolPaths(
   const { KNOWN_AGENTS } = await import('./known-agents.js');
   const { pathExists } = await import('./utils/fs.js');
   const baseDir = resolveBaseDir(localConfig);
+  const isUser = localConfig.scope === 'user';
   const base = scopedToolPaths(teamConfig, localConfig);
   const merged = { ...base };
 
   for (const agent of KNOWN_AGENTS) {
     if (merged[agent.id]) continue;
     if (isAgentDisabled(localConfig, agent.id)) continue;
-    const rootSegment = agent.skillsPath.split('/')[0];
-    if (!rootSegment) continue;
-    const rootPath = path.join(baseDir, rootSegment);
+
+    const registered = DEFAULT_TOOL_PATHS[agent.id];
+
+    // Determine the install-detection root. For user scope, tools with a
+    // userScope override (e.g. opencode → ~/.config/opencode) need the
+    // override's prefix, not the project-scope prefix (.opencode).
+    let detectRoot: string;
+    if (isUser && registered?.userScope?.skills) {
+      detectRoot = registered.userScope.skills.split('/').slice(0, -1).join('/') || registered.userScope.skills.split('/')[0];
+    } else {
+      detectRoot = agent.skillsPath.split('/')[0];
+    }
+    if (!detectRoot) continue;
+
+    const rootPath = path.join(baseDir, detectRoot);
     if (await pathExists(rootPath)) {
-      const registered = DEFAULT_TOOL_PATHS[agent.id];
-      merged[agent.id] = registered ?? { skills: agent.skillsPath };
+      if (registered) {
+        // Apply userScope overrides for user scope, mirroring scopedToolPaths logic
+        if (isUser && registered.userScope) {
+          const us = registered.userScope;
+          merged[agent.id] = {
+            ...registered,
+            ...(us.skills !== undefined ? { skills: us.skills } : {}),
+            ...(us.rules !== undefined ? { rules: us.rules } : {}),
+            ...(us.agents !== undefined ? { agents: us.agents } : {}),
+          };
+        } else {
+          merged[agent.id] = registered;
+        }
+      } else {
+        merged[agent.id] = { skills: agent.skillsPath };
+      }
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1215,6 +1215,53 @@ export function scopedToolPaths(
   return out;
 }
 
+/**
+ * Derive convention-based tool paths from a KNOWN_AGENTS skillsPath.
+ * e.g. '.tclaude/skills' → { skills: '.tclaude/skills', rules: '.tclaude/rules', agents: '.tclaude/agents', claudemd: '.tclaude/CLAUDE.md' }
+ */
+function deriveToolPaths(skillsPath: string): z.infer<typeof ToolPathsSchema> {
+  const root = skillsPath.split('/')[0]; // e.g. '.tclaude'
+  return {
+    skills: skillsPath,
+    rules: `${root}/rules`,
+    agents: `${root}/agents`,
+    claudemd: `${root}/CLAUDE.md`,
+  };
+}
+
+/**
+ * Merge scopedToolPaths with KNOWN_AGENTS auto-discovery.
+ *
+ * scopedToolPaths only returns tools explicitly listed in teamai.yaml toolPaths.
+ * This function supplements those with any KNOWN_AGENTS entry whose install root
+ * exists on disk but is missing from the explicit config — so a tool like tclaude
+ * that is installed (has ~/.tclaude or <project>/.tclaude) gets resources injected
+ * even when the team's teamai.yaml does not list it.
+ */
+export async function effectiveToolPaths(
+  teamConfig: TeamaiConfig,
+  localConfig: LocalConfig,
+): Promise<Record<string, z.infer<typeof ToolPathsSchema>>> {
+  const { KNOWN_AGENTS } = await import('./known-agents.js');
+  const { pathExists } = await import('./utils/fs.js');
+  const baseDir = resolveBaseDir(localConfig);
+  const base = scopedToolPaths(teamConfig, localConfig);
+  const merged = { ...base };
+
+  for (const agent of KNOWN_AGENTS) {
+    if (merged[agent.id]) continue;
+    if (isAgentDisabled(localConfig, agent.id)) continue;
+    const rootSegment = agent.skillsPath.split('/')[0];
+    if (!rootSegment) continue;
+    const rootPath = path.join(baseDir, rootSegment);
+    if (await pathExists(rootPath)) {
+      merged[agent.id] = deriveToolPaths(agent.skillsPath);
+    }
+  }
+
+  return merged;
+}
+
 /** True when the local config is single-repo mode (the business repo is the team repo). */
 export function isSelfMode(localConfig: { repo: { kind?: string } }): boolean {
   return localConfig.repo.kind === 'self';


### PR DESCRIPTION
## Summary

- `pullItem()` in skills/rules/agents handlers only iterated `scopedToolPaths()` (= `teamai.yaml` toolPaths), missing tools like `tclaude`/`tcodex` that are in `KNOWN_AGENTS` and installed on disk
- Added `effectiveToolPaths()` in `types.ts` that merges `scopedToolPaths()` with auto-discovered `KNOWN_AGENTS` entries whose install root (e.g. `.tclaude/`) exists
- Updated all pull/sync call sites (skills, rules, builtin-skills, builtin-rules, builtin-agents, pull.ts) to use `effectiveToolPaths()`
- Added `tclaude` and `tcodex` to `SELF_MODE_AGENT_CHOICES` for `teamai init` single-repo mode detection

## Test plan

- [x] `npx tsc --noEmit` passes (no new type errors)
- [x] `npx vitest run` — all previously-passing tests still pass, updated 3 test files for new SELF_MODE_AGENT_CHOICES size
- [x] E2E: `mkdir -p /root/gpu/.tclaude && teamai pull --force` → skills/rules injected into `.tclaude/skills/` and `.tclaude/rules/`
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)