### PR TITLE
fix(git): keep URL-embedded credentials away from the platform helper

### DIFF
--- a/docs/designs/gitcode-provider.md
+++ b/docs/designs/gitcode-provider.md
@@ -71,6 +71,20 @@ GitHub / TGit 的做法是把 token 内嵌进 remote URL（持久化到 `.git/co
 使 `git push`（分支 + PR 流程）能认证。token 只落在 `~/.teamai/team-repo` 的私有 clone 中，
 与 GitHub / TGit 一致。（`clone.ts` 的浅克隆路径非 push 目标，沿用 extraHeader。）
 
+### 5.2 关键修复：内嵌凭据必须绕开系统 Credential Helper
+
+凭据已经在 URL 里，git 仍会把它交给平台 helper 缓存。实机复现：隔离 `HOME`（Xcode 的
+`git-core/gitconfig` 仍启用 `credential.helper = osxkeychain`）下，`git credential-osxkeychain store`
+找不到默认钥匙串，弹出「找不到用于储存 oauth2 的钥匙串」模态框并阻塞 git —— `teamai init` 撞满
+clone 的 120s 超时后报 `Clone failed: ... Cloning into ...`（无其他 stderr），`teamai pull` 则卡在
+`Pulling team repo...` 永不返回。
+
+**修复**：内嵌凭据的 git 调用统一经 `spawnGit(..., { credentialInUrl: true })`
+（`-c credential.helper=` + `GIT_TERMINAL_PROMPT=0`），clone 成功后 `pinUrlCredential()` 把空的
+`credential.helper` 写入该 clone 的 local config，使后续 pull/fetch/push 一并跳过 helper；
+`createGit()` 另加 120s「无输出」预算，让任何挂死都以报错收场而不是无限等待。
+GitHub / TGit 走同一条内嵌路径，同步修复。
+
 ## 6. 端到端验证（真实 CLI + 真实 GitCode 仓）
 
 - `teamai init https://gitcode.com/...`：✔ Detected provider gitcode / ✔ Authenticated / ✔ Team repo cloned /

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -11,6 +11,20 @@ TeamAI CLI 通过 provider 抽象层支持多个 Git 托管平台。当前实现
 | `gitcode`| gitcode.com     | `GITCODE_TOKEN` 环境变量或 init 交互粘贴 | GitCode（CSDN）用户 |
 | `git`    | 任意 Git host   | 系统 Git Credential Helper 或 SSH Key | 自建 Gitea 等其他平台 |
 
+## 凭据内嵌在 URL 时不走系统 Credential Helper
+
+`github` / `tgit` / `gitcode` 把 token 内嵌进团队仓的 remote URL（见各自章节）。这类 git 调用会以
+`-c credential.helper=` + `GIT_TERMINAL_PROMPT=0` 执行，克隆完成后还会在该仓库的 local config 里写入
+空的 `credential.helper`，让后续 pull / fetch / push 同样跳过系统 helper。
+
+原因：凭据已在 URL 里，git 仍会把它交给平台 helper（macOS osxkeychain、Windows wincred 等）做缓存；
+而 helper 在打不开钥匙串的环境（CI、容器、被改写的 `HOME`、锁定的钥匙串）会弹出无人应答的对话框，
+git 就一直等下去 —— clone 只能等到超时失败，pull 则永远不返回。
+
+`git` 通用 provider 与 `cnb` 依赖 helper 取凭据，因此**不受影响**；`gitlab` 用 `http.extraHeader`，
+也不写 URL 凭据。另外 teamai 自己发起的 git 调用统一有 120s 预算（simple-git 按「无输出」计时），
+避免任意一次挂死变成无限等待。
+
 ## Provider 自动检测
 
 `teamai init <input>`（或等价别名 `teamai init --repo <input>`）根据输入格式自动选择 provider：

--- a/src/__tests__/git-embedded-credential.test.ts
+++ b/src/__tests__/git-embedded-credential.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+
+// ─── Mocks ──────────────────────────────────────────────
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+  spawnSync: vi.fn(),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  log: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    dim: vi.fn(),
+  },
+  spinner: () => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    info: vi.fn().mockReturnThis(),
+    warn: vi.fn().mockReturnThis(),
+  }),
+}));
+
+// ─── Imports after mocks ────────────────────────────────
+
+import { execSync, spawnSync } from 'node:child_process';
+import { gitcodeRepoClone } from '../providers/gitcode/gitcode-api.js';
+import { ghRepoClone } from '../providers/github/gh-cli.js';
+
+const mockedSpawnSync = spawnSync as Mock;
+const mockedExecSync = execSync as Mock;
+
+const originalEnv = { ...process.env };
+
+function cloneCall(): { args: string[]; options: { env?: NodeJS.ProcessEnv } } {
+  const call = mockedSpawnSync.mock.calls.find((c) => (c[1] as string[]).includes('clone'));
+  if (!call) throw new Error('no git clone call recorded');
+  return { args: call[1] as string[], options: (call[2] ?? {}) as { env?: NodeJS.ProcessEnv } };
+}
+
+function configuredHelperValue(): string | undefined {
+  const call = mockedSpawnSync.mock.calls.find((c) => (c[1] as string[]).includes('credential.helper'));
+  if (!call) return undefined;
+  const args = call[1] as string[];
+  return args[args.indexOf('credential.helper') + 1];
+}
+
+describe('git calls whose remote URL carries the credential', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedSpawnSync.mockReset();
+    mockedSpawnSync.mockReturnValue({ status: 0, stdout: '', stderr: '' });
+    mockedExecSync.mockReset();
+    // no gh CLI available, so only env tokens count
+    mockedExecSync.mockImplementation(() => {
+      throw new Error('not found');
+    });
+    for (const key of ['GITCODE_TOKEN', 'GC_TOKEN', 'GITHUB_TOKEN', 'GH_TOKEN']) {
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('clones GitCode with the platform credential helper disabled', () => {
+    process.env.GITCODE_TOKEN = 'gc-token';
+
+    gitcodeRepoClone('owner/repo', '/tmp/team-repo');
+
+    const { args, options } = cloneCall();
+    expect(args.slice(0, 3)).toEqual(['-c', 'credential.helper=', 'clone']);
+    expect(options.env?.GIT_TERMINAL_PROMPT).toBe('0');
+  });
+
+  it('pins the GitCode clone to the URL credential for later pull/push', () => {
+    process.env.GITCODE_TOKEN = 'gc-token';
+
+    gitcodeRepoClone('owner/repo', '/tmp/team-repo');
+
+    expect(configuredHelperValue()).toBe('');
+  });
+
+  it('keeps the credential helper for a GitCode clone with no token', () => {
+    gitcodeRepoClone('owner/repo', '/tmp/team-repo');
+
+    expect(cloneCall().args[0]).toBe('clone');
+    expect(configuredHelperValue()).toBeUndefined();
+  });
+
+  it('clones GitHub with the platform credential helper disabled', () => {
+    process.env.GITHUB_TOKEN = 'gh-token';
+
+    ghRepoClone('owner/repo', '/tmp/team-repo');
+
+    const { args, options } = cloneCall();
+    expect(args.slice(0, 3)).toEqual(['-c', 'credential.helper=', 'clone']);
+    expect(options.env?.GIT_TERMINAL_PROMPT).toBe('0');
+    expect(configuredHelperValue()).toBe('');
+  });
+
+  it('keeps the credential helper for an anonymous GitHub clone', () => {
+    ghRepoClone('owner/repo', '/tmp/team-repo');
+
+    expect(cloneCall().args[0]).toBe('clone');
+    expect(configuredHelperValue()).toBeUndefined();
+  });
+});

--- a/src/providers/gitcode/gitcode-api.ts
+++ b/src/providers/gitcode/gitcode-api.ts
@@ -1,8 +1,8 @@
-import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { GITCODE_HOST } from './repo-url.js';
+import { spawnGit, pinUrlCredential } from '../../utils/git.js';
 import { sanitizeGitUrl } from '../../utils/redact.js';
 
 /**
@@ -177,13 +177,14 @@ function redactCloneOutput(output: string): string {
  */
 export function gitcodeRepoClone(repo: string, localPath: string): void {
   const token = getGitCodeToken();
-  const result = spawnSync('git', ['clone', cloneUrl(repo, token), localPath], {
-    encoding: 'utf-8',
-    stdio: ['pipe', 'pipe', 'pipe'],
-    timeout: 120_000,
+  const result = spawnGit(['clone', cloneUrl(repo, token), localPath], {
+    credentialInUrl: token !== null,
   });
   const allOutput = `${result.stderr ?? ''} ${result.stdout ?? ''}`;
-  if (result.status === 0) return;
+  if (result.status === 0) {
+    if (token) pinUrlCredential(localPath);
+    return;
+  }
 
   if (
     allOutput.includes('not found')

--- a/src/providers/github/gh-cli.ts
+++ b/src/providers/github/gh-cli.ts
@@ -1,4 +1,5 @@
 import { execSync, spawnSync } from 'node:child_process';
+import { spawnGit, pinUrlCredential } from '../../utils/git.js';
 import { log, spinner } from '../../utils/logger.js';
 
 // ─── Constants ───────────────────────────────────────────
@@ -248,11 +249,7 @@ export function ghRepoClone(repo: string, localPath: string): void {
     ? `https://x-access-token:${token}@github.com/${repo}.git`
     : `https://github.com/${repo}.git`;
 
-  const result = spawnSync('git', ['clone', cloneUrl, localPath], {
-    encoding: 'utf-8',
-    stdio: ['pipe', 'pipe', 'pipe'],
-    timeout: 120_000,
-  });
+  const result = spawnGit(['clone', cloneUrl, localPath], { credentialInUrl: Boolean(token) });
 
   const allOutput = `${result.stderr ?? ''} ${result.stdout ?? ''}`;
   if (
@@ -266,6 +263,7 @@ export function ghRepoClone(repo: string, localPath: string): void {
     const sanitized = allOutput.replace(/x-access-token:[^@]+@/g, 'x-access-token:***@');
     throw new Error(`git clone failed: ${sanitized.trim()}`);
   }
+  if (token) pinUrlCredential(localPath);
 }
 
 /**

--- a/src/providers/tgit/gf-cli.ts
+++ b/src/providers/tgit/gf-cli.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { pathExists, ensureDir } from '../../utils/fs.js';
+import { spawnGit, pinUrlCredential } from '../../utils/git.js';
 import { log, spinner } from '../../utils/logger.js';
 import { TEAMAI_HOME } from '../../types.js';
 import { tgitFetch, tgitGitCloneUrl } from './rest-auth.js';
@@ -347,11 +348,7 @@ function gitOutputSaysRepoMissing(output: string): boolean {
 export function gfRepoClone(repo: string, localPath: string): void {
   const cloneUrl = tgitGitCloneUrl(`https://git.woa.com/${repo}.git`);
   if (cloneUrl) {
-    const result = spawnSync('git', ['clone', cloneUrl, localPath], {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 120_000,
-    });
+    const result = spawnGit(['clone', cloneUrl, localPath], { credentialInUrl: true });
     const allOutput = `${result.stderr ?? ''} ${result.stdout ?? ''}`;
     if (gitOutputSaysRepoMissing(allOutput)) {
       throw new RepoNotFoundError(repo);
@@ -361,6 +358,7 @@ export function gfRepoClone(repo: string, localPath: string): void {
       const sanitized = allOutput.replace(/oauth2:[^@]+@/g, 'oauth2:***@');
       throw new Error(`git clone failed: ${sanitized.trim()}`);
     }
+    pinUrlCredential(localPath);
     return;
   }
 

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,9 +1,23 @@
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
 import fs from 'node:fs';
 import { realpath } from 'node:fs/promises';
 import path from 'node:path';
 import fse from 'fs-extra';
 import simpleGit, { type SimpleGit } from 'simple-git';
 import { log } from './logger.js';
+
+/** Wall-clock budget for a single `git` subprocess teamai spawns itself. */
+const GIT_TIMEOUT_MS = 120_000;
+
+/**
+ * How long a simple-git call may produce no output before it is killed.
+ *
+ * Without it a git process that blocks forever — typically waiting on a
+ * credential prompt nobody can answer — makes `teamai pull` hang with no error
+ * at all. The budget only starts over on output, so a slow but progressing
+ * fetch is unaffected.
+ */
+const GIT_BLOCK_TIMEOUT_MS = GIT_TIMEOUT_MS;
 
 /**
  * Create a SimpleGit instance for a given base path.
@@ -12,10 +26,45 @@ import { log } from './logger.js';
  * facilities such as credential helpers, SSH config, and SSH agents.
  */
 export function createGit(basePath?: string): SimpleGit {
+  const timeout = { block: GIT_BLOCK_TIMEOUT_MS };
   if (basePath) {
-    return simpleGit({ baseDir: basePath });
+    return simpleGit({ baseDir: basePath, timeout });
   }
-  return simpleGit();
+  return simpleGit({ timeout });
+}
+
+/**
+ * Spawn `git` for a remote whose credential teamai embeds in the URL.
+ *
+ * Such a call must not reach the platform credential helper: git would hand it
+ * the credential purely to cache it, and a helper that cannot open a keychain
+ * (CI, containers, an overridden HOME, a locked keychain) blocks on a prompt
+ * nobody can answer. `credentialInUrl: false` keeps the helper in play for the
+ * anonymous and helper-backed fallback paths, which do depend on it.
+ */
+export function spawnGit(
+  args: string[],
+  opts: { credentialInUrl: boolean },
+): SpawnSyncReturns<string> {
+  return spawnSync('git', opts.credentialInUrl ? ['-c', 'credential.helper=', ...args] : args, {
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: GIT_TIMEOUT_MS,
+    env: opts.credentialInUrl ? { ...process.env, GIT_TERMINAL_PROMPT: '0' } : process.env,
+  });
+}
+
+/**
+ * Pin a clone to the credential in its own remote URL, so later pull/fetch/push
+ * inside it skip the platform credential helper too (see {@link spawnGit}).
+ *
+ * Best-effort: failing to write the config only costs the protection.
+ */
+export function pinUrlCredential(localPath: string): void {
+  spawnSync('git', ['-C', localPath, 'config', 'credential.helper', ''], {
+    timeout: 5_000,
+    stdio: 'ignore',
+  });
 }
 
 /**


### PR DESCRIPTION
## Problem

`init` against a GitCode team repo failed after ~124s with nothing but

```
✖ Clone failed: git clone failed: Cloning into '.../team-repo'...
```

and, when the clone did succeed, `teamai pull --force` sat on
`- [project] Pulling team repo...` forever.

Root cause (reproduced live): the clone URL for `github` / `tgit` / `gitcode`
embeds the credential, but git still hands it to the platform credential
helper to cache. `git-core/gitconfig` shipped with Xcode enables
`credential.helper = osxkeychain`, and when no keychain is reachable (CI,
containers, an overridden `HOME`, a locked keychain) the helper puts up a
modal dialog — «找不到用于储存 "oauth2" 的钥匙串», `failed to store: -60006` —
and git waits on it. `git clone` therefore only died on its 120s timeout, and
`pullRepo()` (simple-git, no timeout) never returned at all.

## Change

- `spawnGit(args, { credentialInUrl })` in `src/utils/git.ts` runs such clones
  with `-c credential.helper=` and `GIT_TERMINAL_PROMPT=0`.
- `pinUrlCredential()` resets `credential.helper` in the clone's own config, so
  later pull/fetch/push in that repo skip the helper too.
- `createGit()` gets a 120s no-output budget, so any future hang surfaces as an
  error instead of an infinite wait.
- Applied to the three providers that embed the credential (gitcode, github,
  tgit) only when a token is actually embedded. The helper-backed paths (the
  generic `git` provider, `cnb`, anonymous clones) are untouched — they need the
  helper to supply the credential.
- Docs: `docs/providers.md` (new mechanism section) and
  `docs/designs/gitcode-provider.md` §5.2.

## Test Plan

All executed on this branch.

- `npx tsc --noEmit` — clean.
- `npx vitest run` — 2564 passed / 183 files.
- `npm run test:e2e` — 79 passed / 25 skipped (same as `origin/main`).
- New `src/__tests__/git-embedded-credential.test.ts` — 5 tests: clone args carry
  `-c credential.helper=` + `GIT_TERMINAL_PROMPT=0` and the clone is pinned when a
  token is embedded; the helper is left alone for anonymous clones.
- Real CLI, in the isolated `HOME` that used to hang (osxkeychain still active
  via Xcode's `git-core/gitconfig`), against a throwaway private GitCode repo:
  `init` 3.2s → `pull --force` 1.5s → `push` created `.../pull/1` 6.4s →
  `push` again updated the same PR 4.3s → exactly one open PR → repo deleted.
  No dialog appeared. Before this change the same harness timed out at 124s.
- GitHub regression with a throwaway private repo: `init` 4.8s → `pull` 2.6s →
  `push` created a PR 6.5s.

Made with [Cursor](https://cursor.com)