### PR TITLE
chore(release): 0.22.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teamai-cli",
-  "version": "0.22.0-beta.5",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teamai-cli",
-      "version": "0.22.0-beta.5",
+      "version": "0.22.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teamai-cli",
-  "version": "0.22.0-beta.5",
+  "version": "0.22.0",
   "description": "TeamAI — the team harness for AI agents (skill sync + shared knowledge base, powered by Git)",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump version `0.22.0-beta.5` → `0.22.0` so the `v0.22.0` tag can publish `teamai-cli@0.22.0` to public npm `latest`.
- Same tree as GitHub `main` (`29a629a`, includes #392). Does **not** include #394 / #395.

Internal `@tencent/teamai-cli@0.22.0` is already on tnpm `latest`. After this merges, tag `v0.22.0` to trigger GitHub Actions publish.

## Test plan
- [x] `package.json` / `package-lock.json` version is `0.22.0`
- [ ] After merge: tag `v0.22.0` matches package version
- [ ] GitHub Actions Release publishes `teamai-cli@0.22.0` to npm `latest`

Made with [Cursor](https://cursor.com)