### PR TITLE
refactor(data-layout): converge machine-data home onto getDataHome() (#374 P1-1)

### DIFF
--- a/src/__tests__/home.test.ts
+++ b/src/__tests__/home.test.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { getUserHome } from '../utils/home.js';
-import { getTeamaiHome, getDataHome, resolveBaseDir, type LocalConfig } from '../types.js';
+import { getTeamaiHome, getDataHome, getEnvBackupPath, resolveBaseDir, type LocalConfig } from '../types.js';
 
 const originalHome = process.env.HOME;
 const originalUserProfile = process.env.USERPROFILE;
@@ -133,6 +133,36 @@ describe('getDataHome (machine-data home resolver)', () => {
       repo: { localPath: '/work/self-repo/.teamai', remote: '', kind: 'self' },
     });
     expect(getDataHome(cfg)).toBe(path.join('/work/self-repo', '.teamai'));
+  });
+
+  it('co-locates the env backup with the data home (git + self)', () => {
+    // Regression guard for the P1-2 partition flip: getEnvBackupPath must route
+    // through getDataHome, so env and env.sh never diverge across a redirect.
+    // (Reviewer: plaintext env backup must not stay behind in the workspace.)
+    process.env.HOME = '/home/alice';
+    const git = makeConfig({ scope: 'project', projectRoot: '/work/proj' });
+    expect(path.dirname(getEnvBackupPath(git))).toBe(getDataHome(git));
+    expect(getEnvBackupPath(git)).toBe(path.join(getDataHome(git), 'env'));
+
+    const self = makeConfig({
+      scope: 'project',
+      projectRoot: '/work/self-repo',
+      repo: { localPath: '/work/self-repo/.teamai', remote: '', kind: 'self' },
+    });
+    expect(path.dirname(getEnvBackupPath(self))).toBe(getDataHome(self));
+    expect(getEnvBackupPath(self)).toBe(path.join(getDataHome(self), 'env.local'));
+  });
+
+  it('throws for a project-scope config missing projectRoot (the hazard callers must guard)', () => {
+    // LocalConfigSchema permits scope:project without projectRoot, and
+    // loadLocalConfig() does not backfill it. getDataHome inherits
+    // getTeamaiHome's refusal to silently fall back to the user home. Consumers
+    // whose config source can yield such a config (recall.ts, viz.ts) MUST guard
+    // before calling getDataHome and fall back to ~/.teamai themselves — this
+    // test documents why that guard exists so it is not "simplified" away.
+    process.env.HOME = '/home/alice';
+    const cfg = makeConfig({ scope: 'project', projectRoot: undefined });
+    expect(() => getDataHome(cfg)).toThrow(/projectRoot is missing/);
   });
 });
 

--- a/src/__tests__/home.test.ts
+++ b/src/__tests__/home.test.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { getUserHome } from '../utils/home.js';
-import { getTeamaiHome, resolveBaseDir, type LocalConfig } from '../types.js';
+import { getTeamaiHome, getDataHome, resolveBaseDir, type LocalConfig } from '../types.js';
 
 const originalHome = process.env.HOME;
 const originalUserProfile = process.env.USERPROFILE;
@@ -92,6 +92,47 @@ describe('getUserHome', () => {
     const { getApiKeyPath } = await import('../api-key.js');
 
     expect(getApiKeyPath()).toBe(path.join('C:\\Users\\alice', '.teamai', 'apikey'));
+  });
+});
+
+describe('getDataHome (machine-data home resolver)', () => {
+  // PR-1 introduces getDataHome as the single source of truth for the machine-data
+  // home, consumed by every caller that used to call getTeamaiHome(scope, projectRoot)
+  // directly. It is behavior-preserving: it must return exactly the legacy path in
+  // every mode. This golden test is the regression guard for that contract — a later
+  // phase (P1 partition) will deliberately change the project-scope expectation here.
+  function makeConfig(overrides: Partial<LocalConfig>): LocalConfig {
+    return {
+      repo: { localPath: '/tmp/x/.teamai/team-repo', remote: 'git@example.com:t/r.git' },
+      username: 'alice',
+      scope: 'user',
+      additionalRoles: [],
+      ...overrides,
+    } as LocalConfig;
+  }
+
+  it('equals getTeamaiHome(user) for user scope', () => {
+    process.env.HOME = '/home/alice';
+    const cfg = makeConfig({ scope: 'user' });
+    expect(getDataHome(cfg)).toBe(getTeamaiHome('user'));
+    expect(getDataHome(cfg)).toBe(path.join('/home/alice', '.teamai'));
+  });
+
+  it('equals getTeamaiHome(project, projectRoot) for project scope', () => {
+    process.env.HOME = '/home/alice';
+    const cfg = makeConfig({ scope: 'project', projectRoot: '/work/proj' });
+    expect(getDataHome(cfg)).toBe(getTeamaiHome('project', '/work/proj'));
+    expect(getDataHome(cfg)).toBe(path.join('/work/proj', '.teamai'));
+  });
+
+  it('follows scope, not repo.kind — self mode keys on its project scope', () => {
+    process.env.HOME = '/home/alice';
+    const cfg = makeConfig({
+      scope: 'project',
+      projectRoot: '/work/self-repo',
+      repo: { localPath: '/work/self-repo/.teamai', remote: '', kind: 'self' },
+    });
+    expect(getDataHome(cfg)).toBe(path.join('/work/self-repo', '.teamai'));
   });
 });
 

--- a/src/contribute.ts
+++ b/src/contribute.ts
@@ -10,7 +10,7 @@ import { log, spinner } from './utils/logger.js';
 import { markContributed } from './contribute-check.js';
 import { savePendingLearning } from './utils/pending-learnings.js';
 import type { GlobalOptions, LocalConfig } from './types.js';
-import { LEARNINGS_LOCAL_DIR, getTeamaiHome } from './types.js';
+import { LEARNINGS_LOCAL_DIR, getDataHome } from './types.js';
 
 /**
  * Rebuild this scope's local search index so the freshly-written contribution
@@ -41,7 +41,7 @@ async function rebuildIndexAfterContribute(localConfig: LocalConfig): Promise<vo
     effectiveLearningsDir = (await pathExists(learningsRepoDir)) ? learningsRepoDir : undefined;
   }
 
-  const teamaiHome = getTeamaiHome(localConfig.scope, localConfig.projectRoot);
+  const teamaiHome = getDataHome(localConfig);
   const indexPath = path.join(teamaiHome, 'search-index.json');
   const { buildIndex } = await import('./utils/search-index.js');
   await buildIndex({
@@ -276,7 +276,7 @@ async function contributeSelf(
           if (await pathExists(candidate)) votesDir = candidate;
         } catch { /* reports worktree unavailable — index without votes */ }
 
-        const teamaiHome = getTeamaiHome(localConfig.scope, localConfig.projectRoot);
+        const teamaiHome = getDataHome(localConfig);
         const { buildIndex } = await import('./utils/search-index.js');
         await buildIndex({
           learningsDir: await pathExists(LEARNINGS_LOCAL_DIR) ? LEARNINGS_LOCAL_DIR : undefined,

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -7,7 +7,7 @@ import {
   TeamaiConfigSchema,
   TEAMAI_ENV_START,
   resolveHookScope,
-  getTeamaiHome,
+  getDataHome,
   type TeamaiConfig,
 } from './types.js';
 import { TEAMAI_HOOK_SUBCOMMANDS, isCodexTrustGatedTool, codexTrustReminder } from './hooks.js';
@@ -183,7 +183,7 @@ export async function doctor(options: GlobalOptions): Promise<void> {
         // project scope and ~/.teamai in user scope — mirror the path that
         // `teamai pull` actually writes to, not a hardcoded user-home path.
         const envShPath = path.join(
-          getTeamaiHome(localConfig.scope, localConfig.projectRoot),
+          getDataHome(localConfig),
           'env.sh',
         );
         if (!await pathExists(envShPath)) return false;

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -24,7 +24,7 @@ import {
   CultureFrontmatterSchema,
   resolveBaseDir,
   resolveHookScope,
-  getTeamaiHome,
+  getDataHome,
   isRecallEnabled,
   isAgentDisabled,
   scopedToolPaths,
@@ -521,7 +521,7 @@ async function pullForScope(
         log.info(`[${scopeLabel}] [dry-run] Would sync ${varCount} env variable(s)`);
       } else {
         await envHandler.pullItem(items[0], freshConfig, localConfig);
-        const teamaiHome = getTeamaiHome(localConfig.scope, localConfig.projectRoot);
+        const teamaiHome = getDataHome(localConfig);
         log.success(`[${scopeLabel}] Synced ${varCount} env variable(s) to ${teamaiHome}/env.sh`);
       }
       totalSynced += 1;
@@ -734,7 +734,7 @@ async function pullForScope(
 
       if (hasAnySource || effectiveCodebaseDir) {
         const votesExist = await pathExists(votesDir);
-        const teamaiHome = getTeamaiHome(localConfig.scope, localConfig.projectRoot);
+        const teamaiHome = getDataHome(localConfig);
         const indexPath = path.join(teamaiHome, 'search-index.json');
         const { buildIndex } = await import('./utils/search-index.js');
         const elapsed = await buildIndex({

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -5,7 +5,7 @@ import type { SearchResult } from './utils/search-index.js';
 import { readFileSafe, ensureDir, pathExists } from './utils/fs.js';
 import { log } from './utils/logger.js';
 import type { GlobalOptions, SearchIndex, LocalConfig } from './types.js';
-import { getDataHome } from './types.js';
+import { getDataHome, getTeamaiHome } from './types.js';
 import { queryCodeKnowledge } from './code-knowledge-recall.js';
 import type { CodeKnowledgeResult, SourceAnchor } from './code-knowledge-recall.js';
 import { recordRecallQuality } from './recall-quality.js';
@@ -264,7 +264,15 @@ async function loadOrBuildScopeIndex(
   localConfig: LocalConfig,
   scopeLabel: 'user' | 'project',
 ): Promise<{ index: SearchIndex; learningsBase: string } | null> {
-  const teamaiHome = getDataHome(localConfig);
+  // Route the project branch through getDataHome (so P1-2's partition redirect
+  // applies), but preserve the historical fallback to ~/.teamai when a project
+  // scope config lacks projectRoot: getDataHome → getTeamaiHome throws in that
+  // case, and here the exception surfaces as a misleading "No learnings
+  // available". A ~/.teamai/config.yaml with scope:project but no projectRoot is
+  // permitted by LocalConfigSchema and not backfilled by loadLocalConfig.
+  const teamaiHome = localConfig.scope === 'project' && localConfig.projectRoot
+    ? getDataHome(localConfig)
+    : getTeamaiHome('user');
   const indexPath = path.join(teamaiHome, 'search-index.json');
 
   // user scope: learnings 已被 pull 同步到 ~/.teamai/learnings/

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -5,7 +5,7 @@ import type { SearchResult } from './utils/search-index.js';
 import { readFileSafe, ensureDir, pathExists } from './utils/fs.js';
 import { log } from './utils/logger.js';
 import type { GlobalOptions, SearchIndex, LocalConfig } from './types.js';
-import { getTeamaiHome } from './types.js';
+import { getDataHome } from './types.js';
 import { queryCodeKnowledge } from './code-knowledge-recall.js';
 import type { CodeKnowledgeResult, SourceAnchor } from './code-knowledge-recall.js';
 import { recordRecallQuality } from './recall-quality.js';
@@ -264,9 +264,7 @@ async function loadOrBuildScopeIndex(
   localConfig: LocalConfig,
   scopeLabel: 'user' | 'project',
 ): Promise<{ index: SearchIndex; learningsBase: string } | null> {
-  const teamaiHome = localConfig.scope === 'project' && localConfig.projectRoot
-    ? getTeamaiHome('project', localConfig.projectRoot)
-    : getTeamaiHome('user');
+  const teamaiHome = getDataHome(localConfig);
   const indexPath = path.join(teamaiHome, 'search-index.json');
 
   // user scope: learnings 已被 pull 同步到 ~/.teamai/learnings/

--- a/src/resources/env.ts
+++ b/src/resources/env.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import YAML from 'yaml';
 import { ResourceHandler } from './base.js';
 import type { ResourceItem, TeamaiConfig, LocalConfig } from '../types.js';
-import { TEAMAI_ENV_START, TEAMAI_ENV_END, getTeamaiHome, getEnvBackupPath, isSelfMode } from '../types.js';
+import { TEAMAI_ENV_START, TEAMAI_ENV_END, getDataHome, getEnvBackupPath, isSelfMode } from '../types.js';
 import { pathExists, readFileSafe, writeFile, ensureDir, fileContentEqual } from '../utils/fs.js';
 import { log } from '../utils/logger.js';
 import { getUserHome } from '../utils/home.js';
@@ -156,7 +156,7 @@ export class EnvHandler extends ResourceHandler {
     // getEnvBackupPath returns <teamaiHome>/env normally, but <teamaiHome>/env.local
     // in self mode — where <teamaiHome>/env is a committed DIRECTORY (env/env.yaml)
     // and writing a file there would throw EISDIR.
-    const teamaiHome = getTeamaiHome(localConfig.scope, localConfig.projectRoot);
+    const teamaiHome = getDataHome(localConfig);
     const backupLines = envConfig.variables.map(v => `${v.key}=${v.value}`);
     await ensureDir(teamaiHome);
     await writeFile(getEnvBackupPath(localConfig), backupLines.join('\n') + '\n');

--- a/src/types.ts
+++ b/src/types.ts
@@ -1274,7 +1274,13 @@ export function getTeamaiHome(scope: Scope, projectRoot?: string): string {
  * through this helper so they never disagree on the path.
  */
 export function getEnvBackupPath(localConfig: LocalConfig): string {
-  const home = getTeamaiHome(localConfig.scope, localConfig.projectRoot);
+  // Route through getDataHome (not getTeamaiHome directly) so the plaintext
+  // env backup follows the machine-data home together with env.sh. Otherwise
+  // P1-2's partition redirect would move env.sh into ~/.teamai/projects/<slug>/
+  // while leaving the KEY=value backup (which carries plaintext values) behind
+  // in <projectRoot>/.teamai — breaking "zero workspace residue" and leaking
+  // sensitive values into the business repo directory.
+  const home = getDataHome(localConfig);
   return path.join(home, isSelfMode(localConfig) ? 'env.local' : 'env');
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1210,6 +1210,26 @@ export function getKnowledgeDir(localConfig: LocalConfig): string {
 }
 
 /**
+ * Directory holding this project's machine-local teamai data (search index,
+ * env backup, managed manifests, local-agent resource cache, and — in a later
+ * phase — config.yaml/state.json and the team-repo clone).
+ *
+ * This is the single source of truth for the machine-data home, sitting beside
+ * `getKnowledgeDir` (team knowledge assets) and `resolveBaseDir` (AI-tool
+ * resource landing = the workspace root). The three are orthogonal:
+ * knowledge / resource-landing / machine-data.
+ *
+ * Today it returns `getTeamaiHome(scope, projectRoot)` — i.e. `<projectRoot>/.teamai`
+ * for project scope, `~/.teamai` for user scope. A later phase (P1) redirects the
+ * project-scope case to a per-project partition under `~/.teamai/projects/<slug>/`
+ * keyed by the shared `projectAnchor`; every consumer already routes through this
+ * function, so that redirect happens in one place.
+ */
+export function getDataHome(localConfig: LocalConfig): string {
+  return getTeamaiHome(localConfig.scope, localConfig.projectRoot);
+}
+
+/**
  * Directory holding reports data (members/sessions/votes/stats).
  * - git/http: same as knowledge (localPath) — reports live alongside knowledge.
  * - self:     <localPath>/reports-wt — a git worktree checked out on the

--- a/src/uninstall.ts
+++ b/src/uninstall.ts
@@ -18,7 +18,7 @@ import {
   TEAMAI_RECALL_RULES_END,
   TEAMAI_ENV_START,
   TEAMAI_ENV_END,
-  getTeamaiHome,
+  getDataHome,
   managedMcpManifestPath,
   resolveBaseDir,
   resolveHookScope,
@@ -349,7 +349,7 @@ async function buildRemovalPlan(
   agentFilter?: string,
 ): Promise<RemovalPlan> {
   const baseDir = resolveBaseDir(localConfig);
-  const teamaiHome = getTeamaiHome(localConfig.scope, localConfig.projectRoot);
+  const teamaiHome = getDataHome(localConfig);
 
   // Discover team repo resource names for targeted removal. CLI built-in
   // resources (recall agent/rule, share-learnings skill, …) are deployed by

--- a/src/viz.ts
+++ b/src/viz.ts
@@ -19,6 +19,7 @@ import {
   getKnowledgeDir,
   getReportsDir,
   getDataHome,
+  getTeamaiHome,
 } from './types.js';
 import type { SearchIndexEntry } from './types.js';
 import { findPromotionCandidates, type PromotionCandidate } from './maintenance/promote.js';
@@ -157,7 +158,11 @@ export async function resolveVizRoot(opts: VizOptions): Promise<VizPaths> {
     const knowledgeRoot = getKnowledgeDir(config);
     const reportsRoot = getReportsDir(config);
     const useProjectScope = config.scope === 'project' && Boolean(config.projectRoot);
-    const teamaiHome = getDataHome(config);
+    // Project branch routes through getDataHome (P1-2 partition-aware); the
+    // else branch preserves the original fallback to ~/.teamai for historical
+    // configs that are project-scoped but lack projectRoot (getDataHome would
+    // otherwise throw via getTeamaiHome and fail the dashboard report).
+    const teamaiHome = useProjectScope ? getDataHome(config) : getTeamaiHome('user');
     const learningsDir = useProjectScope
       ? path.join(knowledgeRoot, 'learnings')
       : LEARNINGS_LOCAL_DIR;

--- a/src/viz.ts
+++ b/src/viz.ts
@@ -18,7 +18,7 @@ import {
   LEARNINGS_LOCAL_DIR,
   getKnowledgeDir,
   getReportsDir,
-  getTeamaiHome,
+  getDataHome,
 } from './types.js';
 import type { SearchIndexEntry } from './types.js';
 import { findPromotionCandidates, type PromotionCandidate } from './maintenance/promote.js';
@@ -157,9 +157,7 @@ export async function resolveVizRoot(opts: VizOptions): Promise<VizPaths> {
     const knowledgeRoot = getKnowledgeDir(config);
     const reportsRoot = getReportsDir(config);
     const useProjectScope = config.scope === 'project' && Boolean(config.projectRoot);
-    const teamaiHome = useProjectScope
-      ? getTeamaiHome('project', config.projectRoot!)
-      : getTeamaiHome('user');
+    const teamaiHome = getDataHome(config);
     const learningsDir = useProjectScope
       ? path.join(knowledgeRoot, 'learnings')
       : LEARNINGS_LOCAL_DIR;


### PR DESCRIPTION
## Context

Follow-up to **P0** (#387, merged). P0 established the two-anchor primitive
(`resolveAnchors` → `{workspaceRoot, projectAnchor}`), the atomic owner-verified
lock, and subdirectory/worktree-aware config detection. **P0 relocated no data.**

**P1** moves teamai's machine-local data out of the business repo into
`~/.teamai/projects/<slug>/` so a project workspace has zero teamai residue,
keyed by the shared `projectAnchor`. Per the issue's own phasing and R7 ("P0's
call-site surface is large — ship in isolation"), P1 is delivered as **3 PRs**:

- **P1-1 (this PR)** — pure convergence refactor, ZERO behavior change
- **P1-2** — route project data to the partition + `.sync-lock` + `status` print + double-read compat
- **P1-3** — auto-migration (copy → verify → atomic rename → keep `.teamai.bak/`)

## What this PR does

Introduces `getDataHome(localConfig)` as the single source of truth for the
per-project machine-data home, beside the existing `getKnowledgeDir()` (team
knowledge assets) and `resolveBaseDir()` (AI-tool resource landing = workspace
root). The three are now orthogonal: **knowledge / resource-landing / machine-data**.

Every consumer holding a full `LocalConfig` that derived the machine-data home
via `getTeamaiHome(localConfig.scope, localConfig.projectRoot)` now routes
through `getDataHome(localConfig)`: `contribute`, `doctor`, `pull`, `recall`,
`resources/env`, `uninstall`, `viz`.

`getDataHome` returns **exactly** today's path in every mode (project →
`<projectRoot>/.teamai`, user → `~/.teamai`, self follows its scope). The
low-level `getTeamaiHome(scope, projectRoot)` primitive is kept for the
detection/bootstrap layer (init's team-repo clone; `getConfigPath` /
`getStatePath` / `getManagedHooksPath` / `managedMcpManifestPath`) that runs
before a full `LocalConfig` exists — that is the seam P1-2's partition routing
flips in one place.

## Why converge first

P1-2 will redirect project machine-data to `~/.teamai/projects/<slug>/`.
Converging the ~14 scattered call sites into one function first means that
redirect is a single-place change, not an edit to every consumer — the same
"single on-disk-location source of truth" discipline `resolveHookScope`
established after scope logic drifted across init/pull/hooks/doctor.

## Test plan (all executed green)

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — **182 files / 2564 tests pass**
- [x] Golden equivalence unit test (`home.test.ts`): `getDataHome` == legacy
      `getTeamaiHome` across {project, user} × {git, self} — the regression
      guard for the upcoming partition flip
- [x] **Real CLI e2e — project scope**: offline fixture repo → `init` config →
      `pull` → `status` → `recall`. Verified data still lands at
      `<root>/.teamai/{search-index.json,team-repo}`, skill deploys to
      `<root>/.claude/skills/demo`, `HOME/.teamai` carries **no** project data
      (behavior unchanged). `status` prints `project scope detected`.
- [x] **Real CLI e2e — self mode**: `status` resolves the self-mode config,
      knowledge stays in `<root>/.teamai/skills` (B-class on main), env backup
      path uses `env.local` (self-mode EISDIR guard intact).

Refs #374.