### PR TITLE
fix(local-agent): run plugin install commands with bash, not dash

### DIFF
--- a/src/__tests__/plugin-command.test.ts
+++ b/src/__tests__/plugin-command.test.ts
@@ -1,0 +1,37 @@
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import { describe, expect, it, vi } from 'vitest';
+
+const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }));
+
+vi.mock('node:child_process', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:child_process')>()),
+  spawn: spawnMock,
+}));
+
+import { execPluginCommand } from '../local-agent.js';
+
+describe('execPluginCommand', () => {
+  it('uses bash for login-shell plugin commands', async () => {
+    const child = new EventEmitter() as EventEmitter & {
+      stderr: PassThrough;
+      kill: ReturnType<typeof vi.fn>;
+      unref: ReturnType<typeof vi.fn>;
+    };
+    child.stderr = new PassThrough();
+    child.kill = vi.fn();
+    child.unref = vi.fn();
+    spawnMock.mockReturnValue(child);
+
+    const execution = execPluginCommand('printf installed', 1_000);
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledOnce());
+    child.emit('exit', 0, null);
+    await execution;
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'bash',
+      ['-lc', 'printf installed'],
+      { stdio: ['ignore', 'ignore', 'pipe'] },
+    );
+  });
+});

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -731,12 +731,12 @@ function redactSecrets(s: string): string {
  * emit 'close', producing a false timeout even though the command itself finished.
  * Rejects on non-zero exit, termination by signal, or timeout.
  */
-async function execPluginCommand(cmd: string, timeoutMs: number): Promise<void> {
+export async function execPluginCommand(cmd: string, timeoutMs: number): Promise<void> {
   const { spawn } = await import('node:child_process');
   await new Promise<void>((resolve, reject) => {
     const child = process.platform === 'win32'
       ? spawn('cmd', ['/c', cmd], { windowsHide: true, stdio: ['ignore', 'ignore', 'pipe'] })
-      : spawn('/bin/sh', ['-lc', cmd], { stdio: ['ignore', 'ignore', 'pipe'] });
+      : spawn('bash', ['-lc', cmd], { stdio: ['ignore', 'ignore', 'pipe'] });
     let stderr = '';
     let settled = false;
     let timer: ReturnType<typeof setTimeout>;


### PR DESCRIPTION
## Summary
- Plugin reconcile used `/bin/sh -lc`, which is dash on Debian/anydev. Login dash cannot source bash-only `/etc/profile.d` scripts (`[[`, `shopt`), so CLS/plugin install never ran.
- Execute plugin commands with `bash -lc` on non-Windows, matching the rest of teamai hook commands.
- Add a regression test that asserts `spawn('bash', ['-lc', ...])`.

## Test plan
- [x] `npx vitest run src/__tests__/plugin-command.test.ts` (red then green)
- [x] `npx vitest run` (2562 tests)
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] `npm run test:e2e` (79 passed, 25 skipped)
- [x] Real CLI: global worktree install + fixture `get-config` + `teamai source reconcile-plugins` → `plugins.json` `ready: true` and bash `-lc` log
- [ ] After merge: anydev user deletes `plugins.json` cooldown and retries via a new session (not a manual reconcile without `TEAMAI_PLUGIN_LOCAL_AGENT_ID`)


Made with [Cursor](https://cursor.com)