### PR TITLE
feat: substitute any scalar plugin field into install commands

### DIFF
--- a/src/__tests__/plugin-lifecycle.test.ts
+++ b/src/__tests__/plugin-lifecycle.test.ts
@@ -437,6 +437,38 @@ describe('parseGetConfig', () => {
     expect(vars['user_name']).toBe('admin123');
   });
 
+  it('extracts arbitrary scalar fields as substitution vars', () => {
+    const resp = {
+      cls: {
+        endpoint: 'ap-guangzhou.cls.tencentcs.com',
+        cls_uin: '10001',
+        topic_id: 'topic-1',
+        extra_flag: 8,
+        'cls-uin': 'hyphenated',
+        nested: { ignored: true },
+        enabled: true,
+        install_cmd: 'curl install | bash -s -- --cls-uin ${cls_uin}',
+        update_cmd: 'curl install | bash -s -- upgrade',
+        uninstall_cmd: 'bash uninstall',
+        run_cmd: 'true',
+        version: '1.2.3',
+      },
+    };
+    const { vars } = parseGetConfig(resp);
+    expect(vars['cls_uin']).toBe('10001');
+    expect(vars['endpoint']).toBe('ap-guangzhou.cls.tencentcs.com');
+    expect(vars['topic_id']).toBe('topic-1');
+    expect(vars['extra_flag']).toBe('8');
+    expect(vars['cls-uin']).toBeUndefined();
+    expect(vars['nested']).toBeUndefined();
+    expect(vars['enabled']).toBeUndefined();
+    expect(vars['install_cmd']).toBeUndefined();
+    expect(vars['update_cmd']).toBeUndefined();
+    expect(vars['run_cmd']).toBeUndefined();
+    expect(vars['uninstall_cmd']).toBeUndefined();
+    expect(vars['version']).toBeUndefined();
+  });
+
   it('skips non-object section values', () => {
     const resp = { cls: 'not-an-object', other: 42 };
     expect(parseGetConfig(resp).plugins).toHaveLength(0);

--- a/src/plugin-lifecycle.ts
+++ b/src/plugin-lifecycle.ts
@@ -232,13 +232,24 @@ export async function teardownAllPlugins(deps: ReconcileDeps): Promise<void> {
   }
 }
 
+const PLUGIN_CMD_FIELDS = new Set([
+  'install_cmd',
+  'update_cmd',
+  'uninstall_cmd',
+  'run_cmd',
+  'version',
+]);
+const PLUGIN_VAR_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
 /**
  * Parse a raw get-config response into structured plugin descriptors and substitution vars.
  *
  * New contract: iterate over each top-level key; if the value is an object that contains
  * non-empty `install_cmd`, `run_cmd`, and `uninstall_cmd` strings, it is a plugin whose
- * slug equals that key. Substitution vars (endpoint, topic_id, etc.) are extracted from
- * the same section.
+ * slug equals that key. Substitution vars are every finite number or non-empty
+ * string field in the same section whose name is a valid `${placeholder}`
+ * identifier (`[A-Za-z_][A-Za-z0-9_]*`). Command/version fields are excluded.
+ * If two plugin sections share a field name, the later section wins.
  */
 export function parseGetConfig(resp: unknown): { vars: Record<string, string>; plugins: PluginDescriptor[] } {
   const vars: Record<string, string> = {};
@@ -249,12 +260,11 @@ export function parseGetConfig(resp: unknown): { vars: Record<string, string>; p
     const s = section as Record<string, unknown>;
     const isStr = (v: unknown): v is string => typeof v === 'string' && v.length > 0;
     if (!isStr(s['install_cmd']) || !isStr(s['run_cmd']) || !isStr(s['uninstall_cmd'])) continue;
-    // substitution vars: scalar fields referenced by ${...} in run_cmd
-    for (const f of ['endpoint', 'topic_id', 'secret_id', 'secret_key', 'user_name'] as const) {
-      if (isStr(s[f])) vars[f] = s[f] as string;
+    for (const [field, value] of Object.entries(s)) {
+      if (PLUGIN_CMD_FIELDS.has(field) || !PLUGIN_VAR_NAME.test(field)) continue;
+      if (typeof value === 'number' && Number.isFinite(value)) vars[field] = String(value);
+      else if (isStr(value)) vars[field] = value;
     }
-    if (typeof s['user_id'] === 'number') vars['user_id'] = String(s['user_id']);
-    else if (isStr(s['user_id'])) vars['user_id'] = s['user_id'] as string;
     plugins.push({
       slug: key,
       version: isStr(s['version']) ? (s['version'] as string) : undefined,


### PR DESCRIPTION
## Summary
- Plugin `get-config` substitution no longer uses a hardcoded whitelist (`endpoint`, `topic_id`, `secret_id`, …).
- Any non-empty string or finite number field whose name is a valid `${placeholder}` identifier is now available, so commands can use `${cls_uin}` without stuffing UIN into `secret_id`.
- Command/version fields, hyphenated keys (`cls-uin`), booleans, and nested objects are still ignored.

## Test plan
- [x] `npx vitest run src/__tests__/plugin-lifecycle.test.ts`
- [ ] After merge: clawpro `cls` section with `cls_uin` + `install_cmd` containing `--cls-uin ${cls_uin}` is substituted and not skipped
- [ ] Existing `${endpoint}` / `${topic_id}` / `${user_id}` / `${user_name}` / `${secret_id}` still resolve
- [ ] Missing `run_cmd` still causes the plugin to be ignored


Made with [Cursor](https://cursor.com)