### PR TITLE
fix(recall): read self-mode votes from reports worktree

### DIFF
--- a/src/__tests__/maintenance-paths.test.ts
+++ b/src/__tests__/maintenance-paths.test.ts
@@ -4,10 +4,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { LocalConfig } from '../types.js';
 import { REPORTS_WORKTREE_DIRNAME } from '../types.js';
 import { resolveMaintenancePaths } from '../maintenance/paths.js';
-import { ensureReportsWorktree } from '../utils/reports-branch.js';
+import { refreshReportsWorktree } from '../utils/reports-branch.js';
 
 vi.mock('../utils/reports-branch.js', () => ({
-  ensureReportsWorktree: vi.fn(),
+  refreshReportsWorktree: vi.fn(),
 }));
 
 function makeConfig(kind: 'git' | 'self'): LocalConfig {
@@ -31,9 +31,7 @@ function makeConfig(kind: 'git' | 'self'): LocalConfig {
 
 describe('resolveMaintenancePaths', () => {
   beforeEach(() => {
-    vi.mocked(ensureReportsWorktree).mockReset().mockResolvedValue(
-      '/workspace/project/.teamai/reports-wt',
-    );
+    vi.mocked(refreshReportsWorktree).mockReset().mockResolvedValue();
   });
 
   it('reads self-mode votes from the reports worktree', async () => {
@@ -48,8 +46,8 @@ describe('resolveMaintenancePaths', () => {
       ),
       learningsDir: '/workspace/project/.teamai/learnings',
     });
-    expect(ensureReportsWorktree).toHaveBeenCalledOnce();
-    expect(ensureReportsWorktree).toHaveBeenCalledWith(config);
+    expect(refreshReportsWorktree).toHaveBeenCalledOnce();
+    expect(refreshReportsWorktree).toHaveBeenCalledWith(config, { pushIfCreated: false });
   });
 
   it('keeps knowledge and votes together for standalone team repos', async () => {
@@ -60,6 +58,6 @@ describe('resolveMaintenancePaths', () => {
       votesDir: '/home/alice/.teamai/team-repo/votes',
       learningsDir: '/home/alice/.teamai/team-repo/learnings',
     });
-    expect(ensureReportsWorktree).not.toHaveBeenCalled();
+    expect(refreshReportsWorktree).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/maintenance-paths.test.ts
+++ b/src/__tests__/maintenance-paths.test.ts
@@ -1,0 +1,65 @@
+import path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { LocalConfig } from '../types.js';
+import { REPORTS_WORKTREE_DIRNAME } from '../types.js';
+import { resolveMaintenancePaths } from '../maintenance/paths.js';
+import { ensureReportsWorktree } from '../utils/reports-branch.js';
+
+vi.mock('../utils/reports-branch.js', () => ({
+  ensureReportsWorktree: vi.fn(),
+}));
+
+function makeConfig(kind: 'git' | 'self'): LocalConfig {
+  const projectRoot = '/workspace/project';
+  const localPath = kind === 'self'
+    ? path.join(projectRoot, '.teamai')
+    : '/home/alice/.teamai/team-repo';
+  return {
+    repo: {
+      localPath,
+      remote: 'https://example.com/team.git',
+      kind,
+      ...(kind === 'self' ? { businessRepoRoot: projectRoot } : {}),
+    },
+    username: 'alice',
+    scope: kind === 'self' ? 'project' : 'user',
+    ...(kind === 'self' ? { projectRoot } : {}),
+    additionalRoles: [],
+  };
+}
+
+describe('resolveMaintenancePaths', () => {
+  beforeEach(() => {
+    vi.mocked(ensureReportsWorktree).mockReset().mockResolvedValue(
+      '/workspace/project/.teamai/reports-wt',
+    );
+  });
+
+  it('reads self-mode votes from the reports worktree', async () => {
+    const config = makeConfig('self');
+
+    await expect(resolveMaintenancePaths(config)).resolves.toEqual({
+      repoPath: '/workspace/project/.teamai',
+      votesDir: path.join(
+        '/workspace/project/.teamai',
+        REPORTS_WORKTREE_DIRNAME,
+        'votes',
+      ),
+      learningsDir: '/workspace/project/.teamai/learnings',
+    });
+    expect(ensureReportsWorktree).toHaveBeenCalledOnce();
+    expect(ensureReportsWorktree).toHaveBeenCalledWith(config);
+  });
+
+  it('keeps knowledge and votes together for standalone team repos', async () => {
+    const config = makeConfig('git');
+
+    await expect(resolveMaintenancePaths(config)).resolves.toEqual({
+      repoPath: '/home/alice/.teamai/team-repo',
+      votesDir: '/home/alice/.teamai/team-repo/votes',
+      learningsDir: '/home/alice/.teamai/team-repo/learnings',
+    });
+    expect(ensureReportsWorktree).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/reports-branch-readonly.test.ts
+++ b/src/__tests__/reports-branch-readonly.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { LocalConfig } from '../types.js';
+
+const mocks = vi.hoisted(() => ({
+  repoGit: {
+    listRemote: vi.fn(),
+    raw: vi.fn(),
+  },
+  worktreeGit: {
+    raw: vi.fn(),
+    add: vi.fn(),
+    commit: vi.fn(),
+    push: vi.fn(),
+  },
+  isGitRepo: vi.fn(),
+}));
+
+vi.mock('../utils/git.js', () => ({
+  createGit: vi.fn((cwd: string) => (
+    cwd.endsWith('/reports-wt') ? mocks.worktreeGit : mocks.repoGit
+  )),
+  isGitRepo: mocks.isGitRepo,
+  getDefaultBranch: vi.fn(),
+  hasCommits: vi.fn(),
+}));
+
+vi.mock('../utils/fs.js', () => ({
+  ensureDir: vi.fn(),
+  pathExists: vi.fn().mockResolvedValue(false),
+  writeFile: vi.fn(),
+}));
+
+vi.mock('fs-extra', () => ({
+  default: {
+    readdir: vi.fn().mockResolvedValue(['.git']),
+    remove: vi.fn(),
+  },
+}));
+
+vi.mock('../update.js', () => ({
+  acquireLock: vi.fn(),
+  releaseLock: vi.fn(),
+}));
+
+import { ensureReportsWorktree } from '../utils/reports-branch.js';
+
+const config: LocalConfig = {
+  repo: {
+    localPath: '/workspace/project/.teamai',
+    remote: 'https://example.com/team.git',
+    kind: 'self',
+    businessRepoRoot: '/workspace/project',
+  },
+  username: 'alice',
+  scope: 'project',
+  projectRoot: '/workspace/project',
+  additionalRoles: [],
+};
+
+describe('ensureReportsWorktree read-only cold start', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.isGitRepo.mockResolvedValue(false);
+    mocks.repoGit.listRemote.mockResolvedValue('');
+    mocks.repoGit.raw.mockResolvedValue('');
+    mocks.worktreeGit.raw.mockResolvedValue('');
+    mocks.worktreeGit.add.mockResolvedValue(undefined);
+    mocks.worktreeGit.commit.mockResolvedValue(undefined);
+    mocks.worktreeGit.push.mockResolvedValue(undefined);
+  });
+
+  it('does not publish a new reports branch when pushIfCreated is false', async () => {
+    await expect(
+      ensureReportsWorktree(config, { pushIfCreated: false }),
+    ).resolves.toBe('/workspace/project/.teamai/reports-wt');
+
+    expect(mocks.worktreeGit.push).not.toHaveBeenCalled();
+  });
+
+  it('preserves the writer default of publishing a new reports branch', async () => {
+    await ensureReportsWorktree(config);
+
+    expect(mocks.worktreeGit.push).toHaveBeenCalledWith([
+      '-u',
+      'origin',
+      'teamai-reports',
+    ]);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -948,9 +948,8 @@ recallCmd
   .action(async (cmdOpts) => {
     const { autoDetectInit } = await import('./config.js');
     const { localConfig } = await autoDetectInit();
-    const repoPath = localConfig.repo.localPath;
-    const votesDir = `${repoPath}/votes`;
-    const learningsDir = `${repoPath}/learnings`;
+    const { resolveMaintenancePaths } = await import('./maintenance/index.js');
+    const { repoPath, votesDir, learningsDir } = await resolveMaintenancePaths(localConfig);
 
     if (cmdOpts.confidenceWriteback) {
       const { computeAllConfidence, writeBackConfidence } = await import('./maintenance/index.js');
@@ -1020,10 +1019,12 @@ recallCmd
   .action(async (learningId, cmdOpts) => {
     const { autoDetectInit } = await import('./config.js');
     const { localConfig } = await autoDetectInit();
-    const repoPath = localConfig.repo.localPath;
-    const votesDir = `${repoPath}/votes`;
-    const learningsDir = `${repoPath}/learnings`;
-    const { findPromotionCandidates, executePromotion } = await import('./maintenance/index.js');
+    const {
+      resolveMaintenancePaths,
+      findPromotionCandidates,
+      executePromotion,
+    } = await import('./maintenance/index.js');
+    const { repoPath, votesDir, learningsDir } = await resolveMaintenancePaths(localConfig);
     const { log } = await import('./utils/logger.js');
 
     const candidates = await findPromotionCandidates(learningsDir, votesDir);

--- a/src/index.ts
+++ b/src/index.ts
@@ -946,6 +946,12 @@ recallCmd
   .option('--update-quality', 'Find stale docs/rules/skills and suggest updates')
   .option('--dry-run', 'Show what would be done without making changes')
   .action(async (cmdOpts) => {
+    if (!cmdOpts.confidenceWriteback && !cmdOpts.prune && !cmdOpts.updateQuality) {
+      const { log } = await import('./utils/logger.js');
+      log.info('Usage: teamai recall maintenance --prune | --confidence-writeback | --update-quality');
+      return;
+    }
+
     const { autoDetectInit } = await import('./config.js');
     const { localConfig } = await autoDetectInit();
     const { resolveMaintenancePaths } = await import('./maintenance/index.js');
@@ -1006,9 +1012,6 @@ recallCmd
       log.info('\nReview drafts, then rename .draft.md -> .md to apply updates.');
       return;
     }
-
-    const { log } = await import('./utils/logger.js');
-    log.info('Usage: teamai recall maintenance --prune | --confidence-writeback | --update-quality');
   });
 
 recallCmd

--- a/src/maintenance/index.ts
+++ b/src/maintenance/index.ts
@@ -7,3 +7,5 @@ export { findStaleEntries, reportStaleEntries, findRelatedAdoptedLearnings, gene
 export type { StaleEntry, QualityUpdateOptions } from './quality-update.js';
 export { findPromotionCandidates, executePromotion } from './promote.js';
 export type { PromotionCandidate, PromoteOptions } from './promote.js';
+export { resolveMaintenancePaths } from './paths.js';
+export type { MaintenancePaths } from './paths.js';

--- a/src/maintenance/paths.ts
+++ b/src/maintenance/paths.ts
@@ -14,14 +14,16 @@ export interface MaintenancePaths {
  *
  * In self mode, knowledge remains on the business repository's main branch,
  * while votes live in the teamai-reports worktree. Other repository kinds keep
- * both data sets under localConfig.repo.localPath.
+ * both data sets under localConfig.repo.localPath. Maintenance is a report
+ * reader, so a cold start may create its local cache but never publishes a new
+ * reports branch as a side effect.
  */
 export async function resolveMaintenancePaths(
   localConfig: LocalConfig,
 ): Promise<MaintenancePaths> {
   if (isSelfMode(localConfig)) {
-    const { ensureReportsWorktree } = await import('../utils/reports-branch.js');
-    await ensureReportsWorktree(localConfig);
+    const { refreshReportsWorktree } = await import('../utils/reports-branch.js');
+    await refreshReportsWorktree(localConfig, { pushIfCreated: false });
   }
 
   const repoPath = getKnowledgeDir(localConfig);

--- a/src/maintenance/paths.ts
+++ b/src/maintenance/paths.ts
@@ -1,0 +1,33 @@
+import path from 'node:path';
+
+import type { LocalConfig } from '../types.js';
+import { getKnowledgeDir, getReportsDir, isSelfMode } from '../types.js';
+
+export interface MaintenancePaths {
+  repoPath: string;
+  votesDir: string;
+  learningsDir: string;
+}
+
+/**
+ * Resolve the knowledge and report roots used by recall maintenance commands.
+ *
+ * In self mode, knowledge remains on the business repository's main branch,
+ * while votes live in the teamai-reports worktree. Other repository kinds keep
+ * both data sets under localConfig.repo.localPath.
+ */
+export async function resolveMaintenancePaths(
+  localConfig: LocalConfig,
+): Promise<MaintenancePaths> {
+  if (isSelfMode(localConfig)) {
+    const { ensureReportsWorktree } = await import('../utils/reports-branch.js');
+    await ensureReportsWorktree(localConfig);
+  }
+
+  const repoPath = getKnowledgeDir(localConfig);
+  return {
+    repoPath,
+    votesDir: path.join(getReportsDir(localConfig), 'votes'),
+    learningsDir: path.join(repoPath, 'learnings'),
+  };
+}

--- a/src/utils/reports-branch.ts
+++ b/src/utils/reports-branch.ts
@@ -75,7 +75,19 @@ async function remoteBranchExists(repoRoot: string): Promise<boolean> {
  *  - remote branch exists      → worktree add --track -b from origin/teamai-reports.
  *  - remote branch absent      → create the orphan branch locally, then first-push.
  */
-export async function ensureReportsWorktree(localConfig: LocalConfig): Promise<string> {
+export interface EnsureReportsWorktreeOptions {
+  /**
+   * Whether a cold start may publish a newly created reports branch. Writers
+   * keep the default; read-only callers can materialize a local view without
+   * changing origin.
+   */
+  pushIfCreated?: boolean;
+}
+
+export async function ensureReportsWorktree(
+  localConfig: LocalConfig,
+  options: EnsureReportsWorktreeOptions = {},
+): Promise<string> {
   const wt = reportsWorktreePath(localConfig);
   const repoRoot = businessRoot(localConfig);
 
@@ -120,10 +132,12 @@ export async function ensureReportsWorktree(localConfig: LocalConfig): Promise<s
     const wtGit = createGit(wt);
     await wtGit.add(['.gitignore']);
     await wtGit.commit('[teamai] Initialize reports branch');
-    try {
-      await wtGit.push(['-u', 'origin', REPORTS_BRANCH]);
-    } catch (e) {
-      log.debug(`[reports] initial push skipped: ${(e as Error).message}`);
+    if (options.pushIfCreated !== false) {
+      try {
+        await wtGit.push(['-u', 'origin', REPORTS_BRANCH]);
+      } catch (e) {
+        log.debug(`[reports] initial push skipped: ${(e as Error).message}`);
+      }
     }
   }
 
@@ -262,9 +276,12 @@ export async function commitAndPushReports(
  * (digest/members/stats) see other members' latest data. Safe: only touches the
  * orphan-branch worktree, never the active tree.
  */
-export async function refreshReportsWorktree(localConfig: LocalConfig): Promise<void> {
+export async function refreshReportsWorktree(
+  localConfig: LocalConfig,
+  options: EnsureReportsWorktreeOptions = {},
+): Promise<void> {
   try {
-    const wt = await ensureReportsWorktree(localConfig);
+    const wt = await ensureReportsWorktree(localConfig, options);
     const git = createGit(wt);
     await git.fetch(['origin', REPORTS_BRANCH]);
     await git.raw(['reset', '--hard', `origin/${REPORTS_BRANCH}`]);


### PR DESCRIPTION
## Problem

After #398 enabled recall maintenance commands for project-scope configs, single-repo (`repo.kind: self`) projects still read votes from `<project>/.teamai/votes`. Self-mode stores authoritative report data on the `teamai-reports` branch under `<project>/.teamai/reports-wt/votes`, so maintenance and promotion silently reported no candidates.

## Fix

- Add a shared maintenance path resolver based on `getKnowledgeDir()` and `getReportsDir()`
- Materialize the reports worktree before self-mode maintenance reads votes
- Use the resolver in both `recall maintenance` and `recall promote`
- Preserve the existing layout for git/http team repositories

## Tests

- `npm run typecheck`
- `npm run build`
- `npm test` — 188 files, 2616 tests passed
- Added regression coverage for self-mode and standalone git layouts

Fixes the self-mode regression exposed by #398.