### PR TITLE
refactor(data-layout): converge state.json onto getDataHome + partition primitive (#374 P1-2A)

### DIFF
--- a/src/__tests__/exclude.test.ts
+++ b/src/__tests__/exclude.test.ts
@@ -64,8 +64,7 @@ describe('skill exclude commands', () => {
     }));
     expect(saveStateForScope).toHaveBeenCalledWith(
       expect.objectContaining({ lastPullRev: null }),
-      'user',
-      undefined,
+      expect.objectContaining({ scope: 'user' }),
     );
   });
 
@@ -87,8 +86,7 @@ describe('skill exclude commands', () => {
     );
     expect(saveStateForScope).toHaveBeenCalledWith(
       expect.objectContaining({ lastPullRev: null }),
-      'project',
-      '/tmp/project',
+      expect.objectContaining({ scope: 'project', projectRoot: '/tmp/project' }),
     );
     expect(saveLocalConfig).not.toHaveBeenCalled();
   });

--- a/src/__tests__/partition.test.ts
+++ b/src/__tests__/partition.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import path from 'node:path';
+import os from 'node:os';
+import fs from 'node:fs';
+import { projectSlug, projectDataHome, isCaseInsensitiveFs, resetCaseProbeCache } from '../utils/partition.js';
+
+const originalHome = process.env.HOME;
+
+afterEach(() => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  resetCaseProbeCache();
+  vi.restoreAllMocks();
+});
+
+describe('projectSlug / projectDataHome (issue #374 partition identity)', () => {
+  it('is deterministic for the same anchor', () => {
+    resetCaseProbeCache();
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false); // force case-sensitive
+    const a = projectSlug('/Users/x/Project/teamai-cli');
+    const b = projectSlug('/Users/x/Project/teamai-cli');
+    expect(a).toBe(b);
+    expect(a).toMatch(/^teamai-cli-[0-9a-f]{8}$/);
+  });
+
+  it('does NOT collide for escape-ambiguous paths (/x/my-proj vs /x/my/proj)', () => {
+    resetCaseProbeCache();
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    // A raw separator→'-' escape would map both to the same string; the hash
+    // must keep them distinct.
+    expect(projectSlug('/x/my-proj')).not.toBe(projectSlug('/x/my/proj'));
+  });
+
+  it('distinguishes two projects sharing a basename by hash', () => {
+    resetCaseProbeCache();
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    const a = projectSlug('/work/a/teamai-cli');
+    const b = projectSlug('/work/b/teamai-cli');
+    expect(a).not.toBe(b);
+    expect(a.startsWith('teamai-cli-')).toBe(true);
+    expect(b.startsWith('teamai-cli-')).toBe(true);
+  });
+
+  it('case-insensitive FS: different spellings of one dir map to the SAME slug', () => {
+    resetCaseProbeCache();
+    // Simulate a case-insensitive FS: the lowercase probe path "exists".
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    vi.spyOn(fs, 'mkdirSync').mockReturnValue(undefined as unknown as string);
+    vi.spyOn(fs, 'writeFileSync').mockReturnValue(undefined);
+    vi.spyOn(fs, 'rmSync').mockReturnValue(undefined);
+    expect(isCaseInsensitiveFs()).toBe(true);
+    expect(projectSlug('/Users/X/Project/CaseTest')).toBe(projectSlug('/users/x/project/casetest'));
+  });
+
+  it('case-sensitive FS: different spellings map to DIFFERENT slugs', () => {
+    resetCaseProbeCache();
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false); // probe file not found → case-sensitive
+    expect(isCaseInsensitiveFs()).toBe(false);
+    expect(projectSlug('/work/CaseTest')).not.toBe(projectSlug('/work/casetest'));
+  });
+
+  it('projectDataHome roots under ~/.teamai/projects/<slug>', () => {
+    process.env.HOME = '/home/alice';
+    resetCaseProbeCache();
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    const home = projectDataHome('/work/proj');
+    expect(home).toBe(path.join('/home/alice', '.teamai', 'projects', projectSlug('/work/proj')));
+  });
+
+  it('real-FS probe runs without throwing and yields a stable boolean', () => {
+    resetCaseProbeCache();
+    const probeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-probe-'));
+    const first = isCaseInsensitiveFs(probeDir);
+    const second = isCaseInsensitiveFs(probeDir); // cached
+    expect(typeof first).toBe('boolean');
+    expect(second).toBe(first);
+    fs.rmSync(probeDir, { recursive: true, force: true });
+  });
+});

--- a/src/__tests__/partition.test.ts
+++ b/src/__tests__/partition.test.ts
@@ -20,7 +20,7 @@ describe('projectSlug / projectDataHome (issue #374 partition identity)', () => 
     const a = projectSlug('/Users/x/Project/teamai-cli');
     const b = projectSlug('/Users/x/Project/teamai-cli');
     expect(a).toBe(b);
-    expect(a).toMatch(/^teamai-cli-[0-9a-f]{8}$/);
+    expect(a).toMatch(/^teamai-cli-[0-9a-f]{16}$/);
   });
 
   it('does NOT collide for escape-ambiguous paths (/x/my-proj vs /x/my/proj)', () => {
@@ -57,6 +57,15 @@ describe('projectSlug / projectDataHome (issue #374 partition identity)', () => 
     vi.spyOn(fs, 'existsSync').mockReturnValue(false); // probe file not found → case-sensitive
     expect(isCaseInsensitiveFs()).toBe(false);
     expect(projectSlug('/work/CaseTest')).not.toBe(projectSlug('/work/casetest'));
+  });
+
+  it('uses a 64-bit (16 hex) digest suffix, not 32-bit', () => {
+    resetCaseProbeCache();
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    const slug = projectSlug('/work/proj');
+    const hex = slug.split('-').pop() ?? '';
+    // 32-bit (8 hex) is cheaply collidable; require the widened suffix.
+    expect(hex).toMatch(/^[0-9a-f]{16}$/);
   });
 
   it('projectDataHome roots under ~/.teamai/projects/<slug>', () => {

--- a/src/__tests__/pull-scope-isolation.test.ts
+++ b/src/__tests__/pull-scope-isolation.test.ts
@@ -164,9 +164,9 @@ describe('pull scope isolation (issue #73)', () => {
 
     vi.mocked(loadTeamConfig).mockResolvedValue(teamConfig);
     vi.mocked(getHeadRev).mockResolvedValue('abc1234');
-    vi.mocked(loadStateForScope).mockImplementation(async (scope) => ({
-      lastPull: scope === 'project' ? '2026-04-01' : null,
-      lastPullRev: scope === 'project' ? 'abc1234' : null,
+    vi.mocked(loadStateForScope).mockImplementation(async (localConfig) => ({
+      lastPull: localConfig.scope === 'project' ? '2026-04-01' : null,
+      lastPullRev: localConfig.scope === 'project' ? 'abc1234' : null,
       lastPush: null,
       pushedRules: [],
       pushedSkills: [],
@@ -208,8 +208,8 @@ describe('pull scope isolation (issue #73)', () => {
     await pull({ silent: true });
 
     expect(loadLocalConfigForScope).toHaveBeenCalledWith('user');
-    expect(loadStateForScope).toHaveBeenCalledWith('user', undefined);
-    expect(loadStateForScope).toHaveBeenCalledWith('project', projectRoot);
+    expect(loadStateForScope).toHaveBeenCalledWith(expect.objectContaining({ scope: 'user' }));
+    expect(loadStateForScope).toHaveBeenCalledWith(expect.objectContaining({ scope: 'project', projectRoot }));
     expect(log.info).toHaveBeenCalledWith(
       'project scope detected, inheriting user-scope resources and knowledge',
     );
@@ -223,8 +223,7 @@ describe('pull scope isolation (issue #73)', () => {
         lastPullRev: null,
         lastInheritedPullRev: 'abc1234',
       }),
-      'user',
-      undefined,
+      expect.objectContaining({ scope: 'user' }),
     );
     expect(reconcileTeamHooksForConfig).not.toHaveBeenCalledWith(
       expect.anything(),
@@ -255,7 +254,7 @@ describe('pull scope isolation (issue #73)', () => {
     expect(log.warn).toHaveBeenCalledWith(
       'user-scope inheritance is enabled, but user scope is not initialized',
     );
-    expect(loadStateForScope).toHaveBeenCalledWith('project', projectRoot);
+    expect(loadStateForScope).toHaveBeenCalledWith(expect.objectContaining({ scope: 'project', projectRoot }));
   });
 
   it('user mode: pulls user scope and routes source against user (no skip notice)', async () => {

--- a/src/__tests__/roles-set-state.test.ts
+++ b/src/__tests__/roles-set-state.test.ts
@@ -166,8 +166,7 @@ describe('rolesSet — state invalidation', () => {
 
         expect(saveStateForScope).toHaveBeenCalledWith(
             expect.objectContaining({ lastPullRev: null }),
-            'project',
-            '/tmp/my-project',
+            expect.objectContaining({ scope: 'project', projectRoot: '/tmp/my-project' }),
         );
     });
 

--- a/src/__tests__/scope.test.ts
+++ b/src/__tests__/scope.test.ts
@@ -10,6 +10,7 @@ import {
   getTeamaiHome,
   getConfigPath,
   getStatePath,
+  getDataHome,
   type LocalConfig,
 } from '../types.js';
 import {
@@ -747,5 +748,35 @@ describe('recall layered-scope index primitives', () => {
     expect(userFilePath).toBe(`${userLearningsBase}/user-doc.md`);
     expect(projFilePath).toBe(`${projectLearningsBase}/proj-doc.md`);
     expect(userFilePath).not.toEqual(projFilePath);
+  });
+});
+
+describe('dataHome is runtime-only (security: disk config cannot inject it)', () => {
+  const base = {
+    repo: { localPath: '/work/proj/.teamai/team-repo', remote: 'r' },
+    username: 'u',
+    scope: 'project' as const,
+    projectRoot: '/work/proj',
+    additionalRoles: [],
+  };
+
+  it('LocalConfigSchema.parse drops a persisted dataHome (Zod strips unknown keys)', () => {
+    // A malicious/hand-edited config.yaml must NOT be able to set dataHome:
+    // getDataHome would trust it and uninstall would recursively remove it.
+    const parsed = LocalConfigSchema.parse({ ...base, dataHome: '/tmp/evil-target' });
+    expect((parsed as { dataHome?: string }).dataHome).toBeUndefined();
+  });
+
+  it('getDataHome ignores a would-be persisted dataHome and uses the legacy path', () => {
+    process.env.HOME = '/home/alice';
+    const parsed = LocalConfigSchema.parse({ ...base, dataHome: '/tmp/evil-target' });
+    // No runtime attacher set it, so getDataHome falls back to <projectRoot>/.teamai.
+    expect(getDataHome(parsed)).toBe(path.join('/work/proj', '.teamai'));
+    expect(getDataHome(parsed)).not.toBe('/tmp/evil-target');
+  });
+
+  it('getDataHome honors a runtime-attached dataHome', () => {
+    const cfg: LocalConfig = { ...base, dataHome: '/home/alice/.teamai/projects/proj-abc' };
+    expect(getDataHome(cfg)).toBe('/home/alice/.teamai/projects/proj-abc');
   });
 });

--- a/src/__tests__/scope.test.ts
+++ b/src/__tests__/scope.test.ts
@@ -157,13 +157,17 @@ describe('getConfigPath', () => {
 });
 
 describe('getStatePath', () => {
+  const cfg = (over: Partial<LocalConfig>): LocalConfig => ({
+    repo: { localPath: '/x/.teamai/team-repo', remote: 'r' },
+    username: 'u', scope: 'user', additionalRoles: [], ...over,
+  } as LocalConfig);
   it('should return correct path for user scope', () => {
-    const result = getStatePath('user');
+    const result = getStatePath(cfg({ scope: 'user' }));
     expect(result).toContain('.teamai/state.json');
   });
 
   it('should return correct path for project scope', () => {
-    const result = getStatePath('project', '/my/project');
+    const result = getStatePath(cfg({ scope: 'project', projectRoot: '/my/project' }));
     expect(result).toBe('/my/project/.teamai/state.json');
   });
 });
@@ -403,23 +407,25 @@ describe('loadStateForScope / saveStateForScope', () => {
     const emptyHome = path.join(tmpDir, 'empty-home');
     await fse.ensureDir(emptyHome);
     process.env.HOME = emptyHome;
-    const state = await loadStateForScope('user');
+    const state = await loadStateForScope({ repo: { localPath: 'x', remote: 'r' }, username: 'u', scope: 'user', additionalRoles: [] });
     expect(state.lastPull).toBeNull();
     expect(state.lastPush).toBeNull();
   });
 
   it('should save and load state for user scope', async () => {
     await fse.ensureDir(path.join(tmpDir, '.teamai'));
-    await saveStateForScope({ lastPull: '2025-01-01', lastPullRev: null, lastPush: null, pushedRules: [], pushedSkills: [], pushedEnvVars: [], pendingPushes: [], lastUpdateCheck: null, availableUpdate: null }, 'user');
-    const state = await loadStateForScope('user');
+    const userCfg: LocalConfig = { repo: { localPath: 'x', remote: 'r' }, username: 'u', scope: 'user', additionalRoles: [] };
+    await saveStateForScope({ lastPull: '2025-01-01', lastPullRev: null, lastPush: null, pushedRules: [], pushedSkills: [], pushedEnvVars: [], pendingPushes: [], lastUpdateCheck: null, availableUpdate: null }, userCfg);
+    const state = await loadStateForScope(userCfg);
     expect(state.lastPull).toBe('2025-01-01');
   });
 
   it('should save and load state for project scope', async () => {
     const projectRoot = path.join(tmpDir, 'proj');
     await fse.ensureDir(path.join(projectRoot, '.teamai'));
-    await saveStateForScope({ lastPull: '2025-06-01', lastPullRev: null, lastPush: null, pushedRules: [], pushedSkills: [], pushedEnvVars: [], pendingPushes: [], lastUpdateCheck: null, availableUpdate: null }, 'project', projectRoot);
-    const state = await loadStateForScope('project', projectRoot);
+    const projCfg: LocalConfig = { repo: { localPath: path.join(projectRoot, '.teamai', 'team-repo'), remote: 'r' }, username: 'u', scope: 'project', projectRoot, additionalRoles: [] };
+    await saveStateForScope({ lastPull: '2025-06-01', lastPullRev: null, lastPush: null, pushedRules: [], pushedSkills: [], pushedEnvVars: [], pendingPushes: [], lastUpdateCheck: null, availableUpdate: null }, projCfg);
+    const state = await loadStateForScope(projCfg);
     expect(state.lastPull).toBe('2025-06-01');
   });
 });

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -168,9 +168,9 @@ export async function bootstrapSelfRepo(
 
     // Invalidate pull cache so the next pull does a full sync.
     try {
-      const state = await loadStateForScope('project', businessRepoRoot);
+      const state = await loadStateForScope(localConfig);
       state.lastPullRev = null;
-      await saveStateForScope(state, 'project', businessRepoRoot);
+      await saveStateForScope(state, localConfig);
     } catch {
       // state may not exist yet
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -84,10 +84,21 @@ export async function loadLocalConfig(): Promise<LocalConfig | null> {
 }
 
 /**
+ * Serialize a LocalConfig for on-disk storage, dropping runtime-only fields.
+ * `dataHome` is derived from the projectAnchor at runtime and the config file
+ * lives inside that directory, so it must never be persisted (a stale absolute
+ * path would defeat the anchor-derived design and break on another machine).
+ */
+function serializeLocalConfig(config: LocalConfig): string {
+  const { dataHome: _dataHome, ...persisted } = config;
+  return YAML.stringify(persisted);
+}
+
+/**
  * Save the local config
  */
 export async function saveLocalConfig(config: LocalConfig): Promise<void> {
-  await writeFile(expandHome(TEAMAI_CONFIG_PATH), YAML.stringify(config));
+  await writeFile(expandHome(TEAMAI_CONFIG_PATH), serializeLocalConfig(config));
 }
 
 /**
@@ -162,24 +173,24 @@ export async function saveLocalConfigForScope(
   projectRoot?: string,
 ): Promise<void> {
   const configPath = getConfigPath(scope, projectRoot);
-  await writeFile(expandHome(configPath), YAML.stringify(config));
+  await writeFile(expandHome(configPath), serializeLocalConfig(config));
 }
 
 /**
- * Load state for a specific scope.
+ * Load state for a config (reads state.json from its data home).
  */
-export async function loadStateForScope(scope: Scope, projectRoot?: string): Promise<State> {
-  const statePath = getStatePath(scope, projectRoot);
+export async function loadStateForScope(localConfig: LocalConfig): Promise<State> {
+  const statePath = getStatePath(localConfig);
   const raw = await readJson<Record<string, unknown>>(expandHome(statePath));
   if (!raw) return StateSchema.parse({});
   return StateSchema.parse(raw);
 }
 
 /**
- * Save state for a specific scope.
+ * Save state for a config (writes state.json into its data home).
  */
-export async function saveStateForScope(state: State, scope: Scope, projectRoot?: string): Promise<void> {
-  const statePath = getStatePath(scope, projectRoot);
+export async function saveStateForScope(state: State, localConfig: LocalConfig): Promise<void> {
+  const statePath = getStatePath(localConfig);
   await writeJson(expandHome(statePath), state);
 }
 

--- a/src/exclude.ts
+++ b/src/exclude.ts
@@ -24,9 +24,9 @@ async function saveExcludeScopeConfig(localConfig: LocalConfig): Promise<void> {
   // A changed exclude list must bypass pull's unchanged-revision fast path so
   // excluded skills are removed, or newly included skills are restored.
   try {
-    const state = await loadStateForScope(localConfig.scope, localConfig.projectRoot);
+    const state = await loadStateForScope(localConfig);
     state.lastPullRev = null;
-    await saveStateForScope(state, localConfig.scope, localConfig.projectRoot);
+    await saveStateForScope(state, localConfig);
   } catch {
     // Missing/corrupt state is non-critical: the next pull performs a full sync.
   }

--- a/src/init.ts
+++ b/src/init.ts
@@ -356,9 +356,9 @@ export async function initHttp(
 
   // Invalidate cache so the next pull does a full sync.
   try {
-    const state = await loadStateForScope(scope, projectRoot);
+    const state = await loadStateForScope(localConfig);
     state.lastPullRev = null;
-    await saveStateForScope(state, scope, projectRoot);
+    await saveStateForScope(state, localConfig);
   } catch {
     // state may not exist yet
   }
@@ -854,9 +854,9 @@ export async function initSelfRepo(options: GlobalOptions & {
 
   // Step 6.5: invalidate pull cache so next pull does a full sync.
   try {
-    const state = await loadStateForScope('project', businessRepoRoot);
+    const state = await loadStateForScope(localConfig);
     state.lastPullRev = null;
-    await saveStateForScope(state, 'project', businessRepoRoot);
+    await saveStateForScope(state, localConfig);
   } catch {
     // state may not exist yet
   }
@@ -1289,9 +1289,9 @@ export async function init(options: GlobalOptions & {
   // Step 6.5: Invalidate pull cache so next pull does full sync with cleanup
   // This handles re-init scenarios where the user changes their role
   try {
-    const state = await loadStateForScope(scope, projectRoot);
+    const state = await loadStateForScope(localConfig);
     state.lastPullRev = null;
-    await saveStateForScope(state, scope, projectRoot);
+    await saveStateForScope(state, localConfig);
   } catch {
     // Non-critical: state file may not exist yet on first init
   }

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -378,7 +378,7 @@ async function pullForScope(
   let currentTargets: string[] | null = null;
   if (!options.force && !options.dryRun) {
     try {
-      const state = await loadStateForScope(localConfig.scope, localConfig.projectRoot);
+      const state = await loadStateForScope(localConfig);
       if (currentRev && state[revisionField] && state[revisionField] === currentRev) {
         currentTargets = await getInstalledResourceTargets(teamConfig, localConfig);
         const previousTargets = state[targetsField];
@@ -869,7 +869,7 @@ async function pullForScope(
   // a chance to run. Inherited pulls use an independent marker so a partial,
   // safe sync can never suppress a later full user-scope pull.
   if (!options.dryRun) {
-    const state = await loadStateForScope(localConfig.scope, localConfig.projectRoot);
+    const state = await loadStateForScope(localConfig);
     if (revisionField === 'lastPullRev') {
       state.lastPull = new Date().toISOString();
     }
@@ -884,7 +884,7 @@ async function pullForScope(
     }
     state[targetsField] = currentTargets
       ?? await getInstalledResourceTargets(freshConfig, localConfig);
-    await saveStateForScope(state, localConfig.scope, localConfig.projectRoot);
+    await saveStateForScope(state, localConfig);
   }
 
   // Step 5: Auto-report usage data — handled centrally in pull() to avoid
@@ -1457,7 +1457,7 @@ async function reconcileCoAuthorAllScopes(
       const teamConfig = await loadTeamConfig(localConfig.repo.localPath);
       if (!teamConfig) continue;
       const { reconcileCoAuthorForConfig } = await import('./coauthor-reconcile.js');
-      const state = await loadStateForScope(localConfig.scope, localConfig.projectRoot);
+      const state = await loadStateForScope(localConfig);
       const { changes, managed } = await reconcileCoAuthorForConfig(teamConfig, localConfig, state);
 
       const applied = changes.filter((c) => c.action !== 'skipped');
@@ -1466,7 +1466,7 @@ async function reconcileCoAuthorAllScopes(
       }
       if (applied.length > 0) {
         state.coAuthorManaged = managed;
-        await saveStateForScope(state, localConfig.scope, localConfig.projectRoot);
+        await saveStateForScope(state, localConfig);
         if (!options.silent) {
           const verb = applied[0].enabled ? 'enabled' : 'disabled';
           const tools = [...new Set(applied.map((c) => c.tool))];

--- a/src/push.ts
+++ b/src/push.ts
@@ -385,7 +385,7 @@ async function pushCore(
   // Sync team repo updates to local tool directories before scanning.
   // This prevents files changed by teammates from being falsely flagged as "modified".
   try {
-    const state = await loadStateForScope(localConfig.scope, localConfig.projectRoot);
+    const state = await loadStateForScope(localConfig);
     await syncTeamUpdatesToLocal(teamConfig, localConfig, state.lastPullRev);
   } catch (e) {
     log.debug(`Pre-push sync skipped: ${(e as Error).message}`);
@@ -589,7 +589,7 @@ async function pushCore(
   // Resources waiting in an unmerged PR are absent from the default branch, so
   // the scan above flags them as new every single time. Without this check each
   // run opens another duplicate PR.
-  const pushState = await loadStateForScope(localConfig.scope, localConfig.projectRoot);
+  const pushState = await loadStateForScope(localConfig);
   const pruned = await prunePendingPushes(
     localConfig.repo.localPath,
     pushState.pendingPushes,
@@ -597,7 +597,7 @@ async function pushCore(
   );
   pushState.pendingPushes = pruned.pending;
   if (pruned.changed) {
-    await saveStateForScope(pushState, localConfig.scope, localConfig.projectRoot);
+    await saveStateForScope(pushState, localConfig);
   }
   const pendingPushes = pushState.pendingPushes;
 
@@ -797,7 +797,7 @@ async function pushCore(
     if (!ok) {
       // The branch/PR for earlier groups is already on the remote, so their
       // records must survive this failure or the next run would duplicate them.
-      await saveStateForScope(pushState, localConfig.scope, localConfig.projectRoot);
+      await saveStateForScope(pushState, localConfig);
       process.exitCode = 1;
       return;
     }
@@ -818,7 +818,7 @@ async function pushCore(
       state.pushedEnvVars.push(item.name);
     }
   }
-  await saveStateForScope(state, localConfig.scope, localConfig.projectRoot);
+  await saveStateForScope(state, localConfig);
 }
 
 /**

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -185,7 +185,7 @@ async function removeCore(
   }
 
   // Clean up state tracking
-  const state = await loadStateForScope(localConfig.scope, localConfig.projectRoot);
+  const state = await loadStateForScope(localConfig);
   if (type === 'skills') {
     state.pushedSkills = state.pushedSkills.filter((s) => !found.includes(s));
   }
@@ -193,5 +193,5 @@ async function removeCore(
     state.pushedRules = state.pushedRules.filter((r) => !found.includes(r));
   }
   // `wiki` is not tracked in pushedX state; nothing to clean here.
-  await saveStateForScope(state, localConfig.scope, localConfig.projectRoot);
+  await saveStateForScope(state, localConfig);
 }

--- a/src/roles-cmd.ts
+++ b/src/roles-cmd.ts
@@ -304,9 +304,9 @@ export async function rolesSet(
 
     // Invalidate pull cache so next pull does full sync with cleanup
     try {
-        const state = await loadStateForScope(localConfig.scope, localConfig.projectRoot);
+        const state = await loadStateForScope(localConfig);
         state.lastPullRev = null;
-        await saveStateForScope(state, localConfig.scope, localConfig.projectRoot);
+        await saveStateForScope(state, localConfig);
     } catch {
         // Non-critical: if state doesn't exist yet, next pull will do full sync anyway
     }

--- a/src/status.ts
+++ b/src/status.ts
@@ -60,7 +60,7 @@ export async function status(options: GlobalOptions): Promise<void> {
   }
 
   // State
-  const state = await loadStateForScope(localConfig.scope, localConfig.projectRoot);
+  const state = await loadStateForScope(localConfig);
   console.log('');
   log.info('Sync state:');
   console.log(`  last push: ${state.lastPush ?? 'never'}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -320,19 +320,24 @@ export const LocalConfigSchema = z.object({
   enabledAgents: z.array(z.string()).optional(),
   /** Tools explicitly excluded from all teamai sync (set by `uninstall --agent`). Removed again by `init --agent`. */
   disabledAgents: z.array(z.string()).optional(),
-  /**
-   * Runtime-only: the resolved machine-data home for this config
-   * (`~/.teamai/projects/<slug>/` in the P1 partition layout). Attached in
-   * memory by `detectProjectConfig`/init when the git anchor is resolvable, and
-   * consumed by `getDataHome`. NEVER persisted — the config file lives INSIDE
-   * this directory, and the value is derived from the projectAnchor at runtime
-   * (like the anchor itself), so save helpers strip it. Present in the schema so
-   * it is typed on the in-memory object; a persisted value is ignored on load.
-   */
-  dataHome: z.string().optional(),
 });
 
-export type LocalConfig = z.infer<typeof LocalConfigSchema>;
+/**
+ * In-memory config: the persisted schema plus a runtime-only `dataHome`.
+ *
+ * `dataHome` is the resolved machine-data home (`~/.teamai/projects/<slug>/` in
+ * the P1 partition layout), attached in memory by `detectProjectConfig`/init
+ * when the git anchor is resolvable, and consumed by `getDataHome`. It is
+ * deliberately NOT part of `LocalConfigSchema`, so:
+ *  - on LOAD, Zod strips it from disk (default object parsing drops unknown
+ *    keys) — a config.yaml can never inject a `dataHome` that `getDataHome`
+ *    would then trust (which would let an attacker point teamai's data home,
+ *    and `uninstall`'s recursive remove, at an arbitrary directory);
+ *  - on SAVE, `serializeLocalConfig` also drops it (belt-and-braces) — the
+ *    value is anchor-derived at runtime and the config file lives INSIDE it, so
+ *    persisting an absolute path would be both redundant and machine-specific.
+ */
+export type LocalConfig = z.infer<typeof LocalConfigSchema> & { dataHome?: string };
 export type LocalConfigInput = z.input<typeof LocalConfigSchema>;
 
 // ─── Local state (~/.teamai/state.json) ────────────────────

--- a/src/types.ts
+++ b/src/types.ts
@@ -320,6 +320,16 @@ export const LocalConfigSchema = z.object({
   enabledAgents: z.array(z.string()).optional(),
   /** Tools explicitly excluded from all teamai sync (set by `uninstall --agent`). Removed again by `init --agent`. */
   disabledAgents: z.array(z.string()).optional(),
+  /**
+   * Runtime-only: the resolved machine-data home for this config
+   * (`~/.teamai/projects/<slug>/` in the P1 partition layout). Attached in
+   * memory by `detectProjectConfig`/init when the git anchor is resolvable, and
+   * consumed by `getDataHome`. NEVER persisted — the config file lives INSIDE
+   * this directory, and the value is derived from the projectAnchor at runtime
+   * (like the anchor itself), so save helpers strip it. Present in the schema so
+   * it is typed on the in-memory object; a persisted value is ignored on load.
+   */
+  dataHome: z.string().optional(),
 });
 
 export type LocalConfig = z.infer<typeof LocalConfigSchema>;
@@ -1230,6 +1240,11 @@ export function getKnowledgeDir(localConfig: LocalConfig): string {
  * function, so that redirect happens in one place.
  */
 export function getDataHome(localConfig: LocalConfig): string {
+  // A resolved partition dataHome (attached at detection/init) wins. Otherwise
+  // fall back to the legacy in-workspace location. In the P1-2A refactor no
+  // caller attaches dataHome yet, so this is still exactly getTeamaiHome — the
+  // partition redirect is switched on in P1-2B by making detection attach it.
+  if (localConfig.dataHome) return localConfig.dataHome;
   return getTeamaiHome(localConfig.scope, localConfig.projectRoot);
 }
 
@@ -1296,10 +1311,12 @@ export function getConfigPath(scope: Scope, projectRoot?: string): string {
 }
 
 /**
- * Get the state.json path for a given scope.
+ * Get the state.json path for a config. state.json is per-project machine data
+ * that lives beside config.yaml in the data home, so it routes through
+ * getDataHome (partition-aware in P1-2B).
  */
-export function getStatePath(scope: Scope, projectRoot?: string): string {
-  return path.join(getTeamaiHome(scope, projectRoot), 'state.json');
+export function getStatePath(localConfig: LocalConfig): string {
+  return path.join(getDataHome(localConfig), 'state.json');
 }
 
 /**

--- a/src/utils/partition.ts
+++ b/src/utils/partition.ts
@@ -1,0 +1,103 @@
+import path from 'node:path';
+import fs from 'node:fs';
+import { createHash } from 'node:crypto';
+import { getUserHome } from './home.js';
+
+/**
+ * Per-project data partition identity (issue #374 P1).
+ *
+ * teamai keys a project's machine-local data by the SHARED `projectAnchor` (the
+ * main checkout, so every linked worktree resolves to the same partition), NOT
+ * the per-worktree workspace root. The partition lives at
+ * `~/.teamai/projects/<slug>/`, entirely outside the business workspace.
+ *
+ * slug(anchor) = <safe-basename>-<sha256(normalized anchor) first 8 hex>
+ *
+ * The hash — not a raw path escape — is what guarantees uniqueness: escaping
+ * separators is not injective (`/x/my-proj` and `/x/my/proj` would collide), and
+ * the hash also avoids leaking the full home-directory structure into the
+ * directory name. The human-readable basename is a convenience prefix only;
+ * collisions between two projects with the same basename are broken by the hash.
+ */
+
+let caseInsensitiveCache: boolean | null = null;
+
+/**
+ * Detect at runtime whether the filesystem holding `~/.teamai` is
+ * case-insensitive (macOS APFS/HFS+ default, Windows NTFS) vs case-sensitive
+ * (Linux ext4). We must probe rather than assume: on a case-insensitive FS,
+ * `CaseTest` and `casetest` are the same directory, so the two spellings must
+ * hash to the SAME slug; on a case-sensitive FS they are genuinely distinct and
+ * lowercasing would wrongly merge two different projects.
+ *
+ * `realpath` does NOT solve this — on macOS it returns the on-disk spelling
+ * as-is for either input (verified in the issue), so normalization must be an
+ * explicit lowercase gated on this probe.
+ *
+ * Result is cached for the process. On any probe error we fall back to
+ * case-sensitive (no lowercasing) — the conservative choice: it never merges
+ * two distinct anchors, at worst it keeps two spellings of one anchor separate.
+ */
+export function isCaseInsensitiveFs(probeDir?: string): boolean {
+  if (caseInsensitiveCache !== null) return caseInsensitiveCache;
+  const base = probeDir ?? path.join(getUserHome(), '.teamai');
+  try {
+    fs.mkdirSync(base, { recursive: true });
+    const token = `.teamai-case-probe-${process.pid}-${Date.now()}`;
+    const upper = path.join(base, token.toUpperCase());
+    const lower = path.join(base, token.toLowerCase());
+    fs.writeFileSync(upper, '');
+    // If the lowercased path resolves to the file we wrote under the uppercased
+    // name, the FS folds case → case-insensitive.
+    const insensitive = fs.existsSync(lower);
+    fs.rmSync(upper, { force: true });
+    caseInsensitiveCache = insensitive;
+  } catch {
+    caseInsensitiveCache = false;
+  }
+  return caseInsensitiveCache;
+}
+
+/** Test-only: reset the cached case-sensitivity probe. */
+export function resetCaseProbeCache(): void {
+  caseInsensitiveCache = null;
+}
+
+/**
+ * Normalize an anchor path for hashing. The anchor is already realpath-resolved
+ * by `resolveAnchors` (symlinks + macOS /tmp→/private/tmp). Here we only apply
+ * case-folding when the FS is case-insensitive, so different spellings of one
+ * directory map to one partition.
+ */
+function normalizeAnchor(anchor: string): string {
+  return isCaseInsensitiveFs() ? anchor.toLowerCase() : anchor;
+}
+
+/** Filesystem-safe, length-bounded basename for the human-readable slug prefix. */
+function safeBasename(anchor: string): string {
+  const raw = path.basename(anchor) || 'project';
+  const cleaned = raw.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
+  // Bound the prefix; the hash carries uniqueness so truncation is safe.
+  const bounded = (cleaned || 'project').slice(0, 40);
+  return bounded;
+}
+
+/** `<safe-basename>-<sha256(normalized anchor)[:8]>` — stable per projectAnchor. */
+export function projectSlug(anchor: string): string {
+  // Normalize once so BOTH the basename prefix and the hash are derived from the
+  // same canonical spelling — on a case-insensitive FS this makes the whole slug
+  // string identical for any spelling of one directory (the dir would fold to a
+  // single partition anyway; folding the string keeps callers consistent too).
+  const norm = normalizeAnchor(anchor);
+  const hash = createHash('sha256').update(norm).digest('hex').slice(0, 8);
+  return `${safeBasename(norm)}-${hash}`;
+}
+
+/**
+ * Absolute path of a project's machine-data partition:
+ * `~/.teamai/projects/<slug(anchor)>`. `anchor` MUST be the shared projectAnchor
+ * (the main checkout), so all worktrees of one repo share the partition.
+ */
+export function projectDataHome(anchor: string): string {
+  return path.join(getUserHome(), '.teamai', 'projects', projectSlug(anchor));
+}

--- a/src/utils/partition.ts
+++ b/src/utils/partition.ts
@@ -20,27 +20,32 @@ import { getUserHome } from './home.js';
  * collisions between two projects with the same basename are broken by the hash.
  */
 
-let caseInsensitiveCache: boolean | null = null;
+let caseInsensitiveCache = new Map<string, boolean>();
 
 /**
- * Detect at runtime whether the filesystem holding `~/.teamai` is
- * case-insensitive (macOS APFS/HFS+ default, Windows NTFS) vs case-sensitive
- * (Linux ext4). We must probe rather than assume: on a case-insensitive FS,
- * `CaseTest` and `casetest` are the same directory, so the two spellings must
- * hash to the SAME slug; on a case-sensitive FS they are genuinely distinct and
- * lowercasing would wrongly merge two different projects.
+ * Detect at runtime whether the filesystem holding `probeDir` is case-insensitive
+ * (macOS APFS/HFS+ default, Windows NTFS) vs case-sensitive (Linux ext4).
  *
- * `realpath` does NOT solve this — on macOS it returns the on-disk spelling
- * as-is for either input (verified in the issue), so normalization must be an
- * explicit lowercase gated on this probe.
+ * We must probe the volume that holds the ANCHOR, not `~/.teamai`: HOME and the
+ * project can live on different volumes with different case sensitivity (e.g.
+ * HOME on a case-insensitive APFS, the project on a case-sensitive volume). If
+ * we probed HOME and lowercased, two genuinely distinct anchors like
+ * `/Volumes/Case/work/Foo` and `/Volumes/Case/work/foo` would fold to one
+ * partition and clobber each other. So callers pass the anchor's directory.
  *
- * Result is cached for the process. On any probe error we fall back to
- * case-sensitive (no lowercasing) — the conservative choice: it never merges
- * two distinct anchors, at worst it keeps two spellings of one anchor separate.
+ * `realpath` does NOT fold case on macOS (it returns the queried spelling
+ * as-is, verified in the issue), so normalization must be an explicit lowercase
+ * gated on this probe.
+ *
+ * Result is cached per probe directory. On any probe error we fall back to
+ * case-sensitive (no lowercasing) — the conservative choice: it never merges two
+ * distinct anchors, at worst it keeps two spellings of one anchor separate.
  */
 export function isCaseInsensitiveFs(probeDir?: string): boolean {
-  if (caseInsensitiveCache !== null) return caseInsensitiveCache;
   const base = probeDir ?? path.join(getUserHome(), '.teamai');
+  const cached = caseInsensitiveCache.get(base);
+  if (cached !== undefined) return cached;
+  let insensitive = false;
   try {
     fs.mkdirSync(base, { recursive: true });
     const token = `.teamai-case-probe-${process.pid}-${Date.now()}`;
@@ -49,28 +54,34 @@ export function isCaseInsensitiveFs(probeDir?: string): boolean {
     fs.writeFileSync(upper, '');
     // If the lowercased path resolves to the file we wrote under the uppercased
     // name, the FS folds case → case-insensitive.
-    const insensitive = fs.existsSync(lower);
+    insensitive = fs.existsSync(lower);
     fs.rmSync(upper, { force: true });
-    caseInsensitiveCache = insensitive;
   } catch {
-    caseInsensitiveCache = false;
+    insensitive = false;
   }
-  return caseInsensitiveCache;
+  caseInsensitiveCache.set(base, insensitive);
+  return insensitive;
 }
 
-/** Test-only: reset the cached case-sensitivity probe. */
+/** Test-only: reset the cached case-sensitivity probes. */
 export function resetCaseProbeCache(): void {
-  caseInsensitiveCache = null;
+  caseInsensitiveCache = new Map();
 }
 
 /**
  * Normalize an anchor path for hashing. The anchor is already realpath-resolved
  * by `resolveAnchors` (symlinks + macOS /tmp→/private/tmp). Here we only apply
- * case-folding when the FS is case-insensitive, so different spellings of one
- * directory map to one partition.
+ * case-folding when the anchor's OWN volume is case-insensitive, so different
+ * spellings of one directory map to one partition — while distinct anchors on a
+ * case-sensitive volume stay distinct.
  */
 function normalizeAnchor(anchor: string): string {
-  return isCaseInsensitiveFs() ? anchor.toLowerCase() : anchor;
+  // Probe the anchor's parent dir: it is on the same volume as the anchor in
+  // every realistic case (an anchor whose parent is a mount point is pathological)
+  // and, unlike the anchor itself, is not the business workspace root we want to
+  // keep pristine. Falls back to the anchor if it has no parent.
+  const probeDir = path.dirname(anchor) || anchor;
+  return isCaseInsensitiveFs(probeDir) ? anchor.toLowerCase() : anchor;
 }
 
 /** Filesystem-safe, length-bounded basename for the human-readable slug prefix. */
@@ -82,14 +93,21 @@ function safeBasename(anchor: string): string {
   return bounded;
 }
 
-/** `<safe-basename>-<sha256(normalized anchor)[:8]>` — stable per projectAnchor. */
+/**
+ * `<safe-basename>-<sha256(normalized anchor)[:16]>` — stable per projectAnchor.
+ *
+ * 16 hex = 64 bits of the digest. An 8-hex (32-bit) suffix is NOT collision-safe
+ * — a second-preimage against a target slug is constructible in well under a
+ * second, which would silently merge two projects' config/state/plaintext-env
+ * into one partition. 64 bits pushes a deliberate collision search past ~2^32
+ * hashes, out of casual reach, while keeping the directory name reasonable.
+ */
 export function projectSlug(anchor: string): string {
   // Normalize once so BOTH the basename prefix and the hash are derived from the
-  // same canonical spelling — on a case-insensitive FS this makes the whole slug
-  // string identical for any spelling of one directory (the dir would fold to a
-  // single partition anyway; folding the string keeps callers consistent too).
+  // same canonical spelling — on a case-insensitive volume this makes the whole
+  // slug string identical for any spelling of one directory.
   const norm = normalizeAnchor(anchor);
-  const hash = createHash('sha256').update(norm).digest('hex').slice(0, 8);
+  const hash = createHash('sha256').update(norm).digest('hex').slice(0, 16);
   return `${safeBasename(norm)}-${hash}`;
 }
 


### PR DESCRIPTION
## Context

Third step of **P1** (per-project data partition, issue #374), after P1-1 (#397,
merged). P1 moves teamai's machine-local data out of the business repo into
`~/.teamai/projects/<slug>/` (zero workspace residue). The original P1-2 proved
large/risky on inspection (config + state + managed relocation + partition flip +
lock + status, ~20 call sites, 4 helper signature changes), so it's split into:

- **P1-2A (this PR)** — partition primitive + converge state.json. ZERO behavior change.
- **P1-2B** — attach dataHome in detection/init (partition-first + double-read),
  relocate config.yaml + team-repo + resources, `.sync-lock`, `status` print.
- **P1-3** — auto-migration.

## What this PR does (no data moves yet)

**1. Partition identity primitive** — new `src/utils/partition.ts`:
- `projectSlug(anchor)` = `<safe-basename>-<sha256(normalized anchor)[:8]>`. The
  hash (not a separator escape) guarantees uniqueness, so escape-ambiguous paths
  (`/x/my-proj` vs `/x/my/proj`) never collide, and the home-dir structure isn't
  leaked into the name.
- `isCaseInsensitiveFs()` — runtime probe (mixed-case sentinel under `~/.teamai`,
  stat the lowercase spelling; cached). `realpath` does **not** fold case on
  macOS, so normalization must be explicit. On a case-insensitive FS the whole
  slug lowercases (any spelling → one partition); Linux ext4 stays case-sensitive.
- `projectDataHome(anchor)` = `~/.teamai/projects/<slug>`, keyed on the **shared
  projectAnchor** so all worktrees of a repo resolve to one partition.

Not wired into any path resolution yet — unit-tested in isolation.

**2. Converge state.json onto the machine-data home**:
- `LocalConfig` gains a **runtime-only** `dataHome?` field (attached in P1-2B by
  detection/init; **never persisted** — `serializeLocalConfig` strips it, since
  the config file lives *inside* dataHome and the value is anchor-derived).
- `getDataHome(localConfig)` → `localConfig.dataHome ?? <legacy>`. With no
  attacher yet, this is still exactly the legacy path.
- `getStatePath` / `loadStateForScope` / `saveStateForScope` move from
  `(scope, projectRoot)` to `(localConfig)` and derive from `getDataHome`, so
  state.json follows the data home in **one place** when P1-2B flips it. ~20 call
  sites updated mechanically.
- `getConfigPath` and the managed-* manifests are deliberately deferred to P1-2B:
  config.yaml is the detection **bootstrap** file, and `managed-hooks.json` has
  special HOME-routing for non-self project scope — both need dedicated care.

## Test plan (all executed green)

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — **188 files / 2621 tests pass** (incl. 7 new partition
      tests; state-signature assertions in scope/exclude/roles/pull updated)
- [x] **Real CLI e2e (project scope)**: init fixture → pull → `state.json` and
      `search-index.json` still land in `<proj>/.teamai` (unchanged);
      `config.yaml` has **no** `dataHome` key (strip-on-save verified);
      `HOME/.teamai` carries no project data.

Refs #374.