### PR TITLE
feat(data-layout): route new project installs to ~/.teamai/projects/<slug>/ + .sync-lock + status (#374 P1-2B)

### DIFF
--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -87,6 +87,7 @@ vi.mock('../config.js', () => ({
   loadTeamConfig: vi.fn().mockResolvedValue(null),
   loadStateForScope: vi.fn().mockRejectedValue(new Error('no state')),
   saveStateForScope: vi.fn(),
+  resolveProjectDataHome: vi.fn(async (projectRoot: string) => `${projectRoot}/.teamai`),
 }));
 
 vi.mock('../hooks.js', () => ({

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,9 +13,11 @@ import {
   getTeamaiHome,
   getConfigPath,
   getStatePath,
+  getDataHome,
 } from './types.js';
 import { readFileSafe, readJson, writeFile, writeJson, expandHome, pathExists } from './utils/fs.js';
 import { resolveAnchors } from './utils/git.js';
+import { projectDataHome } from './utils/partition.js';
 import { log } from './utils/logger.js';
 import { loadRolesManifest } from './roles.js';
 
@@ -136,28 +138,30 @@ export async function requireInit(): Promise<{ localConfig: LocalConfig; teamCon
 
 /**
  * Load a LocalConfig for a specific scope.
- * - 'user' → reads ~/.teamai/config.yaml (same as loadLocalConfig)
- * - 'project' → reads <projectRoot>/.teamai/config.yaml
+ * - 'user' → reads ~/.teamai/config.yaml
+ * - 'project' → partition-aware double-read via detectProjectConfig(projectRoot):
+ *   tries `~/.teamai/projects/<slug>/config.yaml` (new/migrated) then the legacy
+ *   `<projectRoot>/.teamai/config.yaml`, attaching dataHome + projectRoot.
  */
 export async function loadLocalConfigForScope(
   scope: Scope,
   projectRoot?: string,
 ): Promise<LocalConfig | null> {
+  if (scope === 'project') {
+    if (!projectRoot) return null;
+    // Reuse the single detection path so config location never drifts between
+    // "detect the active project" and "load a named project's config".
+    const detected = await detectProjectConfig(projectRoot);
+    if (!detected) return null;
+    return migrateLegacyRoleConfig(detected, path.join(getDataHome(detected), 'config.yaml'));
+  }
   const configPath = getConfigPath(scope, projectRoot);
   const content = await readFileSafe(expandHome(configPath));
   if (!content) return null;
   try {
     const raw = YAML.parse(content);
     const parsed = LocalConfigSchema.parse(raw);
-    // Config files written before `projectRoot` was added to the schema (or
-    // hand-edited) may be missing it. We already know the project root — it's
-    // the directory this config was loaded for — so backfill it instead of
-    // letting getTeamaiHome()/resolveBaseDir() silently fall back to the user
-    // home directory later (#85).
-    const withProjectRoot = scope === 'project' && projectRoot && !parsed.projectRoot
-      ? { ...parsed, projectRoot }
-      : parsed;
-    return await migrateLegacyRoleConfig(withProjectRoot, configPath);
+    return await migrateLegacyRoleConfig(parsed, configPath);
   } catch (e) {
     log.error(`Invalid ${scope} config at ${configPath}: ${(e as Error).message}`);
     return null;
@@ -165,14 +169,17 @@ export async function loadLocalConfigForScope(
 }
 
 /**
- * Save a LocalConfig for a specific scope.
+ * Save a LocalConfig. The file lives at `<dataHome>/config.yaml` — the partition
+ * for a new project install (config.dataHome attached by detection/init), or the
+ * legacy location otherwise. getDataHome resolves the right base for every mode
+ * (user → ~/.teamai, project → partition ?? <projectRoot>/.teamai).
  */
 export async function saveLocalConfigForScope(
   config: LocalConfig,
-  scope: Scope,
-  projectRoot?: string,
+  _scope?: Scope,
+  _projectRoot?: string,
 ): Promise<void> {
-  const configPath = getConfigPath(scope, projectRoot);
+  const configPath = path.join(getDataHome(config), 'config.yaml');
   await writeFile(expandHome(configPath), serializeLocalConfig(config));
 }
 
@@ -196,46 +203,90 @@ export async function saveStateForScope(state: State, localConfig: LocalConfig):
 
 /**
  * Detect whether the given directory (default: cwd) has a project-scope teamai config.
- * Returns the parsed LocalConfig if scope === 'project', null otherwise.
+ * Returns the parsed LocalConfig (with `dataHome` and `projectRoot` attached) if
+ * scope === 'project', null otherwise.
  *
- * Subdirectory / worktree aware (issue #374): if `dir` itself has no
- * `.teamai/config.yaml` but sits inside a git repository, the lookup retries at
- * the repository's workspace root (`git rev-parse --show-toplevel`). This lets
- * `teamai` run from any subdirectory of a project, and resolves the config's
- * `projectRoot` to the CURRENT checkout — so in a git worktree, project-scope
- * resources land in that worktree rather than the main checkout.
+ * Resolution order (issue #374 P1):
+ *  1. Legacy config directly at `<dir>/.teamai/config.yaml` — the fast path for
+ *     an un-migrated install run from the repo root, and the self-heal bootstrap
+ *     seam for single-repo mode. dataHome = `<dir>/.teamai`.
+ *  2. Otherwise resolve the git anchors and try the per-project PARTITION
+ *     (`~/.teamai/projects/<slug>/config.yaml`, keyed on the shared projectAnchor)
+ *     — where a new/migrated install keeps its machine data out of the workspace.
+ *     dataHome = the partition.
+ *  3. Failing that, the repo's workspace-root `.teamai` (the subdirectory case for
+ *     an un-migrated install). dataHome = `<workspaceRoot>/.teamai`.
+ *
+ * `dataHome` is always the directory the config was actually found in — the same
+ * "anchor to where it lives" rule P0 applies to projectRoot — so every machine
+ * file (state.json, search-index, env, ...) resolves beside it via getDataHome.
  */
+/**
+ * Resolve the machine-data home for a project given its workspace root:
+ * the per-project partition (`~/.teamai/projects/<slug>/`, keyed on the shared
+ * projectAnchor) when inside a git repo, else the legacy `<projectRoot>/.teamai`
+ * (non-git dir). Used by init to place a NEW project's data outside the
+ * workspace. Self mode does not call this (its data stays in the repo until P2).
+ */
+export async function resolveProjectDataHome(projectRoot: string): Promise<string> {
+  const anchors = await resolveAnchors(projectRoot);
+  return anchors ? projectDataHome(anchors.projectAnchor) : path.join(projectRoot, '.teamai');
+}
+
 export async function detectProjectConfig(cwd?: string): Promise<LocalConfig | null> {
   const dir = cwd ?? process.cwd();
-  const direct = await loadProjectConfigAt(dir);
+
+  // 1. Fast path: legacy layout at <dir>/.teamai (also runs the self-heal
+  //    bootstrap for a freshly-cloned single-repo project).
+  const direct = await readConfigFrom(path.join(dir, '.teamai'), dir, dir);
   if (direct) return direct;
 
-  // Not found at `dir`. If we are inside a git repo whose workspace root differs
-  // from `dir` (i.e. `dir` is a subdirectory), retry there. resolveAnchors returns
-  // null outside a git repo, so non-git dirs simply fall through to null.
+  // 2/3. Resolve git anchors: partition first, then the workspace-root legacy
+  //      location. resolveAnchors returns null outside a git repo.
   const anchors = await resolveAnchors(dir);
-  if (anchors && anchors.workspaceRoot !== dir) {
-    return loadProjectConfigAt(anchors.workspaceRoot);
+  if (!anchors) return null;
+
+  const fromPartition = await readConfigFrom(
+    projectDataHome(anchors.projectAnchor),
+    anchors.workspaceRoot,
+  );
+  if (fromPartition) return fromPartition;
+
+  if (anchors.workspaceRoot !== dir) {
+    return readConfigFrom(
+      path.join(anchors.workspaceRoot, '.teamai'),
+      anchors.workspaceRoot,
+      anchors.workspaceRoot,
+    );
   }
   return null;
 }
 
 /**
- * Load a project-scope config from `<dir>/.teamai/config.yaml`, with the
- * single-repo self-heal fallback. Returns null when there is no project-scope
- * config at `dir`.
+ * Read a project-scope config from `<dataHomeDir>/config.yaml`, attaching
+ * `projectRoot` (the workspace root, where resources land) and `dataHome`
+ * (where machine data lives). Returns null when there is no project-scope
+ * config there.
+ *
+ * When `selfHealRepoRoot` is given and the config is missing, run the single-repo
+ * self-heal (issue #198): a teammate who cloned a repo carrying
+ * `.teamai/teamai.yaml` with `mode: self` has the knowledge on disk but no local
+ * config (gitignored). bootstrapSelfRepo writes it under `<repoRoot>/.teamai`,
+ * then we re-read. It is a no-op ('skip') for any non-self dir, so this stays
+ * cheap on the hot path. Only passed for the legacy `<root>/.teamai` shape (the
+ * partition is teamai-managed and never bootstrapped).
  */
-async function loadProjectConfigAt(dir: string): Promise<LocalConfig | null> {
-  const configPath = path.join(dir, '.teamai', 'config.yaml');
+async function readConfigFrom(
+  dataHomeDir: string,
+  projectRoot: string,
+  selfHealRepoRoot?: string,
+): Promise<LocalConfig | null> {
+  const configPath = path.join(dataHomeDir, 'config.yaml');
   if (!(await pathExists(configPath))) {
-    // Single-repo mode self-heal (issue #198): a teammate who cloned a repo
-    // carrying `.teamai/teamai.yaml` with `mode: self` has the team knowledge on
-    // disk but no local config (it is gitignored, not cloned). Auto-bootstrap the
-    // machine side, then re-read. bootstrapSelfRepo is a no-op ('skip') for any
-    // dir that is not a self-mode project, so this stays cheap on the hot path.
+    if (!selfHealRepoRoot) return null;
     try {
       const { bootstrapSelfRepo } = await import('./bootstrap.js');
-      const result = await bootstrapSelfRepo(dir, { silent: true });
+      const result = await bootstrapSelfRepo(selfHealRepoRoot, { silent: true });
       if (result !== 'bootstrapped') return null;
     } catch {
       return null;
@@ -248,13 +299,12 @@ async function loadProjectConfigAt(dir: string): Promise<LocalConfig | null> {
     const raw = YAML.parse(content);
     const config = LocalConfigSchema.parse(raw);
     if (config.scope !== 'project') return null;
-    // Always anchor projectRoot to the directory the config was actually found
-    // in (the current checkout's workspace root). A persisted projectRoot can be
-    // wrong — e.g. a `.teamai/` copied from the main checkout into a worktree
-    // still names the main checkout, which would send project resources to the
-    // wrong tree. Overriding here keeps resource landing tied to the real
-    // workspace (and also backfills when projectRoot was simply absent, #85).
-    return { ...config, projectRoot: dir };
+    // Anchor projectRoot to the workspace root (resource landing) and dataHome to
+    // the directory this config lives in (machine-data location). A persisted
+    // projectRoot can be wrong (e.g. a `.teamai/` copied from the main checkout
+    // into a worktree names the main checkout); overriding keeps landing tied to
+    // the real workspace (also backfills when absent, #85).
+    return { ...config, projectRoot, dataHome: dataHomeDir };
   } catch {
     return null;
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -233,6 +233,22 @@ export async function resolveProjectDataHome(projectRoot: string): Promise<strin
   return anchors ? projectDataHome(anchors.projectAnchor) : path.join(projectRoot, '.teamai');
 }
 
+/**
+ * True when `<dataHomeDir>/teamai.yaml` (the committed team config in single-repo
+ * mode) declares `mode: self`. Marker-only read — no schema validation — so a
+ * partial/older file still triggers. Mirrors bootstrap's readSelfModeMarker.
+ */
+async function declaresSelfMode(dataHomeDir: string): Promise<boolean> {
+  const content = await readFileSafe(path.join(dataHomeDir, 'teamai.yaml'));
+  if (!content) return false;
+  try {
+    const raw = YAML.parse(content) as { mode?: string } | null;
+    return raw?.mode === 'self';
+  } catch {
+    return false;
+  }
+}
+
 export async function detectProjectConfig(cwd?: string): Promise<LocalConfig | null> {
   const dir = cwd ?? process.cwd();
 
@@ -242,18 +258,25 @@ export async function detectProjectConfig(cwd?: string): Promise<LocalConfig | n
   // or a subdirectory. resolveAnchors returns null outside a git repo.
   const anchors = await resolveAnchors(dir);
   if (anchors) {
-    // Strict order, independent of cwd: partition (new/migrated) wins, then the
-    // workspace-root legacy `.teamai` (un-migrated install, with self-heal).
+    const legacyDir = path.join(anchors.workspaceRoot, '.teamai');
+    // Single-repo mode is authoritative: when the workspace's COMMITTED
+    // `.teamai/teamai.yaml` declares `mode: self`, the knowledge and the self
+    // config live in the repo, and a stale project partition (left over from an
+    // earlier git-mode install) must NOT shadow it — otherwise `init --self`
+    // would appear to succeed while pull/push kept using the old external repo.
+    // Self config wins (with self-heal for a fresh clone) before the partition.
+    if (await declaresSelfMode(legacyDir)) {
+      const selfConfig = await readConfigFrom(legacyDir, anchors.workspaceRoot, anchors.workspaceRoot);
+      if (selfConfig) return selfConfig;
+    }
+    // Otherwise, strict cwd-independent order: partition (new/migrated) wins,
+    // then the workspace-root legacy `.teamai` (un-migrated install, self-heal).
     const fromPartition = await readConfigFrom(
       projectDataHome(anchors.projectAnchor),
       anchors.workspaceRoot,
     );
     if (fromPartition) return fromPartition;
-    return readConfigFrom(
-      path.join(anchors.workspaceRoot, '.teamai'),
-      anchors.workspaceRoot,
-      anchors.workspaceRoot,
-    );
+    return readConfigFrom(legacyDir, anchors.workspaceRoot, anchors.workspaceRoot);
   }
 
   // Not a git repo: fall back to a legacy `.teamai` directly at `dir` (also runs

--- a/src/config.ts
+++ b/src/config.ts
@@ -236,30 +236,29 @@ export async function resolveProjectDataHome(projectRoot: string): Promise<strin
 export async function detectProjectConfig(cwd?: string): Promise<LocalConfig | null> {
   const dir = cwd ?? process.cwd();
 
-  // 1. Fast path: legacy layout at <dir>/.teamai (also runs the self-heal
-  //    bootstrap for a freshly-cloned single-repo project).
-  const direct = await readConfigFrom(path.join(dir, '.teamai'), dir, dir);
-  if (direct) return direct;
-
-  // 2/3. Resolve git anchors: partition first, then the workspace-root legacy
-  //      location. resolveAnchors returns null outside a git repo.
+  // Resolve git anchors FIRST so the result never depends on which directory of
+  // the repo we run from (issue #374 review): a repo with both a partition and a
+  // legacy `.teamai/` must resolve to the SAME config whether run from the root
+  // or a subdirectory. resolveAnchors returns null outside a git repo.
   const anchors = await resolveAnchors(dir);
-  if (!anchors) return null;
-
-  const fromPartition = await readConfigFrom(
-    projectDataHome(anchors.projectAnchor),
-    anchors.workspaceRoot,
-  );
-  if (fromPartition) return fromPartition;
-
-  if (anchors.workspaceRoot !== dir) {
+  if (anchors) {
+    // Strict order, independent of cwd: partition (new/migrated) wins, then the
+    // workspace-root legacy `.teamai` (un-migrated install, with self-heal).
+    const fromPartition = await readConfigFrom(
+      projectDataHome(anchors.projectAnchor),
+      anchors.workspaceRoot,
+    );
+    if (fromPartition) return fromPartition;
     return readConfigFrom(
       path.join(anchors.workspaceRoot, '.teamai'),
       anchors.workspaceRoot,
       anchors.workspaceRoot,
     );
   }
-  return null;
+
+  // Not a git repo: fall back to a legacy `.teamai` directly at `dir` (also runs
+  // the self-heal bootstrap for a freshly-cloned single-repo project).
+  return readConfigFrom(path.join(dir, '.teamai'), dir, dir);
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -233,22 +233,6 @@ export async function resolveProjectDataHome(projectRoot: string): Promise<strin
   return anchors ? projectDataHome(anchors.projectAnchor) : path.join(projectRoot, '.teamai');
 }
 
-/**
- * True when `<dataHomeDir>/teamai.yaml` (the committed team config in single-repo
- * mode) declares `mode: self`. Marker-only read — no schema validation — so a
- * partial/older file still triggers. Mirrors bootstrap's readSelfModeMarker.
- */
-async function declaresSelfMode(dataHomeDir: string): Promise<boolean> {
-  const content = await readFileSafe(path.join(dataHomeDir, 'teamai.yaml'));
-  if (!content) return false;
-  try {
-    const raw = YAML.parse(content) as { mode?: string } | null;
-    return raw?.mode === 'self';
-  } catch {
-    return false;
-  }
-}
-
 export async function detectProjectConfig(cwd?: string): Promise<LocalConfig | null> {
   const dir = cwd ?? process.cwd();
 
@@ -259,23 +243,22 @@ export async function detectProjectConfig(cwd?: string): Promise<LocalConfig | n
   const anchors = await resolveAnchors(dir);
   if (anchors) {
     const legacyDir = path.join(anchors.workspaceRoot, '.teamai');
-    // Single-repo mode is authoritative: when the workspace's COMMITTED
-    // `.teamai/teamai.yaml` declares `mode: self`, the knowledge and the self
-    // config live in the repo, and a stale project partition (left over from an
-    // earlier git-mode install) must NOT shadow it — otherwise `init --self`
-    // would appear to succeed while pull/push kept using the old external repo.
-    // Self config wins (with self-heal for a fresh clone) before the partition.
-    if (await declaresSelfMode(legacyDir)) {
-      const selfConfig = await readConfigFrom(legacyDir, anchors.workspaceRoot, anchors.workspaceRoot);
-      if (selfConfig) return selfConfig;
-    }
-    // Otherwise, strict cwd-independent order: partition (new/migrated) wins,
-    // then the workspace-root legacy `.teamai` (un-migrated install, self-heal).
+    // Strict, cwd-independent order:
+    // 1. An existing partition config is AUTHORITATIVE. It was written by a real
+    //    `teamai init`, so it always wins — a mere working-tree `.teamai/teamai.yaml`
+    //    (which may be untracked/unverified) must never hijack it. Switching that
+    //    project to single-repo mode is `init --self`'s job (it retires the
+    //    partition), not detection's.
     const fromPartition = await readConfigFrom(
       projectDataHome(anchors.projectAnchor),
       anchors.workspaceRoot,
     );
     if (fromPartition) return fromPartition;
+    // 2. No partition yet: a workspace that declares `mode: self` self-heals the
+    //    machine config under <workspaceRoot>/.teamai (issue #198 clone bootstrap).
+    // 3. Otherwise read the legacy `<workspaceRoot>/.teamai` config directly.
+    //    readConfigFrom runs the self-heal bootstrap when the config is missing,
+    //    so both cases funnel through the same call.
     return readConfigFrom(legacyDir, anchors.workspaceRoot, anchors.workspaceRoot);
   }
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -275,7 +275,7 @@ export async function initHttp(
     log.warn(fallbackReason);
   }
   const teamaiHome = scope === 'project' && projectRoot
-    ? await resolveProjectDataHome(projectRoot)
+    ? (existingLocalConfig?.dataHome ?? await resolveProjectDataHome(projectRoot))
     : getTeamaiHome(scope, projectRoot);
   printScopeSummary(scope, projectRoot, explicit);
 
@@ -937,7 +937,7 @@ export async function init(options: GlobalOptions & {
     log.warn(fallbackReason);
   }
   const teamaiHome = scope === 'project' && projectRoot
-    ? await resolveProjectDataHome(projectRoot)
+    ? (existingLocalConfig?.dataHome ?? await resolveProjectDataHome(projectRoot))
     : getTeamaiHome(scope, projectRoot);
   printScopeSummary(scope, projectRoot, explicit);
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -761,6 +761,24 @@ export async function initSelfRepo(options: GlobalOptions & {
   await saveLocalConfigForScope(localConfig, 'project', businessRepoRoot);
   log.success(`Local config saved to ${teamaiHome}/config.yaml`);
 
+  // Retire any stale project partition from an earlier git-mode install: detection
+  // treats an existing partition as authoritative, so leaving it behind would make
+  // this self install unreachable (pull/push would keep hitting the old external
+  // repo). Removing the partition config is enough for detection to fall through to
+  // this self config; the rest of the old partition is left for the user to clean.
+  try {
+    const partition = await resolveProjectDataHome(businessRepoRoot);
+    if (partition !== teamaiHome) {
+      const partitionConfig = path.join(partition, 'config.yaml');
+      if (await pathExists(partitionConfig)) {
+        await remove(partitionConfig);
+        log.info(`Retired stale project partition config at ${partitionConfig}`);
+      }
+    }
+  } catch (e) {
+    log.debug(`partition retire skipped: ${(e as Error).message}`);
+  }
+
   const gitignorePath = path.join(teamaiHome, '.gitignore');
   await writeFile(gitignorePath, buildSelfModeGitignore());
   log.debug('Generated single-repo .teamai/.gitignore');

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,7 +1,7 @@
 import YAML from 'yaml';
 import fs from 'node:fs';
 import path from 'node:path';
-import { saveLocalConfig, loadTeamConfig, saveLocalConfigForScope, loadLocalConfigForScope, loadStateForScope, saveStateForScope } from './config.js';
+import { saveLocalConfig, loadTeamConfig, saveLocalConfigForScope, loadLocalConfigForScope, loadStateForScope, saveStateForScope, resolveProjectDataHome } from './config.js';
 import { reconcileTeamHooksForConfig } from './hooks.js';
 import { configureGitUser, initRepo, isGitRepo, getRemoteUrl, remotesMatch, redactGitCredentials } from './utils/git.js';
 import { pushRepoDirectly } from './utils/git.js';
@@ -274,7 +274,9 @@ export async function initHttp(
   if (fallbackReason) {
     log.warn(fallbackReason);
   }
-  const teamaiHome = getTeamaiHome(scope, projectRoot);
+  const teamaiHome = scope === 'project' && projectRoot
+    ? await resolveProjectDataHome(projectRoot)
+    : getTeamaiHome(scope, projectRoot);
   printScopeSummary(scope, projectRoot, explicit);
 
   if (scope === 'project' && !(await isInsideGitRepo(process.cwd()))) {
@@ -282,7 +284,7 @@ export async function initHttp(
   }
 
   // Re-init guard
-  const existingConfigPath = getConfigPath(scope, projectRoot);
+  const existingConfigPath = path.join(teamaiHome, 'config.yaml');
   if (await pathExists(existingConfigPath) && !options.force) {
     const confirmed = await askConfirmation(`teamai already initialized at ${existingConfigPath}. Overwrite? [y/N] `);
     if (!confirmed) {
@@ -325,6 +327,7 @@ export async function initHttp(
     scope,
     projectRoot,
     additionalRoles: [],
+    ...(scope === 'project' ? { dataHome: teamaiHome } : {}),
     ...(inheritUserScope !== undefined ? { inheritUserScope } : {}),
   };
   try {
@@ -933,7 +936,9 @@ export async function init(options: GlobalOptions & {
   if (fallbackReason) {
     log.warn(fallbackReason);
   }
-  const teamaiHome = getTeamaiHome(scope, projectRoot);
+  const teamaiHome = scope === 'project' && projectRoot
+    ? await resolveProjectDataHome(projectRoot)
+    : getTeamaiHome(scope, projectRoot);
   printScopeSummary(scope, projectRoot, explicit);
 
   if (scope === 'project' && !(await isInsideGitRepo(process.cwd()))) {
@@ -941,7 +946,7 @@ export async function init(options: GlobalOptions & {
   }
 
   // Step 0.5: Re-init guard — warn if config already exists
-  const existingConfigPath = getConfigPath(scope, projectRoot);
+  const existingConfigPath = path.join(teamaiHome, 'config.yaml');
   if (await pathExists(existingConfigPath)) {
     log.warn(`teamai is already initialized for ${scope} scope at ${existingConfigPath}`);
     if (options.force) {
@@ -1226,6 +1231,7 @@ export async function init(options: GlobalOptions & {
     scope,
     projectRoot,
     additionalRoles: [],
+    ...(scope === 'project' ? { dataHome: teamaiHome } : {}),
     ...(inheritUserScope !== undefined ? { inheritUserScope } : {}),
   };
 

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -55,7 +55,7 @@ interface RolePullContext {
  */
 async function refreshTeamRepo(
   localConfig: LocalConfig,
-): Promise<{ label: string; version: string | null; reportingOnly: boolean }> {
+): Promise<{ label: string; version: string | null; reportingOnly: boolean; skipped?: boolean }> {
   if (localConfig.repo.kind === 'http') {
     const { resolveApiKey } = await import('./api-key.js');
     const apiKey = resolveApiKey();
@@ -102,14 +102,13 @@ async function refreshTeamRepo(
   const syncLock = path.join(getDataHome(localConfig), SYNC_LOCK_FILENAME);
   const locked = await acquireLock(syncLock);
   if (!locked) {
-    log.debug('[pull] another pull/push holds the sync lock; skipping clone refresh');
-    let heldVersion: string | null = null;
-    try {
-      heldVersion = await getHeadRev(localConfig.repo.localPath);
-    } catch {
-      heldVersion = null;
-    }
-    return { label: 'sync in progress elsewhere — skipped', version: heldVersion, reportingOnly: false };
+    // Another pull/push holds the lock. We must NOT read or deploy from the
+    // shared clone now: the holder may have it checked out on a generated push
+    // branch or be mid reset/checkout, so its tree can contain unmerged,
+    // unreviewed content. Signal `skipped` so pullForScope skips this scope's
+    // deploy entirely rather than syncing a transient tree into the workspace.
+    log.debug('[pull] another pull/push holds the sync lock; skipping this scope');
+    return { label: 'sync in progress elsewhere — skipped', version: null, reportingOnly: false, skipped: true };
   }
 
   try {
@@ -393,7 +392,15 @@ async function pullForScope(
   // there and must not be injected.
   let reportingOnly = false;
   try {
-    const { label, version, reportingOnly: ro } = await refreshTeamRepo(localConfig);
+    const { label, version, reportingOnly: ro, skipped } = await refreshTeamRepo(localConfig);
+    if (skipped) {
+      // The shared clone is locked by a concurrent pull/push; its working tree
+      // may be on a transient branch. Skip this scope entirely — do not scan or
+      // deploy from a clone we could not safely snapshot. Idempotent: the next
+      // pull (once the lock frees) syncs normally.
+      pullSpin.succeed(`[${scopeLabel}] Team repo: ${label}`);
+      return;
+    }
     currentRev = version;
     reportingOnly = ro;
     pullSpin.succeed(`[${scopeLabel}] Team repo: ${label}`);

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -28,10 +28,12 @@ import {
   isRecallEnabled,
   isAgentDisabled,
   scopedToolPaths,
+  SYNC_LOCK_FILENAME,
 } from './types.js';
 import type { CultureFrontmatter } from './types.js';
 import { loadRolesManifest, resolveRoleResourceNamespaces, type ResourceNamespaces } from './roles.js';
 import { getUserHome } from './utils/home.js';
+import { acquireLock, releaseLock } from './update.js';
 
 interface RolePullContext {
   activeNamespaces: ResourceNamespaces;
@@ -89,7 +91,23 @@ async function refreshTeamRepo(
     return { label: 'single-repo (knowledge on main)', version, reportingOnly: false };
   }
 
-  const result = await pullRepo(localConfig.repo.localPath);
+  // Guard the shared team clone with the partition sync-lock: the main checkout
+  // and a worktree can both run `teamai pull` and race `git pull` on one clone.
+  // pull is idempotent, so on contention we skip the fetch and proceed with the
+  // clone's current state (the winner's pull already advanced it).
+  const syncLock = path.join(getDataHome(localConfig), SYNC_LOCK_FILENAME);
+  let result: string;
+  const locked = await acquireLock(syncLock);
+  if (!locked) {
+    log.debug('[pull] another pull/push holds the sync lock; using the current clone state');
+    result = 'sync in progress elsewhere — skipped fetch';
+  } else {
+    try {
+      result = await pullRepo(localConfig.repo.localPath);
+    } finally {
+      await releaseLock(syncLock);
+    }
+  }
 
   // Retry any learnings whose push previously failed (see savePendingLearning).
   // Best-effort: never let a flush error block the pull.

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -92,40 +92,50 @@ async function refreshTeamRepo(
   }
 
   // Guard the shared team clone with the partition sync-lock: the main checkout
-  // and a worktree can both run `teamai pull` and race `git pull` on one clone.
-  // pull is idempotent, so on contention we skip the fetch and proceed with the
-  // clone's current state (the winner's pull already advanced it).
+  // and a worktree resolve to the SAME clone, so two `teamai pull`/`push` runs can
+  // race git operations on it. On contention we skip the ENTIRE clone-mutating
+  // section — both the fetch AND flushPendingLearnings (which writes files and
+  // runs git add/commit/push on this clone) — and report the clone's current HEAD
+  // so the deploy step still proceeds from its present state. The lock is held
+  // across the whole section (fetch + flush + rev read) so no other writer can
+  // reset/checkout the tree mid-operation.
   const syncLock = path.join(getDataHome(localConfig), SYNC_LOCK_FILENAME);
-  let result: string;
   const locked = await acquireLock(syncLock);
   if (!locked) {
-    log.debug('[pull] another pull/push holds the sync lock; using the current clone state');
-    result = 'sync in progress elsewhere — skipped fetch';
-  } else {
+    log.debug('[pull] another pull/push holds the sync lock; skipping clone refresh');
+    let heldVersion: string | null = null;
     try {
-      result = await pullRepo(localConfig.repo.localPath);
-    } finally {
-      await releaseLock(syncLock);
+      heldVersion = await getHeadRev(localConfig.repo.localPath);
+    } catch {
+      heldVersion = null;
     }
+    return { label: 'sync in progress elsewhere — skipped', version: heldVersion, reportingOnly: false };
   }
 
-  // Retry any learnings whose push previously failed (see savePendingLearning).
-  // Best-effort: never let a flush error block the pull.
   try {
-    await flushPendingLearnings(localConfig.repo.localPath, localConfig.username);
-  } catch (e) {
-    log.debug(`pending-learnings flush skipped: ${(e as Error).message}`);
-  }
+    const result = await pullRepo(localConfig.repo.localPath);
 
-  let version: string | null = null;
-  try {
-    version = await getHeadRev(localConfig.repo.localPath);
-  } catch {
-    // Can't resolve a rev → skip the incremental fast-path and do a full sync.
-    log.debug('Rev check failed, proceeding with full sync');
-    version = null;
+    // Retry any learnings whose push previously failed (see savePendingLearning).
+    // Best-effort: never let a flush error block the pull. Inside the lock because
+    // it writes + commits + pushes the shared clone.
+    try {
+      await flushPendingLearnings(localConfig.repo.localPath, localConfig.username);
+    } catch (e) {
+      log.debug(`pending-learnings flush skipped: ${(e as Error).message}`);
+    }
+
+    let version: string | null = null;
+    try {
+      version = await getHeadRev(localConfig.repo.localPath);
+    } catch {
+      // Can't resolve a rev → skip the incremental fast-path and do a full sync.
+      log.debug('Rev check failed, proceeding with full sync');
+      version = null;
+    }
+    return { label: result, version, reportingOnly: false };
+  } finally {
+    await releaseLock(syncLock);
   }
-  return { label: result, version, reportingOnly: false };
 }
 
 async function buildRolePullContext(localConfig: LocalConfig): Promise<RolePullContext | null> {

--- a/src/push.ts
+++ b/src/push.ts
@@ -18,6 +18,8 @@ import { scanTeamRepoNamespaces } from './resources/skills.js';
 import type {
   GlobalOptions, ResourceItem, ResourceType, LocalConfig, TeamaiConfig, State,
 } from './types.js';
+import { getDataHome, SYNC_LOCK_FILENAME } from './types.js';
+import { acquireLock, releaseLock } from './update.js';
 import { assertSafePath, assertSafeResourceName, defaultAllowedRoots } from './utils/path-safety.js';
 import { loadRolesManifest, resolveRoleResourceNamespaces } from './roles.js';
 import { askQuestion, askSelection } from './utils/prompt.js';
@@ -319,7 +321,22 @@ export async function push(options: GlobalOptions & { all?: boolean; role?: stri
     return;
   }
 
-  await pushCore(localConfig, teamConfig, options);
+  // Guard the shared team clone: push resets to clean master, pulls, then
+  // branches/commits/pushes on one clone shared by all worktrees of this repo.
+  // A concurrent pull/push would corrupt it. Unlike pull, push must NOT silently
+  // skip (that would drop the user's changes), so on contention we error out.
+  const syncLock = path.join(getDataHome(localConfig), SYNC_LOCK_FILENAME);
+  const locked = await acquireLock(syncLock);
+  if (!locked) {
+    log.error('Another teamai pull/push is in progress for this project. Re-run once it finishes.');
+    process.exitCode = 1;
+    return;
+  }
+  try {
+    await pushCore(localConfig, teamConfig, options);
+  } finally {
+    await releaseLock(syncLock);
+  }
 }
 
 async function pushCore(

--- a/src/status.ts
+++ b/src/status.ts
@@ -16,7 +16,7 @@ import {
   truncate,
   type AgentSkillsView,
 } from './agent-skills.js';
-import { RESOURCE_TYPES, type GlobalOptions, type ResourceType } from './types.js';
+import { RESOURCE_TYPES, getDataHome, type GlobalOptions, type ResourceType } from './types.js';
 import { maskEnvValue } from './resources/env.js';
 import { parseTeamMcpServers } from './resources/mcp.js';
 import { parseHooksYaml } from './resources/hooks.js';
@@ -39,6 +39,9 @@ export async function status(options: GlobalOptions): Promise<void> {
   // Scope info
   console.log('');
   log.info(`Scope: ${scopeLabel}${scopeLabel === 'project' && localConfig.projectRoot ? ` (${localConfig.projectRoot})` : ''}`);
+  // Machine-data partition: where this project's teamai data actually lives
+  // (~/.teamai/projects/<slug>/ for a partitioned install, else legacy .teamai).
+  log.info(`  data: ${getDataHome(localConfig)}`);
 
   // Git status
   console.log('');

--- a/src/team-push.ts
+++ b/src/team-push.ts
@@ -15,8 +15,9 @@ import { withTimeout } from './utils/async.js';
 import { writeFile, readFileSafe, ensureDir, pathExists, readJson, writeJson } from './utils/fs.js';
 import { log } from './utils/logger.js';
 import type { UserStats, UserInterventionStats, SessionMetrics, TokenUsage, DashboardEvent, LocalConfig } from './types.js';
-import { VOTES_LOCAL_DIR, emptyTokenUsage, addTokenUsage } from './types.js';
+import { VOTES_LOCAL_DIR, emptyTokenUsage, addTokenUsage, SYNC_LOCK_FILENAME } from './types.js';
 import { getUserHome } from './utils/home.js';
+import { acquireLock, releaseLock } from './update.js';
 
 /** Snapshot of already-reported per-session intervention counts (idempotency basis). */
 type ReportedInterventions = Record<string, { interrupt: number; toolReject: number; correction: number }>;
@@ -316,6 +317,19 @@ export async function reportUsageToTeam(
   const selfConfig = options?.selfConfig;
   const selfMode = selfConfig?.repo.kind === 'self';
 
+  // git mode auto-report reset/pull/commit/pushes the SHARED team clone, so it
+  // must hold the same partition sync-lock as pull/push — otherwise it can reset
+  // or checkout a clone another pull/push is mid-operation on. (self mode writes
+  // the reports orphan-branch worktree, coordinated by its own reports-lock.)
+  const syncLock = selfMode ? null : path.join(path.dirname(repoPath), SYNC_LOCK_FILENAME);
+  if (syncLock) {
+    const locked = await acquireLock(syncLock);
+    if (!locked) {
+      log.debug('Skipping report: another pull/push holds the sync lock');
+      return;
+    }
+  }
+
   try {
     const events = await readUsageEvents();
     const filesToPush: string[] = [];
@@ -491,5 +505,7 @@ export async function reportUsageToTeam(
     }
   } catch (e) {
     log.error(`Auto-report skipped: ${(e as Error).message}`);
+  } finally {
+    if (syncLock) await releaseLock(syncLock);
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1216,6 +1216,14 @@ export const KNOWLEDGE_WORKTREE_DIRNAME = 'knowledge-wt';
 export const REPORTS_LOCK_FILENAME = '.reports-lock';
 /** Lock filename (under <repo>/.teamai) guarding concurrent self-mode bootstrap. */
 export const BOOTSTRAP_LOCK_FILENAME = '.bootstrap-lock';
+/**
+ * Lock filename (in the project data home) serializing writes to the SHARED team
+ * clone during pull/push. All worktrees of a repo resolve to the same partition
+ * (keyed on projectAnchor), so this lock coordinates a `git pull`/`git push` that
+ * could otherwise run concurrently from the main checkout and a worktree and
+ * corrupt the shared clone.
+ */
+export const SYNC_LOCK_FILENAME = '.sync-lock';
 
 /**
  * Directory holding team knowledge assets (skills/rules/docs/learnings/...).


### PR DESCRIPTION
## Context

Fourth step of **P1** (per-project data partition, issue #374), after P1-1 (#397)
and P1-2A (#402). This is the flip: a NEW non-self (git/http) project install now
keeps **all** its machine data out of the business workspace, under the per-project
partition `~/.teamai/projects/<slug>/` (keyed on the shared projectAnchor, so every
worktree of a repo shares one partition). Old installs keep working unchanged via a
double-read fallback; self mode stays legacy (its slimming is P2).

## What this PR does

**Detection (`config.ts`)** — `detectProjectConfig` resolves the partition from the
git anchor and does a **partition-first double-read** (partition → legacy
`<workspaceRoot>/.teamai`), attaching a runtime `dataHome` = the directory the
config was actually found in (the same "anchor to where it lives" rule P0 applies
to `projectRoot`). A single shared `readConfigFrom` helper backs both the fast path
and the anchor path, and `loadLocalConfigForScope('project')` delegates to it so
config location never drifts between "detect the active project" and "load a named
project's config". New `resolveProjectDataHome(projectRoot)` (partition in a git
repo, else legacy) used by init.

**init (`init.ts`)** — non-self git/http project scope resolves `teamaiHome` to the
partition, attaches `dataHome` to the saved config, and both the re-init existence
check and the team-repo clone target follow it. A fresh install writes config.yaml,
state.json, env, search-index and the team-repo clone into the partition — **zero
teamai files in the workspace**.

**`.sync-lock` (`pull.ts` / `push.ts`)** — the shared team clone is now reachable
from every worktree, so concurrent `git pull`/`git push` could corrupt it. Guard
the shared-clone mutation with the P0 atomic lock at `<dataHome>/.sync-lock`: pull
skips the fetch on contention (idempotent), push errors out with exit 1 (never
silently drops changes).

**status (`status.ts`)** — prints the resolved data home (`data:` line).

**Deferred to P1-2C**: `managed-mcp.json` and `local-agent/resources`. Both are
resolved inside the local-agent subsystem from `(scope, projectRoot)` with no
LocalConfig; converging only the reconcile side would **desync** the partition vs
legacy path between readers, so they need a shared dataHome resolver done as a unit.

## Test plan (all executed green)

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — **189 files / 2627 tests pass** (init.test config mock
      updated; the legacy-layout `scope-isolation` / `scope-inheritance` /
      `source-project-scope` e2e suites still green ⇒ old-install double-read
      compat is regression-verified)
- [x] **Real CLI e2e (github provider)**: `teamai init` resolves the clone path to
      `~/.teamai/projects/<slug>/team-repo` and leaves `<proj>/.teamai` absent
      (zero residue); 16-hex slug.
- [x] **Real CLI e2e (local no-auth fixture, partitioned install)**: `status` shows
      the partition; `pull` writes `search-index.json` + `state.json` into the
      partition and deploys the skill to `<proj>/.claude/skills`; a **worktree** and
      a **subdirectory** both resolve to the SAME partition; `<proj>/.teamai` stays
      absent.
- [x] **Concurrent pull (main + worktree)**: one fetches, the other skips with
      "sync in progress elsewhere"; both exit 0; `git fsck --connectivity-only` on
      the shared clone passes (no corruption).

Refs #374.