### PR TITLE
fix(frontmatter): warn when YAML frontmatter has opening --- but no closing delimiter

### DIFF
--- a/src/__tests__/frontmatter.test.ts
+++ b/src/__tests__/frontmatter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
     parseFrontmatter,
     splitFrontmatter,
@@ -6,6 +6,7 @@ import {
     hasFrontmatter,
     stringifyFrontmatter,
 } from '../utils/frontmatter.js';
+import { log } from '../utils/logger.js';
 
 const BOM = '﻿';
 
@@ -154,5 +155,50 @@ describe('stringifyFrontmatter', () => {
     it('produces LF-only output (no CR)', () => {
         const out = stringifyFrontmatter({ name: 'a', description: 'b' }, 'body');
         expect(out.includes('\r')).toBe(false);
+    });
+});
+
+describe('splitFrontmatter – unclosed frontmatter warning', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('warns when opening --- exists but closing --- is missing', () => {
+        const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {});
+        const result = splitFrontmatter('---\nname: broken\n');
+        expect(warnSpy).toHaveBeenCalledOnce();
+        expect(warnSpy.mock.calls[0][0]).toMatch(/no closing delimiter/);
+        expect(result.data).toEqual({});
+        expect(result.valid).toBe(false);
+    });
+
+    it('warns for BOM-prefixed unclosed frontmatter', () => {
+        const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {});
+        splitFrontmatter(BOM + '---\nname: broken\n');
+        expect(warnSpy).toHaveBeenCalledOnce();
+    });
+
+    it('warns for CRLF unclosed frontmatter', () => {
+        const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {});
+        splitFrontmatter('---\r\nname: broken\r\n');
+        expect(warnSpy).toHaveBeenCalledOnce();
+    });
+
+    it('does not warn when no frontmatter at all', () => {
+        const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {});
+        splitFrontmatter('# just body');
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not warn for valid closed frontmatter', () => {
+        const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {});
+        splitFrontmatter('---\nname: foo\n---\nbody');
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('warns for --- on its own with no content after', () => {
+        const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {});
+        splitFrontmatter('---\n');
+        expect(warnSpy).toHaveBeenCalledOnce();
     });
 });

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -1,4 +1,5 @@
 import matter from 'gray-matter';
+import { log } from './logger.js';
 
 /** Result of splitting a document into its YAML frontmatter and body. */
 export interface FrontmatterSplit {
@@ -17,6 +18,9 @@ export interface FrontmatterSplit {
  * LF or CRLF line endings, and trailing horizontal whitespace on delimiter lines.
  */
 const FRONTMATTER_BLOCK = /^﻿?---[ \t]*\r?\n[\s\S]*?\r?\n---[ \t]*(?:\r?\n|$)/;
+
+/** Matches a leading line that looks like a frontmatter opening delimiter. */
+const OPENING_FENCE = /^﻿?---[ \t]*(?:\r?\n|$)/;
 
 /** Strip a single leading UTF-8 BOM if present. */
 function stripBom(text: string): string {
@@ -40,6 +44,9 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
 export function splitFrontmatter(content: string): FrontmatterSplit {
     const match = content.match(FRONTMATTER_BLOCK);
     if (!match) {
+        if (OPENING_FENCE.test(content)) {
+            log.warn('Frontmatter block has opening "---" but no closing delimiter; metadata will be ignored');
+        }
         return { data: {}, valid: false, body: stripBom(content), raw: '' };
     }
     const rawFull = match[0];


### PR DESCRIPTION
## Summary

- Detect files that start with `---` but never have a closing `---` delimiter
- Emit `log.warn()` so the issue surfaces in debug.log and CLI output
- Previously this was completely silent — metadata was lost with no indication

## Problem

When a SKILL.md or rule file has a malformed frontmatter block like:

    ---
    name: my-skill
    description: does something

(missing closing `---`), `splitFrontmatter()` silently returns empty metadata.
The skill/rule is loaded without its name, description, or any other fields —
and the user gets no warning that anything went wrong.

## Changes

- `src/utils/frontmatter.ts`: Added `OPENING_FENCE` regex and a warning branch (+4 lines)
- `src/__tests__/frontmatter.test.ts`: 6 new test cases covering LF, CRLF, BOM variants, and negative cases

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npx vitest run src/__tests__/frontmatter.test.ts` — 32/32 passed (26 existing + 6 new)
- [x] `npx vitest run` — 2637/2637 all passed, zero regression
- [x] `npm run build` — success
