### PR TITLE
fix(agents): compare rendered native agent content

### DIFF
--- a/src/__tests__/agents.test.ts
+++ b/src/__tests__/agents.test.ts
@@ -195,6 +195,72 @@ describe('AgentsHandler — Phase 1 push/pull/remove', () => {
     expect(items.find((i) => i.name === 'same')).toBeUndefined();
   });
 
+  it('scanLocalForPush ignores an untouched Codex agent rendered from team YAML', async () => {
+    const codexConfig = buildTeamConfig({
+      codex: { skills: '.codex/skills', agents: '.codex/agents' },
+    });
+    await fse.ensureDir(path.join(homeDir, '.codex', 'agents'));
+
+    const sourcePath = path.join(repoPath, 'agents', 'same.yaml');
+    await fse.writeFile(sourcePath, [
+      'name: same',
+      'description: Unchanged Codex agent',
+      'instructions: Review the current change.',
+      'targets:',
+      '  - codex',
+      '',
+    ].join('\n'));
+
+    await handler.pullItem(
+      {
+        name: 'same',
+        type: 'agents',
+        sourcePath,
+        relativePath: 'agents/same.yaml',
+      },
+      codexConfig,
+      localConfig,
+    );
+
+    const items = await handler.scanLocalForPush(codexConfig, localConfig);
+    expect(items.find((i) => i.name === 'same')).toBeUndefined();
+  });
+
+  it('scanLocalForPush detects edits to a Codex agent rendered from team YAML', async () => {
+    const codexConfig = buildTeamConfig({
+      codex: { skills: '.codex/skills', agents: '.codex/agents' },
+    });
+    const codexAgentsDir = path.join(homeDir, '.codex', 'agents');
+    await fse.ensureDir(codexAgentsDir);
+
+    const sourcePath = path.join(repoPath, 'agents', 'edited.yaml');
+    await fse.writeFile(sourcePath, [
+      'name: edited',
+      'description: Original description',
+      'instructions: Review the current change.',
+      'targets:',
+      '  - codex',
+      '',
+    ].join('\n'));
+
+    await handler.pullItem(
+      {
+        name: 'edited',
+        type: 'agents',
+        sourcePath,
+        relativePath: 'agents/edited.yaml',
+      },
+      codexConfig,
+      localConfig,
+    );
+    const codexPath = path.join(codexAgentsDir, 'edited.toml');
+    const rendered = await fse.readFile(codexPath, 'utf8');
+    await fse.writeFile(codexPath, rendered.replace('Original description', 'Locally edited description'));
+
+    const items = await handler.scanLocalForPush(codexConfig, localConfig);
+    expect(items.find((i) => i.name === 'edited')?.status).toBe('modified');
+  });
+
   it('scanLocalForPush excludes built-in CLI agents (e.g. teamai-recall)', async () => {
     await fse.writeFile(
       path.join(homeDir, '.claude/agents', 'teamai-recall.md'),

--- a/src/resources/agents.ts
+++ b/src/resources/agents.ts
@@ -140,9 +140,9 @@ export class AgentsHandler extends ResourceHandler {
       if (!hasTeamYaml && !hasTeamMd) {
         hasChange = true; // brand new
       } else {
-        for (const [, filePath] of toolFiles) {
+        for (const [tool, filePath] of toolFiles) {
           const teamRef = hasTeamYaml ? teamYamlPath : teamMdPath;
-          const equal = await fileContentEqual(filePath, teamRef).catch((err) => {
+          const equal = await agentContentEqual(tool, filePath, teamRef).catch((err) => {
             console.warn(
               `[agents] 比较文件内容失败 ${filePath} vs ${teamRef}: ${err instanceof Error ? err.message : String(err)}`,
             );
@@ -451,6 +451,26 @@ function getAgentStem(filename: string): string | null {
  */
 function isKnownTool(tool: string): tool is ToolName {
   return (ALL_SUPPORTED_TOOLS as string[]).includes(tool);
+}
+
+/**
+ * Compare a tool-native agent with its canonical team-repo definition.
+ * YAML definitions must be rendered first because tools such as Codex use a
+ * different on-disk format (TOML), making a raw byte comparison always differ.
+ */
+async function agentContentEqual(tool: string, localPath: string, teamPath: string): Promise<boolean> {
+  if (!teamPath.endsWith('.yaml') || !isKnownTool(tool)) {
+    return fileContentEqual(localPath, teamPath);
+  }
+
+  const canonicalContent = await readFileSafe(teamPath);
+  const localContent = await readFileSafe(localPath);
+  if (canonicalContent === null || localContent === null) return false;
+
+  const parsed = parseAgentYaml(canonicalContent, path.basename(teamPath));
+  if (!parsed.ok) return false;
+
+  return localContent === renderForTool(parsed.spec, tool).content;
 }
 
 /**


### PR DESCRIPTION
## Summary

- compare canonical agent YAML against its rendered tool-native representation
- prevent untouched Codex TOML agents from being repeatedly reported as modified
- preserve detection of actual local TOML edits

## Testing

- full test suite verified (2633 tests)
- TypeScript type check passed
- production build passed
- real CLI verification:
  - untouched Codex TOML reports no local changes
  - edited Codex TOML is detected as modified

Closes #410
