### PR TITLE
fix(data-layout): exclude a contended scope from reconcile/report, not just the fetch (#374)

### DIFF
--- a/src/pull.ts
+++ b/src/pull.ts
@@ -1198,30 +1198,37 @@ async function collectClaudemdFiles(
  * it means the user updated the CLI but hooks are still in old format.
  * Reinjects with the current version's hook definitions.
  */
-async function autoMigrateHooksIfNeeded(): Promise<void> {
+async function legacyHooksNeedReinject(): Promise<boolean> {
   const home = getUserHome();
-  // Quick check: read the primary settings file and see if it has hook-dispatch
+  // Quick check: read the primary settings file and see if it has hook-dispatch.
+  // Reads ONLY HOME's settings — never the shared team clone — so it is safe to
+  // call before the scope lock is held.
   const primarySettings = path.join(home, '.claude', 'settings.json');
-  if (!await pathExists(primarySettings)) return;
-
+  if (!await pathExists(primarySettings)) return false;
   const content = await readFileSafe(primarySettings);
-  if (!content) return;
+  if (!content) return false;
+  // If hook-dispatch is already present, no migration needed.
+  if (content.includes('hook-dispatch')) return false;
+  // If no teamai hooks at all (user never ran init), skip.
+  if (!content.includes('teamai')) return false;
+  return true;
+}
 
-  // If hook-dispatch is already present, no migration needed
-  if (content.includes('hook-dispatch')) return;
-
-  // If no teamai hooks at all (user never ran init), skip
-  if (!content.includes('teamai')) return;
-
-  // Old format detected — reinject all tools
+/**
+ * Reinject hooks in the merged dispatch format for a config whose shared clone is
+ * already locked by the caller. MUST run under the scope's sync-lock: it reads
+ * `teamConfig.toolPaths` from the shared clone and writes executable hook config,
+ * so a concurrent push's transient branch must not be visible here.
+ */
+async function reinjectLegacyHooks(localConfig: LocalConfig): Promise<void> {
   log.debug('Auto-migrating hooks to dispatch format...');
-  const { autoDetectInit } = await import('./config.js');
+  const teamConfig = await loadTeamConfig(localConfig.repo.localPath);
+  if (!teamConfig) return;
   const { injectHooksToAllTools } = await import('./hooks.js');
-  const { localConfig, teamConfig } = await autoDetectInit();
   // Reinject where hooks actually live (resolveHookScope), not resolveBaseDir.
-  // The old-format check above reads HOME; for a non-self project scope
-  // resolveBaseDir → <projectRoot>, so reinjecting there never clears HOME's
-  // legacy format and this migration would re-fire on every pull (#370).
+  // The old-format check reads HOME; for a non-self project scope resolveBaseDir
+  // → <projectRoot>, so reinjecting there never clears HOME's legacy format and
+  // this migration would re-fire on every pull (#370).
   const { baseDir } = resolveHookScope(localConfig);
   const disabled = localConfig.disabledAgents;
   let hookFilter = localConfig.enabledAgents;
@@ -1242,14 +1249,10 @@ async function autoMigrateHooksIfNeeded(): Promise<void> {
  * source skills are pulled only for the active project scope.
  */
 export async function pull(options: GlobalOptions): Promise<void> {
-  // 0. Auto-migrate hooks if settings.json has old format (pre-dispatch era).
-  //    This runs on the first session start after a CLI update — the new binary
-  //    detects the old individual hooks and reinjects the merged dispatch format.
-  try {
-    await autoMigrateHooksIfNeeded();
-  } catch {
-    // Non-fatal — pull continues even if hook migration fails
-  }
+  // Whether HOME's settings.json still has the pre-dispatch hook format. Read now
+  // (HOME-only, no shared clone), but the actual reinject runs later under the
+  // scope lock so it never consumes a concurrent push's transient branch config.
+  const needsHookMigration = await legacyHooksNeedReinject().catch(() => false);
 
   // Shared-clone concurrency (issue #374). A git-mode scope's team clone is
   // reachable from every worktree of the repo, so a concurrent pull/push races
@@ -1344,6 +1347,23 @@ export async function pull(options: GlobalOptions): Promise<void> {
   // — the next uncontended pull reconciles and reports normally.
   const reconcileUser = activeUserConfig && !contended.has(activeUserConfig) ? activeUserConfig : null;
   const reconcileProject = projectConfig && !contended.has(projectConfig) ? projectConfig : null;
+
+  // 3.4. Legacy hook-format migration (pre-dispatch era). Runs UNDER the scope
+  // lock (unlike the old step-0 call) against a locked, non-contended scope, so
+  // it reads teamConfig.toolPaths from a stable clone rather than a concurrent
+  // push's transient branch. Skipped when the only active scopes are contended —
+  // the next uncontended pull migrates. self mode reinjects from its own on-disk
+  // .teamai (no external clone) and is covered here too via reconcileProject.
+  if (needsHookMigration) {
+    const migrateScope = reconcileProject ?? reconcileUser;
+    if (migrateScope) {
+      try {
+        await reinjectLegacyHooks(migrateScope);
+      } catch {
+        // Non-fatal — pull continues even if hook migration fails.
+      }
+    }
+  }
 
   // 3.5. Reconcile built-in + team hooks for the active scope only. Runs OUTSIDE
   // pullForScope so it bypasses the "Already synced" rev fast-path — this is

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -371,6 +371,14 @@ async function pullForScope(
   policy: {
     resourceTypes?: readonly ResourceType[];
     revisionField?: 'lastPullRev' | 'lastInheritedPullRev';
+    /**
+     * Accumulator: when the shared-clone sync-lock is contended, this scope's
+     * config is added here so the caller excludes it from EVERY later stage that
+     * reads or mutates the shared clone (hooks/MCP/co-author reconcile, usage
+     * report). Skipping only the fetch is not enough — those stages
+     * loadTeamConfig() and reset/pull the same clone the lock holder is using.
+     */
+    contended?: Set<LocalConfig>;
   } = {},
 ): Promise<void> {
   const scopeLabel = localConfig.scope;
@@ -396,8 +404,10 @@ async function pullForScope(
     if (skipped) {
       // The shared clone is locked by a concurrent pull/push; its working tree
       // may be on a transient branch. Skip this scope entirely — do not scan or
-      // deploy from a clone we could not safely snapshot. Idempotent: the next
-      // pull (once the lock frees) syncs normally.
+      // deploy from a clone we could not safely snapshot, and mark it contended
+      // so the caller also skips the later reconcile/report stages that touch the
+      // same clone. Idempotent: the next pull (once the lock frees) syncs normally.
+      policy.contended?.add(localConfig);
       pullSpin.succeed(`[${scopeLabel}] Team repo: ${label}`);
       return;
     }
@@ -1277,6 +1287,11 @@ export async function pull(options: GlobalOptions): Promise<void> {
     // Non-fatal — pull continues even if hook migration fails
   }
 
+  // Scopes whose shared clone was locked by a concurrent pull/push this run.
+  // pullForScope adds to it on contention; the reconcile/report stages below
+  // exclude these scopes so nothing reads or resets a clone we couldn't snapshot.
+  const contended = new Set<LocalConfig>();
+
   // 1. Detect project scope first. Its presence decides whether user scope is
   //    processed at all (issue #73: project install isolates from user).
   let projectConfig: LocalConfig | null = null;
@@ -1304,10 +1319,11 @@ export async function pull(options: GlobalOptions): Promise<void> {
           await pullForScope(inheritedUserConfig, options, {
             resourceTypes: ['skills', 'rules', 'docs', 'agents'],
             revisionField: 'lastInheritedPullRev',
+            contended,
           });
         } else {
           activeUserConfig = loadedUserConfig;
-          await pullForScope(activeUserConfig, options);
+          await pullForScope(activeUserConfig, options, { contended });
         }
       } else if (inheritUserScope) {
         log.warn('user-scope inheritance is enabled, but user scope is not initialized');
@@ -1322,28 +1338,35 @@ export async function pull(options: GlobalOptions): Promise<void> {
   // 3. Project scope.
   if (projectConfig) {
     try {
-      await pullForScope(projectConfig, options);
+      await pullForScope(projectConfig, options, { contended });
     } catch (e) {
       log.warn(`Project-scope pull error: ${(e as Error).message}`);
     }
   }
+
+  // A scope whose shared clone was locked this run is dropped from every stage
+  // below: they all loadTeamConfig()/reset the same clone, which may be on a
+  // transient branch held by the concurrent writer. Skipping is safe/idempotent
+  // — the next uncontended pull reconciles and reports normally.
+  const reconcileUser = activeUserConfig && !contended.has(activeUserConfig) ? activeUserConfig : null;
+  const reconcileProject = projectConfig && !contended.has(projectConfig) ? projectConfig : null;
 
   // 3.5. Reconcile built-in + team hooks for the active scope only. Runs OUTSIDE
   // pullForScope so it bypasses the "Already synced" rev fast-path — this is
   // what self-heals new built-in hooks and applies hooks.yaml changes on every
   // session start. In project mode user is null, even when safe resources are
   // inherited, so executable hook configuration is never composed implicitly.
-  await reconcileHooksAllScopes(activeUserConfig, projectConfig, options);
+  await reconcileHooksAllScopes(reconcileUser, reconcileProject, options);
 
   // 3.6. Reconcile team MCP servers. Outside pullForScope for the same reason as
   // hooks. User-scope MCP remains isolated in project mode.
-  await reconcileMcpAllScopes(activeUserConfig, projectConfig, options);
+  await reconcileMcpAllScopes(reconcileUser, reconcileProject, options);
 
   // 3.7. Reconcile the team co-author policy (does an AI tool stamp a
   // Co-Authored-By / attribution trailer on its commits?). Outside pullForScope
   // for the same reason as hooks/MCP; write-only, so it self-heals but never
   // strips a trailer once the team drops the policy.
-  await reconcileCoAuthorAllScopes(activeUserConfig, projectConfig, options);
+  await reconcileCoAuthorAllScopes(reconcileUser, reconcileProject, options);
 
   // 4. Auto-report usage data to all active scopes. Events live in a single
   //    shared file (~/.teamai/usage.jsonl), so we report to each repo with
@@ -1355,28 +1378,28 @@ export async function pull(options: GlobalOptions): Promise<void> {
       const { reportUsageToTeam } = await import('./team-push.js');
       const { truncateUsageAfterReport, readUsageEvents } = await import('./usage-tracker.js');
       const targets: Array<{ repoPath: string; username: string; opts: { skipTruncate: true; projectRoot?: string; excludeProjectRoots?: string[]; selfConfig?: LocalConfig } }> = [];
-      if (projectConfig && projectConfig.repo.kind !== 'http') {
+      if (reconcileProject && reconcileProject.repo.kind !== 'http') {
         targets.push({
-          repoPath: projectConfig.repo.localPath,
-          username: projectConfig.username,
+          repoPath: reconcileProject.repo.localPath,
+          username: reconcileProject.username,
           opts: {
             skipTruncate: true,
-            projectRoot: projectConfig.projectRoot,
+            projectRoot: reconcileProject.projectRoot,
             // Self mode routes stats/votes to the teamai-reports orphan branch.
-            ...(projectConfig.repo.kind === 'self' ? { selfConfig: projectConfig } : {}),
+            ...(reconcileProject.repo.kind === 'self' ? { selfConfig: reconcileProject } : {}),
           },
         });
       }
-      if (activeUserConfig && activeUserConfig.repo.kind !== 'http') {
+      if (reconcileUser && reconcileUser.repo.kind !== 'http') {
         targets.push({
-          repoPath: activeUserConfig.repo.localPath,
-          username: activeUserConfig.username,
+          repoPath: reconcileUser.repo.localPath,
+          username: reconcileUser.username,
           opts: {
             skipTruncate: true,
             excludeProjectRoots: projectConfig?.projectRoot ? [projectConfig.projectRoot] : [],
             // Self mode routes stats/votes to the teamai-reports orphan branch —
             // never reset/pull the business repo working tree.
-            ...(activeUserConfig.repo.kind === 'self' ? { selfConfig: activeUserConfig } : {}),
+            ...(reconcileUser.repo.kind === 'self' ? { selfConfig: reconcileUser } : {}),
           },
         });
       }

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -1421,8 +1421,12 @@ export async function pull(options: GlobalOptions): Promise<void> {
   }
 
   // 5. Pull cross-team source skills (always — even in project mode), against
-  //    the active scope so deploys land in the right base dir.
-  const sourceConfig = projectConfig ?? activeUserConfig;
+  //    the active scope so deploys land in the right base dir. Use the
+  //    contention-filtered scopes: pullSources re-reads `sources` from the shared
+  //    clone's teamai.yaml and deploys external skills, so a contended scope must
+  //    be excluded here too — otherwise a lock holder's transient push branch
+  //    could sync unmerged source declarations into the workspace.
+  const sourceConfig = reconcileProject ?? reconcileUser;
   if (sourceConfig) {
     try {
       const { pullSources } = await import('./source.js');

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -55,7 +55,7 @@ interface RolePullContext {
  */
 async function refreshTeamRepo(
   localConfig: LocalConfig,
-): Promise<{ label: string; version: string | null; reportingOnly: boolean; skipped?: boolean }> {
+): Promise<{ label: string; version: string | null; reportingOnly: boolean }> {
   if (localConfig.repo.kind === 'http') {
     const { resolveApiKey } = await import('./api-key.js');
     const apiKey = resolveApiKey();
@@ -91,50 +91,32 @@ async function refreshTeamRepo(
     return { label: 'single-repo (knowledge on main)', version, reportingOnly: false };
   }
 
-  // Guard the shared team clone with the partition sync-lock: the main checkout
-  // and a worktree resolve to the SAME clone, so two `teamai pull`/`push` runs can
-  // race git operations on it. On contention we skip the ENTIRE clone-mutating
-  // section — both the fetch AND flushPendingLearnings (which writes files and
-  // runs git add/commit/push on this clone) — and report the clone's current HEAD
-  // so the deploy step still proceeds from its present state. The lock is held
-  // across the whole section (fetch + flush + rev read) so no other writer can
-  // reset/checkout the tree mid-operation.
-  const syncLock = path.join(getDataHome(localConfig), SYNC_LOCK_FILENAME);
-  const locked = await acquireLock(syncLock);
-  if (!locked) {
-    // Another pull/push holds the lock. We must NOT read or deploy from the
-    // shared clone now: the holder may have it checked out on a generated push
-    // branch or be mid reset/checkout, so its tree can contain unmerged,
-    // unreviewed content. Signal `skipped` so pullForScope skips this scope's
-    // deploy entirely rather than syncing a transient tree into the workspace.
-    log.debug('[pull] another pull/push holds the sync lock; skipping this scope');
-    return { label: 'sync in progress elsewhere — skipped', version: null, reportingOnly: false, skipped: true };
-  }
+  // The shared team clone is mutated here (git pull + flushPendingLearnings'
+  // add/commit/push). The partition sync-lock that serializes this against a
+  // concurrent pull/push is acquired by the CALLER (pull()) and held across this
+  // scope's ENTIRE clone-consuming lifecycle — fetch, resource scan/deploy, and
+  // the reconcile/source/report stages — so there is no unlocked window in which
+  // another writer could reset/checkout the tree. We must NOT lock here: the lock
+  // is non-reentrant, so re-acquiring it in the same process would fail.
+  const result = await pullRepo(localConfig.repo.localPath);
 
+  // Retry any learnings whose push previously failed (see savePendingLearning).
+  // Best-effort: never let a flush error block the pull.
   try {
-    const result = await pullRepo(localConfig.repo.localPath);
-
-    // Retry any learnings whose push previously failed (see savePendingLearning).
-    // Best-effort: never let a flush error block the pull. Inside the lock because
-    // it writes + commits + pushes the shared clone.
-    try {
-      await flushPendingLearnings(localConfig.repo.localPath, localConfig.username);
-    } catch (e) {
-      log.debug(`pending-learnings flush skipped: ${(e as Error).message}`);
-    }
-
-    let version: string | null = null;
-    try {
-      version = await getHeadRev(localConfig.repo.localPath);
-    } catch {
-      // Can't resolve a rev → skip the incremental fast-path and do a full sync.
-      log.debug('Rev check failed, proceeding with full sync');
-      version = null;
-    }
-    return { label: result, version, reportingOnly: false };
-  } finally {
-    await releaseLock(syncLock);
+    await flushPendingLearnings(localConfig.repo.localPath, localConfig.username);
+  } catch (e) {
+    log.debug(`pending-learnings flush skipped: ${(e as Error).message}`);
   }
+
+  let version: string | null = null;
+  try {
+    version = await getHeadRev(localConfig.repo.localPath);
+  } catch {
+    // Can't resolve a rev → skip the incremental fast-path and do a full sync.
+    log.debug('Rev check failed, proceeding with full sync');
+    version = null;
+  }
+  return { label: result, version, reportingOnly: false };
 }
 
 async function buildRolePullContext(localConfig: LocalConfig): Promise<RolePullContext | null> {
@@ -371,14 +353,6 @@ async function pullForScope(
   policy: {
     resourceTypes?: readonly ResourceType[];
     revisionField?: 'lastPullRev' | 'lastInheritedPullRev';
-    /**
-     * Accumulator: when the shared-clone sync-lock is contended, this scope's
-     * config is added here so the caller excludes it from EVERY later stage that
-     * reads or mutates the shared clone (hooks/MCP/co-author reconcile, usage
-     * report). Skipping only the fetch is not enough — those stages
-     * loadTeamConfig() and reset/pull the same clone the lock holder is using.
-     */
-    contended?: Set<LocalConfig>;
   } = {},
 ): Promise<void> {
   const scopeLabel = localConfig.scope;
@@ -400,17 +374,7 @@ async function pullForScope(
   // there and must not be injected.
   let reportingOnly = false;
   try {
-    const { label, version, reportingOnly: ro, skipped } = await refreshTeamRepo(localConfig);
-    if (skipped) {
-      // The shared clone is locked by a concurrent pull/push; its working tree
-      // may be on a transient branch. Skip this scope entirely — do not scan or
-      // deploy from a clone we could not safely snapshot, and mark it contended
-      // so the caller also skips the later reconcile/report stages that touch the
-      // same clone. Idempotent: the next pull (once the lock frees) syncs normally.
-      policy.contended?.add(localConfig);
-      pullSpin.succeed(`[${scopeLabel}] Team repo: ${label}`);
-      return;
-    }
+    const { label, version, reportingOnly: ro } = await refreshTeamRepo(localConfig);
     currentRev = version;
     reportingOnly = ro;
     pullSpin.succeed(`[${scopeLabel}] Team repo: ${label}`);
@@ -1287,10 +1251,35 @@ export async function pull(options: GlobalOptions): Promise<void> {
     // Non-fatal — pull continues even if hook migration fails
   }
 
-  // Scopes whose shared clone was locked by a concurrent pull/push this run.
-  // pullForScope adds to it on contention; the reconcile/report stages below
-  // exclude these scopes so nothing reads or resets a clone we couldn't snapshot.
+  // Shared-clone concurrency (issue #374). A git-mode scope's team clone is
+  // reachable from every worktree of the repo, so a concurrent pull/push races
+  // git operations on it. We hold the partition sync-lock for the FULL lifecycle
+  // in which this pull consumes that clone — fetch, resource scan/deploy, and the
+  // reconcile/source/report stages — because those later stages also
+  // loadTeamConfig()/reset the same clone. Locks are acquired per git-mode scope
+  // up front and released together in the finally at the end of pull(). A scope
+  // whose lock is held by another process is added to `contended` and excluded
+  // from every clone-consuming stage (idempotent — the next pull syncs it).
   const contended = new Set<LocalConfig>();
+  const heldLocks = new Map<LocalConfig, string>();
+  const lockScope = async (config: LocalConfig): Promise<boolean> => {
+    // Only git-mode has a shared team clone to guard. http has no clone; self
+    // mode writes the reports orphan-branch worktree under its own reports-lock.
+    if (config.repo.kind && config.repo.kind !== 'git') return true;
+    const lock = path.join(getDataHome(config), SYNC_LOCK_FILENAME);
+    if (await acquireLock(lock)) {
+      heldLocks.set(config, lock);
+      return true;
+    }
+    // User-visible: this scope is skipped wholesale (no fetch/deploy/reconcile),
+    // so a plain success line would be misleading. Idempotent — the next pull
+    // once the other process finishes syncs it normally.
+    log.info(`[${config.scope}] sync in progress elsewhere — skipped (another pull/push holds the lock)`);
+    contended.add(config);
+    return false;
+  };
+
+  try {
 
   // 1. Detect project scope first. Its presence decides whether user scope is
   //    processed at all (issue #73: project install isolates from user).
@@ -1316,14 +1305,17 @@ export async function pull(options: GlobalOptions): Promise<void> {
         if (inheritUserScope) {
           inheritedUserConfig = loadedUserConfig;
           log.info('project scope detected, inheriting user-scope resources and knowledge');
-          await pullForScope(inheritedUserConfig, options, {
-            resourceTypes: ['skills', 'rules', 'docs', 'agents'],
-            revisionField: 'lastInheritedPullRev',
-            contended,
-          });
+          if (await lockScope(inheritedUserConfig)) {
+            await pullForScope(inheritedUserConfig, options, {
+              resourceTypes: ['skills', 'rules', 'docs', 'agents'],
+              revisionField: 'lastInheritedPullRev',
+            });
+          }
         } else {
           activeUserConfig = loadedUserConfig;
-          await pullForScope(activeUserConfig, options, { contended });
+          if (await lockScope(activeUserConfig)) {
+            await pullForScope(activeUserConfig, options);
+          }
         }
       } else if (inheritUserScope) {
         log.warn('user-scope inheritance is enabled, but user scope is not initialized');
@@ -1338,7 +1330,9 @@ export async function pull(options: GlobalOptions): Promise<void> {
   // 3. Project scope.
   if (projectConfig) {
     try {
-      await pullForScope(projectConfig, options, { contended });
+      if (await lockScope(projectConfig)) {
+        await pullForScope(projectConfig, options);
+      }
     } catch (e) {
       log.warn(`Project-scope pull error: ${(e as Error).message}`);
     }
@@ -1433,6 +1427,13 @@ export async function pull(options: GlobalOptions): Promise<void> {
       await pullSources(sourceConfig, options);
     } catch (e) {
       log.debug(`Source pull skipped: ${(e as Error).message}`);
+    }
+  }
+  } finally {
+    // Release every partition sync-lock this pull held, now that all
+    // shared-clone reads/writes for every scope are done.
+    for (const lock of heldLocks.values()) {
+      await releaseLock(lock);
     }
   }
 }

--- a/src/team-push.ts
+++ b/src/team-push.ts
@@ -15,9 +15,8 @@ import { withTimeout } from './utils/async.js';
 import { writeFile, readFileSafe, ensureDir, pathExists, readJson, writeJson } from './utils/fs.js';
 import { log } from './utils/logger.js';
 import type { UserStats, UserInterventionStats, SessionMetrics, TokenUsage, DashboardEvent, LocalConfig } from './types.js';
-import { VOTES_LOCAL_DIR, emptyTokenUsage, addTokenUsage, SYNC_LOCK_FILENAME } from './types.js';
+import { VOTES_LOCAL_DIR, emptyTokenUsage, addTokenUsage } from './types.js';
 import { getUserHome } from './utils/home.js';
-import { acquireLock, releaseLock } from './update.js';
 
 /** Snapshot of already-reported per-session intervention counts (idempotency basis). */
 type ReportedInterventions = Record<string, { interrupt: number; toolReject: number; correction: number }>;
@@ -317,18 +316,11 @@ export async function reportUsageToTeam(
   const selfConfig = options?.selfConfig;
   const selfMode = selfConfig?.repo.kind === 'self';
 
-  // git mode auto-report reset/pull/commit/pushes the SHARED team clone, so it
-  // must hold the same partition sync-lock as pull/push — otherwise it can reset
-  // or checkout a clone another pull/push is mid-operation on. (self mode writes
-  // the reports orphan-branch worktree, coordinated by its own reports-lock.)
-  const syncLock = selfMode ? null : path.join(path.dirname(repoPath), SYNC_LOCK_FILENAME);
-  if (syncLock) {
-    const locked = await acquireLock(syncLock);
-    if (!locked) {
-      log.debug('Skipping report: another pull/push holds the sync lock');
-      return;
-    }
-  }
+  // git-mode auto-report reset/pull/commit/pushes the SHARED team clone. Its
+  // caller (pull()) holds the partition sync-lock across this scope's whole
+  // clone-consuming lifecycle, so we must NOT acquire it here — the lock is
+  // non-reentrant and re-acquiring in the same process would fail. (self mode
+  // writes the reports orphan-branch worktree, coordinated by its own reports-lock.)
 
   try {
     const events = await readUsageEvents();
@@ -505,7 +497,5 @@ export async function reportUsageToTeam(
     }
   } catch (e) {
     log.error(`Auto-report skipped: ${(e as Error).message}`);
-  } finally {
-    if (syncLock) await releaseLock(syncLock);
   }
 }


### PR DESCRIPTION
## Context

Follow-up to **#406** (P1-2B, already merged). A round of review on #406 flagged
that the sync-lock contention path was incomplete, and #406 landed before the
last fix — so this ships it as its own PR.

On lock contention, #406 skipped only `pullForScope`'s fetch/deploy and locked the
usage report. But the outer `pull()` **still ran the hooks / MCP / co-author
reconcile stages** for that scope. Each of those calls
`loadTeamConfig(localConfig.repo.localPath)` and injects from the **shared team
clone** — the same clone the lock holder (a concurrent `push`) may have checked
out on a generated `teamai/push-in-progress` branch. So a losing pull could still
read unmerged, unreviewed content off a transient branch and deploy it into the
user's tool dirs (hooks/MCP), even though the fetch itself was skipped.

## What this PR does

Propagate contention to the outer stages. `pullForScope` records a contended scope
in a shared `Set<LocalConfig>` accumulator; `pull()` then drops those scopes from
**every** later stage that reads or mutates the shared clone — hooks / MCP /
co-author reconcile and the usage report. Skipping is safe and idempotent: the
next uncontended pull reconciles and reports normally.

This completes the reviewer's original ask ("propagate `skipped` to the outer
`pull()`; at minimum exclude that scope's reconcile/report") — the earlier fix had
only locked the report, not the reconcile stages.

## Test plan (all executed green)

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — **191 files / 2639 tests pass**
- [x] **Real CLI repro**: shared clone checked out on `teamai/push-in-progress`
      carrying an `unmerged` skill that exists only on that branch; hold
      `<dataHome>/.sync-lock` and run `pull --force` → "sync in progress
      elsewhere — skipped"; the unmerged skill is **NOT** deployed to the
      workspace and the clone stays on its branch. The reconcile stages emit
      nothing for the contended scope.

Refs #374 (follow-up to P1-2B / #406).