### PR TITLE
feat(data-layout): route managed-mcp.json + project resource cache to the partition (#374 P1-2C)

### DIFF
--- a/src/__tests__/anchors.test.ts
+++ b/src/__tests__/anchors.test.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import { realpathSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { resolveAnchors } from '../utils/git.js';
+import { resolveAnchors, listWorktrees } from '../utils/git.js';
 
 // ─── Real-git tests for resolveAnchors (issue #374 P0) ──────────────────────
 //
@@ -118,5 +118,25 @@ describe('resolveAnchors', () => {
     // And neither anchor is the shared parent directory.
     expect(a!.projectAnchor).not.toBe(gitdirs);
     expect(b!.projectAnchor).not.toBe(gitdirs);
+  });
+});
+
+describe('listWorktrees', () => {
+  it('lists the main checkout and every linked worktree (realpath\'d)', async () => {
+    const roots = await listWorktrees(repoRoot);
+    expect(roots).toContain(repoRoot);
+    expect(roots).toContain(worktreeRoot);
+    // From a subdirectory of a worktree, the full set is still returned.
+    const sub = path.join(worktreeRoot, 'nested');
+    fs.mkdirSync(sub, { recursive: true });
+    const fromSub = await listWorktrees(sub);
+    expect(fromSub).toContain(repoRoot);
+    expect(fromSub).toContain(worktreeRoot);
+  });
+
+  it('returns [] outside a git repo', async () => {
+    const plain = realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-nogit-')));
+    expect(await listWorktrees(plain)).toEqual([]);
+    fs.rmSync(plain, { recursive: true, force: true });
   });
 });

--- a/src/__tests__/detect-subdir.test.ts
+++ b/src/__tests__/detect-subdir.test.ts
@@ -4,7 +4,9 @@ import fs, { realpathSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import YAML from 'yaml';
-import { detectProjectConfig } from '../config.js';
+import { detectProjectConfig, resolveDataHomeForScope } from '../config.js';
+import { getDataHome, getTeamaiHome } from '../types.js';
+import { projectDataHome } from '../utils/partition.js';
 
 // ─── detectProjectConfig subdirectory / worktree awareness (issue #374 P0) ──
 //
@@ -101,5 +103,68 @@ describe('detectProjectConfig — subdirectory / worktree', () => {
     const plain = path.join(base, 'plain');
     fs.mkdirSync(plain);
     expect(await detectProjectConfig(plain)).toBeNull();
+  });
+});
+
+// resolveDataHomeForScope must agree with getDataHome(detectProjectConfig(...))
+// for every scope — otherwise the local-agent side (which only carries
+// scope+projectRoot) and the reconcile side (which holds a full LocalConfig)
+// would resolve managed-mcp.json / the resource cache to different directories
+// and desync (issue #374 P1-2C).
+describe('resolveDataHomeForScope — desync guard', () => {
+  it('matches getDataHome(detected) for a legacy project install', async () => {
+    const detected = await detectProjectConfig(repoRoot);
+    expect(detected).not.toBeNull();
+    const viaConfig = getDataHome(detected!);
+    const viaScope = await resolveDataHomeForScope('project', repoRoot);
+    expect(viaScope).toBe(viaConfig);
+    expect(viaScope).toBe(path.join(repoRoot, '.teamai'));
+  });
+
+  it('matches from a subdirectory of the project', async () => {
+    const sub = path.join(repoRoot, 'a', 'b');
+    fs.mkdirSync(sub, { recursive: true });
+    const detected = await detectProjectConfig(sub);
+    expect(await resolveDataHomeForScope('project', sub)).toBe(getDataHome(detected!));
+  });
+
+  it('resolves user scope to ~/.teamai', async () => {
+    expect(await resolveDataHomeForScope('user')).toBe(getTeamaiHome('user'));
+  });
+
+  it('falls back to legacy <projectRoot>/.teamai for a non-git dir with no config', async () => {
+    const plain = path.join(base, 'plain2');
+    fs.mkdirSync(plain, { recursive: true });
+    expect(await resolveDataHomeForScope('project', plain)).toBe(path.join(plain, '.teamai'));
+  });
+
+  it('matches getDataHome(detected) for a PARTITIONED install (config in ~/.teamai/projects/<slug>)', async () => {
+    // Point HOME at a tmp home, write the project config into the partition, and
+    // confirm both resolvers land on the partition (not the workspace).
+    const home = path.join(base, 'part-home');
+    fs.mkdirSync(home, { recursive: true });
+    const origHome = process.env.HOME;
+    process.env.HOME = home;
+    try {
+      const pRepo = path.join(base, 'prepo');
+      fs.mkdirSync(pRepo);
+      git(pRepo, 'init', '-q');
+      git(pRepo, 'config', 'user.email', 't@e');
+      git(pRepo, 'config', 'user.name', 'T');
+      git(pRepo, 'commit', '--allow-empty', '-q', '-m', 'init');
+      const anchorReal = realpathSync(pRepo);
+      const partition = projectDataHome(anchorReal);
+      fs.mkdirSync(partition, { recursive: true });
+      fs.writeFileSync(path.join(partition, 'config.yaml'), YAML.stringify({
+        repo: { localPath: path.join(partition, 'team-repo'), remote: 'https://example.com/x.git', kind: 'git' },
+        username: 'test', scope: 'project', projectRoot: anchorReal, additionalRoles: [],
+      }));
+      const detected = await detectProjectConfig(pRepo);
+      expect(detected).not.toBeNull();
+      expect(getDataHome(detected!)).toBe(partition);
+      expect(await resolveDataHomeForScope('project', pRepo)).toBe(partition);
+    } finally {
+      if (origHome === undefined) delete process.env.HOME; else process.env.HOME = origHome;
+    }
   });
 });

--- a/src/__tests__/local-agent-mcp.test.ts
+++ b/src/__tests__/local-agent-mcp.test.ts
@@ -342,15 +342,14 @@ describe('local-agent: MCP install/uninstall commands', () => {
     expect(mcpConfig.mcpServers['enterprise-search']).toBeDefined();
     expect(mcpConfig.mcpServers['enterprise-search'].url).toBe('https://search.example.com/mcp');
 
-    // 检查 project 级 manifest — key 现按 workspace 身份隔离(#374 P1-2C 修复:
-    // 分区内 manifest 跨 worktree 共享,所有权 key 必须带当前 workspaceRoot)。
-    // 断言存在一个 codebuddy project key(形如 `codebuddy:project:<id>`)持有该 entry。
-    const manifest = await fse.readJson(path.join(wsPath, '.teamai', 'managed-mcp.json'));
-    const projectKeys = Object.keys(manifest).filter((k) => k.startsWith('codebuddy:project'));
-    expect(projectKeys.length).toBe(1);
-    // key 必须带 workspace 身份段(不是裸 `codebuddy:project`),否则跨 worktree 会串所有权。
-    expect(projectKeys[0]).toMatch(/^codebuddy:project:[0-9a-f]{12}$/);
-    expect(manifest[projectKeys[0]]).toEqual(
+    // 检查 project 级 manifest — 现为 PER-WORKTREE 文件(#374:分区内每 worktree 一个
+    // 独立 managed-mcp.json),key 回归普通 `codebuddy:project`。定位 workspaces/ 下唯一文件
+    // (id 由 install 侧解析的 workspacePath 决定,可能经 realpath,故不硬算)。
+    const wsDir = path.join(wsPath, '.teamai', 'workspaces');
+    const ids = await fse.readdir(wsDir);
+    expect(ids.length).toBe(1);
+    const manifest = await fse.readJson(path.join(wsDir, ids[0], 'managed-mcp.json'));
+    expect(manifest['codebuddy:project']).toEqual(
       expect.arrayContaining([expect.objectContaining({ name: 'enterprise-search' })]),
     );
   });

--- a/src/__tests__/local-agent-mcp.test.ts
+++ b/src/__tests__/local-agent-mcp.test.ts
@@ -342,9 +342,15 @@ describe('local-agent: MCP install/uninstall commands', () => {
     expect(mcpConfig.mcpServers['enterprise-search']).toBeDefined();
     expect(mcpConfig.mcpServers['enterprise-search'].url).toBe('https://search.example.com/mcp');
 
-    // 检查 project 级 manifest
+    // 检查 project 级 manifest — key 现按 workspace 身份隔离(#374 P1-2C 修复:
+    // 分区内 manifest 跨 worktree 共享,所有权 key 必须带当前 workspaceRoot)。
+    // 断言存在一个 codebuddy project key(形如 `codebuddy:project:<id>`)持有该 entry。
     const manifest = await fse.readJson(path.join(wsPath, '.teamai', 'managed-mcp.json'));
-    expect(manifest['codebuddy:project']).toEqual(
+    const projectKeys = Object.keys(manifest).filter((k) => k.startsWith('codebuddy:project'));
+    expect(projectKeys.length).toBe(1);
+    // key 必须带 workspace 身份段(不是裸 `codebuddy:project`),否则跨 worktree 会串所有权。
+    expect(projectKeys[0]).toMatch(/^codebuddy:project:[0-9a-f]{12}$/);
+    expect(manifest[projectKeys[0]]).toEqual(
       expect.arrayContaining([expect.objectContaining({ name: 'enterprise-search' })]),
     );
   });

--- a/src/__tests__/local-agent.test.ts
+++ b/src/__tests__/local-agent.test.ts
@@ -1812,3 +1812,81 @@ describe('local-agent: cmds[] migration', () => {
     expect(acks.find((a) => a.id === 9)?.status).toBe('success');
   });
 });
+
+describe('local-agent: per-worktree claudemd isolation (issue #374 P1-2C)', () => {
+  it('worktree B\'s CLAUDE.md never merges worktree A\'s instructions', async () => {
+    const { execFileSync } = await import('node:child_process');
+    const { realpathSync } = await import('node:fs');
+
+    // Real git repo + linked worktree → shared partition data home. The resource
+    // cache used to be shared, so syncClaudemd merged A's + B's fragments.
+    const repo = realpathSync(await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-cmd-wt-')));
+    const git = (cwd: string, ...a: string[]) => execFileSync('git', a, { cwd, stdio: 'pipe' });
+    git(repo, 'init', '-q');
+    git(repo, 'config', 'user.email', 't@e'); git(repo, 'config', 'user.name', 'T');
+    git(repo, 'commit', '--allow-empty', '-q', '-m', 'init');
+    const wtB = path.join(repo, '..', path.basename(repo) + '-B');
+    git(repo, 'worktree', 'add', '-q', wtB, 'HEAD');
+    const wtBReal = realpathSync(wtB);
+    // codebuddy is the "installed" tool in each worktree.
+    for (const wt of [repo, wtBReal]) await fse.ensureDir(path.join(wt, '.codebuddy', 'skills'));
+
+    // A partition config so both worktrees resolve to the shared partition.
+    const YAML = (await import('yaml')).default;
+    const { projectDataHome } = await import('../utils/partition.js');
+    const partition = projectDataHome(repo);
+    await fse.ensureDir(partition);
+    await fse.writeFile(path.join(partition, 'config.yaml'), YAML.stringify({
+      repo: { localPath: path.join(partition, 'team-repo'), remote: 'https://example.com/x.git', kind: 'git' },
+      username: 'u', scope: 'project', projectRoot: repo, additionalRoles: [],
+    }));
+
+    await fse.ensureDir(path.join(tmpDir, '.teamai', 'local-agent'));
+    await fse.writeJson(path.join(tmpDir, '.teamai', 'local-agent', 'config.json'), {
+      endpoint: 'https://test.example.com/api', token: 't', localAgentId: 'id',
+      createdAt: '2026-01-01T00:00:00.000Z', workspaceBindings: {},
+    });
+
+    // fetch stub: distinct claudemd body per URL; sync returns a workspace-scoped
+    // install_prompt command for the requested worktree.
+    const install = (ws: string, slug: string) => ({
+      ok: true,
+      cmds: [{
+        id: slug === 'a-doc' ? 101 : 102,
+        type: 'install_prompt_rule', handle_type: 'prompt', slug,
+        version: '1.0.0', download_url: `http://127.0.0.1:42100/${slug}.md`,
+        scope: 'workspace', workspace_path: ws,
+      }],
+    });
+    let syncFor: { ws: string; slug: string } | null = null;
+    const fetchMock = vi.fn(async (input: string | URL) => {
+      const url = String(input);
+      if (url.endsWith('a-doc.md')) return new Response('INSTRUCTION-FROM-A');
+      if (url.endsWith('b-doc.md')) return new Response('INSTRUCTION-FROM-B');
+      if (url.includes('/local-agent/sync') && syncFor) return new Response(JSON.stringify(install(syncFor.ws, syncFor.slug)));
+      return new Response(JSON.stringify({ ok: true }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    // Install A-only instruction from worktree A, then B-only from worktree B.
+    syncFor = { ws: repo, slug: 'a-doc' };
+    await reportAndSyncLocalAgent({ cwd: repo, tool: 'codebuddy', status: 'running' });
+    syncFor = { ws: wtBReal, slug: 'b-doc' };
+    await reportAndSyncLocalAgent({ cwd: wtBReal, tool: 'codebuddy', status: 'running' });
+
+    // B's injected claudemd (.codebuddy/CODEBUDDY.md) must contain ONLY B's
+    // instruction (the pre-fix shared cache made syncClaudemd merge A's in too).
+    const readTxt = async (p: string) => (await fse.pathExists(p)) ? fse.readFile(p, 'utf-8') : '';
+    const bClaudemd = await readTxt(path.join(wtBReal, '.codebuddy', 'CODEBUDDY.md'));
+    expect(bClaudemd).toContain('INSTRUCTION-FROM-B');
+    expect(bClaudemd).not.toContain('INSTRUCTION-FROM-A');
+    // A keeps only A's.
+    const aClaudemd = await readTxt(path.join(repo, '.codebuddy', 'CODEBUDDY.md'));
+    expect(aClaudemd).toContain('INSTRUCTION-FROM-A');
+    expect(aClaudemd).not.toContain('INSTRUCTION-FROM-B');
+
+    await fse.remove(repo).catch(() => {});
+    await fse.remove(wtBReal).catch(() => {});
+  });
+});

--- a/src/__tests__/local-agent.test.ts
+++ b/src/__tests__/local-agent.test.ts
@@ -103,6 +103,66 @@ describe('local-agent: buildReportPayload disk scan', () => {
   });
 });
 
+describe('local-agent: project MCP report is per-worktree (issue #374 P1-2C)', () => {
+  it('reports only the current workspace\'s MCP records from the shared partition manifest', async () => {
+    const { execFileSync } = await import('node:child_process');
+    const { realpathSync } = await import('node:fs');
+    const { managedMcpWorkspaceId } = await import('../types.js');
+
+    // Real git repo + linked worktree → same projectAnchor → same partition.
+    const repo = realpathSync(await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-la-wt-')));
+    const git = (cwd: string, ...a: string[]) => execFileSync('git', a, { cwd, stdio: 'pipe' });
+    git(repo, 'init', '-q');
+    git(repo, 'config', 'user.email', 't@e'); git(repo, 'config', 'user.name', 'T');
+    git(repo, 'commit', '--allow-empty', '-q', '-m', 'init');
+    const wtB = path.join(repo, '..', path.basename(repo) + '-wtB');
+    git(repo, 'worktree', 'add', '-q', wtB, 'HEAD');
+    const wtBReal = realpathSync(wtB);
+
+    // Partition manifest (shared): A owns `a-only`, B owns `b-only`, each under
+    // its own workspace-scoped key.
+    const { projectDataHome } = await import('../utils/partition.js');
+    const partition = projectDataHome(repo); // keyed on the shared anchor
+    await fse.ensureDir(partition);
+    // A project config in the partition makes detectProjectConfig resolve the
+    // data home to this partition (both worktrees share it).
+    const YAML = (await import('yaml')).default;
+    await fse.writeFile(path.join(partition, 'config.yaml'), YAML.stringify({
+      repo: { localPath: path.join(partition, 'team-repo'), remote: 'https://example.com/x.git', kind: 'git' },
+      username: 'u', scope: 'project', projectRoot: repo, additionalRoles: [],
+    }));
+    await fse.writeJson(path.join(partition, 'managed-mcp.json'), {
+      [`codebuddy:project:${managedMcpWorkspaceId(repo)}`]: [{ name: 'a-only', hash: 'h1' }],
+      [`codebuddy:project:${managedMcpWorkspaceId(wtBReal)}`]: [{ name: 'b-only', hash: 'h2' }],
+    });
+
+    // config with a binding for worktree B so the report scans it.
+    const configDir = path.join(tmpDir, '.teamai', 'local-agent');
+    await fse.ensureDir(configDir);
+    await fse.writeJson(path.join(configDir, 'config.json'), {
+      endpoint: 'https://test.example.com/api', token: 't', localAgentId: 'id',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      workspaceBindings: { [wtBReal]: { projectId: 1, projectName: 'p', ideType: 'codebuddy' } },
+    });
+
+    const { buildReportPayload, loadLocalAgentConfig } = await import('../local-agent.js');
+    const config = await loadLocalAgentConfig();
+    const payload = await buildReportPayload(config!, { tool: 'codebuddy', cwd: wtBReal }) as {
+      workspaces?: Array<{ path: string; mcps?: Array<{ slug: string }> }>;
+    };
+
+    const wsB = payload.workspaces?.find((w) => w.path === wtBReal);
+    expect(wsB).toBeDefined();
+    const slugs = (wsB!.mcps ?? []).map((m) => m.slug);
+    // B reports ONLY its own MCP — never A's, even though both live in the shared manifest.
+    expect(slugs).toContain('b-only');
+    expect(slugs).not.toContain('a-only');
+
+    await fse.remove(repo).catch(() => {});
+    await fse.remove(wtBReal).catch(() => {});
+  });
+});
+
 describe('local-agent: local_agent_id derivation (per-tool install dir)', () => {
   it('derives the id from ~/.<tool>, matching the historical status-report口径', async () => {
     await setupConfig();

--- a/src/__tests__/local-agent.test.ts
+++ b/src/__tests__/local-agent.test.ts
@@ -158,6 +158,18 @@ describe('local-agent: project MCP report is per-worktree (issue #374 P1-2C)', (
     expect(slugs).toContain('b-only');
     expect(slugs).not.toContain('a-only');
 
+    // Migration must be DURABLE: the first report migrated B's record out of the
+    // shared file into B's per-worktree file. A SECOND report must still see it
+    // (the pre-fix bug deleted the shared record without persisting the
+    // destination, so the second report returned empty).
+    const { managedMcpManifestPath } = await import('../types.js');
+    expect(await fse.pathExists(managedMcpManifestPath(partition, wtBReal))).toBe(true);
+    const payload2 = await buildReportPayload(config!, { tool: 'codebuddy', cwd: wtBReal }) as {
+      workspaces?: Array<{ path: string; mcps?: Array<{ slug: string }> }>;
+    };
+    const wsB2 = payload2.workspaces?.find((w) => w.path === wtBReal);
+    expect((wsB2!.mcps ?? []).map((m) => m.slug)).toContain('b-only');
+
     await fse.remove(repo).catch(() => {});
     await fse.remove(wtBReal).catch(() => {});
   });

--- a/src/__tests__/mcp-reconcile.test.ts
+++ b/src/__tests__/mcp-reconcile.test.ts
@@ -722,6 +722,50 @@ servers:
       expect((mf['claude:project'] ?? []).some((r: { name: string }) => r.name === 'shared')).toBe(false);
     }
   });
+
+  it('migrates ownership from the TRUE old path <workspace>/.teamai/managed-mcp.json (partition install)', async () => {
+    const { managedMcpManifestPath } = await import('../types.js');
+    // A PARTITION install whose pre-#374 MCP manifest was written to the ORIGINAL
+    // workspace path (not the partition). Data home is the partition, but the old
+    // ownership lives at <projectRoot>/.teamai/managed-mcp.json.
+    const partition = path.join(tmpDir, 'p1-partition');
+    const projectRoot = path.join(tmpDir, 'p1-proj');
+    for (const d of ['.claude', '.cursor', '.codebuddy']) {
+      await fse.ensureDir(path.join(projectRoot, d, 'skills'));
+    }
+    await fse.ensureDir(partition);
+    const cfg = { ...localConfig, scope: 'project', projectRoot, dataHome: partition } as unknown as LocalConfig;
+
+    // Old on-disk state: injected v1 in .mcp.json + ownership at the REAL old path.
+    await fse.writeJson(path.join(projectRoot, '.mcp.json'), {
+      mcpServers: { shared: { type: 'http', url: 'https://team-v1.example/mcp' } },
+    });
+    await fse.outputJson(path.join(projectRoot, '.teamai', 'managed-mcp.json'), {
+      'claude:project': [{ name: 'shared', hash: 'stale' }],
+    });
+    // The partition shared file has nothing — the bug read only here.
+    await fse.outputJson(path.join(partition, 'managed-mcp.json'), {});
+
+    await writeMcpYaml(`
+servers:
+  - name: shared
+    transport: http
+    url: https://team-v2.example/mcp
+`);
+    const { changes } = await reconcileMcpForConfig(teamConfig, cfg);
+
+    // Ownership recognized → the team server is UPDATED (not skipped as unmanaged).
+    expect((await fse.readJson(path.join(projectRoot, '.mcp.json'))).mcpServers.shared.url)
+      .toBe('https://team-v2.example/mcp');
+    expect(changes.find((c) => c.tool === 'claude' && c.server === 'shared')?.action).toBe('updated');
+
+    // Ownership migrated into this worktree's per-worktree file under the partition.
+    const wt = await fse.readJson(managedMcpManifestPath(partition, projectRoot));
+    expect(wt['claude:project'].some((r: { name: string }) => r.name === 'shared')).toBe(true);
+    // The true old path no longer owns it.
+    const oldFile = await fse.readJson(path.join(projectRoot, '.teamai', 'managed-mcp.json'));
+    expect(oldFile['claude:project']).toBeUndefined();
+  });
 });
 
 describe('MCP reconcile — OpenCode', () => {

--- a/src/__tests__/mcp-reconcile.test.ts
+++ b/src/__tests__/mcp-reconcile.test.ts
@@ -678,6 +678,50 @@ servers:
     expect((await fse.readJson(path.join(wtA, '.mcp.json'))).mcpServers.shared).toBeDefined();
     expect((await fse.readJson(path.join(wtB, '.mcp.json'))).mcpServers.shared).toBeDefined();
   });
+
+  it('project-wide uninstall clears every worktree — no sibling left "server present, ownership missing"', async () => {
+    const { managedMcpManifestPath } = await import('../types.js');
+    // Two worktrees sharing one partition, both with `shared` installed. This is
+    // what `teamai uninstall` (project scope) must handle: it now runs a
+    // removeAll reconcile for EVERY worktree before deleting the shared partition,
+    // so no sibling is left with an injected server whose ownership record is gone.
+    const sharedDataHome = path.join(tmpDir, 'un-partition');
+    await fse.ensureDir(sharedDataHome);
+    const wtA = path.join(tmpDir, 'unA');
+    const wtB = path.join(tmpDir, 'unB');
+    for (const wt of [wtA, wtB]) {
+      for (const d of ['.claude', '.cursor', '.codebuddy']) {
+        await fse.ensureDir(path.join(wt, d, 'skills'));
+      }
+    }
+    const cfgA = { ...localConfig, scope: 'project', projectRoot: wtA, dataHome: sharedDataHome } as unknown as LocalConfig;
+    const cfgB = { ...localConfig, scope: 'project', projectRoot: wtB, dataHome: sharedDataHome } as unknown as LocalConfig;
+
+    await writeMcpYaml(`
+servers:
+  - name: shared
+    transport: http
+    url: https://team.example/mcp
+`);
+    await reconcileMcpForConfig(teamConfig, cfgA);
+    await reconcileMcpForConfig(teamConfig, cfgB);
+
+    // Project-wide uninstall: removeAll reconcile for BOTH worktrees (mirrors the
+    // loop uninstall now runs before deleting the partition).
+    await reconcileMcpForConfig(teamConfig, cfgA, { removeAll: true });
+    await reconcileMcpForConfig(teamConfig, cfgB, { removeAll: true });
+
+    // Neither worktree ends in the invalid "server present, ownership missing"
+    // state: the server is gone from both .mcp.json files.
+    for (const [wt, cfg] of [[wtA, cfgA], [wtB, cfgB]] as const) {
+      const doc = await fse.readJson(path.join(wt, '.mcp.json'));
+      expect(doc.mcpServers?.shared).toBeUndefined();
+      // ownership record also cleared for each worktree's own manifest.
+      const mfPath = managedMcpManifestPath(sharedDataHome, cfg.projectRoot);
+      const mf = (await fse.pathExists(mfPath)) ? await fse.readJson(mfPath) : {};
+      expect((mf['claude:project'] ?? []).some((r: { name: string }) => r.name === 'shared')).toBe(false);
+    }
+  });
 });
 
 describe('MCP reconcile — OpenCode', () => {

--- a/src/__tests__/mcp-reconcile.test.ts
+++ b/src/__tests__/mcp-reconcile.test.ts
@@ -537,14 +537,12 @@ servers:
     expect(changes[0].reason).toContain('allowedHosts');
   });
 
-  // issue #374 P1-2C: the partition keys managed-mcp.json by projectAnchor, so the
-  // main checkout and every linked worktree SHARE one manifest. A project MCP file
-  // (<workspace>/.mcp.json) is per-worktree, so the manifest ownership key must be
-  // per-worktree too — otherwise one worktree's reconcile claims/overwrites the MCP
-  // entries another worktree owns in its own file.
+  // issue #374 P1-2C: the partition is shared by every linked worktree, so each
+  // worktree now gets its OWN managed-mcp.json under
+  // <partition>/workspaces/<id>/. One worktree's reconcile can never see or
+  // overwrite another worktree's ownership.
   it('reconciling from worktree B does not claim/overwrite B\'s own same-name MCP that A manages', async () => {
-    // Two worktrees of one repo: distinct workspace roots, SHARED data home (the
-    // partition), so both read/write the same managed-mcp.json.
+    const { managedMcpManifestPath } = await import('../types.js');
     const sharedDataHome = path.join(tmpDir, 'partition');
     await fse.ensureDir(sharedDataHome);
     const wtA = path.join(tmpDir, 'wtA');
@@ -557,7 +555,7 @@ servers:
     const cfgA = { ...localConfig, scope: 'project', projectRoot: wtA, dataHome: sharedDataHome } as unknown as LocalConfig;
     const cfgB = { ...localConfig, scope: 'project', projectRoot: wtB, dataHome: sharedDataHome } as unknown as LocalConfig;
 
-    // 1. Team defines `shared`; worktree A reconciles → A owns it in the manifest.
+    // 1. Team defines `shared`; worktree A reconciles → A owns it in ITS OWN file.
     await writeMcpYaml(`
 servers:
   - name: shared
@@ -568,16 +566,13 @@ servers:
     expect((await fse.readJson(path.join(wtA, '.mcp.json'))).mcpServers.shared.url)
       .toBe('https://team-v1.example/mcp');
 
-    // 2. Worktree B independently has a USER-OWNED same-name `shared` (NOT managed
-    //    by teamai — no manifest record under B's key).
+    // 2. Worktree B independently has a USER-OWNED same-name `shared`.
     await fse.writeJson(path.join(wtB, '.mcp.json'), {
       mcpServers: { shared: { type: 'http', url: 'https://mine.example/mcp' } },
     });
 
-    // 3. Replay the exact reported trigger: reconcile FROM worktree B (team def v2).
-    //    B must NOT treat A's manifest ownership as its own — B's `shared` is
-    //    user-owned from B's perspective, so it is left untouched (not overwritten
-    //    with the team URL, and reported skipped rather than updated).
+    // 3. Reconcile FROM worktree B (team def v2). B reads its OWN (empty) manifest,
+    //    so `shared` is unmanaged from B's view → left untouched, reported skipped.
     await writeMcpYaml(`
 servers:
   - name: shared
@@ -586,28 +581,27 @@ servers:
 `);
     const { changes } = await reconcileMcpForConfig(teamConfig, cfgB);
 
-    // B's own server is preserved verbatim (the pre-fix bug overwrote it).
     expect((await fse.readJson(path.join(wtB, '.mcp.json'))).mcpServers.shared.url)
       .toBe('https://mine.example/mcp');
-    // …and it is reported as skipped (unmanaged), never "updated".
     const claudeShared = changes.find((c) => c.tool === 'claude' && c.server === 'shared');
     expect(claudeShared?.action).toBe('skipped');
-    // A's ownership + workspace file are unaffected.
     expect((await fse.readJson(path.join(wtA, '.mcp.json'))).mcpServers.shared.url)
       .toBe('https://team-v1.example/mcp');
 
-    // Two DISTINCT workspace-scoped keys now exist (A's owning + B's, if B wrote one).
-    const manifest = await fse.readJson(path.join(sharedDataHome, 'managed-mcp.json'));
-    const claudeKeys = Object.keys(manifest).filter((k) => k.startsWith('claude:project'));
-    expect(claudeKeys.every((k) => /^claude:project:[0-9a-f]{12}$/.test(k))).toBe(true);
-    // A's key is present and still owns `shared`.
-    const aKey = claudeKeys.find((k) => manifest[k].some((r: { name: string }) => r.name === 'shared'));
-    expect(aKey).toBeDefined();
+    // Each worktree has its OWN manifest file; A's owns `shared`, B's does not.
+    const aManifest = await fse.readJson(managedMcpManifestPath(sharedDataHome, wtA));
+    expect(aManifest['claude:project'].some((r: { name: string }) => r.name === 'shared')).toBe(true);
+    const bPath = managedMcpManifestPath(sharedDataHome, wtB);
+    const bManifest = (await fse.pathExists(bPath)) ? await fse.readJson(bPath) : {};
+    expect((bManifest['claude:project'] ?? []).some((r: { name: string }) => r.name === 'shared')).toBe(false);
+    // The two files are at distinct per-worktree paths.
+    expect(managedMcpManifestPath(sharedDataHome, wtA)).not.toBe(bPath);
   });
 
-  it('migrates a pre-#374 bare `<tool>:project` manifest key for a legacy workspace-local install', async () => {
-    // Legacy layout: data home IS <projectRoot>/.teamai (no partition), and the
-    // manifest was written under the bare `claude:project` key by an old CLI.
+  it('migrates a legacy shared `<tool>:project` manifest into this worktree\'s own file', async () => {
+    const { managedMcpManifestPath } = await import('../types.js');
+    // Legacy layout: data home IS <projectRoot>/.teamai, ownership under the bare
+    // `claude:project` key in the SHARED file written by an old CLI.
     const projectRoot = path.join(tmpDir, 'legacyproj');
     for (const d of ['.claude', '.cursor', '.codebuddy']) {
       await fse.ensureDir(path.join(projectRoot, d, 'skills'));
@@ -616,15 +610,14 @@ servers:
     await fse.ensureDir(legacyDataHome);
     const cfg = { ...localConfig, scope: 'project', projectRoot, dataHome: legacyDataHome } as unknown as LocalConfig;
 
-    // Old on-disk state: team-injected v1 in .mcp.json + bare-key ownership.
     await fse.writeJson(path.join(projectRoot, '.mcp.json'), {
       mcpServers: { shared: { type: 'http', url: 'https://team-v1.example/mcp' } },
     });
+    // Old shared file at <dataHome>/managed-mcp.json.
     await fse.writeJson(path.join(legacyDataHome, 'managed-mcp.json'), {
       'claude:project': [{ name: 'shared', hash: 'stale' }],
     });
 
-    // Team bumps to v2; reconcile must UPDATE (adopt the bare key), not skip.
     await writeMcpYaml(`
 servers:
   - name: shared
@@ -638,12 +631,52 @@ servers:
     const claudeShared = changes.find((c) => c.tool === 'claude' && c.server === 'shared');
     expect(claudeShared?.action).toBe('updated');
 
-    // The bare key is migrated to the workspace-scoped key (no ambiguous key left).
-    const manifest = await fse.readJson(path.join(legacyDataHome, 'managed-mcp.json'));
-    expect(manifest['claude:project']).toBeUndefined();
-    const wsKey = Object.keys(manifest).find((k) => /^claude:project:[0-9a-f]{12}$/.test(k));
-    expect(wsKey).toBeDefined();
-    expect(manifest[wsKey!].some((r: { name: string }) => r.name === 'shared')).toBe(true);
+    // Ownership migrated INTO this worktree's own file, under the bare key.
+    const wtManifest = await fse.readJson(managedMcpManifestPath(legacyDataHome, projectRoot));
+    expect(wtManifest['claude:project'].some((r: { name: string }) => r.name === 'shared')).toBe(true);
+    // The legacy shared file no longer owns it (claimed key removed).
+    const shared = await fse.readJson(path.join(legacyDataHome, 'managed-mcp.json'));
+    expect(shared['claude:project']).toBeUndefined();
+  });
+
+  it('concurrent reconcile of two worktrees keeps BOTH ownership records (no lost update)', async () => {
+    const { managedMcpManifestPath } = await import('../types.js');
+    // Two worktrees sharing one partition data home — the exact concurrency the
+    // reviewer flagged. Per-worktree files mean simultaneous reconciles touch
+    // disjoint files, so neither can clobber the other's ownership record.
+    const sharedDataHome = path.join(tmpDir, 'cc-partition');
+    await fse.ensureDir(sharedDataHome);
+    const wtA = path.join(tmpDir, 'ccA');
+    const wtB = path.join(tmpDir, 'ccB');
+    for (const wt of [wtA, wtB]) {
+      for (const d of ['.claude', '.cursor', '.codebuddy']) {
+        await fse.ensureDir(path.join(wt, d, 'skills'));
+      }
+    }
+    const cfgA = { ...localConfig, scope: 'project', projectRoot: wtA, dataHome: sharedDataHome } as unknown as LocalConfig;
+    const cfgB = { ...localConfig, scope: 'project', projectRoot: wtB, dataHome: sharedDataHome } as unknown as LocalConfig;
+
+    await writeMcpYaml(`
+servers:
+  - name: shared
+    transport: http
+    url: https://team.example/mcp
+`);
+
+    // Reconcile both worktrees simultaneously.
+    await Promise.all([
+      reconcileMcpForConfig(teamConfig, cfgA),
+      reconcileMcpForConfig(teamConfig, cfgB),
+    ]);
+
+    // BOTH ownership records survive — each in its own per-worktree file.
+    const aManifest = await fse.readJson(managedMcpManifestPath(sharedDataHome, wtA));
+    const bManifest = await fse.readJson(managedMcpManifestPath(sharedDataHome, wtB));
+    expect(aManifest['claude:project'].some((r: { name: string }) => r.name === 'shared')).toBe(true);
+    expect(bManifest['claude:project'].some((r: { name: string }) => r.name === 'shared')).toBe(true);
+    // And both workspace files got the server.
+    expect((await fse.readJson(path.join(wtA, '.mcp.json'))).mcpServers.shared).toBeDefined();
+    expect((await fse.readJson(path.join(wtB, '.mcp.json'))).mcpServers.shared).toBeDefined();
   });
 });
 

--- a/src/__tests__/mcp-reconcile.test.ts
+++ b/src/__tests__/mcp-reconcile.test.ts
@@ -542,7 +542,7 @@ servers:
   // (<workspace>/.mcp.json) is per-worktree, so the manifest ownership key must be
   // per-worktree too — otherwise one worktree's reconcile claims/overwrites the MCP
   // entries another worktree owns in its own file.
-  it('does not touch a sibling worktree\'s own MCP when reconciling from another worktree', async () => {
+  it('reconciling from worktree B does not claim/overwrite B\'s own same-name MCP that A manages', async () => {
     // Two worktrees of one repo: distinct workspace roots, SHARED data home (the
     // partition), so both read/write the same managed-mcp.json.
     const sharedDataHome = path.join(tmpDir, 'partition');
@@ -557,7 +557,7 @@ servers:
     const cfgA = { ...localConfig, scope: 'project', projectRoot: wtA, dataHome: sharedDataHome } as unknown as LocalConfig;
     const cfgB = { ...localConfig, scope: 'project', projectRoot: wtB, dataHome: sharedDataHome } as unknown as LocalConfig;
 
-    // 1. Team defines `shared`; reconcile it in worktree A.
+    // 1. Team defines `shared`; worktree A reconciles → A owns it in the manifest.
     await writeMcpYaml(`
 servers:
   - name: shared
@@ -568,31 +568,82 @@ servers:
     expect((await fse.readJson(path.join(wtA, '.mcp.json'))).mcpServers.shared.url)
       .toBe('https://team-v1.example/mcp');
 
-    // 2. Worktree B has a USER-OWNED server with the same name, pointing elsewhere.
+    // 2. Worktree B independently has a USER-OWNED same-name `shared` (NOT managed
+    //    by teamai — no manifest record under B's key).
     await fse.writeJson(path.join(wtB, '.mcp.json'), {
       mcpServers: { shared: { type: 'http', url: 'https://mine.example/mcp' } },
     });
 
-    // 3. Team bumps `shared`; reconcile again FROM worktree A only.
+    // 3. Replay the exact reported trigger: reconcile FROM worktree B (team def v2).
+    //    B must NOT treat A's manifest ownership as its own — B's `shared` is
+    //    user-owned from B's perspective, so it is left untouched (not overwritten
+    //    with the team URL, and reported skipped rather than updated).
     await writeMcpYaml(`
 servers:
   - name: shared
     transport: http
     url: https://team-v2.example/mcp
 `);
-    await reconcileMcpForConfig(teamConfig, cfgA);
+    const { changes } = await reconcileMcpForConfig(teamConfig, cfgB);
 
-    // A gets the new team URL…
-    expect((await fse.readJson(path.join(wtA, '.mcp.json'))).mcpServers.shared.url)
-      .toBe('https://team-v2.example/mcp');
-    // …but B's user-owned same-name server is left completely untouched.
+    // B's own server is preserved verbatim (the pre-fix bug overwrote it).
     expect((await fse.readJson(path.join(wtB, '.mcp.json'))).mcpServers.shared.url)
       .toBe('https://mine.example/mcp');
+    // …and it is reported as skipped (unmanaged), never "updated".
+    const claudeShared = changes.find((c) => c.tool === 'claude' && c.server === 'shared');
+    expect(claudeShared?.action).toBe('skipped');
+    // A's ownership + workspace file are unaffected.
+    expect((await fse.readJson(path.join(wtA, '.mcp.json'))).mcpServers.shared.url)
+      .toBe('https://team-v1.example/mcp');
 
-    // The shared manifest carries a distinct ownership key per worktree.
+    // Two DISTINCT workspace-scoped keys now exist (A's owning + B's, if B wrote one).
     const manifest = await fse.readJson(path.join(sharedDataHome, 'managed-mcp.json'));
     const claudeKeys = Object.keys(manifest).filter((k) => k.startsWith('claude:project'));
     expect(claudeKeys.every((k) => /^claude:project:[0-9a-f]{12}$/.test(k))).toBe(true);
+    // A's key is present and still owns `shared`.
+    const aKey = claudeKeys.find((k) => manifest[k].some((r: { name: string }) => r.name === 'shared'));
+    expect(aKey).toBeDefined();
+  });
+
+  it('migrates a pre-#374 bare `<tool>:project` manifest key for a legacy workspace-local install', async () => {
+    // Legacy layout: data home IS <projectRoot>/.teamai (no partition), and the
+    // manifest was written under the bare `claude:project` key by an old CLI.
+    const projectRoot = path.join(tmpDir, 'legacyproj');
+    for (const d of ['.claude', '.cursor', '.codebuddy']) {
+      await fse.ensureDir(path.join(projectRoot, d, 'skills'));
+    }
+    const legacyDataHome = path.join(projectRoot, '.teamai');
+    await fse.ensureDir(legacyDataHome);
+    const cfg = { ...localConfig, scope: 'project', projectRoot, dataHome: legacyDataHome } as unknown as LocalConfig;
+
+    // Old on-disk state: team-injected v1 in .mcp.json + bare-key ownership.
+    await fse.writeJson(path.join(projectRoot, '.mcp.json'), {
+      mcpServers: { shared: { type: 'http', url: 'https://team-v1.example/mcp' } },
+    });
+    await fse.writeJson(path.join(legacyDataHome, 'managed-mcp.json'), {
+      'claude:project': [{ name: 'shared', hash: 'stale' }],
+    });
+
+    // Team bumps to v2; reconcile must UPDATE (adopt the bare key), not skip.
+    await writeMcpYaml(`
+servers:
+  - name: shared
+    transport: http
+    url: https://team-v2.example/mcp
+`);
+    const { changes } = await reconcileMcpForConfig(teamConfig, cfg);
+
+    expect((await fse.readJson(path.join(projectRoot, '.mcp.json'))).mcpServers.shared.url)
+      .toBe('https://team-v2.example/mcp');
+    const claudeShared = changes.find((c) => c.tool === 'claude' && c.server === 'shared');
+    expect(claudeShared?.action).toBe('updated');
+
+    // The bare key is migrated to the workspace-scoped key (no ambiguous key left).
+    const manifest = await fse.readJson(path.join(legacyDataHome, 'managed-mcp.json'));
+    expect(manifest['claude:project']).toBeUndefined();
+    const wsKey = Object.keys(manifest).find((k) => /^claude:project:[0-9a-f]{12}$/.test(k));
+    expect(wsKey).toBeDefined();
+    expect(manifest[wsKey!].some((r: { name: string }) => r.name === 'shared')).toBe(true);
   });
 });
 

--- a/src/__tests__/mcp-reconcile.test.ts
+++ b/src/__tests__/mcp-reconcile.test.ts
@@ -536,6 +536,64 @@ servers:
     expect(changes[0]).toMatchObject({ action: 'skipped' });
     expect(changes[0].reason).toContain('allowedHosts');
   });
+
+  // issue #374 P1-2C: the partition keys managed-mcp.json by projectAnchor, so the
+  // main checkout and every linked worktree SHARE one manifest. A project MCP file
+  // (<workspace>/.mcp.json) is per-worktree, so the manifest ownership key must be
+  // per-worktree too — otherwise one worktree's reconcile claims/overwrites the MCP
+  // entries another worktree owns in its own file.
+  it('does not touch a sibling worktree\'s own MCP when reconciling from another worktree', async () => {
+    // Two worktrees of one repo: distinct workspace roots, SHARED data home (the
+    // partition), so both read/write the same managed-mcp.json.
+    const sharedDataHome = path.join(tmpDir, 'partition');
+    await fse.ensureDir(sharedDataHome);
+    const wtA = path.join(tmpDir, 'wtA');
+    const wtB = path.join(tmpDir, 'wtB');
+    for (const wt of [wtA, wtB]) {
+      for (const d of ['.claude', '.cursor', '.codebuddy']) {
+        await fse.ensureDir(path.join(wt, d, 'skills'));
+      }
+    }
+    const cfgA = { ...localConfig, scope: 'project', projectRoot: wtA, dataHome: sharedDataHome } as unknown as LocalConfig;
+    const cfgB = { ...localConfig, scope: 'project', projectRoot: wtB, dataHome: sharedDataHome } as unknown as LocalConfig;
+
+    // 1. Team defines `shared`; reconcile it in worktree A.
+    await writeMcpYaml(`
+servers:
+  - name: shared
+    transport: http
+    url: https://team-v1.example/mcp
+`);
+    await reconcileMcpForConfig(teamConfig, cfgA);
+    expect((await fse.readJson(path.join(wtA, '.mcp.json'))).mcpServers.shared.url)
+      .toBe('https://team-v1.example/mcp');
+
+    // 2. Worktree B has a USER-OWNED server with the same name, pointing elsewhere.
+    await fse.writeJson(path.join(wtB, '.mcp.json'), {
+      mcpServers: { shared: { type: 'http', url: 'https://mine.example/mcp' } },
+    });
+
+    // 3. Team bumps `shared`; reconcile again FROM worktree A only.
+    await writeMcpYaml(`
+servers:
+  - name: shared
+    transport: http
+    url: https://team-v2.example/mcp
+`);
+    await reconcileMcpForConfig(teamConfig, cfgA);
+
+    // A gets the new team URL…
+    expect((await fse.readJson(path.join(wtA, '.mcp.json'))).mcpServers.shared.url)
+      .toBe('https://team-v2.example/mcp');
+    // …but B's user-owned same-name server is left completely untouched.
+    expect((await fse.readJson(path.join(wtB, '.mcp.json'))).mcpServers.shared.url)
+      .toBe('https://mine.example/mcp');
+
+    // The shared manifest carries a distinct ownership key per worktree.
+    const manifest = await fse.readJson(path.join(sharedDataHome, 'managed-mcp.json'));
+    const claudeKeys = Object.keys(manifest).filter((k) => k.startsWith('claude:project'));
+    expect(claudeKeys.every((k) => /^claude:project:[0-9a-f]{12}$/.test(k))).toBe(true);
+  });
 });
 
 describe('MCP reconcile — OpenCode', () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -233,6 +233,26 @@ export async function resolveProjectDataHome(projectRoot: string): Promise<strin
   return anchors ? projectDataHome(anchors.projectAnchor) : path.join(projectRoot, '.teamai');
 }
 
+/**
+ * Resolve the machine-data home for a (scope, projectRoot) pair the SAME way
+ * detection does — so subsystems that only carry `(scope, projectRoot)` (the
+ * local-agent) land on the identical directory as callers that hold a full
+ * LocalConfig and use `getDataHome(localConfig)`. Without this, a partitioned
+ * install's reconcile side (partition) and the local-agent side (legacy) would
+ * disagree on where managed-mcp.json / the resource cache live and desync.
+ *
+ * - user scope → `~/.teamai`
+ * - project scope → the config's dataHome via detectProjectConfig's double-read
+ *   (partition for a new/migrated install, else legacy `<projectRoot>/.teamai`),
+ *   falling back to legacy when no config is present yet.
+ */
+export async function resolveDataHomeForScope(scope: Scope, projectRoot?: string): Promise<string> {
+  if (scope !== 'project' || !projectRoot) return getTeamaiHome('user');
+  const detected = await detectProjectConfig(projectRoot);
+  if (detected) return getDataHome(detected);
+  return path.join(projectRoot, '.teamai');
+}
+
 export async function detectProjectConfig(cwd?: string): Promise<LocalConfig | null> {
   const dir = cwd ?? process.cwd();
 

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -620,9 +620,14 @@ function createResourceLocalConfig(
   };
 }
 
-function getResourceRepoPath(scope: LocalAgentScope, workspacePath?: string): string {
+async function getResourceRepoPath(scope: LocalAgentScope, workspacePath?: string): Promise<string> {
   if (scope === 'project' && workspacePath) {
-    return path.join(workspacePath, '.teamai', LOCAL_AGENT_DIR, 'resources');
+    // Project resource cache is A1 (per-project): it lives in the machine-data
+    // home so a partitioned install keeps it out of the business workspace. Same
+    // resolver as detection/reconcile so the path never diverges.
+    const { resolveDataHomeForScope } = await import('./config.js');
+    const dataHome = await resolveDataHomeForScope('project', workspacePath);
+    return path.join(dataHome, LOCAL_AGENT_DIR, 'resources');
   }
   return path.join(getLocalAgentHome(), 'resources', scope);
 }
@@ -1260,9 +1265,9 @@ async function scanMcpFromManifest(
   scope: 'user' | 'project',
   projectRoot?: string,
 ): Promise<ReportedResource[]> {
+  const { resolveDataHomeForScope } = await import('./config.js');
   const manifestPath = managedMcpManifestPath(
-    scope === 'project' ? 'project' : 'user',
-    projectRoot,
+    await resolveDataHomeForScope(scope, projectRoot),
   );
   const manifest = await readJson<ManagedMcpManifest>(manifestPath);
   if (!manifest || typeof manifest !== 'object') return [];
@@ -1697,8 +1702,12 @@ async function installDownloadedResource(input: {
     throw new Error(`Missing download_url for ${input.command.type ?? 'install_skill'}`);
   }
 
-  const repoPath = getResourceRepoPath(input.scope, input.workspacePath);
-  if (input.scope === 'project' && input.workspacePath) {
+  const repoPath = await getResourceRepoPath(input.scope, input.workspacePath);
+  if (input.scope === 'project' && input.workspacePath
+      && repoPath.startsWith(path.join(input.workspacePath, '.teamai') + path.sep)) {
+    // Only gitignore when the cache actually lands inside the workspace (a legacy,
+    // un-migrated install). A partitioned install keeps it under ~/.teamai, so
+    // there is nothing in the workspace to ignore.
     await ensureProjectGitignore(input.workspacePath);
   }
   await ensureDir(repoPath);
@@ -1801,7 +1810,7 @@ async function uninstallResource(input: {
   workspacePath?: string;
   tool?: string;
 }): Promise<void> {
-  const repoPath = getResourceRepoPath(input.scope, input.workspacePath);
+  const repoPath = await getResourceRepoPath(input.scope, input.workspacePath);
   const fullTeamConfig = createLocalAgentTeamConfig(input.config.endpoint);
   const tool = input.tool ?? 'workbuddy';
   const toolPath = fullTeamConfig.toolPaths[tool];
@@ -2265,9 +2274,9 @@ async function installMcpServer(
   const baseDir = projectScope && workspacePath ? workspacePath : getUserHome();
   const targetFile = path.join(baseDir, mcpRel);
 
+  const { resolveDataHomeForScope } = await import('./config.js');
   const manifestPath = managedMcpManifestPath(
-    projectScope ? 'project' : 'user',
-    projectScope ? workspacePath : undefined,
+    await resolveDataHomeForScope(projectScope ? 'project' : 'user', projectScope ? workspacePath : undefined),
   );
   const manifest = (await readJson<ManagedMcpManifest>(manifestPath)) ?? {};
   const manifestKey = `${tool}${projectScope ? ':project' : ''}`;
@@ -2328,9 +2337,9 @@ async function uninstallMcpServer(
   const baseDir = projectScope && workspacePath ? workspacePath : getUserHome();
   const targetFile = path.join(baseDir, mcpRel);
 
+  const { resolveDataHomeForScope } = await import('./config.js');
   const manifestPath = managedMcpManifestPath(
-    projectScope ? 'project' : 'user',
-    projectScope ? workspacePath : undefined,
+    await resolveDataHomeForScope(projectScope ? 'project' : 'user', projectScope ? workspacePath : undefined),
   );
   const manifest = (await readJson<ManagedMcpManifest>(manifestPath)) ?? {};
   const manifestKey = `${tool}${projectScope ? ':project' : ''}`;

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -55,6 +55,7 @@ import {
   TEAMAI_CLAUDEMD_END,
   TeamaiConfigSchema,
   managedMcpManifestPath,
+  managedMcpManifestKey,
   type DashboardEvent,
   type LocalConfig,
   type ManagedMcpManifest,
@@ -2279,7 +2280,7 @@ async function installMcpServer(
     await resolveDataHomeForScope(projectScope ? 'project' : 'user', projectScope ? workspacePath : undefined),
   );
   const manifest = (await readJson<ManagedMcpManifest>(manifestPath)) ?? {};
-  const manifestKey = `${tool}${projectScope ? ':project' : ''}`;
+  const manifestKey = managedMcpManifestKey(tool, projectScope, projectScope ? workspacePath : undefined);
   const owned = manifest[manifestKey] ?? [];
   const ownedNames = new Set(owned.map((r: ManagedMcpRecord) => r.name));
 
@@ -2342,7 +2343,7 @@ async function uninstallMcpServer(
     await resolveDataHomeForScope(projectScope ? 'project' : 'user', projectScope ? workspacePath : undefined),
   );
   const manifest = (await readJson<ManagedMcpManifest>(manifestPath)) ?? {};
-  const manifestKey = `${tool}${projectScope ? ':project' : ''}`;
+  const manifestKey = managedMcpManifestKey(tool, projectScope, projectScope ? workspacePath : undefined);
   const owned = manifest[manifestKey] ?? [];
   const ownedNames = new Set(owned.map((r: ManagedMcpRecord) => r.name));
 

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -55,8 +55,7 @@ import {
   TEAMAI_CLAUDEMD_END,
   TeamaiConfigSchema,
   managedMcpManifestPath,
-  managedMcpWorkspaceId,
-  resolveManagedMcpOwnership,
+  managedMcpManifestKey,
   type DashboardEvent,
   type LocalConfig,
   type ManagedMcpManifest,
@@ -1269,34 +1268,23 @@ async function scanMcpFromManifest(
 ): Promise<ReportedResource[]> {
   const { resolveDataHomeForScope } = await import('./config.js');
   const dataHome = await resolveDataHomeForScope(scope, projectRoot);
-  const manifestPath = managedMcpManifestPath(dataHome);
-  const manifest = await readJson<ManagedMcpManifest>(manifestPath);
-  if (!manifest || typeof manifest !== 'object') return [];
 
-  // The partition manifest is SHARED across worktrees, so it holds per-worktree
-  // keys (`<tool>:project:<id>`). Report ONLY this scope's own keys — otherwise
-  // worktree B would report MCPs owned by worktree A and confuse the backend.
-  // - project: keys carrying THIS workspace's id (any tool), i.e.
-  //   managedMcpWorkspaceId(projectRoot). Legacy workspace-local
-  //   manifests may still hold a bare `<tool>:project`; include those too since
-  //   such a manifest belongs to exactly this workspace.
-  // - user: bare `<tool>` keys only (no `:project` segment).
-  const isProject = scope === 'project';
-  const workspaceLocalManifest = isProject && !!projectRoot
-    && dataHome === path.join(projectRoot, '.teamai');
-  const wsId = isProject && projectRoot ? managedMcpWorkspaceId(projectRoot) : '';
-  const keyBelongsToScope = (key: string): boolean => {
-    const parts = key.split(':');
-    if (!isProject) return parts.length === 1; // `<tool>`
-    if (parts.length === 3 && parts[1] === 'project') return parts[2] === wsId;
-    if (parts.length === 2 && parts[1] === 'project') return workspaceLocalManifest; // legacy bare
-    return false;
-  };
+  // Project scope reads THIS worktree's own manifest file (per-worktree under the
+  // partition; migrates legacy shared records on first read). User scope reads the
+  // single global file. Either way every record in the loaded file belongs to this
+  // scope, so no key filtering is needed.
+  let manifest: ManagedMcpManifest;
+  if (scope === 'project' && projectRoot) {
+    const { loadProjectMcpManifest } = await import('./utils/mcp-manifest.js');
+    ({ manifest } = await loadProjectMcpManifest(dataHome, projectRoot));
+  } else {
+    manifest = (await readJson<ManagedMcpManifest>(managedMcpManifestPath(dataHome))) ?? {};
+  }
 
   const seen = new Set<string>();
   const results: ReportedResource[] = [];
-  for (const [key, records] of Object.entries(manifest)) {
-    if (!Array.isArray(records) || !keyBelongsToScope(key)) continue;
+  for (const records of Object.values(manifest)) {
+    if (!Array.isArray(records)) continue;
     for (const rec of records) {
       if (!rec.name || seen.has(rec.name)) continue;
       seen.add(rec.name);
@@ -2297,15 +2285,20 @@ async function installMcpServer(
 
   const { resolveDataHomeForScope } = await import('./config.js');
   const dataHome = await resolveDataHomeForScope(projectScope ? 'project' : 'user', projectScope ? workspacePath : undefined);
-  const manifestPath = managedMcpManifestPath(dataHome);
-  const manifest = (await readJson<ManagedMcpManifest>(manifestPath)) ?? {};
-  // Adopt a pre-#374 bare `<tool>:project` record only when the manifest is
-  // workspace-local (legacy <workspace>/.teamai), matching the CLI reconcile path.
-  const workspaceLocalManifest = projectScope && !!workspacePath
-    && dataHome === path.join(workspacePath, '.teamai');
-  const { key: manifestKey, records: owned } = resolveManagedMcpOwnership(
-    manifest, tool, projectScope, projectScope ? workspacePath : undefined, workspaceLocalManifest,
-  );
+  // Project scope uses THIS worktree's own manifest file (per-worktree under the
+  // partition; migrates legacy shared records on first read). User scope uses the
+  // single global file. The ownership key needs no workspace segment.
+  let manifestPath: string;
+  let manifest: ManagedMcpManifest;
+  if (projectScope && workspacePath) {
+    const { loadProjectMcpManifest } = await import('./utils/mcp-manifest.js');
+    ({ manifestPath, manifest } = await loadProjectMcpManifest(dataHome, workspacePath));
+  } else {
+    manifestPath = managedMcpManifestPath(dataHome);
+    manifest = (await readJson<ManagedMcpManifest>(manifestPath)) ?? {};
+  }
+  const manifestKey = managedMcpManifestKey(tool, projectScope);
+  const owned = manifest[manifestKey] ?? [];
   const ownedNames = new Set(owned.map((r: ManagedMcpRecord) => r.name));
 
   if (format === 'codex') {
@@ -2364,15 +2357,20 @@ async function uninstallMcpServer(
 
   const { resolveDataHomeForScope } = await import('./config.js');
   const dataHome = await resolveDataHomeForScope(projectScope ? 'project' : 'user', projectScope ? workspacePath : undefined);
-  const manifestPath = managedMcpManifestPath(dataHome);
-  const manifest = (await readJson<ManagedMcpManifest>(manifestPath)) ?? {};
-  // Adopt a pre-#374 bare `<tool>:project` record only when the manifest is
-  // workspace-local (legacy <workspace>/.teamai), matching the CLI reconcile path.
-  const workspaceLocalManifest = projectScope && !!workspacePath
-    && dataHome === path.join(workspacePath, '.teamai');
-  const { key: manifestKey, records: owned } = resolveManagedMcpOwnership(
-    manifest, tool, projectScope, projectScope ? workspacePath : undefined, workspaceLocalManifest,
-  );
+  // Project scope uses THIS worktree's own manifest file (per-worktree under the
+  // partition; migrates legacy shared records on first read). User scope uses the
+  // single global file. The ownership key needs no workspace segment.
+  let manifestPath: string;
+  let manifest: ManagedMcpManifest;
+  if (projectScope && workspacePath) {
+    const { loadProjectMcpManifest } = await import('./utils/mcp-manifest.js');
+    ({ manifestPath, manifest } = await loadProjectMcpManifest(dataHome, workspacePath));
+  } else {
+    manifestPath = managedMcpManifestPath(dataHome);
+    manifest = (await readJson<ManagedMcpManifest>(manifestPath)) ?? {};
+  }
+  const manifestKey = managedMcpManifestKey(tool, projectScope);
+  const owned = manifest[manifestKey] ?? [];
   const ownedNames = new Set(owned.map((r: ManagedMcpRecord) => r.name));
 
   if (!ownedNames.has(slug)) return;

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -56,6 +56,7 @@ import {
   TeamaiConfigSchema,
   managedMcpManifestPath,
   managedMcpManifestKey,
+  managedMcpWorkspaceId,
   type DashboardEvent,
   type LocalConfig,
   type ManagedMcpManifest,
@@ -623,12 +624,15 @@ function createResourceLocalConfig(
 
 async function getResourceRepoPath(scope: LocalAgentScope, workspacePath?: string): Promise<string> {
   if (scope === 'project' && workspacePath) {
-    // Project resource cache is A1 (per-project): it lives in the machine-data
-    // home so a partitioned install keeps it out of the business workspace. Same
-    // resolver as detection/reconcile so the path never diverges.
+    // Project resource cache is A1 (per-project) AND per-worktree: the resource
+    // cache (claudemd/skills/rules fragments) is what each worktree installs
+    // independently, and syncClaudemd merges EVERY file in this dir. The partition
+    // data home is shared by all linked worktrees, so the cache must live in a
+    // per-worktree subdir — otherwise worktree B's CLAUDE.md would merge in
+    // worktree A's instructions. Mirror managed-mcp's per-worktree layout.
     const { resolveDataHomeForScope } = await import('./config.js');
     const dataHome = await resolveDataHomeForScope('project', workspacePath);
-    return path.join(dataHome, LOCAL_AGENT_DIR, 'resources');
+    return path.join(dataHome, 'workspaces', managedMcpWorkspaceId(workspacePath), LOCAL_AGENT_DIR, 'resources');
   }
   return path.join(getLocalAgentHome(), 'resources', scope);
 }

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -55,7 +55,8 @@ import {
   TEAMAI_CLAUDEMD_END,
   TeamaiConfigSchema,
   managedMcpManifestPath,
-  managedMcpManifestKey,
+  managedMcpWorkspaceId,
+  resolveManagedMcpOwnership,
   type DashboardEvent,
   type LocalConfig,
   type ManagedMcpManifest,
@@ -1267,16 +1268,35 @@ async function scanMcpFromManifest(
   projectRoot?: string,
 ): Promise<ReportedResource[]> {
   const { resolveDataHomeForScope } = await import('./config.js');
-  const manifestPath = managedMcpManifestPath(
-    await resolveDataHomeForScope(scope, projectRoot),
-  );
+  const dataHome = await resolveDataHomeForScope(scope, projectRoot);
+  const manifestPath = managedMcpManifestPath(dataHome);
   const manifest = await readJson<ManagedMcpManifest>(manifestPath);
   if (!manifest || typeof manifest !== 'object') return [];
 
+  // The partition manifest is SHARED across worktrees, so it holds per-worktree
+  // keys (`<tool>:project:<id>`). Report ONLY this scope's own keys — otherwise
+  // worktree B would report MCPs owned by worktree A and confuse the backend.
+  // - project: keys carrying THIS workspace's id (any tool), i.e.
+  //   managedMcpWorkspaceId(projectRoot). Legacy workspace-local
+  //   manifests may still hold a bare `<tool>:project`; include those too since
+  //   such a manifest belongs to exactly this workspace.
+  // - user: bare `<tool>` keys only (no `:project` segment).
+  const isProject = scope === 'project';
+  const workspaceLocalManifest = isProject && !!projectRoot
+    && dataHome === path.join(projectRoot, '.teamai');
+  const wsId = isProject && projectRoot ? managedMcpWorkspaceId(projectRoot) : '';
+  const keyBelongsToScope = (key: string): boolean => {
+    const parts = key.split(':');
+    if (!isProject) return parts.length === 1; // `<tool>`
+    if (parts.length === 3 && parts[1] === 'project') return parts[2] === wsId;
+    if (parts.length === 2 && parts[1] === 'project') return workspaceLocalManifest; // legacy bare
+    return false;
+  };
+
   const seen = new Set<string>();
   const results: ReportedResource[] = [];
-  for (const records of Object.values(manifest)) {
-    if (!Array.isArray(records)) continue;
+  for (const [key, records] of Object.entries(manifest)) {
+    if (!Array.isArray(records) || !keyBelongsToScope(key)) continue;
     for (const rec of records) {
       if (!rec.name || seen.has(rec.name)) continue;
       seen.add(rec.name);
@@ -2276,12 +2296,16 @@ async function installMcpServer(
   const targetFile = path.join(baseDir, mcpRel);
 
   const { resolveDataHomeForScope } = await import('./config.js');
-  const manifestPath = managedMcpManifestPath(
-    await resolveDataHomeForScope(projectScope ? 'project' : 'user', projectScope ? workspacePath : undefined),
-  );
+  const dataHome = await resolveDataHomeForScope(projectScope ? 'project' : 'user', projectScope ? workspacePath : undefined);
+  const manifestPath = managedMcpManifestPath(dataHome);
   const manifest = (await readJson<ManagedMcpManifest>(manifestPath)) ?? {};
-  const manifestKey = managedMcpManifestKey(tool, projectScope, projectScope ? workspacePath : undefined);
-  const owned = manifest[manifestKey] ?? [];
+  // Adopt a pre-#374 bare `<tool>:project` record only when the manifest is
+  // workspace-local (legacy <workspace>/.teamai), matching the CLI reconcile path.
+  const workspaceLocalManifest = projectScope && !!workspacePath
+    && dataHome === path.join(workspacePath, '.teamai');
+  const { key: manifestKey, records: owned } = resolveManagedMcpOwnership(
+    manifest, tool, projectScope, projectScope ? workspacePath : undefined, workspaceLocalManifest,
+  );
   const ownedNames = new Set(owned.map((r: ManagedMcpRecord) => r.name));
 
   if (format === 'codex') {
@@ -2339,12 +2363,16 @@ async function uninstallMcpServer(
   const targetFile = path.join(baseDir, mcpRel);
 
   const { resolveDataHomeForScope } = await import('./config.js');
-  const manifestPath = managedMcpManifestPath(
-    await resolveDataHomeForScope(projectScope ? 'project' : 'user', projectScope ? workspacePath : undefined),
-  );
+  const dataHome = await resolveDataHomeForScope(projectScope ? 'project' : 'user', projectScope ? workspacePath : undefined);
+  const manifestPath = managedMcpManifestPath(dataHome);
   const manifest = (await readJson<ManagedMcpManifest>(manifestPath)) ?? {};
-  const manifestKey = managedMcpManifestKey(tool, projectScope, projectScope ? workspacePath : undefined);
-  const owned = manifest[manifestKey] ?? [];
+  // Adopt a pre-#374 bare `<tool>:project` record only when the manifest is
+  // workspace-local (legacy <workspace>/.teamai), matching the CLI reconcile path.
+  const workspaceLocalManifest = projectScope && !!workspacePath
+    && dataHome === path.join(workspacePath, '.teamai');
+  const { key: manifestKey, records: owned } = resolveManagedMcpOwnership(
+    manifest, tool, projectScope, projectScope ? workspacePath : undefined, workspaceLocalManifest,
+  );
   const ownedNames = new Set(owned.map((r: ManagedMcpRecord) => r.name));
 
   if (!ownedNames.has(slug)) return;

--- a/src/mcp-cmd.ts
+++ b/src/mcp-cmd.ts
@@ -10,7 +10,7 @@ import {
 import { referencedVars } from './resources/mcp-format.js';
 import { log } from './utils/logger.js';
 import type { GlobalOptions } from './types.js';
-import { managedMcpManifestPath } from './types.js';
+import { managedMcpManifestPath, getDataHome } from './types.js';
 import { readJson } from './utils/fs.js';
 import type { ManagedMcpManifest } from './types.js';
 import { getUserHome } from './utils/home.js';
@@ -34,7 +34,7 @@ export async function mcpList(_options: GlobalOptions): Promise<void> {
   const targets = await resolveMcpTargets(teamConfig, localConfig);
   const vars = await buildVarTable(localConfig);
   const manifest = (await readJson<ManagedMcpManifest>(
-    managedMcpManifestPath(localConfig.scope, localConfig.projectRoot),
+    managedMcpManifestPath(getDataHome(localConfig)),
   )) ?? {};
 
   console.log(`Team MCP servers — mcp/mcp.yaml (${servers.length}):`);

--- a/src/mcp-cmd.ts
+++ b/src/mcp-cmd.ts
@@ -10,7 +10,7 @@ import {
 import { referencedVars } from './resources/mcp-format.js';
 import { log } from './utils/logger.js';
 import type { GlobalOptions } from './types.js';
-import { managedMcpManifestPath, getDataHome } from './types.js';
+import { managedMcpManifestPath, managedMcpManifestKey, getDataHome } from './types.js';
 import { readJson } from './utils/fs.js';
 import type { ManagedMcpManifest } from './types.js';
 import { getUserHome } from './utils/home.js';
@@ -53,7 +53,7 @@ export async function mcpList(_options: GlobalOptions): Promise<void> {
     }
 
     const installedIn = targets
-      .filter((t) => (manifest[`${t.tool}${t.projectScope ? ':project' : ''}`] ?? []).some((r) => r.name === s.name))
+      .filter((t) => (manifest[managedMcpManifestKey(t.tool, t.projectScope, localConfig.projectRoot)] ?? []).some((r) => r.name === s.name))
       .map((t) => t.tool);
     console.log(`    installed: ${installedIn.length > 0 ? installedIn.join(', ') : '(none)'}`);
     console.log('');

--- a/src/mcp-cmd.ts
+++ b/src/mcp-cmd.ts
@@ -33,8 +33,12 @@ export async function mcpList(_options: GlobalOptions): Promise<void> {
 
   const targets = await resolveMcpTargets(teamConfig, localConfig);
   const vars = await buildVarTable(localConfig);
+  // Project scope reads THIS worktree's own per-worktree manifest; user the global file.
   const manifest = (await readJson<ManagedMcpManifest>(
-    managedMcpManifestPath(getDataHome(localConfig)),
+    managedMcpManifestPath(
+      getDataHome(localConfig),
+      localConfig.scope === 'project' ? localConfig.projectRoot : undefined,
+    ),
   )) ?? {};
 
   console.log(`Team MCP servers — mcp/mcp.yaml (${servers.length}):`);
@@ -53,7 +57,7 @@ export async function mcpList(_options: GlobalOptions): Promise<void> {
     }
 
     const installedIn = targets
-      .filter((t) => (manifest[managedMcpManifestKey(t.tool, t.projectScope, localConfig.projectRoot)] ?? []).some((r) => r.name === s.name))
+      .filter((t) => (manifest[managedMcpManifestKey(t.tool, t.projectScope)] ?? []).some((r) => r.name === s.name))
       .map((t) => t.tool);
     console.log(`    installed: ${installedIn.length > 0 ? installedIn.join(', ') : '(none)'}`);
     console.log('');

--- a/src/mcp-reconcile.ts
+++ b/src/mcp-reconcile.ts
@@ -11,6 +11,7 @@ import type {
 import {
   getMcpSharing,
   getEnvBackupPath,
+  getDataHome,
   managedMcpManifestPath,
   resolveBaseDir,
   scopedToolPaths,
@@ -325,7 +326,7 @@ export async function reconcileMcpForConfig(
   const targets = await resolveMcpTargets(teamConfig, localConfig);
   if (targets.length === 0) return { changes, wrote };
 
-  const manifestPath = managedMcpManifestPath(localConfig.scope, localConfig.projectRoot);
+  const manifestPath = managedMcpManifestPath(getDataHome(localConfig));
   const manifest = await readManifest(manifestPath);
 
   // An empty desired set still has to run: it is how servers dropped from

--- a/src/mcp-reconcile.ts
+++ b/src/mcp-reconcile.ts
@@ -13,7 +13,7 @@ import {
   getEnvBackupPath,
   getDataHome,
   managedMcpManifestPath,
-  managedMcpManifestKey,
+  resolveManagedMcpOwnership,
   resolveBaseDir,
   scopedToolPaths,
 } from './types.js';
@@ -337,9 +337,21 @@ export async function reconcileMcpForConfig(
 
   const vars = await buildVarTable(localConfig);
 
+  // A pre-#374 manifest keyed entries under a bare `<tool>:project`. Adopting that
+  // key is only unambiguous when the manifest is workspace-local (a legacy
+  // `<projectRoot>/.teamai` data home, not the shared partition).
+  const dataHome = getDataHome(localConfig);
+  const workspaceLocalManifest = !!localConfig.projectRoot
+    && dataHome === path.join(localConfig.projectRoot, '.teamai');
+
   for (const target of targets) {
-    const manifestKey = managedMcpManifestKey(target.tool, target.projectScope, localConfig.projectRoot);
-    const owned = manifest[manifestKey] ?? [];
+    const { key: manifestKey, records: owned } = resolveManagedMcpOwnership(
+      manifest,
+      target.tool,
+      target.projectScope,
+      localConfig.projectRoot,
+      workspaceLocalManifest,
+    );
     const ownedNames = new Set(owned.map((r) => r.name));
     const nextRecords: ManagedMcpRecord[] = [];
 

--- a/src/mcp-reconcile.ts
+++ b/src/mcp-reconcile.ts
@@ -13,6 +13,7 @@ import {
   getEnvBackupPath,
   getDataHome,
   managedMcpManifestPath,
+  managedMcpManifestKey,
   resolveBaseDir,
   scopedToolPaths,
 } from './types.js';
@@ -337,7 +338,7 @@ export async function reconcileMcpForConfig(
   const vars = await buildVarTable(localConfig);
 
   for (const target of targets) {
-    const manifestKey = `${target.tool}${target.projectScope ? ':project' : ''}`;
+    const manifestKey = managedMcpManifestKey(target.tool, target.projectScope, localConfig.projectRoot);
     const owned = manifest[manifestKey] ?? [];
     const ownedNames = new Set(owned.map((r) => r.name));
     const nextRecords: ManagedMcpRecord[] = [];

--- a/src/mcp-reconcile.ts
+++ b/src/mcp-reconcile.ts
@@ -13,7 +13,7 @@ import {
   getEnvBackupPath,
   getDataHome,
   managedMcpManifestPath,
-  resolveManagedMcpOwnership,
+  managedMcpManifestKey,
   resolveBaseDir,
   scopedToolPaths,
 } from './types.js';
@@ -38,6 +38,7 @@ import {
   expandHome,
 } from './utils/fs.js';
 import { log } from './utils/logger.js';
+import { loadProjectMcpManifest } from './utils/mcp-manifest.js';
 
 // ─── Reconcile engine ────────────────────────────────────────
 //
@@ -327,8 +328,19 @@ export async function reconcileMcpForConfig(
   const targets = await resolveMcpTargets(teamConfig, localConfig);
   if (targets.length === 0) return { changes, wrote };
 
-  const manifestPath = managedMcpManifestPath(getDataHome(localConfig));
-  const manifest = await readManifest(manifestPath);
+  const dataHome = getDataHome(localConfig);
+  const projectScope = localConfig.scope === 'project';
+  // Project scope uses a PER-WORKTREE manifest under the partition (migrating this
+  // worktree's records out of any legacy shared file on first read); user scope
+  // keeps the single global file. Either way this reconcile owns exactly one file.
+  let manifestPath: string;
+  let manifest: ManagedMcpManifest;
+  if (projectScope && localConfig.projectRoot) {
+    ({ manifestPath, manifest } = await loadProjectMcpManifest(dataHome, localConfig.projectRoot));
+  } else {
+    manifestPath = managedMcpManifestPath(dataHome);
+    manifest = await readManifest(manifestPath);
+  }
 
   // An empty desired set still has to run: it is how servers dropped from
   // mcp.yaml get cleaned out of the tools we previously injected them into.
@@ -337,21 +349,9 @@ export async function reconcileMcpForConfig(
 
   const vars = await buildVarTable(localConfig);
 
-  // A pre-#374 manifest keyed entries under a bare `<tool>:project`. Adopting that
-  // key is only unambiguous when the manifest is workspace-local (a legacy
-  // `<projectRoot>/.teamai` data home, not the shared partition).
-  const dataHome = getDataHome(localConfig);
-  const workspaceLocalManifest = !!localConfig.projectRoot
-    && dataHome === path.join(localConfig.projectRoot, '.teamai');
-
   for (const target of targets) {
-    const { key: manifestKey, records: owned } = resolveManagedMcpOwnership(
-      manifest,
-      target.tool,
-      target.projectScope,
-      localConfig.projectRoot,
-      workspaceLocalManifest,
-    );
+    const manifestKey = managedMcpManifestKey(target.tool, target.projectScope);
+    const owned = manifest[manifestKey] ?? [];
     const ownedNames = new Set(owned.map((r) => r.name));
     const nextRecords: ManagedMcpRecord[] = [];
 

--- a/src/mcp-reconcile.ts
+++ b/src/mcp-reconcile.ts
@@ -336,7 +336,7 @@ export async function reconcileMcpForConfig(
   let manifestPath: string;
   let manifest: ManagedMcpManifest;
   if (projectScope && localConfig.projectRoot) {
-    ({ manifestPath, manifest } = await loadProjectMcpManifest(dataHome, localConfig.projectRoot));
+    ({ manifestPath, manifest } = await loadProjectMcpManifest(dataHome, localConfig.projectRoot, { dryRun: options.dryRun }));
   } else {
     manifestPath = managedMcpManifestPath(dataHome);
     manifest = await readManifest(manifestPath);

--- a/src/types.ts
+++ b/src/types.ts
@@ -520,9 +520,9 @@ export interface ManagedMcpRecord {
 /** ~/.teamai/managed-mcp.json — team MCP servers injected per tool+scope key. */
 export type ManagedMcpManifest = Record<string, ManagedMcpRecord[]>;
 
-/** Path of the managed-MCP manifest for a scope. */
-export function managedMcpManifestPath(scope: Scope, projectRoot?: string): string {
-  return path.join(getTeamaiHome(scope, projectRoot), 'managed-mcp.json');
+/** Path of the managed-MCP manifest within a resolved data home. */
+export function managedMcpManifestPath(dataHome: string): string {
+  return path.join(dataHome, 'managed-mcp.json');
 }
 
 // ─── Global options ─────────────────────────────────────

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import path from 'node:path';
+import { createHash } from 'node:crypto';
 import { getUserHome } from './utils/home.js';
 
 // ─── Tool path config ───────────────────────────────────
@@ -519,6 +520,33 @@ export interface ManagedMcpRecord {
 
 /** ~/.teamai/managed-mcp.json — team MCP servers injected per tool+scope key. */
 export type ManagedMcpManifest = Record<string, ManagedMcpRecord[]>;
+
+/**
+ * Ownership key for the managed-MCP manifest, per tool and scope.
+ *
+ * The P1 partition (issue #374) keys the data home by the shared `projectAnchor`,
+ * so the main checkout and every linked worktree share ONE managed-mcp.json.
+ * But a project MCP file (`<workspace>/.mcp.json`, `.codex/config.toml`, …) is
+ * per-worktree. If the manifest key were just `<tool>:project`, one worktree's
+ * reconcile/uninstall would claim ownership of — and overwrite or remove — the
+ * MCP entries another worktree wrote into ITS own workspace file. So a
+ * project-scope key must carry the CURRENT workspace identity (the per-worktree
+ * `workspaceRoot`, not the shared anchor). Both the CLI reconcile/uninstall paths
+ * and the local-agent install/uninstall/report paths must build the key here so
+ * they agree. user scope has a single global file, so no workspace segment.
+ */
+export function managedMcpManifestKey(
+  tool: string,
+  projectScope: boolean,
+  workspaceRoot?: string,
+): string {
+  if (!projectScope) return tool;
+  // Fall back to the bare project key only when no workspace is known (should not
+  // happen for a real project install); otherwise isolate by workspace identity.
+  if (!workspaceRoot) return `${tool}:project`;
+  const id = createHash('sha1').update(workspaceRoot).digest('hex').slice(0, 12);
+  return `${tool}:project:${id}`;
+}
 
 /** Path of the managed-MCP manifest within a resolved data home. */
 export function managedMcpManifestPath(dataHome: string): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -548,6 +548,47 @@ export function managedMcpManifestKey(
   return `${tool}:project:${id}`;
 }
 
+/** Legacy bare project ownership key written before workspace-scoped keys (#374). */
+export function legacyManagedMcpManifestKey(tool: string, projectScope: boolean): string {
+  return projectScope ? `${tool}:project` : tool;
+}
+
+/**
+ * Resolve the effective ownership entry for a (tool, scope) in a managed-mcp
+ * manifest, migrating a pre-#374 bare `<tool>:project` key into the current
+ * workspace-scoped key WHEN SAFE.
+ *
+ * A bare key is ambiguous in a shared partition (it could belong to any worktree),
+ * so we only adopt it when `workspaceLocalManifest` is true — i.e. the manifest
+ * lives at a legacy `<workspaceRoot>/.teamai` data home, which by construction
+ * belonged to exactly this workspace. In the partition case the bare key is left
+ * untouched (a later explicit layout migration that knows the source workspace can
+ * claim it). Returns the resolved `{ key, records }`; when it migrates, the caller
+ * writes back under `key` and the bare key is removed from `manifest`.
+ */
+export function resolveManagedMcpOwnership(
+  manifest: ManagedMcpManifest,
+  tool: string,
+  projectScope: boolean,
+  workspaceRoot: string | undefined,
+  workspaceLocalManifest: boolean,
+): { key: string; records: ManagedMcpRecord[] } {
+  const key = managedMcpManifestKey(tool, projectScope, workspaceRoot);
+  if (manifest[key]) return { key, records: manifest[key] };
+  if (projectScope && workspaceLocalManifest) {
+    const legacyKey = legacyManagedMcpManifestKey(tool, true);
+    if (legacyKey !== key && manifest[legacyKey]) {
+      // Migrate: adopt the legacy records under the workspace-scoped key and drop
+      // the ambiguous bare key. Safe because this manifest is workspace-local.
+      const records = manifest[legacyKey];
+      manifest[key] = records;
+      delete manifest[legacyKey];
+      return { key, records };
+    }
+  }
+  return { key, records: [] };
+}
+
 /** Path of the managed-MCP manifest within a resolved data home. */
 export function managedMcpManifestPath(dataHome: string): string {
   return path.join(dataHome, 'managed-mcp.json');

--- a/src/types.ts
+++ b/src/types.ts
@@ -535,66 +535,49 @@ export type ManagedMcpManifest = Record<string, ManagedMcpRecord[]>;
  * and the local-agent install/uninstall/report paths must build the key here so
  * they agree. user scope has a single global file, so no workspace segment.
  */
-export function managedMcpManifestKey(
-  tool: string,
-  projectScope: boolean,
-  workspaceRoot?: string,
-): string {
-  if (!projectScope) return tool;
-  // Fall back to the bare project key only when no workspace is known (should not
-  // happen for a real project install); otherwise isolate by workspace identity.
-  if (!workspaceRoot) return `${tool}:project`;
-  return `${tool}:project:${managedMcpWorkspaceId(workspaceRoot)}`;
+/**
+ * Ownership key for the managed-MCP manifest, per tool and scope.
+ *
+ * Each project WORKTREE now has its OWN manifest file (see managedMcpManifestPath),
+ * so the file already isolates ownership by worktree — the key needs no workspace
+ * segment. It is `<tool>:project` for project scope and `<tool>` for user scope.
+ */
+export function managedMcpManifestKey(tool: string, projectScope: boolean): string {
+  return projectScope ? `${tool}:project` : tool;
 }
 
-/** Stable per-worktree identity segment used in project-scope manifest keys (#374). */
+/** Stable per-worktree identity segment; names the worktree's manifest subdirectory (#374). */
 export function managedMcpWorkspaceId(workspaceRoot: string): string {
   return createHash('sha1').update(workspaceRoot).digest('hex').slice(0, 12);
 }
 
-/** Legacy bare project ownership key written before workspace-scoped keys (#374). */
-export function legacyManagedMcpManifestKey(tool: string, projectScope: boolean): string {
-  return projectScope ? `${tool}:project` : tool;
+/**
+ * Path of the managed-MCP manifest.
+ *
+ * user scope keeps ONE global file at `<dataHome>/managed-mcp.json`.
+ *
+ * project scope gets a PER-WORKTREE file at
+ * `<dataHome>/workspaces/<workspaceId>/managed-mcp.json` (#374). The partition data
+ * home is shared by every linked worktree, so a single shared manifest suffered
+ * both cross-worktree ownership bleed AND lost updates under concurrent
+ * read-modify-write. A file per worktree removes both: each reconcile/install
+ * reads and rewrites only its own file, and the key needs no workspace segment.
+ */
+export function managedMcpManifestPath(dataHome: string, workspaceRoot?: string): string {
+  if (workspaceRoot) {
+    return path.join(dataHome, 'workspaces', managedMcpWorkspaceId(workspaceRoot), 'managed-mcp.json');
+  }
+  return path.join(dataHome, 'managed-mcp.json');
 }
 
 /**
- * Resolve the effective ownership entry for a (tool, scope) in a managed-mcp
- * manifest, migrating a pre-#374 bare `<tool>:project` key into the current
- * workspace-scoped key WHEN SAFE.
- *
- * A bare key is ambiguous in a shared partition (it could belong to any worktree),
- * so we only adopt it when `workspaceLocalManifest` is true — i.e. the manifest
- * lives at a legacy `<workspaceRoot>/.teamai` data home, which by construction
- * belonged to exactly this workspace. In the partition case the bare key is left
- * untouched (a later explicit layout migration that knows the source workspace can
- * claim it). Returns the resolved `{ key, records }`; when it migrates, the caller
- * writes back under `key` and the bare key is removed from `manifest`.
+ * Legacy shared manifest path (pre-#374-per-worktree). Older installs wrote all
+ * project ownership into `<dataHome>/managed-mcp.json` (possibly under a bare
+ * `<tool>:project` key, or the interim `<tool>:project:<id>` keys). The migration
+ * on first project reconcile lifts THIS worktree's records out of that file into
+ * its per-worktree file. Same path as the user-scope file, read for compat only.
  */
-export function resolveManagedMcpOwnership(
-  manifest: ManagedMcpManifest,
-  tool: string,
-  projectScope: boolean,
-  workspaceRoot: string | undefined,
-  workspaceLocalManifest: boolean,
-): { key: string; records: ManagedMcpRecord[] } {
-  const key = managedMcpManifestKey(tool, projectScope, workspaceRoot);
-  if (manifest[key]) return { key, records: manifest[key] };
-  if (projectScope && workspaceLocalManifest) {
-    const legacyKey = legacyManagedMcpManifestKey(tool, true);
-    if (legacyKey !== key && manifest[legacyKey]) {
-      // Migrate: adopt the legacy records under the workspace-scoped key and drop
-      // the ambiguous bare key. Safe because this manifest is workspace-local.
-      const records = manifest[legacyKey];
-      manifest[key] = records;
-      delete manifest[legacyKey];
-      return { key, records };
-    }
-  }
-  return { key, records: [] };
-}
-
-/** Path of the managed-MCP manifest within a resolved data home. */
-export function managedMcpManifestPath(dataHome: string): string {
+export function legacyManagedMcpManifestPath(dataHome: string): string {
   return path.join(dataHome, 'managed-mcp.json');
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -544,8 +544,12 @@ export function managedMcpManifestKey(
   // Fall back to the bare project key only when no workspace is known (should not
   // happen for a real project install); otherwise isolate by workspace identity.
   if (!workspaceRoot) return `${tool}:project`;
-  const id = createHash('sha1').update(workspaceRoot).digest('hex').slice(0, 12);
-  return `${tool}:project:${id}`;
+  return `${tool}:project:${managedMcpWorkspaceId(workspaceRoot)}`;
+}
+
+/** Stable per-worktree identity segment used in project-scope manifest keys (#374). */
+export function managedMcpWorkspaceId(workspaceRoot: string): string {
+  return createHash('sha1').update(workspaceRoot).digest('hex').slice(0, 12);
 }
 
 /** Legacy bare project ownership key written before workspace-scoped keys (#374). */

--- a/src/uninstall.ts
+++ b/src/uninstall.ts
@@ -461,7 +461,7 @@ async function buildRemovalPlan(
     // ownership model as hooks). These live under ~/.teamai, so they are shared
     // resources: only removed when the target is the last tool using teamai.
     const mcpManifestPath = expandHome(
-      managedMcpManifestPath(localConfig.scope, localConfig.projectRoot),
+      managedMcpManifestPath(getDataHome(localConfig)),
     );
     const mcpManifest = (await readJson<ManagedMcpManifest>(mcpManifestPath)) ?? {};
     for (const [toolKey, records] of Object.entries(mcpManifest)) {

--- a/src/uninstall.ts
+++ b/src/uninstall.ts
@@ -458,10 +458,13 @@ async function buildRemovalPlan(
 
   if (includeShared) {
     // (d3) teamai-managed MCP servers, tracked in managed-mcp.json (same
-    // ownership model as hooks). These live under ~/.teamai, so they are shared
-    // resources: only removed when the target is the last tool using teamai.
+    // ownership model as hooks). Project scope reads THIS worktree's own
+    // per-worktree manifest; user scope reads the single global file.
     const mcpManifestPath = expandHome(
-      managedMcpManifestPath(getDataHome(localConfig)),
+      managedMcpManifestPath(
+        getDataHome(localConfig),
+        localConfig.scope === 'project' ? localConfig.projectRoot : undefined,
+      ),
     );
     const mcpManifest = (await readJson<ManagedMcpManifest>(mcpManifestPath)) ?? {};
     for (const [toolKey, records] of Object.entries(mcpManifest)) {

--- a/src/uninstall.ts
+++ b/src/uninstall.ts
@@ -857,9 +857,30 @@ export async function uninstall(opts: UninstallOptions): Promise<void> {
     if (plan.includeShared) {
       try {
         const { reconcileMcpForConfig } = await import('./mcp-reconcile.js');
-        const { changes } = await reconcileMcpForConfig(teamConfig, localConfig, { removeAll: true });
-        const removed = changes.filter((c) => c.action === 'removed');
-        if (removed.length > 0) log.info(`Removed ${removed.length} teamai-managed MCP server(s)`);
+        // Project scope: the managed-mcp manifests are PER-WORKTREE under the
+        // shared partition (#374 P1-2C), and each worktree's MCP config lives in
+        // its own checkout. Since executeRemoval deletes the whole shared
+        // partition, we must first remove the managed MCP servers from EVERY
+        // linked worktree — otherwise a sibling worktree is left with an injected
+        // server whose ownership record just got deleted (orphaned). User scope
+        // has a single global manifest, so the current config is enough.
+        const configs: LocalConfig[] = [localConfig];
+        if (localConfig.scope === 'project' && localConfig.projectRoot) {
+          const { listWorktrees } = await import('./utils/git.js');
+          const { resolveProjectDataHome } = await import('./config.js');
+          const worktrees = await listWorktrees(localConfig.projectRoot);
+          for (const wt of worktrees) {
+            if (wt === localConfig.projectRoot) continue;
+            const dataHome = await resolveProjectDataHome(wt);
+            configs.push({ ...localConfig, projectRoot: wt, dataHome });
+          }
+        }
+        let removedTotal = 0;
+        for (const cfg of configs) {
+          const { changes } = await reconcileMcpForConfig(teamConfig, cfg, { removeAll: true });
+          removedTotal += changes.filter((c) => c.action === 'removed').length;
+        }
+        if (removedTotal > 0) log.info(`Removed ${removedTotal} teamai-managed MCP server(s)`);
       } catch (e) {
         log.warn(`Failed to remove MCP servers: ${(e as Error).message}`);
       }

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -728,6 +728,32 @@ export async function resolveAnchors(cwd?: string): Promise<ProjectAnchors | nul
 }
 
 /**
+ * List the realpath'd top-level directory of every worktree of the repo that
+ * contains `cwd` (main checkout + all linked worktrees), from
+ * `git worktree list --porcelain`. Returns [] outside a git repo. Used by a
+ * project-wide uninstall to clean each worktree's managed resources before the
+ * shared partition is deleted (issue #374 P1-2C).
+ */
+export async function listWorktrees(cwd?: string): Promise<string[]> {
+  const git = createGit(cwd);
+  let list: string;
+  try {
+    list = await git.raw(['worktree', 'list', '--porcelain']);
+  } catch {
+    return [];
+  }
+  const roots = list
+    .split('\n')
+    .filter((l) => l.startsWith('worktree '))
+    .map((l) => l.slice('worktree '.length).trim())
+    .filter(Boolean);
+  const resolved = await Promise.all(
+    roots.map((r) => realpath(r).catch(() => r)),
+  );
+  return Array.from(new Set(resolved));
+}
+
+/**
  * Reset the team repo to a clean default-branch state.
  *
  * The team repo is a local cache — any uncommitted or conflicted state is

--- a/src/utils/mcp-manifest.ts
+++ b/src/utils/mcp-manifest.ts
@@ -25,9 +25,18 @@ import { readJson, writeJsonAtomic, expandHome } from './fs.js';
  *  - a bare `<tool>:project` key is claimed only when the data home is
  *    workspace-local (legacy `<workspaceRoot>/.teamai`), where it is unambiguous;
  *  - a `<tool>:project:<thisWorkspaceId>` key is always this worktree's.
- * The migrated records are written into the per-worktree file and removed from the
- * shared file (best-effort; a stale shared entry is harmless once the per-worktree
- * file exists, since all readers/writers use the per-worktree file afterwards).
+ *
+ * Migration is made DURABLE here, independent of the caller: we first atomically
+ * write the per-worktree destination file, and only AFTER that succeeds do we
+ * best-effort remove the claimed keys from the shared file. Persisting inside the
+ * loader (rather than relying on the caller to save) is required because callers
+ * may be read-only (report) or may skip their write when nothing changed
+ * (`reconcile` with `wrote === false`) — removing the source first in those cases
+ * would orphan the records. Ordering (destination first, source second) means a
+ * crash between the two leaves the records readable in BOTH files, never neither.
+ *
+ * `dryRun` suppresses all writes (preview): the migrated records are returned in
+ * memory but neither file is touched.
  *
  * Returns the per-worktree manifest path plus its loaded contents. Callers mutate
  * `manifest` and persist with `saveProjectMcpManifest`.
@@ -35,6 +44,7 @@ import { readJson, writeJsonAtomic, expandHome } from './fs.js';
 export async function loadProjectMcpManifest(
   dataHome: string,
   workspaceRoot: string,
+  options: { dryRun?: boolean } = {},
 ): Promise<{ manifestPath: string; manifest: ManagedMcpManifest }> {
   const manifestPath = managedMcpManifestPath(dataHome, workspaceRoot);
   const existing = (await readJson<ManagedMcpManifest>(expandHome(manifestPath))) ?? null;
@@ -55,8 +65,11 @@ export async function loadProjectMcpManifest(
         migratedFrom.push(key);
       }
     }
-    if (migratedFrom.length > 0) {
-      // Drop the claimed keys from the shared file so it can't double-own.
+    if (migratedFrom.length > 0 && !options.dryRun) {
+      // Durable order: write the destination FIRST, then drop the claimed keys
+      // from the shared file. A crash in between leaves the records in both files
+      // (harmless — the per-worktree file wins), never in neither.
+      await writeJsonAtomic(expandHome(manifestPath), manifest);
       for (const key of migratedFrom) delete shared[key];
       await writeJsonAtomic(expandHome(sharedPath), shared).catch(() => {});
     }

--- a/src/utils/mcp-manifest.ts
+++ b/src/utils/mcp-manifest.ts
@@ -50,31 +50,59 @@ export async function loadProjectMcpManifest(
   const existing = (await readJson<ManagedMcpManifest>(expandHome(manifestPath))) ?? null;
   if (existing) return { manifestPath, manifest: existing };
 
-  // No per-worktree file yet — attempt one-time migration from the shared file.
+  // No per-worktree file yet — attempt one-time migration from any legacy source.
+  // Two legacy locations must both be checked:
+  //  1. `<dataHome>/managed-mcp.json` — the interim shared partition file (rounds
+  //     before the per-worktree split), keyed `<tool>:project:<id>` or bare.
+  //  2. `<workspaceRoot>/.teamai/managed-mcp.json` — the ORIGINAL pre-partition
+  //     path. Even a partition install (data home under ~/.teamai) wrote the MCP
+  //     manifest into the workspace's .teamai before this PR, so a plain
+  //     `<dataHome>/managed-mcp.json` read misses it and the old ownership is
+  //     lost on upgrade (uninstall then leaves the injected server behind).
+  // When the two paths are the same file (legacy workspace-local data home) we
+  // read it once.
   const manifest: ManagedMcpManifest = {};
-  const sharedPath = legacyManagedMcpManifestPath(dataHome);
-  const workspaceLocal = dataHome === path.join(workspaceRoot, '.teamai');
-  const shared = (await readJson<ManagedMcpManifest>(expandHome(sharedPath))) ?? null;
-  if (shared) {
+  const sources: Array<{ path: string; workspaceLocal: boolean }> = [];
+  const partitionShared = expandHome(legacyManagedMcpManifestPath(dataHome));
+  const workspaceShared = expandHome(path.join(workspaceRoot, '.teamai', 'managed-mcp.json'));
+  sources.push({ path: partitionShared, workspaceLocal: dataHome === path.join(workspaceRoot, '.teamai') });
+  if (workspaceShared !== partitionShared) {
+    // The original workspace-local path belongs unambiguously to THIS worktree.
+    sources.push({ path: workspaceShared, workspaceLocal: true });
+  }
+
+  for (const src of sources) {
+    const shared = (await readJson<ManagedMcpManifest>(src.path)) ?? null;
+    if (!shared) continue;
     const migratedFrom: string[] = [];
     for (const [key, records] of Object.entries(shared)) {
       if (!Array.isArray(records)) continue;
-      if (claimsThisWorkspace(key, workspaceRoot, workspaceLocal)) {
+      if (claimsThisWorkspace(key, workspaceRoot, src.workspaceLocal)) {
         const tool = key.split(':')[0];
-        manifest[`${tool}:project`] = records;
+        // Merge (a worktree could have records split across both sources).
+        const destKey = `${tool}:project`;
+        manifest[destKey] = mergeRecords(manifest[destKey], records);
         migratedFrom.push(key);
       }
     }
     if (migratedFrom.length > 0 && !options.dryRun) {
       // Durable order: write the destination FIRST, then drop the claimed keys
-      // from the shared file. A crash in between leaves the records in both files
-      // (harmless — the per-worktree file wins), never in neither.
+      // from this source. A crash in between leaves the records readable in both
+      // files (the per-worktree file wins), never in neither.
       await writeJsonAtomic(expandHome(manifestPath), manifest);
       for (const key of migratedFrom) delete shared[key];
-      await writeJsonAtomic(expandHome(sharedPath), shared).catch(() => {});
+      await writeJsonAtomic(src.path, shared).catch(() => {});
     }
   }
   return { manifestPath, manifest };
+}
+
+/** Merge two record lists by name (later wins), keeping ownership de-duplicated. */
+function mergeRecords(a: ManagedMcpRecord[] | undefined, b: ManagedMcpRecord[]): ManagedMcpRecord[] {
+  const byName = new Map<string, ManagedMcpRecord>();
+  for (const r of a ?? []) byName.set(r.name, r);
+  for (const r of b) byName.set(r.name, r);
+  return Array.from(byName.values());
 }
 
 /** True when a shared-file key belongs to this worktree (see loadProjectMcpManifest). */

--- a/src/utils/mcp-manifest.ts
+++ b/src/utils/mcp-manifest.ts
@@ -1,0 +1,88 @@
+import path from 'node:path';
+import {
+  managedMcpManifestPath,
+  legacyManagedMcpManifestPath,
+  managedMcpWorkspaceId,
+  type ManagedMcpManifest,
+  type ManagedMcpRecord,
+} from '../types.js';
+import { readJson, writeJsonAtomic, expandHome } from './fs.js';
+
+/**
+ * Load a project worktree's own managed-MCP manifest, migrating this worktree's
+ * ownership records out of any pre-#374 shared file on first read.
+ *
+ * Each worktree now has its OWN file at
+ * `<dataHome>/workspaces/<workspaceId>/managed-mcp.json` (see
+ * managedMcpManifestPath). This removes the two hazards of a single shared file
+ * in the partition: cross-worktree ownership bleed and lost updates under
+ * concurrent read-modify-write.
+ *
+ * Compatibility: older installs kept everything in the shared
+ * `<dataHome>/managed-mcp.json`, keyed by `<tool>:project` (or the interim
+ * `<tool>:project:<id>`). When this worktree has no per-worktree file yet, we lift
+ * the records belonging to THIS worktree out of the shared file:
+ *  - a bare `<tool>:project` key is claimed only when the data home is
+ *    workspace-local (legacy `<workspaceRoot>/.teamai`), where it is unambiguous;
+ *  - a `<tool>:project:<thisWorkspaceId>` key is always this worktree's.
+ * The migrated records are written into the per-worktree file and removed from the
+ * shared file (best-effort; a stale shared entry is harmless once the per-worktree
+ * file exists, since all readers/writers use the per-worktree file afterwards).
+ *
+ * Returns the per-worktree manifest path plus its loaded contents. Callers mutate
+ * `manifest` and persist with `saveProjectMcpManifest`.
+ */
+export async function loadProjectMcpManifest(
+  dataHome: string,
+  workspaceRoot: string,
+): Promise<{ manifestPath: string; manifest: ManagedMcpManifest }> {
+  const manifestPath = managedMcpManifestPath(dataHome, workspaceRoot);
+  const existing = (await readJson<ManagedMcpManifest>(expandHome(manifestPath))) ?? null;
+  if (existing) return { manifestPath, manifest: existing };
+
+  // No per-worktree file yet — attempt one-time migration from the shared file.
+  const manifest: ManagedMcpManifest = {};
+  const sharedPath = legacyManagedMcpManifestPath(dataHome);
+  const workspaceLocal = dataHome === path.join(workspaceRoot, '.teamai');
+  const shared = (await readJson<ManagedMcpManifest>(expandHome(sharedPath))) ?? null;
+  if (shared) {
+    const migratedFrom: string[] = [];
+    for (const [key, records] of Object.entries(shared)) {
+      if (!Array.isArray(records)) continue;
+      if (claimsThisWorkspace(key, workspaceRoot, workspaceLocal)) {
+        const tool = key.split(':')[0];
+        manifest[`${tool}:project`] = records;
+        migratedFrom.push(key);
+      }
+    }
+    if (migratedFrom.length > 0) {
+      // Drop the claimed keys from the shared file so it can't double-own.
+      for (const key of migratedFrom) delete shared[key];
+      await writeJsonAtomic(expandHome(sharedPath), shared).catch(() => {});
+    }
+  }
+  return { manifestPath, manifest };
+}
+
+/** True when a shared-file key belongs to this worktree (see loadProjectMcpManifest). */
+function claimsThisWorkspace(key: string, workspaceRoot: string, workspaceLocal: boolean): boolean {
+  const parts = key.split(':');
+  if (parts.length === 2 && parts[1] === 'project') return workspaceLocal; // bare `<tool>:project`
+  if (parts.length === 3 && parts[1] === 'project') {
+    return parts[2] === managedMcpWorkspaceId(workspaceRoot); // interim `<tool>:project:<id>`
+  }
+  return false;
+}
+
+/** Persist a per-worktree project manifest (atomic), pruning empty ownership keys. */
+export async function saveProjectMcpManifest(
+  manifestPath: string,
+  manifest: ManagedMcpManifest,
+): Promise<void> {
+  for (const [key, records] of Object.entries(manifest)) {
+    if (!Array.isArray(records) || records.length === 0) delete manifest[key];
+  }
+  await writeJsonAtomic(expandHome(manifestPath), manifest);
+}
+
+export type { ManagedMcpRecord };


### PR DESCRIPTION
## Context

Completes the P1-2 partition routing deferred from #406. Two A1 items still landed
in the business workspace for a **project** install; they now follow the
machine-data home so a partitioned install has zero teamai residue:

- **`managed-mcp.json`** — the per-project MCP injection manifest.
- **project-scope `local-agent/resources`** — the ~4MB skill cache the issue calls out.

(local-agent's own config/manifest are A2 — already global under `~/.teamai` — and
are left untouched, per the issue's A1/A2 split.)

## Why these were deferred (the desync trap)

Both are resolved from **two sides**: callers holding a full `LocalConfig`
(`mcp-reconcile` / `mcp-cmd` / `uninstall`) and the **local-agent** subsystem,
which only carries `(scope, projectRoot)` and has no `LocalConfig`. Converging one
side alone would make a partitioned install's writer and reader disagree
(partition vs legacy) and **desync**. So both must resolve through one source.

## What this PR does

- `managedMcpManifestPath(dataHome)` now takes a **resolved data home**;
  LocalConfig holders pass `getDataHome(localConfig)`.
- New **`resolveDataHomeForScope(scope, projectRoot)`** (config.ts) reproduces
  detection's double-read: user → `~/.teamai`; project → `getDataHome` of
  `detectProjectConfig`'s result (partition for a new/migrated install, else
  legacy `<projectRoot>/.teamai`). The local-agent managed-mcp + resource paths
  route through it, so both sides always land on the identical directory.
- `getResourceRepoPath` (local-agent) is now async and uses the shared resolver
  for its project branch; user scope unchanged (`~/.teamai/local-agent/resources`).
- `ensureProjectGitignore` runs **only** when the cache actually lands inside the
  workspace (a legacy install); a partitioned cache is under `~/.teamai`, so
  there's nothing in the workspace to ignore.

## Test plan (all executed green)

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — **191 files / 2644 tests pass**
- [x] New real **git+fs integration tests** (`detect-subdir.test.ts`) prove the
      desync guard: `resolveDataHomeForScope` **==** `getDataHome(detectProjectConfig(...))`
      for legacy, subdirectory, user, non-git, **and partitioned** installs
      (config in `~/.teamai/projects/<slug>/` resolves to the partition from
      *both* sides).

Note: the full http-backend local-agent install flow (`install_skill`/`install_mcp`
end-to-end) is covered by the 65 existing local-agent unit tests; a live-backend
e2e remains a manual TODO, as with the http provider.

Refs #374 (P1-2C).