### PR TITLE
fix(git): skip hooks on isolated worktree commits

### DIFF
--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -218,7 +218,7 @@ teamai init . --agent claude,codex   # non-interactive: set up Claude Code + Cod
 
 **Clone = initialized.** Because knowledge and the `mode: self` marker in `.teamai/teamai.yaml` are committed to main, a teammate who clones the repo is auto-initialized: the next `teamai` command or AI session detects the marker, and (when their git provider is already authenticated) writes their local config, injects hooks, and registers them on the reports branch — no need to re-type repo/role. If they aren't authenticated yet, teamai prompts them to run `teamai init .` once.
 
-**Safety.** Every git write teamai performs in single-repo mode (knowledge PRs and the reports orphan branch) runs in an isolated git worktree under `.teamai/`. Your working tree and current branch are never checked out, reset, or switched.
+**Safety.** Every git write teamai performs in single-repo mode (knowledge PRs and the reports orphan branch) runs in an isolated git worktree under `.teamai/`. Your working tree and current branch are never checked out, reset, or switched. Isolated worktree commits skip local git hooks (for example husky / lint-staged): a clean checkout from `origin/<default>` often has hook scripts without the locally generated `husky.sh`, and knowledge/report files should not run the business-repo lint pipeline. Your ordinary `git commit` in the business repo still runs hooks.
 
 **Admin checklist after `teamai init .`:**
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -216,7 +216,7 @@ teamai init . --agent claude,codex   # 非交互:启用 Claude Code + Codex
 
 **克隆即初始化。** 由于知识资产和 `.teamai/teamai.yaml` 里的 `mode: self` 标记都提交在 main 上，团队成员 clone 仓库后会被自动初始化：下一条 `teamai` 命令或 AI 会话会识别该标记，并（在其 git provider 已认证的前提下）自动写入本机配置、注入 hooks、在孤儿分支上注册成员 —— 无需手抄 repo/role 参数。若尚未认证，teamai 会提示其运行一次 `teamai init .`。
 
-**安全性。** 单仓模式下 teamai 的每一次 git 写操作（知识 PR 和上报孤儿分支）都在 `.teamai/` 下的隔离 git worktree 中进行，绝不会 checkout、reset 或切换你的工作区和当前分支。
+**安全性。** 单仓模式下 teamai 的每一次 git 写操作（知识 PR 和上报孤儿分支）都在 `.teamai/` 下的隔离 git worktree 中进行，绝不会 checkout、reset 或切换你的工作区和当前分支。隔离 worktree 里的提交会跳过本地 git hook（例如 husky / lint-staged）：从 `origin/<default>` 检出的干净工作区往往只有 hook 脚本、没有本地生成的 `husky.sh`，而且知识/上报文件本来就不该跑业务仓的 lint。你在业务仓里的普通 `git commit` 仍会走 hook。
 
 **管理员在 `teamai init .` 之后的清单：**
 

--- a/src/__tests__/git-skip-hooks.test.ts
+++ b/src/__tests__/git-skip-hooks.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import simpleGit from 'simple-git';
+import { commitPaths, commitSkippingHooks, createGit } from '../utils/git.js';
+
+// Real-git tests: TeamAI-managed isolated commits skip hooks; ordinary
+// commitPaths (teamai init seeding the user's working tree) still runs them.
+
+let dir: string;
+function git(args: string[]) {
+  execFileSync('git', args, { cwd: dir, stdio: 'ignore' });
+}
+
+function writeHuskyStyleHook(repo: string, body: string) {
+  const huskyDir = path.join(repo, '.husky');
+  fs.mkdirSync(huskyDir, { recursive: true });
+  fs.writeFileSync(path.join(huskyDir, 'pre-commit'), body, { mode: 0o755 });
+  execFileSync('git', ['config', 'core.hooksPath', '.husky'], { cwd: repo });
+}
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-skip-hooks-'));
+  git(['init', '-q', '-b', 'main']);
+  git(['config', 'user.email', 't@t.co']);
+  git(['config', 'user.name', 't']);
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('commitSkippingHooks', () => {
+  it('commits when a husky v8 hook sources a missing husky.sh', async () => {
+    writeHuskyStyleHook(dir, [
+      '#!/bin/sh',
+      '. "$(dirname -- "$0")/_/husky.sh"',
+      'exit 1',
+      '',
+    ].join('\n'));
+
+    fs.mkdirSync(path.join(dir, '.teamai', 'skills'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '.teamai', 'skills', 'note.md'), 'knowledge\n');
+    git(['add', '.teamai/skills/note.md']);
+
+    await commitSkippingHooks(createGit(dir), '[teamai] Add skill');
+
+    const log = execFileSync('git', ['log', '-1', '--pretty=%s'], { cwd: dir, encoding: 'utf-8' });
+    expect(log.trim()).toBe('[teamai] Add skill');
+  });
+});
+
+describe('commitPaths (ordinary path)', () => {
+  it('still runs git hooks — does not pass --no-verify', async () => {
+    const marker = path.join(dir, 'hook-ran');
+    writeHuskyStyleHook(dir, [
+      '#!/bin/sh',
+      `touch "${marker}"`,
+      'exit 0',
+      '',
+    ].join('\n'));
+
+    fs.mkdirSync(path.join(dir, '.teamai', 'skills'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '.teamai', 'skills', '.gitkeep'), '');
+
+    const committed = await commitPaths(dir, 'init skeleton', ['.teamai/skills']);
+    expect(committed).toBe(true);
+    expect(fs.existsSync(marker)).toBe(true);
+  });
+
+  it('fails when a husky v8 hook sources a missing husky.sh', async () => {
+    writeHuskyStyleHook(dir, [
+      '#!/bin/sh',
+      '. "$(dirname -- "$0")/_/husky.sh"',
+      '',
+    ].join('\n'));
+
+    fs.mkdirSync(path.join(dir, '.teamai', 'skills'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '.teamai', 'skills', '.gitkeep'), '');
+
+    await expect(commitPaths(dir, 'init skeleton', ['.teamai/skills'])).rejects.toThrow();
+  });
+});
+
+describe('ordinary simple-git commit still invokes hooks', () => {
+  it('createGit().commit without --no-verify is blocked by a missing husky.sh', async () => {
+    writeHuskyStyleHook(dir, [
+      '#!/bin/sh',
+      '. "$(dirname -- "$0")/_/husky.sh"',
+      '',
+    ].join('\n'));
+
+    fs.writeFileSync(path.join(dir, 'file.txt'), 'x\n');
+    git(['add', 'file.txt']);
+
+    await expect(simpleGit({ baseDir: dir }).commit('user commit')).rejects.toThrow(/husky\.sh/);
+  });
+});

--- a/src/__tests__/git.test.ts
+++ b/src/__tests__/git.test.ts
@@ -123,7 +123,7 @@ describe('pushRepoBranch', () => {
     expect(result).toBe(true);
     expect(mockGit.checkoutLocalBranch).toHaveBeenCalledWith('teamai/push/test/123');
     expect(mockGit.add).toHaveBeenCalledWith(['file.txt']);
-    expect(mockGit.commit).toHaveBeenCalledWith('commit msg');
+    expect(mockGit.commit).toHaveBeenCalledWith('commit msg', { '--no-verify': null });
     expect(mockGit.push).toHaveBeenCalledWith(['-u', 'origin', 'teamai/push/test/123']);
     // Should NOT switch back to master — caller does that after gfMrCreate
     expect(mockGit.checkout).not.toHaveBeenCalled();
@@ -250,7 +250,9 @@ describe('pushRepoDirectly', () => {
     await pushRepoDirectly('/repo', 'direct commit', ['file.txt']);
 
     expect(mockGit.add).toHaveBeenCalledWith(['file.txt']);
+    // Ordinary path: do not skip hooks (unlike isolated worktree commits).
     expect(mockGit.commit).toHaveBeenCalledWith('direct commit');
+    expect(mockGit.commit.mock.calls[0]).toHaveLength(1);
     expect(mockGit.revparse).toHaveBeenCalledWith(['--abbrev-ref', 'HEAD']);
     expect(mockGit.push).toHaveBeenCalledWith(['-u', 'origin', 'main']);
   });

--- a/src/__tests__/reports-branch-readonly.test.ts
+++ b/src/__tests__/reports-branch-readonly.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
     add: vi.fn(),
     commit: vi.fn(),
     push: vi.fn(),
+    status: vi.fn(),
   },
   isGitRepo: vi.fn(),
 }));
@@ -23,6 +24,8 @@ vi.mock('../utils/git.js', () => ({
   isGitRepo: mocks.isGitRepo,
   getDefaultBranch: vi.fn(),
   hasCommits: vi.fn(),
+  commitSkippingHooks: (git: { commit: (...args: unknown[]) => unknown }, message: string) =>
+    git.commit(message, { '--no-verify': null }),
 }));
 
 vi.mock('../utils/fs.js', () => ({
@@ -43,7 +46,8 @@ vi.mock('../update.js', () => ({
   releaseLock: vi.fn(),
 }));
 
-import { ensureReportsWorktree } from '../utils/reports-branch.js';
+import { acquireLock, releaseLock } from '../update.js';
+import { commitAndPushReports, ensureReportsWorktree } from '../utils/reports-branch.js';
 
 const config: LocalConfig = {
   repo: {
@@ -86,5 +90,37 @@ describe('ensureReportsWorktree read-only cold start', () => {
       'origin',
       'teamai-reports',
     ]);
+  });
+
+  it('skips git hooks when initializing the reports orphan branch', async () => {
+    await ensureReportsWorktree(config, { pushIfCreated: false });
+
+    expect(mocks.worktreeGit.commit).toHaveBeenCalledWith(
+      '[teamai] Initialize reports branch',
+      { '--no-verify': null },
+    );
+  });
+});
+
+describe('commitAndPushReports', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.isGitRepo.mockResolvedValue(true);
+    mocks.worktreeGit.add.mockResolvedValue(undefined);
+    mocks.worktreeGit.commit.mockResolvedValue(undefined);
+    mocks.worktreeGit.push.mockResolvedValue(undefined);
+    mocks.worktreeGit.status.mockResolvedValue({ staged: ['members/alice.yaml'] });
+    vi.mocked(acquireLock).mockResolvedValue(true);
+    vi.mocked(releaseLock).mockResolvedValue(undefined);
+  });
+
+  it('skips git hooks on the isolated reports worktree commit', async () => {
+    const pushed = await commitAndPushReports(config, '[teamai] Register member: alice', ['members/']);
+
+    expect(pushed).toBe(true);
+    expect(mocks.worktreeGit.commit).toHaveBeenCalledWith(
+      '[teamai] Register member: alice',
+      { '--no-verify': null },
+    );
   });
 });

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -19,6 +19,22 @@ export function createGit(basePath?: string): SimpleGit {
 }
 
 /**
+ * Commit TeamAI makes in a managed checkout (knowledge-wt, reports-wt, or a
+ * dedicated team-repo PR branch created by {@link pushRepoBranch}).
+ *
+ * Isolated worktrees are based on origin/<default> and often have tracked hook
+ * scripts (e.g. `.husky/pre-commit`) without the locally generated `husky.sh`
+ * (`HUSKY=0` lives inside that file, so it cannot save the commit). Those
+ * commits only add knowledge or report files and must not run lint-staged.
+ *
+ * `--no-verify` is scoped to this git process. It does not write
+ * `core.hooksPath` and does not change the user's ordinary `git commit`.
+ */
+export function commitSkippingHooks(git: SimpleGit, message: string) {
+  return git.commit(message, { '--no-verify': null });
+}
+
+/**
  * Check whether localPath is a valid git repository (has a `.git` entry).
  *
  * Returns false if the path does not exist, or exists but is not a git repo
@@ -516,8 +532,9 @@ export async function pushRepoBranch(
     return false;
   }
 
-  // Commit and push branch
-  await git.commit(message);
+  // Commit and push branch. Skip hooks: this is a CLI-managed knowledge commit
+  // (often inside knowledge-wt, which has hook scripts but no husky.sh).
+  await commitSkippingHooks(git, message);
 
   if (opts.reuseBranch) {
     // Re-running push with no real change would otherwise force-push an

--- a/src/utils/reports-branch.ts
+++ b/src/utils/reports-branch.ts
@@ -17,7 +17,7 @@
  */
 import path from 'node:path';
 import fse from 'fs-extra';
-import { createGit, isGitRepo, getDefaultBranch, hasCommits } from './git.js';
+import { createGit, isGitRepo, getDefaultBranch, hasCommits, commitSkippingHooks } from './git.js';
 import { acquireLock, releaseLock } from '../update.js';
 import { ensureDir, writeFile, pathExists } from './fs.js';
 import { log } from './logger.js';
@@ -131,7 +131,7 @@ export async function ensureReportsWorktree(
     await writeWorktreeGitignore(wt);
     const wtGit = createGit(wt);
     await wtGit.add(['.gitignore']);
-    await wtGit.commit('[teamai] Initialize reports branch');
+    await commitSkippingHooks(wtGit, '[teamai] Initialize reports branch');
     if (options.pushIfCreated !== false) {
       try {
         await wtGit.push(['-u', 'origin', REPORTS_BRANCH]);
@@ -234,7 +234,7 @@ export async function commitAndPushReports(
       return false;
     }
 
-    await git.commit(message);
+    await commitSkippingHooks(git, message);
 
     // Push with fetch+rebase retry. Each member only writes <user>.yaml, so
     // rebase conflicts are effectively impossible; retries handle the pure


### PR DESCRIPTION
## Summary

Fixes #421.

单仓模式 `teamai push` / `teamai remove` 会在 `.teamai/knowledge-wt` 里从 `origin/<default>` 做干净检出再提交。很多业务仓把 husky 的 hook 脚本入库，但不提交 `husky.sh`，隔离 worktree 里 `git commit` 会在 source 到一半时报错；`HUSKY=0` 也救不了。

这次只在 TeamAI 托管的那几次 commit 上加 `--no-verify`（`pushRepoBranch`、reports 孤儿分支初始化和 `commitAndPushReports`），不写仓库 `core.hooksPath`，也不改用户当前分支和工作区。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing behavior to change)
- [ ] Documentation only
- [ ] Refactor / internal cleanup

## 怎么修的

新增 `commitSkippingHooks`，对 simple-git 传 `{ '--no-verify': null }`，只给 CLI 代用户提交的路径用：

- `pushRepoBranch`：知识 PR（单仓 knowledge-wt，以及独立 team-repo 的同类提交）
- reports worktree 的初始化提交和 `commitAndPushReports`

`--no-verify` 只作用于这一次 git 进程，跳过 `pre-commit` / `commit-msg`（不绑死 husky）。隔离提交只加知识/上报文件，本来就不该跑业务仓 lint-staged。

**故意没改：** `commitPaths`（`teamai init` 往业务仓当前树种文件）、`pushRepoDirectly`、`pushLearningToOrigin`。用户在业务仓里的普通 `git commit` 仍走 hook。

## 影响

- 没配 git hook 的仓：行为与现在一致（`--no-verify` 在没有 hook 时是空操作）。
- 有 husky 且 `husky.sh` 未入库的仓：单仓 `push` / `remove` / reports 写入不再因残缺 hook 失败。
- 用户当前业务分支、工作区、本机 `core.hooksPath` 不被改写。
- 独立 team-repo 的 `teamai push` 也走 `pushRepoBranch`，现在同样不跑 hook；那些提交同样是知识文件，影响很小。
- `--no-verify` 不管 `pre-push`。如果业务仓的 `pre-push` 也 source 缺失的 `husky.sh`，提交会过、push 仍可能挂（#421 死在 `pre-commit`，这次没扩到 push）。

文档：`docs/usage-guide.md` / `docs/usage-guide.zh-CN.md` 的 Safety / 安全性段落补了这条行为。

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` passes（194 files / 2668 tests）
- [x] Added/updated tests for the change
  - 隔离路径：`pushRepoBranch` / reports 提交调用了 `--no-verify`
  - 普通路径：`commitPaths` / `pushRepoDirectly` 不带 `--no-verify`
  - 真实 git：缺 `husky.sh` 时 `commitSkippingHooks` 能提交，`commitPaths` 仍会跑 hook 并失败
- [x] 真实 git 复现：`knowledge-wt` 里普通 commit 报同样的 `husky.sh` 错误；`pushRepoBranch` 提交并推送成功；业务仓仍在 `main`，`core.hooksPath=.husky` 未改

## Related Issues

Fixes #421

## Notes for Reviewers

没有新 CLI 命令，没有在用户仓库写 `core.hooksPath=/dev/null`。跳过 hook 不是全局默认，只覆盖 TeamAI 自己在隔离 worktree（以及同类「CLI 代用户提交」）里的 commit。