### PR TITLE
fix(dashboard): collect Codex token usage

### DIFF
--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -1085,7 +1085,7 @@ Each session card also shows two badges:
 | Badge | Meaning | Data source |
 |------|------|----------|
 | `💬 N` | The **number of human conversation turns** in the session (how many prompts were sent) | Count of `UserPromptSubmit` events |
-| `⛁ X` | The session's cumulative **token usage** (hover to see input / output / cache read / cache write breakdown) | Claude Code transcript's `message.usage` (deduplicated by `message.id` to avoid double counting) |
+| `⛁ X` | The session's cumulative **token usage** (hover to see input / output / cache read / cache write breakdown) | Claude Code `message.usage`, CodeBuddy `requests[].usage`, or the latest cumulative Codex `token_usage_record` / `event_msg.token_count` snapshot |
 
 > Privacy: only turn counts and token counts are tracked — no prompt or transcript text is ever stored.
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -1085,7 +1085,7 @@ Each session card also shows two badges:
 | Badge | Meaning | Data source |
 |------|------|----------|
 | `💬 N` | The **number of human conversation turns** in the session (how many prompts were sent) | Count of `UserPromptSubmit` events |
-| `⛁ X` | The session's cumulative **token usage** (hover to see input / output / cache read / cache write breakdown) | Claude Code `message.usage`, CodeBuddy `requests[].usage`, or the latest cumulative Codex `token_usage_record` / `event_msg.token_count` snapshot |
+| `⛁ X` | The session's cumulative **token usage** (hover to see input / output / cache read / cache write breakdown) | Claude Code `message.usage`, CodeBuddy `requests[].usage`, or Codex's latest session-level `token_usage_record`; legacy `event_msg.token_count` snapshots are summed once per rollout file |
 
 > Privacy: only turn counts and token counts are tracked — no prompt or transcript text is ever stored.
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -1080,7 +1080,7 @@ teamai dashboard --port 8080
 | 徽标 | 含义 | 数据来源 |
 |------|------|----------|
 | `💬 N` | 该会话里**人类对话的轮数**（发了几次 prompt） | `UserPromptSubmit` 事件数 |
-| `⛁ X` | 该会话累计 **token 用量**（鼠标悬停看 输入 / 输出 / 缓存读 / 缓存写 明细） | Claude Code transcript 的 `message.usage`（按 `message.id` 去重，避免重复计数） |
+| `⛁ X` | 该会话累计 **token 用量**（鼠标悬停看 输入 / 输出 / 缓存读 / 缓存写 明细） | Claude Code `message.usage`、CodeBuddy `requests[].usage`，或 Codex 最新的累计 `token_usage_record` / `event_msg.token_count` 快照 |
 
 > 隐私：只统计**轮数与 token 数量**，不落地任何 prompt 或 transcript 原文。
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -1080,7 +1080,7 @@ teamai dashboard --port 8080
 | 徽标 | 含义 | 数据来源 |
 |------|------|----------|
 | `💬 N` | 该会话里**人类对话的轮数**（发了几次 prompt） | `UserPromptSubmit` 事件数 |
-| `⛁ X` | 该会话累计 **token 用量**（鼠标悬停看 输入 / 输出 / 缓存读 / 缓存写 明细） | Claude Code `message.usage`、CodeBuddy `requests[].usage`，或 Codex 最新的累计 `token_usage_record` / `event_msg.token_count` 快照 |
+| `⛁ X` | 该会话累计 **token 用量**（鼠标悬停看 输入 / 输出 / 缓存读 / 缓存写 明细） | Claude Code `message.usage`、CodeBuddy `requests[].usage`，或 Codex 最新的会话级 `token_usage_record`；旧版 `event_msg.token_count` 按 rollout 文件各取最新快照后累加 |
 
 > 隐私：只统计**轮数与 token 数量**，不落地任何 prompt 或 transcript 原文。
 

--- a/src/__tests__/conversation-token-metrics.test.ts
+++ b/src/__tests__/conversation-token-metrics.test.ts
@@ -83,7 +83,7 @@ describe('scanTranscriptStop — token usage', () => {
     expect(tokens).toEqual({ input: 0, output: 7, cacheRead: 0, cacheCreation: 0 });
   });
 
-  it('uses the latest cumulative Codex Desktop token_usage_record without double counting', async () => {
+  it('uses the latest cumulative Codex token_usage_record without double counting', async () => {
     const record = (threadUsage: Record<string, number>, responseId: string) => JSON.stringify({
       type: 'token_usage_record',
       payload: {
@@ -112,12 +112,13 @@ describe('scanTranscriptStop — token usage', () => {
       }, 'resp_2'),
     ]);
 
-    const { tokens } = await scanTranscriptStop(p);
+    const { tokens, tokenScope } = await scanTranscriptStop(p);
     // input_tokens includes both cache buckets and output_tokens includes reasoning.
     expect(tokens).toEqual({ input: 1100, output: 80, cacheRead: 400, cacheCreation: 100 });
+    expect(tokenScope).toBe('session');
   });
 
-  it('uses the latest cumulative Codex CLI event_msg/token_count snapshot', async () => {
+  it('uses the latest cumulative legacy Codex event_msg/token_count snapshot', async () => {
     const tokenCount = (usage: Record<string, number>) => JSON.stringify({
       type: 'event_msg',
       payload: {
@@ -131,8 +132,44 @@ describe('scanTranscriptStop — token usage', () => {
       tokenCount({ input_tokens: 900, cached_input_tokens: 350, output_tokens: 45 }),
     ]);
 
-    const { tokens } = await scanTranscriptStop(p);
+    const { tokens, tokenScope } = await scanTranscriptStop(p);
     expect(tokens).toEqual({ input: 550, output: 45, cacheRead: 350, cacheCreation: 0 });
+    expect(tokenScope).toBe('transcript');
+  });
+
+  it('prefers a thread-level Codex snapshot when both record formats are present', async () => {
+    const p = writeTranscript([
+      JSON.stringify({
+        type: 'token_usage_record',
+        payload: {
+          thread_token_usage: {
+            input_tokens: 1000,
+            cached_input_tokens: 300,
+            cache_write_input_tokens: 100,
+            output_tokens: 50,
+          },
+        },
+      }),
+      // A later legacy record is only rollout-scoped and must not replace the
+      // authoritative thread-level total above.
+      JSON.stringify({
+        type: 'event_msg',
+        payload: {
+          type: 'token_count',
+          info: {
+            total_token_usage: {
+              input_tokens: 200,
+              cached_input_tokens: 50,
+              output_tokens: 10,
+            },
+          },
+        },
+      }),
+    ]);
+
+    const { tokens, tokenScope } = await scanTranscriptStop(p);
+    expect(tokens).toEqual({ input: 600, output: 50, cacheRead: 300, cacheCreation: 100 });
+    expect(tokenScope).toBe('session');
   });
 
   it('waits for a newer Codex cumulative snapshot flushed after Stop', async () => {
@@ -165,9 +202,10 @@ describe('scanTranscriptStop — token usage', () => {
       }) + '\n');
     }, 300);
 
-    const { tokens } = await scanTranscriptStop(p, { tool: 'codex' });
+    const { tokens, tokenScope } = await scanTranscriptStop(p, { tool: 'codex' });
     clearTimeout(timer);
     expect(tokens).toEqual({ input: 280, output: 60, cacheRead: 100, cacheCreation: 20 });
+    expect(tokenScope).toBe('session');
   });
 
   it('parses CodeBuddy index.json (requests[].usage + user messages)', async () => {
@@ -288,6 +326,69 @@ describe('aggregateSessionMetrics', () => {
     ];
     const m = aggregateSessionMetrics(events).get('s1')!;
     expect(m.tokens).toEqual({ input: 30, output: 4, cacheRead: 2, cacheCreation: 1 });
+  });
+
+  it('sums legacy Codex snapshots per rollout path across same-session resume', () => {
+    const firstPartialTokens = { input: 100_000, output: 1_000, cacheRead: 300_000, cacheCreation: 0 };
+    const firstTokens = { input: 283_144, output: 27_733, cacheRead: 8_339_712, cacheCreation: 0 };
+    const resumedTokens = { input: 29_828, output: 2_936, cacheRead: 2_490_368, cacheCreation: 0 };
+    const firstPartialStop: DashboardEvent = {
+      type: 'stop', timestamp: '2026-09-01T12:40:11.785Z', sessionId: 'same-session', tool: 'codex',
+      transcriptPath: '/rollouts/rollout-a.jsonl', tokenScope: 'transcript', tokens: firstPartialTokens,
+    };
+    const firstStop: DashboardEvent = {
+      type: 'stop', timestamp: '2026-09-01T13:26:15.211Z', sessionId: 'same-session', tool: 'codex',
+      transcriptPath: '/rollouts/rollout-a.jsonl', tokenScope: 'transcript', tokens: firstTokens,
+    };
+    const resumedStop: DashboardEvent = {
+      type: 'stop', timestamp: '2026-09-01T13:27:33.513Z', sessionId: 'same-session', tool: 'codex',
+      transcriptPath: '/rollouts/rollout-b.jsonl', tokenScope: 'transcript', tokens: resumedTokens,
+    };
+
+    const firstMetrics = aggregateSessionMetrics([firstPartialStop, firstStop]);
+    const firstReport = computePromptTokenDelta(firstMetrics, {});
+    expect(firstReport.delta.tokens).toEqual(firstTokens);
+
+    // Re-scanning either rollout replaces that path's snapshot. It must not replace
+    // the other rollout or add the same segment twice. Put the older partial scan
+    // last to model background Stop handlers appending out of chronological order.
+    const resumedMetrics = aggregateSessionMetrics([
+      firstStop, resumedStop, { ...resumedStop }, firstPartialStop,
+    ]);
+    expect(resumedMetrics.get('same-session')!.tokens).toEqual({
+      input: firstTokens.input + resumedTokens.input,
+      output: firstTokens.output + resumedTokens.output,
+      cacheRead: firstTokens.cacheRead + resumedTokens.cacheRead,
+      cacheCreation: 0,
+    });
+
+    const resumedReport = computePromptTokenDelta(resumedMetrics, firstReport.nextReported);
+    expect(resumedReport.delta.tokens).toEqual(resumedTokens);
+    expect(computePromptTokenDelta(resumedMetrics, resumedReport.nextReported).delta.tokens)
+      .toEqual({ input: 0, output: 0, cacheRead: 0, cacheCreation: 0 });
+  });
+
+  it('does not add transcript-scoped Codex totals to a session-scoped snapshot', () => {
+    const events: DashboardEvent[] = [
+      {
+        type: 'stop', timestamp: '2026-09-01T13:00:00Z', sessionId: 's1', tool: 'codex',
+        transcriptPath: '/rollouts/a.jsonl', tokenScope: 'transcript',
+        tokens: { input: 100, output: 10, cacheRead: 20, cacheCreation: 0 },
+      },
+      {
+        type: 'stop', timestamp: '2026-09-01T13:01:00Z', sessionId: 's1', tool: 'codex',
+        transcriptPath: '/rollouts/b.jsonl', tokenScope: 'session',
+        tokens: { input: 160, output: 16, cacheRead: 30, cacheCreation: 0 },
+      },
+      {
+        type: 'stop', timestamp: '2026-09-01T13:02:00Z', sessionId: 's1', tool: 'codex',
+        transcriptPath: '/rollouts/b.jsonl', tokenScope: 'transcript',
+        tokens: { input: 40, output: 4, cacheRead: 10, cacheCreation: 0 },
+      },
+    ];
+
+    expect(aggregateSessionMetrics(events).get('s1')!.tokens)
+      .toEqual({ input: 160, output: 16, cacheRead: 30, cacheCreation: 0 });
   });
 
   it('prefers the Stop prompt snapshot over the live submit count (max)', () => {

--- a/src/__tests__/conversation-token-metrics.test.ts
+++ b/src/__tests__/conversation-token-metrics.test.ts
@@ -83,6 +83,93 @@ describe('scanTranscriptStop — token usage', () => {
     expect(tokens).toEqual({ input: 0, output: 7, cacheRead: 0, cacheCreation: 0 });
   });
 
+  it('uses the latest cumulative Codex Desktop token_usage_record without double counting', async () => {
+    const record = (threadUsage: Record<string, number>, responseId: string) => JSON.stringify({
+      type: 'token_usage_record',
+      payload: {
+        response_id: responseId,
+        // Per-response usage must not be added when a cumulative thread snapshot exists.
+        usage: { input_tokens: 999999, output_tokens: 999999 },
+        thread_token_usage: threadUsage,
+      },
+    });
+    const p = writeTranscript([
+      record({
+        input_tokens: 1000,
+        cached_input_tokens: 300,
+        cache_write_input_tokens: 100,
+        output_tokens: 50,
+        reasoning_output_tokens: 20,
+        total_tokens: 1050,
+      }, 'resp_1'),
+      record({
+        input_tokens: 1600,
+        cached_input_tokens: 400,
+        cache_write_input_tokens: 100,
+        output_tokens: 80,
+        reasoning_output_tokens: 30,
+        total_tokens: 1680,
+      }, 'resp_2'),
+    ]);
+
+    const { tokens } = await scanTranscriptStop(p);
+    // input_tokens includes both cache buckets and output_tokens includes reasoning.
+    expect(tokens).toEqual({ input: 1100, output: 80, cacheRead: 400, cacheCreation: 100 });
+  });
+
+  it('uses the latest cumulative Codex CLI event_msg/token_count snapshot', async () => {
+    const tokenCount = (usage: Record<string, number>) => JSON.stringify({
+      type: 'event_msg',
+      payload: {
+        type: 'token_count',
+        info: { total_token_usage: usage, last_token_usage: { input_tokens: 9999 } },
+      },
+    });
+    const p = writeTranscript([
+      tokenCount({ input_tokens: 500, cached_input_tokens: 200, output_tokens: 25 }),
+      JSON.stringify({ type: 'event_msg', payload: { type: 'agent_message', message: 'done' } }),
+      tokenCount({ input_tokens: 900, cached_input_tokens: 350, output_tokens: 45 }),
+    ]);
+
+    const { tokens } = await scanTranscriptStop(p);
+    expect(tokens).toEqual({ input: 550, output: 45, cacheRead: 350, cacheCreation: 0 });
+  });
+
+  it('waits for a newer Codex cumulative snapshot flushed after Stop', async () => {
+    const p = writeTranscript([
+      JSON.stringify({
+        type: 'token_usage_record',
+        payload: {
+          response_id: 'resp_old',
+          thread_token_usage: {
+            input_tokens: 100,
+            cached_input_tokens: 40,
+            cache_write_input_tokens: 10,
+            output_tokens: 20,
+          },
+        },
+      }),
+    ]);
+    const timer = setTimeout(() => {
+      fs.appendFileSync(p, JSON.stringify({
+        type: 'token_usage_record',
+        payload: {
+          response_id: 'resp_new',
+          thread_token_usage: {
+            input_tokens: 400,
+            cached_input_tokens: 100,
+            cache_write_input_tokens: 20,
+            output_tokens: 60,
+          },
+        },
+      }) + '\n');
+    }, 300);
+
+    const { tokens } = await scanTranscriptStop(p, { tool: 'codex' });
+    clearTimeout(timer);
+    expect(tokens).toEqual({ input: 280, output: 60, cacheRead: 100, cacheCreation: 20 });
+  });
+
   it('parses CodeBuddy index.json (requests[].usage + user messages)', async () => {
     // CodeBuddy persists a single index.json, not Claude JSONL. Tokens live in
     // requests[].usage.{inputTokens,outputTokens}; prompts = user messages.

--- a/src/dashboard-collector.ts
+++ b/src/dashboard-collector.ts
@@ -144,10 +144,9 @@ export interface TranscriptScanResult {
  * snapshots of:
  * - interrupt:  user message whose text starts with "[Request interrupted by user"
  * - toolReject: tool_result with is_error=true marked as a user rejection
- * - tokens:     usage.{input,output,cache_*}_tokens summed across assistant messages,
- *               deduplicated by `message.id` (falling back to top-level `requestId`)
- *               because Claude Code repeats the same usage on every content-block
- *               line of a single turn, so naive summing would massively over-count.
+ * - tokens:     Claude usage summed across deduplicated assistant messages, or the
+ *               latest cumulative Codex token snapshot (`token_usage_record` in
+ *               Codex Desktop and `event_msg/token_count` in Codex CLI).
  * - prompts:    genuine human prompt turns (user entries with real text, excluding
  *               interrupts, tool_results, and meta/sidechain entries).
  *
@@ -157,37 +156,60 @@ export interface TranscriptScanResult {
  * Set `opts.frictionOnly` to true for low-latency foreground callers (e.g.
  * contribute-check) that only need friction signals. On the CodeBuddy index.json
  * path this skips the token-flush retry loop — friction comes from a single blob
- * scan that completes before the retry, so no token wait is required. The Claude
- * JSONL path is a single streaming scan with no retry, so the flag is a no-op there.
+ * scan that completes before the retry, so no token wait is required. It also
+ * skips the Codex post-Stop flush wait. The Claude JSONL path is a single streaming
+ * scan with no retry, so the flag is a no-op there.
  */
 export async function scanTranscriptStop(
   transcriptPath: string,
-  opts?: { frictionOnly?: boolean },
+  opts?: { frictionOnly?: boolean; tool?: string },
 ): Promise<TranscriptScanResult> {
-  let interrupt = 0;
-  let toolReject = 0;
-  let toolError = 0;
-  let prompts = 0;
-  const tokens = emptyTokenUsage();
-  // Dedup assistant usage per message (one turn spans many JSONL lines that repeat
-  // the same usage). Prefer message.id; fall back to the top-level requestId.
-  const countedUsageKeys = new Set<string>();
-
   // CodeBuddy persists its transcript as a single `index.json` document (a JSON
-  // object with `requests[].usage` + `messages[]`), NOT the Claude Code JSONL
-  // schema the streaming scanner below expects. Detect and parse that shape
-  // separately — otherwise every line fails JSON.parse and tokens stay 0.
+  // object with `requests[].usage` + `messages[]`), NOT the JSONL schema used by
+  // Claude and Codex. Detect and parse that shape separately.
   if (path.basename(transcriptPath) === 'index.json') {
     const cb = await scanCodebuddyIndex(transcriptPath, opts?.frictionOnly ?? false);
     if (cb) return cb;
   }
 
+  const initial = await scanJsonlTranscriptOnce(transcriptPath);
+  if (opts?.frictionOnly || !isCodexTool(opts?.tool)) return initial.result;
+
+  // Codex can append the final cumulative usage record shortly after firing Stop.
+  // Keep the full-scan friction/prompt result, but poll only a small file tail for
+  // a newer token snapshot so a previous turn's non-zero total is not mistaken for
+  // the just-finished turn. This is bounded to ~1.75s and never loads the whole file
+  // repeatedly.
+  const flushedTokens = await waitForCodexUsageFlush(transcriptPath, initial.codexTokens);
+  return flushedTokens ? { ...initial.result, tokens: flushedTokens } : initial.result;
+}
+
+interface JsonlTranscriptScan {
+  result: TranscriptScanResult;
+  /** Latest cumulative Codex snapshot encountered, if this is a Codex transcript. */
+  codexTokens: TokenUsage | null;
+}
+
+/** Scan the Claude/Codex JSONL transcript once. */
+async function scanJsonlTranscriptOnce(transcriptPath: string): Promise<JsonlTranscriptScan> {
+  let interrupt = 0;
+  let toolReject = 0;
+  let toolError = 0;
+  let prompts = 0;
+  const tokens = emptyTokenUsage();
+  let codexTokens: TokenUsage | null = null;
+  // Dedup assistant usage per message (one turn spans many JSONL lines that repeat
+  // the same usage). Prefer message.id; fall back to the top-level requestId.
+  const countedUsageKeys = new Set<string>();
+
   try {
     const stat = await fs.promises.stat(transcriptPath);
-    if (stat.size === 0) return { interrupt, toolReject, toolError, tokens, prompts };
+    if (stat.size === 0) {
+      return { result: { interrupt, toolReject, toolError, tokens, prompts }, codexTokens };
+    }
     if (stat.size > INTERVENTION_SCAN_MAX_BYTES) {
       log.warn(`dashboard: transcript too large to scan (${stat.size} bytes)`);
-      return { interrupt, toolReject, toolError, tokens, prompts };
+      return { result: { interrupt, toolReject, toolError, tokens, prompts }, codexTokens };
     }
 
     const rl = readline.createInterface({
@@ -197,20 +219,37 @@ export async function scanTranscriptStop(
 
     for await (const line of rl) {
       const trimmed = line.trim();
-      // Cheap pre-filter: we only care about `user` entries (interventions/prompts)
-      // and `assistant` entries (token usage); skip JSON.parse on anything else.
-      if (!trimmed || (!trimmed.includes('"user"') && !trimmed.includes('"assistant"'))) continue;
+      // Cheap pre-filter: Claude uses user/assistant records; Codex Desktop emits
+      // token_usage_record and Codex CLI emits event_msg/token_count records.
+      if (
+        !trimmed || (
+          !trimmed.includes('"user"') &&
+          !trimmed.includes('"assistant"') &&
+          !trimmed.includes('"token_usage_record"') &&
+          !trimmed.includes('"token_count"')
+        )
+      ) continue;
 
       let entry: {
         type?: string;
         isMeta?: unknown;
         isSidechain?: unknown;
         requestId?: unknown;
+        payload?: unknown;
         message?: { content?: unknown; id?: unknown; usage?: Record<string, unknown> };
       };
       try {
         entry = JSON.parse(trimmed);
       } catch {
+        continue;
+      }
+
+      const codexUsage = parseCodexCumulativeUsage(entry);
+      if (codexUsage) {
+        // Both supported Codex formats are cumulative. Replacing with the latest
+        // record is essential: summing records would count the whole thread again
+        // after every turn.
+        codexTokens = codexUsage;
         continue;
       }
 
@@ -283,7 +322,113 @@ export async function scanTranscriptStop(
     log.warn(`dashboard: failed to scan transcript: ${(e as Error).message}`);
   }
 
-  return { interrupt, toolReject, toolError, tokens, prompts };
+  const result = { interrupt, toolReject, toolError, tokens: codexTokens ?? tokens, prompts };
+  return { result, codexTokens };
+}
+
+/** Narrow an unknown JSON value to an object record. */
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+/**
+ * Convert Codex's inclusive input token count into TeamAI's disjoint buckets.
+ * Codex input_tokens includes cached/cache-write tokens; output_tokens already
+ * includes reasoning output, so neither subset may be added a second time.
+ */
+function codexUsageToTokenUsage(usage: Record<string, unknown>): TokenUsage {
+  const inclusiveInput = toNum(usage.input_tokens);
+  const cacheRead = toNum(usage.cached_input_tokens);
+  const cacheCreation = toNum(usage.cache_write_input_tokens);
+  return {
+    input: Math.max(0, inclusiveInput - cacheRead - cacheCreation),
+    output: toNum(usage.output_tokens),
+    cacheRead,
+    cacheCreation,
+  };
+}
+
+/** Parse one cumulative Codex usage record (Desktop or CLI), if present. */
+function parseCodexCumulativeUsage(entry: { type?: string; payload?: unknown }): TokenUsage | null {
+  const payload = asRecord(entry.payload);
+  let usage: Record<string, unknown> | null = null;
+
+  if (entry.type === 'token_usage_record') {
+    usage = asRecord(payload?.thread_token_usage);
+  } else if (entry.type === 'event_msg' && payload?.type === 'token_count') {
+    usage = asRecord(asRecord(payload.info)?.total_token_usage);
+  }
+
+  return usage ? codexUsageToTokenUsage(usage) : null;
+}
+
+const CODEX_USAGE_TAIL_BYTES = 256 * 1024;
+const CODEX_USAGE_MAX_ATTEMPTS = 8;
+const CODEX_USAGE_RETRY_MS = 250;
+
+function isCodexTool(tool: string | undefined): boolean {
+  return typeof tool === 'string' && tool.toLowerCase().includes('codex');
+}
+
+function tokenUsageEquals(a: TokenUsage | null, b: TokenUsage): boolean {
+  return a !== null && a.input === b.input && a.output === b.output
+    && a.cacheRead === b.cacheRead && a.cacheCreation === b.cacheCreation;
+}
+
+/** Read only the transcript tail and return its latest cumulative Codex snapshot. */
+async function readLatestCodexUsageFromTail(transcriptPath: string): Promise<TokenUsage | null> {
+  try {
+    const stat = await fs.promises.stat(transcriptPath);
+    if (stat.size === 0) return null;
+    const readSize = Math.min(stat.size, CODEX_USAGE_TAIL_BYTES);
+    const offset = stat.size - readSize;
+    const fh = await fs.promises.open(transcriptPath, 'r');
+    try {
+      const buffer = Buffer.alloc(readSize);
+      await fh.read(buffer, 0, readSize, offset);
+      const lines = buffer.toString('utf-8').split('\n');
+      // When reading a tail slice, the first line may start in the middle of JSON.
+      if (offset > 0) lines.shift();
+      let latest: TokenUsage | null = null;
+      for (const line of lines) {
+        if (!line.includes('"token_usage_record"') && !line.includes('"token_count"')) continue;
+        try {
+          const parsed = JSON.parse(line) as { type?: string; payload?: unknown };
+          latest = parseCodexCumulativeUsage(parsed) ?? latest;
+        } catch {
+          // The final line can be mid-write; a later retry will see it completed.
+        }
+      }
+      return latest;
+    } finally {
+      await fh.close();
+    }
+  } catch {
+    return null;
+  }
+}
+
+/** Wait for Codex's post-Stop cumulative token record without rescanning the file. */
+async function waitForCodexUsageFlush(
+  transcriptPath: string,
+  initial: TokenUsage | null,
+): Promise<TokenUsage | null> {
+  let latest = initial;
+  for (let attempt = 1; attempt < CODEX_USAGE_MAX_ATTEMPTS; attempt++) {
+    await new Promise((resolve) => setTimeout(resolve, CODEX_USAGE_RETRY_MS));
+    const observed = await readLatestCodexUsageFromTail(transcriptPath);
+    if (!observed) continue;
+    latest = observed;
+
+    // A changed cumulative snapshot is the record for the turn that just stopped.
+    // For a first-turn session, the transition from no record to non-zero is enough.
+    if (!tokenUsageEquals(initial, observed) && (initial !== null || totalTokenCount(observed) > 0)) {
+      return observed;
+    }
+  }
+  return latest;
 }
 
 /**
@@ -666,7 +811,7 @@ export async function parseHookEvent(
     }
     // Full-transcript snapshot of interrupt/tool_reject counts + token usage +
     // human prompt count (all idempotent, sourced from the non-compactable transcript).
-    const scan = await scanTranscriptStop(hookData.transcript_path);
+    const scan = await scanTranscriptStop(hookData.transcript_path, { tool });
     if (scan.interrupt > 0 || scan.toolReject > 0 || scan.toolError > 0) {
       event.interventions = {
         interrupt: scan.interrupt,

--- a/src/dashboard-collector.ts
+++ b/src/dashboard-collector.ts
@@ -28,6 +28,7 @@ import {
   type DashboardSession,
   type DashboardSessionStatus,
   type TokenUsage,
+  type TokenSnapshotScope,
   type SessionMetrics,
 } from './types.js';
 import { getUserHome } from './utils/home.js';
@@ -131,6 +132,8 @@ export interface TranscriptScanResult {
    */
   toolError: number;
   tokens: TokenUsage;
+  /** Scope of a Codex cumulative snapshot; absent for other transcript formats. */
+  tokenScope?: TokenSnapshotScope;
   /**
    * Cumulative count of genuine human prompt turns in the transcript. Sourced here
    * (not from compactable prompt_submit events) so the reported baseline stays
@@ -145,8 +148,9 @@ export interface TranscriptScanResult {
  * - interrupt:  user message whose text starts with "[Request interrupted by user"
  * - toolReject: tool_result with is_error=true marked as a user rejection
  * - tokens:     Claude usage summed across deduplicated assistant messages, or the
- *               latest cumulative Codex token snapshot (`token_usage_record` in
- *               Codex Desktop and `event_msg/token_count` in Codex CLI).
+ *               latest cumulative Codex token snapshot. Modern
+ *               `token_usage_record` is session-scoped; legacy
+ *               `event_msg/token_count` is scoped to one transcript/rollout file.
  * - prompts:    genuine human prompt turns (user entries with real text, excluding
  *               interrupts, tool_results, and meta/sidechain entries).
  *
@@ -180,14 +184,21 @@ export async function scanTranscriptStop(
   // a newer token snapshot so a previous turn's non-zero total is not mistaken for
   // the just-finished turn. This is bounded to ~1.75s and never loads the whole file
   // repeatedly.
-  const flushedTokens = await waitForCodexUsageFlush(transcriptPath, initial.codexTokens);
-  return flushedTokens ? { ...initial.result, tokens: flushedTokens } : initial.result;
+  const flushedSnapshot = await waitForCodexUsageFlush(transcriptPath, initial.codexSnapshot);
+  return flushedSnapshot
+    ? { ...initial.result, tokens: flushedSnapshot.tokens, tokenScope: flushedSnapshot.scope }
+    : initial.result;
+}
+
+interface CodexTokenSnapshot {
+  tokens: TokenUsage;
+  scope: TokenSnapshotScope;
 }
 
 interface JsonlTranscriptScan {
   result: TranscriptScanResult;
-  /** Latest cumulative Codex snapshot encountered, if this is a Codex transcript. */
-  codexTokens: TokenUsage | null;
+  /** Preferred cumulative Codex snapshot encountered, if this is a Codex transcript. */
+  codexSnapshot: CodexTokenSnapshot | null;
 }
 
 /** Scan the Claude/Codex JSONL transcript once. */
@@ -197,7 +208,8 @@ async function scanJsonlTranscriptOnce(transcriptPath: string): Promise<JsonlTra
   let toolError = 0;
   let prompts = 0;
   const tokens = emptyTokenUsage();
-  let codexTokens: TokenUsage | null = null;
+  let codexSessionSnapshot: CodexTokenSnapshot | null = null;
+  let codexTranscriptSnapshot: CodexTokenSnapshot | null = null;
   // Dedup assistant usage per message (one turn spans many JSONL lines that repeat
   // the same usage). Prefer message.id; fall back to the top-level requestId.
   const countedUsageKeys = new Set<string>();
@@ -205,11 +217,11 @@ async function scanJsonlTranscriptOnce(transcriptPath: string): Promise<JsonlTra
   try {
     const stat = await fs.promises.stat(transcriptPath);
     if (stat.size === 0) {
-      return { result: { interrupt, toolReject, toolError, tokens, prompts }, codexTokens };
+      return { result: { interrupt, toolReject, toolError, tokens, prompts }, codexSnapshot: null };
     }
     if (stat.size > INTERVENTION_SCAN_MAX_BYTES) {
       log.warn(`dashboard: transcript too large to scan (${stat.size} bytes)`);
-      return { result: { interrupt, toolReject, toolError, tokens, prompts }, codexTokens };
+      return { result: { interrupt, toolReject, toolError, tokens, prompts }, codexSnapshot: null };
     }
 
     const rl = readline.createInterface({
@@ -219,8 +231,8 @@ async function scanJsonlTranscriptOnce(transcriptPath: string): Promise<JsonlTra
 
     for await (const line of rl) {
       const trimmed = line.trim();
-      // Cheap pre-filter: Claude uses user/assistant records; Codex Desktop emits
-      // token_usage_record and Codex CLI emits event_msg/token_count records.
+      // Cheap pre-filter: Claude uses user/assistant records; modern Codex emits
+      // token_usage_record and legacy Codex emits event_msg/token_count records.
       if (
         !trimmed || (
           !trimmed.includes('"user"') &&
@@ -246,10 +258,11 @@ async function scanJsonlTranscriptOnce(transcriptPath: string): Promise<JsonlTra
 
       const codexUsage = parseCodexCumulativeUsage(entry);
       if (codexUsage) {
-        // Both supported Codex formats are cumulative. Replacing with the latest
-        // record is essential: summing records would count the whole thread again
-        // after every turn.
-        codexTokens = codexUsage;
+        // Replace within the matching scope. A session-scoped thread record is
+        // authoritative when both formats are present; the legacy transcript-scoped
+        // counter must not be added to it.
+        if (codexUsage.scope === 'session') codexSessionSnapshot = codexUsage;
+        else codexTranscriptSnapshot = codexUsage;
         continue;
       }
 
@@ -322,8 +335,16 @@ async function scanJsonlTranscriptOnce(transcriptPath: string): Promise<JsonlTra
     log.warn(`dashboard: failed to scan transcript: ${(e as Error).message}`);
   }
 
-  const result = { interrupt, toolReject, toolError, tokens: codexTokens ?? tokens, prompts };
-  return { result, codexTokens };
+  const codexSnapshot = codexSessionSnapshot ?? codexTranscriptSnapshot;
+  const result: TranscriptScanResult = {
+    interrupt,
+    toolReject,
+    toolError,
+    tokens: codexSnapshot?.tokens ?? tokens,
+    prompts,
+    ...(codexSnapshot ? { tokenScope: codexSnapshot.scope } : {}),
+  };
+  return { result, codexSnapshot };
 }
 
 /** Narrow an unknown JSON value to an object record. */
@@ -350,18 +371,21 @@ function codexUsageToTokenUsage(usage: Record<string, unknown>): TokenUsage {
   };
 }
 
-/** Parse one cumulative Codex usage record (Desktop or CLI), if present. */
-function parseCodexCumulativeUsage(entry: { type?: string; payload?: unknown }): TokenUsage | null {
+/** Parse one cumulative Codex usage record (modern or legacy), if present. */
+function parseCodexCumulativeUsage(entry: { type?: string; payload?: unknown }): CodexTokenSnapshot | null {
   const payload = asRecord(entry.payload);
-  let usage: Record<string, unknown> | null = null;
 
   if (entry.type === 'token_usage_record') {
-    usage = asRecord(payload?.thread_token_usage);
-  } else if (entry.type === 'event_msg' && payload?.type === 'token_count') {
-    usage = asRecord(asRecord(payload.info)?.total_token_usage);
+    const usage = asRecord(payload?.thread_token_usage);
+    return usage ? { tokens: codexUsageToTokenUsage(usage), scope: 'session' } : null;
   }
 
-  return usage ? codexUsageToTokenUsage(usage) : null;
+  if (entry.type === 'event_msg' && payload?.type === 'token_count') {
+    const usage = asRecord(asRecord(payload.info)?.total_token_usage);
+    return usage ? { tokens: codexUsageToTokenUsage(usage), scope: 'transcript' } : null;
+  }
+
+  return null;
 }
 
 const CODEX_USAGE_TAIL_BYTES = 256 * 1024;
@@ -372,13 +396,24 @@ function isCodexTool(tool: string | undefined): boolean {
   return typeof tool === 'string' && tool.toLowerCase().includes('codex');
 }
 
-function tokenUsageEquals(a: TokenUsage | null, b: TokenUsage): boolean {
-  return a !== null && a.input === b.input && a.output === b.output
-    && a.cacheRead === b.cacheRead && a.cacheCreation === b.cacheCreation;
+function codexSnapshotEquals(a: CodexTokenSnapshot | null, b: CodexTokenSnapshot): boolean {
+  return a !== null && a.scope === b.scope
+    && a.tokens.input === b.tokens.input && a.tokens.output === b.tokens.output
+    && a.tokens.cacheRead === b.tokens.cacheRead
+    && a.tokens.cacheCreation === b.tokens.cacheCreation;
+}
+
+/** Prefer session-scoped records; otherwise keep the latest record in the same scope. */
+function preferCodexSnapshot(
+  current: CodexTokenSnapshot | null,
+  observed: CodexTokenSnapshot,
+): CodexTokenSnapshot {
+  if (current?.scope === 'session' && observed.scope === 'transcript') return current;
+  return observed;
 }
 
 /** Read only the transcript tail and return its latest cumulative Codex snapshot. */
-async function readLatestCodexUsageFromTail(transcriptPath: string): Promise<TokenUsage | null> {
+async function readLatestCodexUsageFromTail(transcriptPath: string): Promise<CodexTokenSnapshot | null> {
   try {
     const stat = await fs.promises.stat(transcriptPath);
     if (stat.size === 0) return null;
@@ -391,17 +426,20 @@ async function readLatestCodexUsageFromTail(transcriptPath: string): Promise<Tok
       const lines = buffer.toString('utf-8').split('\n');
       // When reading a tail slice, the first line may start in the middle of JSON.
       if (offset > 0) lines.shift();
-      let latest: TokenUsage | null = null;
+      let latestSession: CodexTokenSnapshot | null = null;
+      let latestTranscript: CodexTokenSnapshot | null = null;
       for (const line of lines) {
         if (!line.includes('"token_usage_record"') && !line.includes('"token_count"')) continue;
         try {
           const parsed = JSON.parse(line) as { type?: string; payload?: unknown };
-          latest = parseCodexCumulativeUsage(parsed) ?? latest;
+          const snapshot = parseCodexCumulativeUsage(parsed);
+          if (snapshot?.scope === 'session') latestSession = snapshot;
+          else if (snapshot) latestTranscript = snapshot;
         } catch {
           // The final line can be mid-write; a later retry will see it completed.
         }
       }
-      return latest;
+      return latestSession ?? latestTranscript;
     } finally {
       await fh.close();
     }
@@ -413,19 +451,20 @@ async function readLatestCodexUsageFromTail(transcriptPath: string): Promise<Tok
 /** Wait for Codex's post-Stop cumulative token record without rescanning the file. */
 async function waitForCodexUsageFlush(
   transcriptPath: string,
-  initial: TokenUsage | null,
-): Promise<TokenUsage | null> {
+  initial: CodexTokenSnapshot | null,
+): Promise<CodexTokenSnapshot | null> {
   let latest = initial;
   for (let attempt = 1; attempt < CODEX_USAGE_MAX_ATTEMPTS; attempt++) {
     await new Promise((resolve) => setTimeout(resolve, CODEX_USAGE_RETRY_MS));
     const observed = await readLatestCodexUsageFromTail(transcriptPath);
     if (!observed) continue;
-    latest = observed;
+    latest = preferCodexSnapshot(latest, observed);
 
     // A changed cumulative snapshot is the record for the turn that just stopped.
     // For a first-turn session, the transition from no record to non-zero is enough.
-    if (!tokenUsageEquals(initial, observed) && (initial !== null || totalTokenCount(observed) > 0)) {
-      return observed;
+    if (!codexSnapshotEquals(initial, latest)
+      && (initial !== null || totalTokenCount(latest.tokens) > 0)) {
+      return latest;
     }
   }
   return latest;
@@ -822,6 +861,7 @@ export async function parseHookEvent(
     if (scan.tokens.input > 0 || scan.tokens.output > 0
       || scan.tokens.cacheRead > 0 || scan.tokens.cacheCreation > 0) {
       event.tokens = scan.tokens;
+      if (scan.tokenScope) event.tokenScope = scan.tokenScope;
     }
     if (scan.prompts > 0) {
       event.prompts = scan.prompts;
@@ -1034,12 +1074,37 @@ export function rebuildSessions(events: DashboardEvent[]): DashboardSession[] {
   return result;
 }
 
+interface TimedTokenSnapshot {
+  timestamp: string;
+  tokens: TokenUsage;
+}
+
+/**
+ * Keep the chronologically latest snapshot. Stop handlers run in the background,
+ * so append order can differ from hook/event order when two scans overlap.
+ */
+function setLatestTokenSnapshot(
+  snapshots: Map<string, TimedTokenSnapshot>,
+  key: string,
+  event: DashboardEvent,
+): void {
+  if (!event.tokens) return;
+  const current = snapshots.get(key);
+  const candidateTime = Date.parse(event.timestamp);
+  const currentTime = current ? Date.parse(current.timestamp) : Number.NaN;
+  if (!current || !Number.isFinite(candidateTime) || !Number.isFinite(currentTime)
+    || candidateTime >= currentTime) {
+    snapshots.set(key, { timestamp: event.timestamp, tokens: event.tokens });
+  }
+}
+
 /**
  * Aggregate per-session metrics from raw events (no timeout filtering).
  *
- * - interrupt / toolReject / tokens: taken from the latest Stop event's snapshot
- *   (idempotent — a later Stop overrides an earlier one, so re-scanning never
- *   double-counts).
+ * - interrupt / toolReject: taken from the latest Stop event's snapshot.
+ * - tokens: unscoped and session-scoped snapshots use latest-wins. Legacy Codex
+ *   transcript-scoped snapshots use latest-wins per transcript path, then sum the
+ *   distinct rollout segments for the logical session.
  * - correction: a prompt_submit arriving within CORRECTION_WINDOW_MS of a Stop AND
  *   matching a correction keyword. Each Stop is consumed by the next prompt only once.
  * - prompts: total number of prompt_submit events (human conversation turns).
@@ -1056,6 +1121,9 @@ export function aggregateSessionMetrics(
   // - stopPrompts: latest Stop transcript snapshot (compaction/resume-proof).
   const submitCount = new Map<string, number>();
   const stopPrompts = new Map<string, number>();
+  const unscopedTokens = new Map<string, TimedTokenSnapshot>();
+  const sessionTokens = new Map<string, TimedTokenSnapshot>();
+  const transcriptTokens = new Map<string, Map<string, TimedTokenSnapshot>>();
 
   for (const event of events) {
     let m = map.get(event.sessionId);
@@ -1069,9 +1137,23 @@ export function aggregateSessionMetrics(
         m.interrupt = event.interventions.interrupt;
         m.toolReject = event.interventions.toolReject;
       }
-      // Token + prompt snapshots are full cumulative totals — latest wins.
       if (event.tokens) {
-        m.tokens = { ...event.tokens };
+        if (event.tokenScope === 'session') {
+          setLatestTokenSnapshot(sessionTokens, event.sessionId, event);
+        } else if (event.tokenScope === 'transcript' && event.transcriptPath) {
+          let segments = transcriptTokens.get(event.sessionId);
+          if (!segments) {
+            segments = new Map<string, TimedTokenSnapshot>();
+            transcriptTokens.set(event.sessionId, segments);
+          }
+          // A rollout's counter is cumulative within that file. Repeated Stop scans
+          // replace the same segment; a resumed rollout has a distinct path and adds
+          // one new segment to the logical session total.
+          setLatestTokenSnapshot(segments, event.transcriptPath, event);
+        } else {
+          // Claude, CodeBuddy, and pre-existing events retain latest-Stop semantics.
+          setLatestTokenSnapshot(unscopedTokens, event.sessionId, event);
+        }
       }
       if (typeof event.prompts === 'number') {
         stopPrompts.set(event.sessionId, event.prompts);
@@ -1095,6 +1177,19 @@ export function aggregateSessionMetrics(
   // (survives compaction + resume); live submit events cover the period before the
   // first Stop. max() keeps the count monotonic across both.
   for (const [sid, m] of map) {
+    const sessionSnapshot = sessionTokens.get(sid);
+    const segments = transcriptTokens.get(sid);
+    if (sessionSnapshot) {
+      // The newer thread-level counter already spans rollout files.
+      m.tokens = { ...sessionSnapshot.tokens };
+    } else if (segments && segments.size > 0) {
+      let total = emptyTokenUsage();
+      for (const segment of segments.values()) total = addTokenUsage(total, segment.tokens);
+      m.tokens = total;
+    } else {
+      const unscoped = unscopedTokens.get(sid);
+      if (unscoped) m.tokens = { ...unscoped.tokens };
+    }
     m.prompts = Math.max(submitCount.get(sid) ?? 0, stopPrompts.get(sid) ?? 0);
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -648,8 +648,9 @@ export interface UserStats {
    */
   prompts?: number;
   /**
-   * Cumulative token usage across all reported sessions (Claude Code transcripts
-   * only; tools without transcripts contribute nothing). Privacy: counts only.
+   * Cumulative token usage across all reported sessions (Claude Code, CodeBuddy,
+   * and Codex transcripts; tools without token records contribute nothing).
+   * Privacy: counts only.
    */
   tokens?: TokenUsage;
 }
@@ -686,9 +687,9 @@ export interface UserInterventionStats {
 //
 
 /**
- * Token usage breakdown for a session/user, summed from Claude Code transcript
- * `message.usage` records (deduplicated by message id). All fields are cumulative
- * token counts; tools without a transcript (e.g. Cursor) leave these at zero.
+ * Token usage breakdown for a session/user. Claude Code and CodeBuddy usage is
+ * summed per request; Codex uses the latest cumulative transcript snapshot. All
+ * fields are cumulative token counts; tools without token records leave these at zero.
  */
 export interface TokenUsage {
   /** Sum of usage.input_tokens. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -688,8 +688,9 @@ export interface UserInterventionStats {
 
 /**
  * Token usage breakdown for a session/user. Claude Code and CodeBuddy usage is
- * summed per request; Codex uses the latest cumulative transcript snapshot. All
- * fields are cumulative token counts; tools without token records leave these at zero.
+ * summed per request. Codex uses a thread-level cumulative snapshot when available;
+ * legacy rollout-scoped snapshots are summed once per transcript. All fields are
+ * cumulative token counts; tools without token records leave these at zero.
  */
 export interface TokenUsage {
   /** Sum of usage.input_tokens. */
@@ -701,6 +702,9 @@ export interface TokenUsage {
   /** Sum of usage.cache_creation_input_tokens. */
   cacheCreation: number;
 }
+
+/** Scope of a cumulative token snapshot captured from an agent transcript. */
+export type TokenSnapshotScope = 'session' | 'transcript';
 
 /** A fresh zeroed TokenUsage. */
 export function emptyTokenUsage(): TokenUsage {
@@ -733,7 +737,7 @@ export interface SessionMetrics {
   correction: number;
   /** Number of human conversation turns (UserPromptSubmit events). */
   prompts: number;
-  /** Cumulative token usage (latest Stop snapshot). */
+  /** Cumulative token usage across the logical session. */
   tokens: TokenUsage;
 }
 
@@ -777,12 +781,17 @@ export interface DashboardEvent {
    */
   interventions?: { interrupt: number; toolReject: number; toolError?: number };
   /**
-   * Cumulative token usage scanned from the transcript at Stop time. Full snapshot
-   * (idempotent): each Stop carries the running total for the whole session, so a
-   * later Stop overrides an earlier one in rebuildSessions. Absent for tools with
-   * no transcript (e.g. Cursor) and for sessions with no recorded usage.
+   * Cumulative token usage scanned from the transcript at Stop time. Absent for
+   * tools with no transcript (e.g. Cursor) and for sessions with no recorded usage.
    */
   tokens?: TokenUsage;
+  /**
+   * Scope of `tokens` when the producer exposes it. Codex `token_usage_record`
+   * snapshots cover the logical session, while legacy `event_msg.token_count`
+   * snapshots cover one rollout/transcript file. Older events and other agents omit
+   * this field and retain the historical latest-Stop behavior.
+   */
+  tokenScope?: TokenSnapshotScope;
   /**
    * Cumulative count of human prompt turns scanned from the transcript at Stop time.
    * Full snapshot (idempotent), sourced from the non-compactable transcript so the


### PR DESCRIPTION
## Summary

- Add native Codex token usage collection for Desktop `token_usage_record` and CLI `event_msg` / `token_count` transcripts.
- Treat Codex totals as cumulative snapshots, wait for the final post-Stop flush, and split inclusive input/cache buckets without double counting.
- Preserve existing prompts, token totals, and intervention stats when skill usage is merged.
- Update the usage guide for Claude Code, CodeBuddy, and Codex token sources.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing behavior to change)
- [ ] Documentation only
- [ ] Refactor / internal cleanup

## Test Plan

- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npx vitest run src/__tests__/dashboard-collector.test.ts src/__tests__/conversation-token-metrics.test.ts` (99 passed)
- [x] `npx vitest run --config vitest.e2e.config.ts src/__tests__/conversation-token-e2e.test.ts` (2 passed)
- [x] `npx vitest run src/__tests__/usage-tracking.test.ts -t mergeStats` (6 passed)

Full `npm test` on Windows completed with 2,552 passing and 91 pre-existing platform/environment failures (POSIX path, permission-mode, and bash assumptions); all tests covering the changed behavior pass.

## Notes for Reviewers

Codex reports inclusive `input_tokens` and cumulative thread totals. The collector uses the latest cumulative snapshot and maps cached/cache-write subsets into TeamAI's disjoint buckets so the digest total is not inflated. The Stop collector runs in the existing detached background handler, so the bounded flush wait does not delay the agent UI.