### PR TITLE
refactor(cli): rename `install` command to `packages`

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,11 +168,11 @@ The add/remove change takes effect locally right away, and subscribed skills syn
 Share and restore the team's npm packages and Claude Code plugins:
 
 ```bash
-teamai install typescript
-teamai install typescript@5.9.2 --npm
-teamai install code-review@claude-plugins-official
+teamai packages install typescript
+teamai packages install typescript@5.9.2 --npm
+teamai packages install code-review@claude-plugins-official
 teamai push       # Share the declarations
-teamai install    # Install everything declared by the team
+teamai packages    # Install everything declared by the team
 ```
 
 See the [Usage Guide](docs/usage-guide.md#team-packages) for the complete workflow and configuration.
@@ -259,7 +259,7 @@ Insight into how the team actually uses its AI tools, and a starting point for t
 | `teamai init` | Initialize: OAuth login, link repo, register member, inject hooks |
 | `teamai pull` | Pull team resources and inject into local AI tools |
 | `teamai push` | Push local resources to a branch and open a Merge Request |
-| `teamai install [target]` | Install declared npm packages and Claude plugins; with a target, also update `teamai.yaml` |
+| `teamai packages [install] [target]` | Install declared npm packages and Claude plugins; with a target, also update `teamai.yaml`. Bare `teamai packages` installs everything; `teamai packages install <target>` adds one |
 | `teamai status` | Show local vs team repo diff |
 | `teamai contribute` | Share session experience to team repo |
 | `teamai recall <query>` | Search the team knowledge base (BM25 + graph-boost) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -168,11 +168,11 @@ teamai source remove other-team
 共享并一键恢复团队的 npm 包和 Claude Code 插件：
 
 ```bash
-teamai install typescript
-teamai install typescript@5.9.2 --npm
-teamai install code-review@claude-plugins-official
+teamai packages install typescript
+teamai packages install typescript@5.9.2 --npm
+teamai packages install code-review@claude-plugins-official
 teamai push       # 分享团队声明
-teamai install    # 安装团队声明的全部包
+teamai packages    # 安装团队声明的全部包
 ```
 
 完整工作流和配置见[使用指南](docs/usage-guide.zh-CN.md#团队包)。
@@ -259,7 +259,7 @@ WASM 解析器是纯 JavaScript 依赖，无需任何原生编译工具链。若
 | `teamai init` | 初始化：OAuth 登录、关联仓库、注册成员、注入 hooks |
 | `teamai pull` | 拉取团队资源并注入到本地 AI 工具 |
 | `teamai push` | 推送本地资源到分支并创建合并请求 |
-| `teamai install [target]` | 安装团队 npm 包和 Claude 插件；带 target 时同步更新声明 |
+| `teamai packages [install] [target]` | 安装团队 npm 包和 Claude 插件。裸 `teamai packages` 安装全部；`teamai packages install <target>` 添加单个并更新声明 |
 | `teamai status` | 显示本地与团队仓库的差异 |
 | `teamai contribute` | 将 session 经验分享到团队仓库 |
 | `teamai recall <query>` | 搜索团队知识库（BM25 + 图谱增强） |

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -60,7 +60,7 @@ TeamAI's product is one loop, not three separate products:
 | **Rules** | Markdown-formatted team conventions, automatically merged into AI tool configs |
 | **Docs** | Shared team documentation for the AI to reference |
 | **Env** | Shared team environment variables, automatically injected into the shell |
-| **Packages** | Team-wide npm packages and Claude Code plugins, installed explicitly with `teamai install` |
+| **Packages** | Team-wide npm packages and Claude Code plugins, installed explicitly with `teamai packages` |
 
 ```
 ┌───────────────┐    teamai push (MR)    ┌───────────────────┐
@@ -329,7 +329,7 @@ With role-based skills enabled, `pull`'s skill sync source becomes the contents 
 
 ### Team packages
 
-`teamai install` lets a team declare and restore npm packages and Claude Code plugins through the existing team repository. TeamAI invokes the native `npm` and `claude plugin` CLIs; it does not distribute package contents itself.
+`teamai packages` lets a team declare and restore npm packages and Claude Code plugins through the existing team repository. TeamAI invokes the native `npm` and `claude plugin` CLIs; it does not distribute package contents itself.
 
 **Admin operations:**
 
@@ -337,17 +337,17 @@ Passing a target installs it and adds its declaration to the team repo's `teamai
 
 ```bash
 # npm package (project dependency by default)
-teamai install typescript
+teamai packages install typescript
 
 # Unscoped name@version is ambiguous with plugin@marketplace; identify npm explicitly
-teamai install typescript@5.9.2 --npm
+teamai packages install typescript@5.9.2 --npm
 
 # Global npm CLI from a specific registry
-teamai install eslint@latest --global \
+teamai packages install eslint@latest --global \
   --registry https://registry.npmjs.org/
 
 # Claude plugin
-teamai install code-review@claude-plugins-official
+teamai packages install code-review@claude-plugins-official
 
 # Share the updated teamai.yaml through the normal review flow
 teamai push
@@ -362,8 +362,8 @@ A Claude plugin target uses `plugin@marketplace`. The official `claude-plugins-o
 The existing SessionStart hook runs `teamai pull`. When the `packages` declaration changes, it asks the member to review `teamai.yaml` and install explicitly; it never runs third-party package or plugin code automatically. Pull remains detached so network latency cannot block the IDE. If a declaration arrives after the SessionStart output window, TeamAI safely queues the same notice for the next UserPromptSubmit in that session.
 
 ```bash
-teamai install             # Install every team declaration
-teamai install --dry-run   # Preview native commands without installing or writing files
+teamai packages             # Install every team declaration
+teamai packages --dry-run   # Preview native commands without installing or writing files
 teamai doctor              # Check runtimes and declared package/marketplace/plugin status
 ```
 
@@ -371,7 +371,7 @@ After a successful install, TeamAI writes a local snapshot to `teamai.lock` unde
 
 **Declaration format:**
 
-`teamai install <target>` manages this section automatically:
+`teamai packages install <target>` manages this section automatically:
 
 ```yaml
 packages:

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -59,7 +59,7 @@ TeamAI 的产品是一条闭环，而不是三个独立产品：
 | **Rules** | Markdown 格式的团队规范，自动合并到 AI 工具配置中 |
 | **Docs** | 团队共享文档，供 AI 参考 |
 | **Env** | 团队共享环境变量，自动注入 shell |
-| **Packages** | 全团队统一的 npm 包和 Claude Code 插件，通过 `teamai install` 主动安装 |
+| **Packages** | 全团队统一的 npm 包和 Claude Code 插件，通过 `teamai packages` 主动安装 |
 
 ```
 ┌───────────────┐    teamai push (MR)    ┌───────────────────┐
@@ -327,7 +327,7 @@ teamai pull --dry-run    # 试运行，不实际修改
 
 ### 团队包
 
-`teamai install` 通过现有团队仓库统一声明和恢复 npm 包与 Claude Code 插件。TeamAI 调用原生 `npm` 和 `claude plugin` CLI，不自行分发包内容。
+`teamai packages` 通过现有团队仓库统一声明和恢复 npm 包与 Claude Code 插件。TeamAI 调用原生 `npm` 和 `claude plugin` CLI，不自行分发包内容。
 
 **管理员操作：**
 
@@ -335,17 +335,17 @@ teamai pull --dry-run    # 试运行，不实际修改
 
 ```bash
 # npm 包（默认安装为项目依赖）
-teamai install typescript
+teamai packages install typescript
 
 # 未带 scope 的 name@version 与 plugin@marketplace 有歧义，需显式指定 npm
-teamai install typescript@5.9.2 --npm
+teamai packages install typescript@5.9.2 --npm
 
 # 从指定 registry 安装全局 npm CLI
-teamai install eslint@latest --global \
+teamai packages install eslint@latest --global \
   --registry https://registry.npmjs.org/
 
 # Claude 插件
-teamai install code-review@claude-plugins-official
+teamai packages install code-review@claude-plugins-official
 
 # 通过现有评审流程分享更新后的 teamai.yaml
 teamai push
@@ -360,8 +360,8 @@ Claude 插件 target 使用 `plugin@marketplace` 格式。`claude-plugins-offici
 现有 SessionStart hook 会执行 `teamai pull`。当 `packages` 声明发生变化时，它只会提示成员检查 `teamai.yaml` 并主动安装，不会自动执行第三方包或插件代码。pull 继续在后台运行，避免网络延迟阻塞 IDE；如果声明在 SessionStart 输出窗口结束后才拉取完成，TeamAI 会把同一条提示安全地排队，并在本会话下一次 UserPromptSubmit 时投递。
 
 ```bash
-teamai install             # 安装团队声明的全部包和插件
-teamai install --dry-run   # 预览底层命令，不安装也不写文件
+teamai packages             # 安装团队声明的全部包和插件
+teamai packages --dry-run   # 预览底层命令，不安装也不写文件
 teamai doctor              # 检查运行环境及声明的包、marketplace、插件状态
 ```
 
@@ -369,7 +369,7 @@ teamai doctor              # 检查运行环境及声明的包、marketplace、�
 
 **声明格式：**
 
-以下内容由 `teamai install <target>` 自动维护：
+以下内容由 `teamai packages install <target>` 自动维护：
 
 ```yaml
 packages:

--- a/src/__tests__/e2e/e2e.test.ts
+++ b/src/__tests__/e2e/e2e.test.ts
@@ -83,9 +83,19 @@ describe('CLI basics', () => {
 
   it('--help should list core commands', async () => {
     const { output } = await runCLI(['--help']);
-    for (const cmd of ['init', 'pull', 'push', 'status', 'members', 'tags', 'uninstall']) {
+    for (const cmd of ['init', 'pull', 'push', 'status', 'members', 'tags', 'packages', 'uninstall']) {
       expect(output).toContain(cmd);
     }
+  });
+
+  it('teamai packages exposes an install subcommand', async () => {
+    const pkgHelp = await runCLI(['packages', '--help']);
+    const installHelp = await runCLI(['packages', 'install', '--help']);
+    expect(pkgHelp.code).toBe(0);
+    expect(installHelp.code).toBe(0);
+    // Parent lists the install subcommand; the subcommand is reachable.
+    expect(pkgHelp.output).toContain('install');
+    expect(installHelp.output).toContain('Install team npm packages and Claude plugins');
   });
 });
 

--- a/src/__tests__/hook-handlers.test.ts
+++ b/src/__tests__/hook-handlers.test.ts
@@ -321,7 +321,7 @@ describe('hook-handlers registry', () => {
   });
 
   it('delivers a post-pull package hint on prompt-submit for Claude', async () => {
-    mockTakePendingPackageHint.mockResolvedValue('Run `teamai install`');
+    mockTakePendingPackageHint.mockResolvedValue('Run `teamai packages`');
     const handler = buildHandlerRegistry().find(
       (r) => r.event === 'prompt-submit' && r.handler.name === 'package-pending-hint',
     )!.handler;
@@ -329,7 +329,7 @@ describe('hook-handlers registry', () => {
     const output = await handler.execute({ session_id: 's6', cwd: '/x' }, 'claude');
 
     expect(JSON.parse(output!).hookSpecificOutput.additionalContext)
-      .toBe('Run `teamai install`');
+      .toBe('Run `teamai packages`');
   });
 
   it('post-tool-use wildcard has dashboard-report', () => {

--- a/src/__tests__/pkg-hint.test.ts
+++ b/src/__tests__/pkg-hint.test.ts
@@ -70,7 +70,7 @@ describe('package SessionStart hint', () => {
     const output = await computePackageHintOutput(cwd);
     expect(output).not.toBeNull();
     const parsed = JSON.parse(output!);
-    expect(parsed.hookSpecificOutput.additionalContext).toContain('teamai install');
+    expect(parsed.hookSpecificOutput.additionalContext).toContain('teamai packages');
     expect(parsed.hookSpecificOutput.additionalContext).toContain('never installs');
   });
 
@@ -105,7 +105,7 @@ describe('package SessionStart hint', () => {
 
     try {
       expect(await computePackageHintOutput(cwd)).toBeNull();
-      expect(await computePackageHintOutput(otherProject)).toContain('teamai install');
+      expect(await computePackageHintOutput(otherProject)).toContain('teamai packages');
     } finally {
       fs.rmSync(otherProject, { recursive: true, force: true });
     }
@@ -128,7 +128,7 @@ describe('package SessionStart hint', () => {
     await stashPackageHintAfterPull(cwd, 'session-1', beforeHash);
 
     expect(await claimPackageHintOutput(cwd, 'session-1')).toBeNull();
-    expect(await takePendingPackageHint('session-1')).toContain('teamai install');
+    expect(await takePendingPackageHint('session-1')).toContain('teamai packages');
     expect(await takePendingPackageHint('session-1')).toBeNull();
   });
 });

--- a/src/__tests__/pkg-register-command.test.ts
+++ b/src/__tests__/pkg-register-command.test.ts
@@ -1,0 +1,64 @@
+import { Command } from 'commander';
+import { describe, expect, it, vi } from 'vitest';
+import { registerPackagesCommand } from '../pkg/register-command.js';
+import type { GlobalOptions } from '../types.js';
+
+/**
+ * Regression test for the P1 where install options declared on the `packages`
+ * parent (--global, --registry, --npm, --claude) were silently dropped when
+ * invoked via the `packages install` subcommand, because the action merged only
+ * the root global options and the subcommand's own options — never the parent's.
+ *
+ * This drives the REAL command wiring (registerPackagesCommand) through
+ * commander's parser and asserts exactly which options reach pkgInstall.
+ */
+function buildProgram() {
+  const run = vi.fn(async (_target: string | undefined, _opts: GlobalOptions) => {});
+  const program = new Command();
+  program.exitOverride(); // throw instead of process.exit on parse errors
+  // Root global options, same as the real teamai program.
+  program.option('--dry-run').option('-v, --verbose');
+  registerPackagesCommand(program, run);
+  return { program, run };
+}
+
+async function parse(program: Command, args: string[]) {
+  await program.parseAsync(args, { from: 'user' });
+}
+
+describe('packages command option wiring', () => {
+  it('passes --global and --registry through the install subcommand', async () => {
+    const { program, run } = buildProgram();
+    await parse(program, [
+      'packages',
+      'install',
+      'private-tool',
+      '--global',
+      '--registry',
+      'https://registry.example.test',
+      '--dry-run',
+    ]);
+    expect(run).toHaveBeenCalledTimes(1);
+    const [target, opts] = run.mock.calls[0]!;
+    expect(target).toBe('private-tool');
+    expect(opts.global).toBe(true);
+    expect(opts.registry).toBe('https://registry.example.test');
+    expect(opts.dryRun).toBe(true);
+  });
+
+  it('passes --npm through the install subcommand', async () => {
+    const { program, run } = buildProgram();
+    await parse(program, ['packages', 'install', 'typescript@5.9.2', '--npm']);
+    const [target, opts] = run.mock.calls[0]!;
+    expect(target).toBe('typescript@5.9.2');
+    expect(opts.npm).toBe(true);
+  });
+
+  it('passes install options through the bare default action too', async () => {
+    const { program, run } = buildProgram();
+    await parse(program, ['packages', 'private-tool', '--global']);
+    const [target, opts] = run.mock.calls[0]!;
+    expect(target).toBe('private-tool');
+    expect(opts.global).toBe(true);
+  });
+});

--- a/src/__tests__/pkg-team-distribution.test.ts
+++ b/src/__tests__/pkg-team-distribution.test.ts
@@ -233,7 +233,7 @@ describe('team package distribution flow', () => {
       { cwd: teammateProject },
       'claude',
     );
-    expect(hint).toContain('teamai install');
+    expect(hint).toContain('teamai packages');
 
     mocks.npmInstall.mockClear();
     await pkgInstall(undefined, {});

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { createRequire } from 'node:module';
 import { Command, Option } from 'commander';
 import { setVerbose, setSilent, log } from './utils/logger.js';
 import type { GlobalOptions } from './types.js';
+import { registerPackagesCommand } from './pkg/register-command.js';
 
 const require = createRequire(import.meta.url);
 const { version } = require('../package.json');
@@ -179,18 +180,7 @@ program
     await remove(type, names, globalOpts);
   });
 
-program
-  .command('install [target]')
-  .description('Install team npm packages and Claude plugins declared in teamai.yaml')
-  .option('-g, --global', 'Install an npm target globally (for CLI tools)')
-  .option('--registry <url>', 'Use a specific npm registry for this target')
-  .option('--npm', 'Treat an ambiguous target as an npm package')
-  .option('--claude', 'Treat the target as a Claude plugin')
-  .action(async (target: string | undefined, cmdOpts) => {
-    const globalOpts = program.opts() as GlobalOptions;
-    const { pkgInstall } = await import('./pkg/commands.js');
-    await pkgInstall(target, { ...globalOpts, ...cmdOpts });
-  });
+registerPackagesCommand(program);
 
 program
   .command('doctor')

--- a/src/pkg/commands.ts
+++ b/src/pkg/commands.ts
@@ -201,7 +201,7 @@ export async function pkgInstall(
   if (!target && (options.global || options.registry || options.npm || options.claude)) {
     throw new Error('--global, --registry, --npm, and --claude require a package target');
   }
-  if (target) assertNotReadOnly(localConfig, 'teamai install <target>');
+  if (target) assertNotReadOnly(localConfig, 'teamai packages install <target>');
   const added = target ? await addTarget(target, manifest, claude, options) : undefined;
   if (!hasPackageDeclarations(manifest)) {
     log.info('No packages are declared in teamai.yaml');
@@ -355,6 +355,6 @@ export async function pkgDoctorReport(
       if (!ok) allPassed = false;
     }
   }
-  if (!allPassed) lines.push('    → Run `teamai install`');
+  if (!allPassed) lines.push('    → Run `teamai packages`');
   return { lines, allPassed };
 }

--- a/src/pkg/pkg-hint.ts
+++ b/src/pkg/pkg-hint.ts
@@ -32,7 +32,7 @@ export function buildPackageHintMessage(
   ].filter(Boolean).join(' and ');
   return [
     `[teamai:pkg-hint] Team package declarations changed (${summary}).`,
-    'Review the packages section, then run `teamai install` to apply it.',
+    'Review the packages section, then run `teamai packages` to apply it.',
     'TeamAI never installs third-party package or plugin code automatically at SessionStart.',
   ].join('\n');
 }

--- a/src/pkg/register-command.ts
+++ b/src/pkg/register-command.ts
@@ -1,0 +1,57 @@
+import type { Command } from 'commander';
+import type { GlobalOptions } from '../types.js';
+
+// Options shared by the `packages` parent (default action) and its `install`
+// subcommand, so `teamai packages` and `teamai packages install` both accept
+// the same flags.
+function addInstallOptions(cmd: Command): Command {
+  return cmd
+    .option('-g, --global', 'Install an npm target globally (for CLI tools)')
+    .option('--registry <url>', 'Use a specific npm registry for this target')
+    .option('--npm', 'Treat an ambiguous target as an npm package')
+    .option('--claude', 'Treat the target as a Claude plugin');
+}
+
+/**
+ * Register the `packages` command (with its `install` subcommand) on `program`.
+ * Exported so tests can drive the real command wiring through commander's parser.
+ *
+ * `run` defaults to the real `pkgInstall`; tests inject a spy to assert exactly
+ * which options reach it. Each action resolves options via optsWithGlobals(),
+ * which merges the command's own options with every ancestor's — so install
+ * options declared on the `packages` parent (--global, --registry, --npm,
+ * --claude) are still passed when invoked via `packages install`, not only the
+ * root global options such as --dry-run.
+ */
+export function registerPackagesCommand(
+  program: Command,
+  run: (target: string | undefined, opts: GlobalOptions) => Promise<void> = async (
+    target,
+    opts,
+  ) => {
+    const { pkgInstall } = await import('./commands.js');
+    await pkgInstall(target, opts);
+  },
+): Command {
+  const invoke = (target: string | undefined, command: Command) =>
+    run(target, command.optsWithGlobals() as GlobalOptions);
+
+  const packagesCmd = addInstallOptions(
+    program
+      .command('packages [target]')
+      .description('Install team npm packages and Claude plugins declared in teamai.yaml'),
+  ).action(async (target: string | undefined, _opts, command: Command) => {
+    // Default action: install (equivalent to `teamai packages install`).
+    await invoke(target, command);
+  });
+
+  addInstallOptions(
+    packagesCmd
+      .command('install [target]')
+      .description('Install team npm packages and Claude plugins declared in teamai.yaml'),
+  ).action(async (target: string | undefined, _opts, command: Command) => {
+    await invoke(target, command);
+  });
+
+  return packagesCmd;
+}


### PR DESCRIPTION
## What & Why

The package-install command was added recently (PR #380) as `teamai install`. **It has not shipped in any stable release yet** — it landed after `v0.22.0` and currently exists only in unreleased code / `0.23.0-beta`. Since no released version ever exposed `teamai install`, this is a **clean rename with no backward-compat alias**.

The name reads awkwardly:

- It sits next to the unrelated `teamai uninstall` (a full machine teardown), creating a **false install/uninstall pairing**.
- `install` suggests installing teamai itself, rather than applying the `packages` section of `teamai.yaml`.

This restructures it as a **`packages` namespace with an `install` subcommand**, leaving room for a future `packages uninstall` (not added in this PR):

| Command | Behavior |
|---------|----------|
| `teamai packages` | Install every declaration (default action) |
| `teamai packages install [target]` | Install; with a target, also add it to `teamai.yaml` |

The old `teamai install` is **removed entirely** (no alias): `teamai install` now returns `error: unknown command 'install'`.

## P1 fixed during review: install options dropped by the subcommand

A reviewer caught a P1 in an earlier revision: `--global`, `--registry`, `--npm`, `--claude` are declared on the `packages` **parent**, and the action merged only the root globals + the subcommand's own options — so invoking `packages install <target> --global --registry <url>` **silently dropped both flags**. Impact: private packages would hit the default npm registry, `--global` CLI tools would install into the project, and `--npm` would fail to disambiguate `name@value`.

**Fix:** each action resolves options via commander's `optsWithGlobals()`, which merges the command's own options with every ancestor's (root globals + `packages` parent + subcommand).

**Verification that the test actually catches the bug:** the command registration is extracted to `src/pkg/register-command.ts` (exported) so `pkg-register-command.test.ts` drives the **real** wiring through commander's parser and asserts every install option reaches `pkgInstall`. Reintroducing the pre-fix merge made those assertions fail, confirming the test's discriminating power.

## Changes

- `src/pkg/register-command.ts` (new): `packages` parent (default action) + `install` subcommand; options via `optsWithGlobals()`
- `src/index.ts`: register via `registerPackagesCommand(program)`
- `src/pkg/commands.ts`, `src/pkg/pkg-hint.ts`: hint/error strings updated
- Docs (README / usage-guide, both `en` + `zh-CN`): updated + document the parent/subcommand split
- Tests: `pkg-register-command.test.ts` (option-passing regression); updated `pkg-hint` / `pkg-team-distribution` / `hook-handlers`; e2e covers the `install` subcommand

## Test Plan

All against the real built CLI (`npm run build` first).

| Check | Result |
|-------|--------|
| `npx tsc --noEmit` | ✅ pass |
| `npm run build` | ✅ pass |
| **Full unit suite** `npx vitest run` | ✅ 2671 passed (195 files) |
| Option-passing regression (`pkg-register-command`) | ✅ 3 passed; verified to FAIL against pre-fix wiring |
| e2e: core-commands list + `packages` install subcommand | ✅ 2 passed |
| `node dist/index.js packages --help` | ✅ `Usage: teamai packages` (no alias), lists `install` subcommand |
| `node dist/index.js packages install --help` | ✅ shows `--global` / `--registry` / `--npm` / `--claude` |
| `node dist/index.js install` | ✅ `error: unknown command 'install'` |
