### PR TITLE
fix(stats): preserve interventions/prompts/tokens across partial reports

### DIFF
--- a/src/__tests__/team-push-interventions.test.ts
+++ b/src/__tests__/team-push-interventions.test.ts
@@ -91,3 +91,86 @@ describe('reportUsageToTeam — intervention reporting', () => {
     expect(fs.existsSync(path.join(repoDir, 'stats', 'me.yaml'))).toBe(false);
   });
 });
+
+describe('reportUsageToTeam — preserve fields across partial reports (Issue #425)', () => {
+  it('keeps interventions when a follow-up report is tokens-only', async () => {
+    const ts = new Date().toISOString();
+    // Report 1: interventions + prompts/tokens together
+    writeDashboardEvents([
+      { type: 'session_start', timestamp: ts, sessionId: 's1', tool: 'claude', cwd: '/p' },
+      { type: 'prompt_submit', timestamp: ts, sessionId: 's1', tool: 'claude', promptSummary: 'hi' },
+      {
+        type: 'stop', timestamp: ts, sessionId: 's1', tool: 'claude',
+        interventions: { interrupt: 2, toolReject: 1 },
+        tokens: { input: 10, output: 5, cacheRead: 0, cacheCreation: 0 },
+      },
+    ]);
+    await reportUsageToTeam(repoDir, 'me');
+
+    const statsPath = path.join(repoDir, 'stats', 'me.yaml');
+    let stats = YAML.parse(fs.readFileSync(statsPath, 'utf-8'));
+    expect(stats.interventions).toEqual({ sessions: 1, interrupt: 2, toolReject: 1, correction: 0 });
+    expect(stats.prompts).toBe(1);
+    expect(stats.tokens).toEqual({ input: 10, output: 5, cacheRead: 0, cacheCreation: 0 });
+
+    // Report 2: tokens/prompts advance only — same intervention counts (no intervention delta)
+    writeDashboardEvents([
+      { type: 'session_start', timestamp: ts, sessionId: 's1', tool: 'claude', cwd: '/p' },
+      { type: 'prompt_submit', timestamp: ts, sessionId: 's1', tool: 'claude', promptSummary: 'hi' },
+      { type: 'prompt_submit', timestamp: ts, sessionId: 's1', tool: 'claude', promptSummary: 'more' },
+      {
+        type: 'stop', timestamp: ts, sessionId: 's1', tool: 'claude',
+        interventions: { interrupt: 2, toolReject: 1 },
+        tokens: { input: 50, output: 20, cacheRead: 0, cacheCreation: 0 },
+      },
+    ]);
+    pushRepoDirectly.mockClear();
+    await reportUsageToTeam(repoDir, 'me');
+
+    stats = YAML.parse(fs.readFileSync(statsPath, 'utf-8'));
+    // Must still have interventions after a tokens-only report
+    expect(stats.interventions).toEqual({ sessions: 1, interrupt: 2, toolReject: 1, correction: 0 });
+    expect(stats.prompts).toBe(2);
+    expect(stats.tokens).toEqual({ input: 50, output: 20, cacheRead: 0, cacheCreation: 0 });
+    expect(pushRepoDirectly).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps prompts/tokens when a follow-up report is intervention-only', async () => {
+    const ts = new Date().toISOString();
+    // Report 1: prompts/tokens only (no intervention counts yet)
+    writeDashboardEvents([
+      { type: 'session_start', timestamp: ts, sessionId: 's1', tool: 'claude', cwd: '/p' },
+      { type: 'prompt_submit', timestamp: ts, sessionId: 's1', tool: 'claude', promptSummary: 'hi' },
+      {
+        type: 'stop', timestamp: ts, sessionId: 's1', tool: 'claude',
+        tokens: { input: 10, output: 5, cacheRead: 0, cacheCreation: 0 },
+      },
+    ]);
+    await reportUsageToTeam(repoDir, 'me');
+
+    const statsPath = path.join(repoDir, 'stats', 'me.yaml');
+    let stats = YAML.parse(fs.readFileSync(statsPath, 'utf-8'));
+    expect(stats.prompts).toBe(1);
+    expect(stats.tokens).toEqual({ input: 10, output: 5, cacheRead: 0, cacheCreation: 0 });
+
+    // Report 2: interventions only — same prompts/tokens (no prompt/token delta)
+    writeDashboardEvents([
+      { type: 'session_start', timestamp: ts, sessionId: 's1', tool: 'claude', cwd: '/p' },
+      { type: 'prompt_submit', timestamp: ts, sessionId: 's1', tool: 'claude', promptSummary: 'hi' },
+      {
+        type: 'stop', timestamp: ts, sessionId: 's1', tool: 'claude',
+        interventions: { interrupt: 1, toolReject: 0 },
+        tokens: { input: 10, output: 5, cacheRead: 0, cacheCreation: 0 },
+      },
+    ]);
+    pushRepoDirectly.mockClear();
+    await reportUsageToTeam(repoDir, 'me');
+
+    stats = YAML.parse(fs.readFileSync(statsPath, 'utf-8'));
+    expect(stats.interventions).toEqual({ sessions: 1, interrupt: 1, toolReject: 0, correction: 0 });
+    // Must still have prompts/tokens after an intervention-only report
+    expect(stats.prompts).toBe(1);
+    expect(stats.tokens).toEqual({ input: 10, output: 5, cacheRead: 0, cacheCreation: 0 });
+    expect(pushRepoDirectly).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/usage-tracking.test.ts
+++ b/src/__tests__/usage-tracking.test.ts
@@ -848,6 +848,25 @@ describe('mergeStats', () => {
     const result = mergeStats(existing, 'alice', []);
     expect(result.skills.tdd.count).toBe(10);
   });
+
+  it('preserves interventions/prompts/tokens when only skills are refreshed (Issue #425)', () => {
+    const existing: UserStats = {
+      username: 'alice',
+      updatedAt: '2026-03-19T10:00:00Z',
+      skills: {
+        tdd: { count: 10, lastUsed: '2026-03-18T10:00:00Z' },
+      },
+      interventions: { sessions: 2, interrupt: 3, toolReject: 1, correction: 0 },
+      prompts: 7,
+      tokens: { input: 100, output: 20, cacheRead: 5, cacheCreation: 1 },
+    };
+
+    const result = mergeStats(existing, 'alice', []);
+    expect(result.skills.tdd.count).toBe(10);
+    expect(result.interventions).toEqual(existing.interventions);
+    expect(result.prompts).toBe(7);
+    expect(result.tokens).toEqual(existing.tokens);
+  });
 });
 
 // ─── trackSlashCommand tests ──────────────────────────

--- a/src/team-push.ts
+++ b/src/team-push.ts
@@ -109,6 +109,12 @@ export function mergeStats(
     username,
     updatedAt: new Date().toISOString(),
     skills,
+    // Preserve session metrics across partial reports (Issue #425).
+    // mergeStats only refreshes skills/username/updatedAt; callers overwrite
+    // interventions/prompts/tokens when that report carries a non-empty delta.
+    ...(existing?.interventions !== undefined ? { interventions: existing.interventions } : {}),
+    ...(existing?.prompts !== undefined ? { prompts: existing.prompts } : {}),
+    ...(existing?.tokens !== undefined ? { tokens: existing.tokens } : {}),
   };
 }
 
@@ -413,7 +419,8 @@ export async function reportUsageToTeam(
       const statsPath = path.join(statsDir, `${username}.yaml`);
 
       // See also: stats.ts mergeLocalAndReported() — same merge logic for display.
-      // mergeStats with [] preserves existing skills while refreshing username/updatedAt.
+      // mergeStats with [] preserves existing skills while refreshing username/updatedAt,
+      // and carries interventions/prompts/tokens so partial reports do not clobber them (#425).
       const existing = await readExistingStats(statsPath);
       const newStats = hasUsage ? aggregateUsage(events) : [];
       const merged = mergeStats(existing, username, newStats);


### PR DESCRIPTION
## Summary

`reportUsageToTeam` dropped previously reported session metrics whenever a later auto-report only carried one kind of delta. A token-only write erased `interventions` (sessions); an intervention-only write erased `prompts`/`tokens`. `mergeStats` now carries those fields through, so partial reports no longer clobber them.

Fixes #425

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing behavior to change)
- [ ] Documentation only
- [ ] Refactor / internal cleanup

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` passes
- [x] Added/updated tests for the change

Regression coverage:

- `src/__tests__/usage-tracking.test.ts`: `mergeStats` keeps existing `interventions`/`prompts`/`tokens` when only skills are refreshed.
- `src/__tests__/team-push-interventions.test.ts`: end-to-end `reportUsageToTeam` path — tokens-only follow-up keeps sessions; intervention-only follow-up keeps prompts/tokens.

## Related Issues

Fixes #425

## Notes for Reviewers

`mergeStats` is the shared rebuild of `stats/<user>.yaml`. It always returned `{ username, updatedAt, skills }`, and the write site only re-attached `interventions` / `prompts` / `tokens` when that report had a non-empty delta. Carrying the existing fields through `mergeStats` is the smallest style-matching fix; the write-site `if (hasInterventions)` / `if (hasPromptTokens)` merge still overwrites the carried values when a real delta exists.

`stats.ts` `mergeLocalAndReported` is display-only (skills) and did not need a change.