### PR TITLE
feat(contribute): recognize Japanese course-correction prompts

### DIFF
--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -1072,7 +1072,7 @@ Each session card shows a `⚠ N` badge, counting the **number of human interven
 |------|------|----------|
 | `interrupt` | User pressed ESC to interrupt the agent mid-execution | An interrupted turn in the transcript |
 | `toolReject` | User rejected a tool call (permission deny) | A tool_result marked as rejected in the transcript |
-| `correction` | Within 60s after the agent stops, the user submits a follow-up prompt containing a correction keyword ("not right" / "redo" / "wrong" / etc.) | The stop → prompt_submit event pattern |
+| `correction` | Within 60s after the agent stops, the user submits a follow-up prompt containing a correction keyword ("not right" / "redo" / "wrong" / 「違う」 / 「やり直し」 / etc. — Chinese, English and Japanese) | The stop → prompt_submit event pattern |
 
 > Privacy: only counts are tracked — no prompt or transcript text is ever stored.
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -1067,7 +1067,7 @@ teamai dashboard --port 8080
 |------|------|----------|
 | `interrupt` | 用户在 agent 执行中途按 ESC 打断 | transcript 中被中断的 turn |
 | `toolReject` | 用户拒绝某个工具调用（permission deny） | transcript 中标记拒绝的 tool_result |
-| `correction` | agent stop 后 60s 内用户追加含「不对 / 重来 / 错了 / wrong / redo」等纠偏词的 prompt | stop → prompt_submit 事件模式 |
+| `correction` | agent stop 后 60s 内用户追加含「不对 / 重来 / 错了 / wrong / redo / 違う / やり直し」等纠偏词（中、英、日）的 prompt | stop → prompt_submit 事件模式 |
 
 > 隐私：只统计**次数**，不落地任何 prompt 或 transcript 原文。
 

--- a/src/__tests__/dashboard-collector.test.ts
+++ b/src/__tests__/dashboard-collector.test.ts
@@ -699,6 +699,26 @@ describe('rebuildSessions interventions', () => {
     expect(sessions[0].interventions.correction).toBe(0);
   });
 
+  it('counts a Japanese correction prompt within the window', () => {
+    const t0 = new Date();
+    const sessions = rebuildSessions([
+      { type: 'session_start', timestamp: t0.toISOString(), sessionId: 's1', tool: 'claude', cwd: '/p' },
+      { type: 'stop', timestamp: t0.toISOString(), sessionId: 's1', tool: 'claude' },
+      { type: 'prompt_submit', timestamp: new Date(t0.getTime() + 10_000).toISOString(), sessionId: 's1', tool: 'claude', promptSummary: '違う、そうじゃない。やり直して' },
+    ]);
+    expect(sessions[0].interventions.correction).toBe(1);
+  });
+
+  it('does not count a Japanese follow-up task as correction', () => {
+    const t0 = new Date();
+    const sessions = rebuildSessions([
+      { type: 'session_start', timestamp: t0.toISOString(), sessionId: 's1', tool: 'claude', cwd: '/p' },
+      { type: 'stop', timestamp: t0.toISOString(), sessionId: 's1', tool: 'claude' },
+      { type: 'prompt_submit', timestamp: new Date(t0.getTime() + 5_000).toISOString(), sessionId: 's1', tool: 'claude', promptSummary: '次はテスト環境へデプロイして' },
+    ]);
+    expect(sessions[0].interventions.correction).toBe(0);
+  });
+
   it('does not count a correction-keyword prompt outside the time window', () => {
     const t0 = new Date();
     const sessions = rebuildSessions([

--- a/src/types.ts
+++ b/src/types.ts
@@ -914,6 +914,8 @@ export const CORRECTION_WINDOW_MS = 60 * 1000;
 export const CORRECTION_KEYWORDS = [
   '不对', '不是', '错了', '错误', '重来', '重新', '撤销', '回退', '别这样', '不要',
   'wrong', 'redo', 'undo', 'revert', 'mistake', 'instead', "don't", "that's not", 'not what',
+  // Japanese: "that's wrong" / "not that" / "redo" / "you got it wrong" / "on your own" / "put it back".
+  '違う', 'ちがう', 'そうじゃな', 'そうではな', 'やり直', 'やりなおし', '間違って', '間違え', '勝手に', '戻して',
 ];
 /** Max bytes to scan from a transcript when counting interventions (guards huge files). */
 export const INTERVENTION_SCAN_MAX_BYTES = 50 * 1024 * 1024;


### PR DESCRIPTION
## Summary

`CORRECTION_KEYWORDS` only covers Chinese and English, so a Japanese user correcting the agent right after a stop (e.g. 「違う、やり直して」) is never counted as a `correction`. For Japanese-speaking teams this quietly lowers the friction score (the share-learnings hint rarely fires) and under-reports corrections in `digest` / dashboard intervention metrics. This PR adds the common Japanese correction phrases and documents the language coverage.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing behavior to change)
- [ ] Documentation only
- [ ] Refactor / internal cleanup

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` passes (full suite; the only failures on my macOS machine are `lock-atomic.test.ts` and `push-*.test.ts` concurrency/timing tests, which fail identically on a pristine `main` checkout and are unrelated to this change)
- [x] Added/updated tests for the change

New tests in `dashboard-collector.test.ts`:
- a Japanese correction prompt within the 60s window counts as `correction: 1`
- a Japanese follow-up task (「次はテスト環境へデプロイして」) does not count

Mutation check: removing the new keyword line makes the first new test fail, so the test actually guards the change.

## Related Issues

None. Found while integrating TeamAI with a Japanese team's personal retrospective loop.

## Notes for Reviewers

- Matching stays a plain substring check on the lowercased prompt summary, so no logic changes — only the keyword list and two doc lines (`docs/usage-guide.md`, `docs/usage-guide.zh-CN.md`) that describe the `correction` signal.
- Keyword choice: I kept to phrases that are almost always a course-correction in a follow-up prompt (違う / ちがう / そうじゃな / そうではな / やり直 / やりなおし / 間違って / 間違え / 勝手に / 戻して). I deliberately left out bare 「間違」 because 「間違いない」 ("no doubt") is a common affirmative, and 「不要」-style single words that read differently in Japanese.
- Happy to trim or extend the list if you'd prefer a different balance between recall and false positives.
