### PR TITLE
feat(contribute): add sharing.contributeHint.enabled to opt out of the share-learnings nudge

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Task: Fix duplicate project-level Hook injection
 Consider running /teamai-share-learnings to summarize what you learned and share it with your team.
 ```
 
-The hint names the non-zero friction signals that triggered it and, when available, includes a redacted, single-line summary of the first task. The `/teamai-share-learnings` skill summarizes the session and pushes a learning document directly to the team repo. Each session is prompted at most once.
+The hint names the non-zero friction signals that triggered it and, when available, includes a redacted, single-line summary of the first task. The `/teamai-share-learnings` skill summarizes the session and pushes a learning document directly to the team repo. Each session is prompted at most once. Teams can switch the hint off with `sharing.contributeHint.enabled: false` in `teamai.yaml` (members: `contributeHintEnabled` in local config) while keeping the rest of the Stop hook.
 
 ### Team Knowledge Recall
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -195,7 +195,7 @@ Task: Fix duplicate project-level Hook injection
 Consider running /teamai-share-learnings to summarize what you learned and share it with your team.
 ```
 
-提示会列出实际触发它的非零摩擦信号；如果能取得首个任务摘要，还会在脱敏、单行化后附上任务上下文。`/teamai-share-learnings` skill 自动总结 session 经验并推送到团队仓库。每个 session 最多提示一次。
+提示会列出实际触发它的非零摩擦信号；如果能取得首个任务摘要，还会在脱敏、单行化后附上任务上下文。`/teamai-share-learnings` skill 自动总结 session 经验并推送到团队仓库。每个 session 最多提示一次。团队可在 `teamai.yaml` 设置 `sharing.contributeHint.enabled: false` 关闭该提示（成员可用本地配置 `contributeHintEnabled` 覆盖），Stop hook 的其余功能不受影响。
 
 ### 团队知识检索
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -645,6 +645,18 @@ teamai contribute --file /tmp/session.md
 teamai contribute --file /tmp/session.md --scope project
 ```
 
+#### Turning the hint off
+
+Teams that route knowledge sharing through their own review flow (for example, a personal retrospective that opens ordinary PRs) can switch the hint off without touching the rest of the Stop hook — update checks, votes sync, and dashboard reporting keep running. Same two-tier pattern as recall:
+
+| Tier | Config file | Field | Description |
+|------|----------|------|------|
+| Team default | `teamai.yaml` | `sharing.contributeHint.enabled` | `true` (default) / `false` |
+| User override | `~/.teamai/config.yaml` | `contributeHintEnabled` | `true` / `false`, takes priority over the team default |
+| Environment variable | shell | `TEAMAI_CONTRIBUTE_HINT_DISABLED=1` | Force-disables the hint (emergency kill switch) |
+
+Only the nudge is affected: friction scoring, `teamai contribute --file`, and `/teamai-share-learnings` keep working when invoked manually.
+
 ### Searching knowledge
 
 ```bash
@@ -1327,6 +1339,8 @@ sharing:
     injectShellProfile: true
   coAuthor:
     enabled: false             # optional; strip AI-tool commit trailers team-wide
+  contributeHint:
+    enabled: true              # optional; false = no /teamai-share-learnings nudge after high-friction sessions
 ```
 
 ### config.yaml (local config)
@@ -1341,6 +1355,7 @@ scope: project                 # project (default from init) or user
 projectRoot: /path/to/project  # project scope only
 inheritUserScope: true         # optional; project scope only, defaults to false
 coAuthorEnabled: true          # optional; per-machine co-author override
+contributeHintEnabled: false   # optional; per-machine override of sharing.contributeHint.enabled
 ```
 
 ---

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -643,6 +643,18 @@ teamai contribute --file /tmp/session.md
 teamai contribute --file /tmp/session.md --scope project
 ```
 
+#### 关闭提醒
+
+如果团队通过自己的评审流程沉淀知识（例如个人复盘后提交普通 PR），可以只关闭这条提醒，Stop hook 的其余功能（更新检查、votes 同步、dashboard 上报）照常运行。配置方式与 recall 相同，分两层：
+
+| 层级 | 配置文件 | 字段 | 说明 |
+|------|----------|------|------|
+| 团队默认 | `teamai.yaml` | `sharing.contributeHint.enabled` | `true`（默认）/ `false` |
+| 用户覆盖 | `~/.teamai/config.yaml` | `contributeHintEnabled` | `true` / `false`，优先级高于团队默认 |
+| 环境变量 | shell | `TEAMAI_CONTRIBUTE_HINT_DISABLED=1` | 强制关闭提醒（紧急开关） |
+
+只影响提醒本身：摩擦评分、`teamai contribute --file` 和手动调用 `/teamai-share-learnings` 不受影响。
+
 ### 搜索知识
 
 ```bash
@@ -1322,6 +1334,8 @@ sharing:
     injectShellProfile: true
   coAuthor:
     enabled: false             # 可选，为全团队去除 AI 工具提交尾注
+  contributeHint:
+    enabled: true              # 可选，false = 高摩擦 session 结束后不再提示 /teamai-share-learnings
 ```
 
 ### config.yaml（本地配置）
@@ -1336,6 +1350,7 @@ scope: project                 # project（init 默认）或 user
 projectRoot: /path/to/project  # 仅 project scope
 inheritUserScope: true         # 可选，仅 project scope，默认 false
 coAuthorEnabled: true          # 可选，每机器的 co-author 覆盖
+contributeHintEnabled: false   # 可选，每机器覆盖 sharing.contributeHint.enabled
 ```
 
 ---

--- a/src/__tests__/contribute-hint-toggle.test.ts
+++ b/src/__tests__/contribute-hint-toggle.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { isContributeHintEnabled, TeamaiConfigSchema, LocalConfigSchema } from '../types.js';
+
+describe('isContributeHintEnabled', () => {
+  const env = {} as NodeJS.ProcessEnv;
+
+  it('defaults to enabled when neither team nor user has an opinion', () => {
+    expect(isContributeHintEnabled({}, {}, env)).toBe(true);
+    expect(isContributeHintEnabled({}, { sharing: {} }, env)).toBe(true);
+  });
+
+  it('honors the team default', () => {
+    expect(isContributeHintEnabled({}, { sharing: { contributeHint: { enabled: false } } }, env)).toBe(false);
+    expect(isContributeHintEnabled({}, { sharing: { contributeHint: { enabled: true } } }, env)).toBe(true);
+  });
+
+  it('lets the user override the team default in both directions', () => {
+    expect(isContributeHintEnabled({ contributeHintEnabled: true }, { sharing: { contributeHint: { enabled: false } } }, env)).toBe(true);
+    expect(isContributeHintEnabled({ contributeHintEnabled: false }, { sharing: { contributeHint: { enabled: true } } }, env)).toBe(false);
+    expect(isContributeHintEnabled({ contributeHintEnabled: false }, {}, env)).toBe(false);
+  });
+
+  it('TEAMAI_CONTRIBUTE_HINT_DISABLED=1 wins over every config layer', () => {
+    const killed = { TEAMAI_CONTRIBUTE_HINT_DISABLED: '1' } as NodeJS.ProcessEnv;
+    expect(isContributeHintEnabled({ contributeHintEnabled: true }, { sharing: { contributeHint: { enabled: true } } }, killed)).toBe(false);
+    expect(isContributeHintEnabled({}, {}, { TEAMAI_CONTRIBUTE_HINT_DISABLED: '0' } as NodeJS.ProcessEnv)).toBe(true);
+  });
+
+  it('parses the new fields and leaves existing configs valid', () => {
+    const team = TeamaiConfigSchema.parse({ team: 't', repo: 'r', sharing: { contributeHint: { enabled: false } } });
+    expect(team.sharing.contributeHint?.enabled).toBe(false);
+    expect(TeamaiConfigSchema.parse({ team: 't', repo: 'r' }).sharing.contributeHint).toBeUndefined();
+    const local = LocalConfigSchema.parse({ repo: { localPath: '/x', remote: '' }, username: 'u', contributeHintEnabled: false });
+    expect(local.contributeHintEnabled).toBe(false);
+  });
+});

--- a/src/__tests__/hook-handlers.test.ts
+++ b/src/__tests__/hook-handlers.test.ts
@@ -58,11 +58,13 @@ vi.mock('../update.js', () => ({
   checkForUpdate: vi.fn().mockResolvedValue({ available: false, current: '1.0.0' }),
 }));
 
+const mockAutoDetectInit = vi.fn().mockResolvedValue({
+  localConfig: { repo: { localPath: '/tmp', remote: '' }, username: 'test', scope: 'user' },
+  teamConfig: { team: 'test', repo: '', toolPaths: {} },
+});
+
 vi.mock('../config.js', () => ({
-  autoDetectInit: vi.fn().mockResolvedValue({
-    localConfig: { repo: { localPath: '/tmp', remote: '' }, username: 'test', scope: 'user' },
-    teamConfig: { team: 'test', repo: '', toolPaths: {} },
-  }),
+  autoDetectInit: mockAutoDetectInit,
 }));
 
 vi.mock('../utils/logger.js', () => ({
@@ -279,6 +281,87 @@ describe('hook-handlers registry', () => {
     expect(result).toContain('do share');
     // claude is not a stash tool: called with stash=false.
     expect(mockContributeCheckForSession).toHaveBeenCalledWith('s2', '/x', undefined, false);
+  });
+
+  it('contribute-check handler stays silent when the team turned the hint off', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'stop' && r.handler.name === 'contribute-check',
+    )!.handler;
+    mockAutoDetectInit.mockResolvedValueOnce({
+      localConfig: { repo: { localPath: '/tmp', remote: '' }, username: 'test', scope: 'user' },
+      teamConfig: { team: 'test', repo: '', toolPaths: {}, sharing: { contributeHint: { enabled: false } } },
+    });
+    mockContributeCheckForSession.mockClear();
+
+    const result = await handler.execute({ session_id: 's3', cwd: '/x' }, 'claude');
+    expect(result).toBeNull();
+    expect(mockContributeCheckForSession).not.toHaveBeenCalled();
+  });
+
+  it('contribute-check handler honors a member override that re-enables the hint', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'stop' && r.handler.name === 'contribute-check',
+    )!.handler;
+    mockAutoDetectInit.mockResolvedValueOnce({
+      localConfig: { repo: { localPath: '/tmp', remote: '' }, username: 'test', scope: 'user', contributeHintEnabled: true },
+      teamConfig: { team: 'test', repo: '', toolPaths: {}, sharing: { contributeHint: { enabled: false } } },
+    });
+    mockContributeCheckForSession.mockResolvedValueOnce({ hint: '[teamai] do share' });
+
+    const result = await handler.execute({ session_id: 's4', cwd: '/x' }, 'claude');
+    expect(result).toContain('do share');
+  });
+
+  it('contribute-check handler keeps hinting when config cannot be loaded', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'stop' && r.handler.name === 'contribute-check',
+    )!.handler;
+    mockAutoDetectInit.mockRejectedValueOnce(new Error('not initialized'));
+    mockContributeCheckForSession.mockResolvedValueOnce({ hint: '[teamai] do share' });
+
+    const result = await handler.execute({ session_id: 's5', cwd: '/x' }, 'claude');
+    expect(result).toContain('do share');
+  });
+
+  it('contribute-check handler obeys TEAMAI_CONTRIBUTE_HINT_DISABLED=1', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'stop' && r.handler.name === 'contribute-check',
+    )!.handler;
+    const previous = process.env.TEAMAI_CONTRIBUTE_HINT_DISABLED;
+    process.env.TEAMAI_CONTRIBUTE_HINT_DISABLED = '1';
+    mockContributeCheckForSession.mockClear();
+    try {
+      const result = await handler.execute({ session_id: 's6', cwd: '/x' }, 'claude');
+      expect(result).toBeNull();
+      expect(mockContributeCheckForSession).not.toHaveBeenCalled();
+    } finally {
+      if (previous === undefined) delete process.env.TEAMAI_CONTRIBUTE_HINT_DISABLED;
+      else process.env.TEAMAI_CONTRIBUTE_HINT_DISABLED = previous;
+    }
+  });
+
+  it('pending-hint handler drops a stashed hint when the team turned the hint off but still delivers votes hints', async () => {
+    const registry = buildHandlerRegistry();
+    const handler = registry.find(
+      (r) => r.event === 'prompt-submit' && r.handler.name === 'pending-hint',
+    )!.handler;
+    mockAutoDetectInit.mockResolvedValueOnce({
+      localConfig: { repo: { localPath: '/tmp', remote: '' }, username: 'test', scope: 'user' },
+      teamConfig: { team: 'test', repo: '', toolPaths: {}, sharing: { contributeHint: { enabled: false } } },
+    });
+    mockTakePendingHint.mockResolvedValueOnce('[teamai] stashed');
+    mockTakePendingVotesHint.mockResolvedValueOnce('[teamai] votes nudge');
+
+    const result = await handler.execute({ session_id: 's7', cwd: '/x' }, 'codebuddy');
+    // The stash is consumed (so it is not delivered later) but not shown.
+    expect(mockTakePendingHint).toHaveBeenCalledWith(expect.any(String));
+    expect(result).not.toBeNull();
+    expect(result).not.toContain('stashed');
+    expect(result).toContain('votes nudge');
   });
 
   it('pending-hint handler injects stashed hint for codebuddy on prompt-submit', async () => {

--- a/src/hook-handlers.ts
+++ b/src/hook-handlers.ts
@@ -190,9 +190,28 @@ const trackSlashHandler: HookHandler = {
   },
 };
 
+/**
+ * Whether the share-learnings hint may be emitted at all. Resolved lazily per
+ * hook run so a team can switch it off via teamai.yaml (or a member via local
+ * config) without re-injecting hooks. Falls back to enabled when config can't
+ * be read, preserving pre-toggle behavior for half-initialized installs.
+ */
+async function contributeHintAllowed(): Promise<boolean> {
+  const { isContributeHintEnabled } = await import('./types.js');
+  try {
+    const { autoDetectInit } = await import('./config.js');
+    const { localConfig, teamConfig } = await autoDetectInit();
+    return isContributeHintEnabled(localConfig, teamConfig);
+  } catch {
+    return isContributeHintEnabled({}, {});
+  }
+}
+
 const contributeCheckHandler: HookHandler = {
   name: 'contribute-check',
   async execute(stdin, tool) {
+    if (!(await contributeHintAllowed())) return null;
+
     const { contributeCheckForSession } = await import('./contribute-check.js');
     const { formatStopHookOutput } = await import('./utils/hook-output.js');
     const { STOP_STDOUT_UNSUPPORTED_TOOLS } = await import('./utils/tool-names.js');
@@ -228,7 +247,10 @@ const pendingHintHandler: HookHandler = {
     // differ across the two hook processes and orphan the stash (best-effort).
     const sessionId = deriveSessionId(stdin, { includeCwd: true });
     const pending = await import('./contribute-check.js');
-    const hint = await pending.takePendingHint(sessionId);
+    // Always consume the stash so a hint stashed before the team turned the
+    // feature off is not delivered later when it is turned back on.
+    const stashed = await pending.takePendingHint(sessionId);
+    const hint = (await contributeHintAllowed()) ? stashed : null;
     const votesHint = await pending.takePendingVotesHint(sessionId);
 
     const combined = [hint, votesHint].filter(Boolean).join('\n');

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,16 @@ export const SharingConfigSchema = z.object({
   recall: z.object({
     enabled: z.boolean().default(false),
   }).optional(),
+  // Optional (not .default) so existing TeamaiConfig literals stay valid; use
+  // isContributeHintEnabled() for the resolved view.
+  contributeHint: z.object({
+    /** Team default: whether the Stop hook nudges members to run
+     *  /teamai-share-learnings after a high-friction session. Teams that route
+     *  knowledge sharing through their own review flow can turn the nudge off
+     *  without disabling the rest of the Stop hook (update check, votes sync,
+     *  dashboard reporting). */
+    enabled: z.boolean().default(true),
+  }).optional(),
   // Optional (not .default) so existing TeamaiConfig literals stay valid, AND so
   // "team has no opinion" (block absent) stays distinct from "team says off"
   // (enabled: false). Only the former is a no-op; see resolveCoAuthor().
@@ -128,6 +138,20 @@ export function isRecallEnabled(
 ): boolean {
   if (localConfig.recallEnabled !== undefined) return localConfig.recallEnabled;
   return getRecallSharing(teamConfig).enabled;
+}
+
+/**
+ * Resolve whether the share-learnings hint is enabled: env kill switch >
+ * user override > team config > default (true).
+ */
+export function isContributeHintEnabled(
+  localConfig: { contributeHintEnabled?: boolean },
+  teamConfig: { sharing?: { contributeHint?: { enabled?: boolean } } },
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (env.TEAMAI_CONTRIBUTE_HINT_DISABLED === '1') return false;
+  if (localConfig.contributeHintEnabled !== undefined) return localConfig.contributeHintEnabled;
+  return teamConfig.sharing?.contributeHint?.enabled ?? true;
 }
 
 /**
@@ -327,6 +351,8 @@ export const LocalConfigSchema = z.object({
   excludedSkills: z.array(z.string()).optional(),
   /** User-level override for recall feature. When set, takes precedence over team config. */
   recallEnabled: z.boolean().optional(),
+  /** User-level override for the share-learnings hint. When set, takes precedence over team config. */
+  contributeHintEnabled: z.boolean().optional(),
   /** Per-machine override for the co-author trailer in AI-tool commits. When set,
    *  takes precedence over the team `sharing.coAuthor` default. Undefined means
    *  "defer to the team" (see resolveCoAuthor). */


### PR DESCRIPTION
## Summary

Add `sharing.contributeHint.enabled` (team default), `contributeHintEnabled` (member override) and `TEAMAI_CONTRIBUTE_HINT_DISABLED=1` (kill switch) so a team can turn off the post-session `/teamai-share-learnings` nudge without disabling the whole built-in Stop hook. Today the only way to silence the nudge is `builtin.disabled: ["Hook dispatch stop"]` in `hooks/hooks.yaml`, which also drops the CLI update check, votes sync and dashboard reporting.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing behavior to change)
- [ ] Documentation only
- [ ] Refactor / internal cleanup

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` passes (full suite; the only failures on my macOS machine are `lock-atomic.test.ts` and `push-*.test.ts` concurrency/timing tests, which fail identically on a pristine `main` checkout and are unrelated to this change)
- [x] Added/updated tests for the change

- `contribute-hint-toggle.test.ts` (new): resolution order (default true → team → member override → env kill switch) and schema parsing, including that existing `teamai.yaml` / `config.yaml` without the new fields still parse.
- `hook-handlers.test.ts`: `contribute-check` returns `null` and never calls `contributeCheckForSession` when the team turned the hint off; a member override re-enables it; config load failure keeps the old behavior (hint still emitted); `TEAMAI_CONTRIBUTE_HINT_DISABLED=1` silences it; `pending-hint` consumes a stashed hint without delivering it while still delivering votes hints.

Mutation check: removing the guard in `contributeCheckHandler` makes two of the new tests fail.

## Related Issues

None directly. Related context: #354 (share-learnings hint delivery on stdout-less tools) — this PR keeps that stash path intact and only decides whether the stashed hint is shown.

## Notes for Reviewers

- Shape follows the existing two-tier pattern of `sharing.recall` / `sharing.coAuthor` (optional block, no `.default` so existing `TeamaiConfig` literals stay valid; resolved through `isContributeHintEnabled()`).
- The handler resolves the switch per run via `autoDetectInit()` (project scope first, then user), so flipping it in `teamai.yaml` takes effect on the next `pull` with no hook re-injection. If config cannot be loaded it falls back to enabled, so half-initialized installs behave exactly as before.
- On stdout-less tools (`codebuddy` / `workbuddy`) the `pending-hint` handler still **consumes** the stash when disabled, so a hint stashed before the switch flipped is never delivered later when it is turned back on. Votes hints on the same handler are unaffected.
- Scope: only the nudge. Friction scoring, `teamai contribute --file`, and manual `/teamai-share-learnings` keep working. Docs updated in both usage guides (new "Turning the hint off" subsection + config reference) and both READMEs (one sentence).
- Motivation: our team runs a personal retrospective loop that files ordinary PRs to the team repo, so the automatic nudge is noise for us — but we still want update checks and reporting from the Stop hook.
