### PR TITLE
fix(reporter): scope MCP inventory to the current tool (#427)

### DIFF
--- a/src/__tests__/local-agent-mcp.test.ts
+++ b/src/__tests__/local-agent-mcp.test.ts
@@ -476,4 +476,43 @@ describe('local-agent: MCP install/uninstall commands', () => {
       expect.arrayContaining([expect.objectContaining({ name: 'clawpro' })]),
     );
   });
+
+  // ─── issue #427: MCP inventory 按工具隔离，不跨工具合并 ────────────
+  it('buildReportPayload does not leak another tool\'s MCPs (issue #427)', async () => {
+    // 仅为 codebuddy 安装 MCP（runResponse 默认 tool=codebuddy）
+    await runResponse({
+      cmds: [{
+        id: 9050,
+        type: 'install_mcp',
+        scope: 'user',
+        slug: 'codebuddy-only-mcp',
+        version: '1.0.0',
+        mcp_config: { transport: 'http', url: 'https://cb.example.com/mcp' },
+      }],
+    });
+
+    // manifest 里只有 codebuddy 拥有该 MCP
+    const manifest = await fse.readJson(path.join(tmpDir, '.teamai', 'managed-mcp.json'));
+    expect(manifest.codebuddy).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'codebuddy-only-mcp' })]),
+    );
+
+    const { buildReportPayload, loadLocalAgentConfig } = await import('../local-agent.js');
+    const config = await loadLocalAgentConfig();
+
+    // workbuddy 的 report 不应包含 codebuddy 的 MCP
+    const wbPayload = await buildReportPayload(config!, { cwd: tmpDir, tool: 'workbuddy', status: 'running' });
+    const wbUserLevel = wbPayload.user_level as Record<string, unknown>;
+    expect(wbUserLevel.mcps).toBeUndefined();
+
+    // codebuddy 自身的 report 仍应包含它
+    const cbPayload = await buildReportPayload(config!, { cwd: tmpDir, tool: 'codebuddy', status: 'running' });
+    const cbUserLevel = cbPayload.user_level as Record<string, unknown>;
+    const cbMcps = cbUserLevel.mcps as Array<{ slug: string; source: string }>;
+    expect(cbMcps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ slug: 'codebuddy-only-mcp', source: 'enterprise' }),
+      ]),
+    );
+  });
 });

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -1255,9 +1255,16 @@ function collectManifestSlugs(manifest: LocalAgentManifest): { skills: Set<strin
  * Scan the managed-mcp manifest for a given scope and return MCP servers as
  * ReportedResource entries. Only servers tracked in managed-mcp.json (i.e.
  * installed via HTTP distribution) are reported with source = 'enterprise'.
+ *
+ * Results are scoped to the current `tool` so a report never leaks another
+ * tool's MCP inventory. The manifest is keyed by the same key the installer
+ * writes under (see `installMcpServer`): `tool` at user scope, `${tool}:project`
+ * at project scope. `tool` is the raw hook-context value (not run through
+ * normalizeAgentType), matching how the installer keys the manifest.
  */
 async function scanMcpFromManifest(
   scope: 'user' | 'project',
+  tool: string,
   projectRoot?: string,
 ): Promise<ReportedResource[]> {
   const manifestPath = managedMcpManifestPath(
@@ -1267,15 +1274,16 @@ async function scanMcpFromManifest(
   const manifest = await readJson<ManagedMcpManifest>(manifestPath);
   if (!manifest || typeof manifest !== 'object') return [];
 
+  const manifestKey = `${tool}${scope === 'project' ? ':project' : ''}`;
+  const records = manifest[manifestKey];
+  if (!Array.isArray(records)) return [];
+
   const seen = new Set<string>();
   const results: ReportedResource[] = [];
-  for (const records of Object.values(manifest)) {
-    if (!Array.isArray(records)) continue;
-    for (const rec of records) {
-      if (!rec.name || seen.has(rec.name)) continue;
-      seen.add(rec.name);
-      results.push({ slug: rec.name, source: 'enterprise' });
-    }
+  for (const rec of records) {
+    if (!rec.name || seen.has(rec.name)) continue;
+    seen.add(rec.name);
+    results.push({ slug: rec.name, source: 'enterprise' });
   }
   return results.sort((a, b) => a.slug.localeCompare(b.slug));
 }
@@ -1389,7 +1397,7 @@ export async function buildReportPayload(
   const userLevel: Record<string, unknown> = { group_id: config.userGroupId };
   if (userScope.skills.length > 0) userLevel.skills = userScope.skills;
   if (userScope.rules.length > 0) userLevel.rules = userScope.rules;
-  const userMcps = await scanMcpFromManifest('user');
+  const userMcps = await scanMcpFromManifest('user', tool);
   if (userMcps.length > 0) userLevel.mcps = userMcps;
 
   const payload: Record<string, unknown> = {
@@ -1423,7 +1431,7 @@ export async function buildReportPayload(
         };
         if (wsScope.skills.length > 0) workspace.skills = wsScope.skills;
         if (wsScope.rules.length > 0) workspace.rules = wsScope.rules;
-        const wsMcps = await scanMcpFromManifest('project', wsPath);
+        const wsMcps = await scanMcpFromManifest('project', tool, wsPath);
         if (wsMcps.length > 0) workspace.mcps = wsMcps;
         return workspace;
       }),


### PR DESCRIPTION
## 问题

Fixes #427

同机多 Agent 环境下,TeamAI Reporter 为某个 Agent 上报的 `user_level.mcps` / `workspaces[].mcps` 会包含其他 Agent 的 MCP。例如 CodeBuddy 装了 3 个 MCP、WorkBuddy 一个都没装时,WorkBuddy 的 report 却带上了 CodeBuddy 的 3 个 MCP。下游据此误判 WorkBuddy 已安装,不再向其下发安装命令;同时也造成 MCP 名跨 Agent 泄露。

## 根因

`scanMcpFromManifest()` 用 `for (const records of Object.values(manifest))` 遍历 `managed-mcp.json` 里**所有工具** key 并合并,且未接收当前 `tool`。这与 skill/rule 走 `toolPaths[tool]` 按工具隔离的语义不一致。

## 修改

`src/local-agent.ts`:

- `scanMcpFromManifest` 新增 `tool` 参数,只读当前工具对应的 manifest key —— user 级用 `tool`、project 级用 `${tool}:project`。该 key 规则与写入侧 `installMcpServer` 完全对齐(用原始 hook-context tool,不经 `normalizeAgentType`,与写入侧一致),保证读写同源。
- `buildReportPayload` 的 user 级与 project 级两处调用均传入当前 `tool`。

## Test Plan

| 验证 | 命令 | 结果 |
|---|---|---|
| 类型检查 | `npx tsc --noEmit` | ✅ 无报错 |
| MCP 单测(含新增 issue #427 隔离用例) | `npx vitest run src/__tests__/local-agent-mcp.test.ts` | ✅ 14/14 |
| local-agent 回归 | `npx vitest run src/__tests__/local-agent.test.ts` | ✅ 65/65 |
| **端到端(真实 CLI 子进程)** | 真实 HTTP server 捕获 `node dist/index.js hook-dispatch session-start --tool ...` 发出的 report payload | ✅ codebuddy 上报自身 3 个 MCP;workbuddy `user_level.mcps=undefined` |
| **反向验证** | 临时回退修复后重跑单测与 e2e | 均如期 FAIL(workbuddy 泄露 codebuddy 的 3 个 MCP),证明测试真能抓 bug;恢复后转 PASS |

端到端脚本按 issue 原文场景构造(codebuddy 拥有 mcp-a/b/c、workbuddy 零),验证后已清理,不入库;稳定回归由新增单测承载。

### 新增单测
`src/__tests__/local-agent-mcp.test.ts`:`buildReportPayload does not leak another tool's MCPs (issue #427)` —— 仅为 codebuddy 安装 MCP,断言 workbuddy report 的 `user_level.mcps` 为 undefined,而 codebuddy 自身 report 仍含该 MCP。
