### PR TITLE
docs: add contributors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,3 +287,13 @@ Insight into how the team actually uses its AI tools, and a starting point for t
 ## Contributing
 
 PRs are welcome! Please read [CONTRIBUTING.md](.github/CONTRIBUTING.md) first.
+
+## Contributors
+
+Thanks to everyone who has contributed to TeamAI!
+
+<a href="https://github.com/Tencent/teamai-cli/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=Tencent/teamai-cli" alt="Contributors" />
+</a>
+
+Made with [contrib.rocks](https://contrib.rocks).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -287,3 +287,13 @@ WASM 解析器是纯 JavaScript 依赖，无需任何原生编译工具链。若
 ## 贡献
 
 欢迎提交 PR！请先阅读 [CONTRIBUTING.md](.github/CONTRIBUTING.md)。
+
+## 贡献者
+
+感谢每一位为 TeamAI 贡献代码的伙伴！
+
+<a href="https://github.com/Tencent/teamai-cli/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=Tencent/teamai-cli" alt="Contributors" />
+</a>
+
+由 [contrib.rocks](https://contrib.rocks) 生成。


### PR DESCRIPTION
## What

Add a `Contributors` section at the end of both READMEs (`README.md` / `README.zh-CN.md`), right after `Contributing`.

Uses the [contrib.rocks](https://contrib.rocks) dynamic avatar image, so no contributor list needs to be maintained by hand — new contributors show up automatically.

```
<a href="https://github.com/Tencent/teamai-cli/graphs/contributors">
  <img src="https://contrib.rocks/image?repo=Tencent/teamai-cli" alt="Contributors" />
</a>
```

## Why

Give visible credit to everyone who has contributed, and make the contributors graph one click away from the README.

## Test Plan

Docs-only change; no CLI behavior is affected, so no build or end-to-end run applies.

- [x] Verified the image endpoint actually resolves: `curl -sS -o /dev/null -w "%{http_code} %{content_type}" "https://contrib.rocks/image?repo=Tencent/teamai-cli"` → `200 image/svg+xml`
- [x] Inspected the returned SVG: 812x200, contains 28 embedded contributor avatars
- [x] Both language READMEs updated in sync, with localized wording in the Chinese version
- [x] Single commit, only `README.md` and `README.zh-CN.md` touched

## Note

contrib.rocks is cached by its own CDN and by GitHub's camo proxy, so newly merged contributors can take hours to appear. If instant accuracy matters more than zero maintenance, a scheduled action such as `contributors-readme-action` that writes a real table into the README would be the alternative.

Made with [Cursor](https://cursor.com)