### PR TITLE
fix(status): count nested rule files recursively

### DIFF
--- a/src/__tests__/status-list.test.ts
+++ b/src/__tests__/status-list.test.ts
@@ -155,4 +155,12 @@ describe('teamai list / status resource coverage', () => {
     expect(out).toMatch(/hooks:\s*1/);
     expect(out).toMatch(/mcp:\s*1/);
   });
+
+  it('status counts nested rule files', async () => {
+    await fse.ensureDir(path.join(repoPath, 'rules', 'common'));
+    await fse.writeFile(path.join(repoPath, 'rules', 'common', 'example.md'), '# Rule\n');
+    await status({});
+    const out = lines.join('\n');
+    expect(out).toMatch(/rules:\s*1/);
+  });
 });

--- a/src/status.ts
+++ b/src/status.ts
@@ -5,7 +5,7 @@ import { getRepoStatus } from './utils/git.js';
 import { assertSafeResourceName } from './utils/path-safety.js';
 import { log } from './utils/logger.js';
 import { getAllHandlers } from './resources/index.js';
-import { listDirs, listFiles, pathExists, readFileSafe } from './utils/fs.js';
+import { listDirs, listFiles, listFilesRecursive, pathExists, readFileSafe } from './utils/fs.js';
 import { SkillsHandler } from './resources/skills.js';
 import { detectInstalledAgents, type ResolvedAgent } from './known-agents.js';
 import {
@@ -79,7 +79,7 @@ export async function status(options: GlobalOptions): Promise<void> {
   const skillsDirs = await listDirs(path.join(repoPath, 'skills'));
   counts.skills = skillsDirs.length;
 
-  const rulesFiles = (await listFiles(path.join(repoPath, 'rules'))).filter(f => f.endsWith('.md'));
+  const rulesFiles = (await listFilesRecursive(path.join(repoPath, 'rules'))).filter(f => f.endsWith('.md'));
   counts.rules = rulesFiles.length;
 
   const docsExists = await pathExists(path.join(repoPath, 'docs'));


### PR DESCRIPTION
## Summary

`teamai status` called `listFiles()` for the rules directory, which only scans direct children. Rules organized in subdirectories (e.g. `rules/common/*.md`) were silently counted as zero. Switch to `listFilesRecursive()` to match the logic already used in `RulesHandler`. Fixes #436.

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)

  ## Test Plan

  - [x] `npx tsc --noEmit` passes
  - [x] `npx vitest run` passes
  - [x] Added/updated tests for the change

  Added regression test in `src/__tests__/status-list.test.ts`: creates
  `rules/common/example.md` in a temp repo, calls `status()`, and asserts
  the output contains `rules: 1`.

  ## Related Issues

  Fixes #436

  ## Notes for Reviewers

  One-line change in `src/status.ts`. The recursive helper `listFilesRecursive`
  was already imported and used throughout `RulesHandler` — this PR simply
  applies the same function to the status count.

<!--
Thanks for opening a PR! Please fill out this template to help reviewers understand your change quickly.
-->