### PR TITLE
test: isolate push/pull unit tests from shared .sync-lock

### DIFF
--- a/src/__tests__/pull-exclude.test.ts
+++ b/src/__tests__/pull-exclude.test.ts
@@ -44,6 +44,13 @@ vi.mock('../roles.js', () => ({
   })),
 }));
 
+// Isolation: pull() takes a real ~/.teamai/.sync-lock. Parallel vitest workers
+// sharing that path race and skip/error, so these tests mock the lock.
+vi.mock('../update.js', () => ({
+  acquireLock: vi.fn().mockResolvedValue(true),
+  releaseLock: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { detectProjectConfig, loadLocalConfigForScope, loadTeamConfig } from '../config.js';
 import { pull } from '../pull.js';
 import type { LocalConfig, TeamaiConfig } from '../types.js';

--- a/src/__tests__/pull-scope-isolation.test.ts
+++ b/src/__tests__/pull-scope-isolation.test.ts
@@ -74,6 +74,13 @@ vi.mock('../roles.js', () => ({
   resolveRoleResourceNamespaces: vi.fn(() => ({ knowledge: [], skills: [], learnings: [] })),
 }));
 
+// Isolation: pull() takes a real ~/.teamai/.sync-lock. Parallel vitest workers
+// sharing that path race and skip/error, so these tests mock the lock.
+vi.mock('../update.js', () => ({
+  acquireLock: vi.fn().mockResolvedValue(true),
+  releaseLock: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { pull } from '../pull.js';
 import {
   loadLocalConfigForScope,

--- a/src/__tests__/pull-skip-sync.test.ts
+++ b/src/__tests__/pull-skip-sync.test.ts
@@ -65,6 +65,13 @@ vi.mock('../roles.js', () => ({
   }),
 }));
 
+// Isolation: pull() takes a real ~/.teamai/.sync-lock. Parallel vitest workers
+// sharing that path race and skip/error, so these tests mock the lock.
+vi.mock('../update.js', () => ({
+  acquireLock: vi.fn().mockResolvedValue(true),
+  releaseLock: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { pull, compileRecallRulesBlock } from '../pull.js';
 import { loadLocalConfigForScope, loadTeamConfig, detectProjectConfig, loadStateForScope, saveStateForScope } from '../config.js';
 import { getHeadRev } from '../utils/git.js';

--- a/src/__tests__/pull-tombstone.test.ts
+++ b/src/__tests__/pull-tombstone.test.ts
@@ -85,6 +85,13 @@ vi.mock('../roles.js', () => ({
   }),
 }));
 
+// Isolation: pull() takes a real ~/.teamai/.sync-lock. Parallel vitest workers
+// sharing that path race and skip/error, so these tests mock the lock.
+vi.mock('../update.js', () => ({
+  acquireLock: vi.fn().mockResolvedValue(true),
+  releaseLock: vi.fn().mockResolvedValue(undefined),
+}));
+
 describe('pull role-aware sync and cleanup', () => {
   let tmpDir: string;
   let homeDir: string;

--- a/src/__tests__/push-pending-pr.test.ts
+++ b/src/__tests__/push-pending-pr.test.ts
@@ -79,6 +79,13 @@ vi.mock('../providers/index.js', () => ({
   }),
 }));
 
+// Isolation: push() takes a real ~/.teamai/.sync-lock. Parallel vitest workers
+// sharing that path race and skip/error, so these tests mock the lock.
+vi.mock('../update.js', () => ({
+  acquireLock: vi.fn().mockResolvedValue(true),
+  releaseLock: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock('../utils/logger.js', () => ({
   log: {
     info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), dim: vi.fn(),

--- a/src/__tests__/push-role.test.ts
+++ b/src/__tests__/push-role.test.ts
@@ -109,6 +109,13 @@ vi.mock('../providers/index.js', () => ({
   }),
 }));
 
+// Isolation: push() takes a real ~/.teamai/.sync-lock. Parallel vitest workers
+// sharing that path race and skip/error, so these tests mock the lock.
+vi.mock('../update.js', () => ({
+  acquireLock: vi.fn().mockResolvedValue(true),
+  releaseLock: vi.fn().mockResolvedValue(undefined),
+}));
+
 function makeLocalConfig(overrides: Record<string, unknown> = {}) {
   return {
     repo: { localPath: '/tmp/team-repo', remote: 'https://git.woa.com/test/repo.git' },

--- a/src/__tests__/push-skill-flag.test.ts
+++ b/src/__tests__/push-skill-flag.test.ts
@@ -102,6 +102,13 @@ vi.mock('../providers/index.js', () => ({
   }),
 }));
 
+// Isolation: push() takes a real ~/.teamai/.sync-lock. Parallel vitest workers
+// sharing that path race and skip/error, so these tests mock the lock.
+vi.mock('../update.js', () => ({
+  acquireLock: vi.fn().mockResolvedValue(true),
+  releaseLock: vi.fn().mockResolvedValue(undefined),
+}));
+
 function makeLocalConfig(overrides: Record<string, unknown> = {}) {
   return {
     repo: { localPath: '/tmp/team-repo', remote: 'https://git.woa.com/test/repo.git' },


### PR DESCRIPTION
## Summary
- `push()` / `pull()` take a real `~/.teamai/.sync-lock`. Parallel Vitest workers race on that file, so unit tests fail flakily (Coding CI #535: 27 failures in `push-role` / `push-skill-flag`).
- Mock `acquireLock` / `releaseLock` in the user-scope tests that call `push()` / `pull()` directly. Product lock behavior is unchanged.
- GitHub CI can miss this because the overlap is scheduling-dependent; serial runs pass, overlapping files fail.

## Test plan
- [x] `npx vitest run src/__tests__/push-role.test.ts src/__tests__/push-skill-flag.test.ts` (parallel, previously failed)
- [x] `npx vitest run --coverage` (197 files / 2728 tests)
- [ ] GitHub Actions CI on this PR
- [ ] After merge: re-sync GitHub `main` to TGit and re-run Coding CI on the sync MR


Made with [Cursor](https://cursor.com)