### PR TITLE
fix(codex): defer Stop hints to the next prompt

### DIFF
--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -638,6 +638,8 @@ Consider running /teamai-share-learnings to summarize what you learned and share
 
 The reminder lists the non-zero friction signals that triggered it. When the first task is available, it also includes a redacted, single-line task summary so you can decide whether the session is worth sharing. Using the built-in `/teamai-share-learnings` skill, the AI will automatically summarize the session's learnings and contribute them to the team knowledge base. Each session is prompted at most once.
 
+For Codex, the Stop hook saves contribution and knowledge-reference reminders for the next UserPromptSubmit in the same session. It does not force an extra agent turn. Contribution reminders are delivered once and discarded if you contribute before the next prompt.
+
 You can also specify a file manually:
 
 ```bash

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -636,6 +636,8 @@ Consider running /teamai-share-learnings to summarize what you learned and share
 
 提醒会列出实际触发它的非零摩擦信号；如果能取得首个任务，还会附上脱敏、单行化后的任务摘要，便于判断本次 session 是否值得分享。使用内置 skill `/teamai-share-learnings`，AI 会自动总结本次 session 经验并贡献到团队知识库。每个 session 最多提示一次。
 
+在 Codex 中，Stop hook 会暂存贡献和知识引用提醒，在同一会话的下一次 UserPromptSubmit 交付，不会强制开启额外一轮。贡献提醒只交付一次；若下一次输入前已经贡献，则丢弃该提醒。
+
 也可以手动指定文件：
 
 ```bash

--- a/src/__tests__/codex-stop-hint.test.ts
+++ b/src/__tests__/codex-stop-hint.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { buildHandlerRegistry } from '../hook-handlers.js';
+import { readContributeState, writeContributeState } from '../contribute-check.js';
+import { CONTRIBUTE_BASE_THRESHOLD, CONTRIBUTE_SMART_THRESHOLD } from '../types.js';
+
+describe('Codex Stop hint handoff with persisted session state', () => {
+  let tmpHome: string;
+  const originalHome = process.env.HOME;
+  const registry = buildHandlerRegistry();
+  const stop = registry.find(r => r.handler.name === 'contribute-check')!.handler;
+  const prompt = registry.find(r => r.handler.name === 'pending-hint')!.handler;
+  const stdin = { session_id: 'codex-stop-regression', cwd: '/tmp/project' };
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-codex-stop-'));
+    process.env.HOME = tmpHome;
+  });
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  async function seed(score: number) {
+    await writeContributeState(stdin.session_id, {
+      contributed: false,
+      smartScore: score,
+      toolCount: CONTRIBUTE_BASE_THRESHOLD,
+      lastEvaluated: Date.now(),
+      friction: { interrupt: 0, toolReject: 0, correction: 1, toolError: 0 },
+    });
+  }
+
+  it('keeps Stop silent, persists the hint, and delivers it only once on the next prompt', async () => {
+    await seed(CONTRIBUTE_SMART_THRESHOLD + 1);
+    expect(await stop.execute(stdin, 'codex')).toBeNull();
+    const state = await readContributeState(stdin.session_id);
+    expect(state.hinted).toBe(true);
+    expect(state.pendingHint).toContain('teamai-share-learnings');
+    expect(await stop.execute(stdin, 'codex')).toBeNull();
+    expect((await readContributeState(stdin.session_id)).pendingHint).toBe(state.pendingHint);
+    expect(JSON.parse((await prompt.execute(stdin, 'codex'))!)).toEqual({
+      hookSpecificOutput: { hookEventName: 'UserPromptSubmit', additionalContext: state.pendingHint },
+    });
+    expect((await readContributeState(stdin.session_id)).pendingHint).toBeUndefined();
+    expect(await prompt.execute(stdin, 'codex')).toBeNull();
+    expect(await stop.execute(stdin, 'codex')).toBeNull();
+  });
+
+  it('does not queue or deliver a hint below threshold', async () => {
+    await seed(CONTRIBUTE_SMART_THRESHOLD - 1);
+    expect(await stop.execute(stdin, 'codex')).toBeNull();
+    expect((await readContributeState(stdin.session_id)).hinted).toBeFalsy();
+    expect(await prompt.execute(stdin, 'codex')).toBeNull();
+  });
+
+  it('drops a queued hint if the user contributed before the next prompt', async () => {
+    await seed(CONTRIBUTE_SMART_THRESHOLD + 1);
+    await stop.execute(stdin, 'codex');
+    await writeContributeState(stdin.session_id, {
+      ...await readContributeState(stdin.session_id), contributed: true,
+    });
+    expect(await prompt.execute(stdin, 'codex')).toBeNull();
+    expect((await readContributeState(stdin.session_id)).pendingHint).toBeUndefined();
+  });
+});

--- a/src/__tests__/contribute-check-e2e.test.ts
+++ b/src/__tests__/contribute-check-e2e.test.ts
@@ -57,11 +57,12 @@ function readSessionState(homeDir: string, sessionId: string): Record<string, un
 function runContributeCheck(
   homeDir: string,
   stdinPayload: string,
+  tool = 'claude',
 ): Promise<{ stdout: string; stderr: string; code: number }> {
   return new Promise((resolve) => {
     const child = execFile(
       'node',
-      [CLI_PATH, 'contribute-check', '--stdin', '--tool', 'claude'],
+      [CLI_PATH, 'contribute-check', '--stdin', '--tool', tool],
       {
         env: { ...process.env, HOME: homeDir, TEAMAI_LOG_LEVEL: 'silent' },
         timeout: 10000,
@@ -152,6 +153,19 @@ describe('contribute-check E2E', () => {
 
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it('standalone Codex Stop queues the hint without emitting incompatible JSON', async () => {
+    writeEventsFile(tmpHome, buildRichSessionEvents(SESSION_ID));
+    const result = await runContributeCheck(tmpHome, makeStdinPayload(SESSION_ID), 'codex');
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe('');
+    const state = readSessionState(tmpHome, SESSION_ID)!;
+    expect(state.hinted).toBe(true);
+    expect(state.pendingHint).toContain('teamai-share-learnings');
+    const repeated = await runContributeCheck(tmpHome, makeStdinPayload(SESSION_ID), 'codex');
+    expect(repeated.stdout).toBe('');
+    expect(readSessionState(tmpHome, SESSION_ID)!.pendingHint).toBe(state.pendingHint);
   });
 
   it('outputs contextual, sanitized hint JSON for a rich session that exceeds threshold', async () => {

--- a/src/__tests__/hook-handlers.test.ts
+++ b/src/__tests__/hook-handlers.test.ts
@@ -253,7 +253,7 @@ describe('hook-handlers registry', () => {
     expect(parsed.followup_message).toBe('[teamai] hello');
   });
 
-  it('contribute-check handler asks to stash (not stdout) for codebuddy', async () => {
+  it.each(['codebuddy', 'codex'])('contribute-check handler asks to stash (not stdout) for %s', async (tool) => {
     const registry = buildHandlerRegistry();
     const handler = registry.find(
       (r) => r.event === 'stop' && r.handler.name === 'contribute-check',
@@ -263,7 +263,7 @@ describe('hook-handlers registry', () => {
     // returns hint:null (it persisted the hint as pendingHint itself).
     mockContributeCheckForSession.mockResolvedValueOnce({ hint: null });
 
-    const result = await handler.execute({ session_id: 's1', cwd: '/x' }, 'codebuddy');
+    const result = await handler.execute({ session_id: 's1', cwd: '/x' }, tool);
     expect(result).toBeNull();
     expect(mockContributeCheckForSession).toHaveBeenCalledWith('s1', '/x', undefined, true);
   });
@@ -364,7 +364,7 @@ describe('hook-handlers registry', () => {
     expect(result).toContain('votes nudge');
   });
 
-  it('pending-hint handler injects stashed hint for codebuddy on prompt-submit', async () => {
+  it.each(['codebuddy', 'codex'])('pending-hint handler injects stashed hint for %s on prompt-submit', async (tool) => {
     const registry = buildHandlerRegistry();
     const handler = registry.find(
       (r) => r.event === 'prompt-submit' && r.handler.name === 'pending-hint',
@@ -372,7 +372,7 @@ describe('hook-handlers registry', () => {
 
     mockTakePendingHint.mockResolvedValueOnce('[teamai] stashed');
 
-    const result = await handler.execute({ session_id: 's3', cwd: '/x' }, 'codebuddy');
+    const result = await handler.execute({ session_id: 's3', cwd: '/x' }, tool);
     expect(result).not.toBeNull();
     const parsed = JSON.parse(result!);
     expect(parsed.hookSpecificOutput.hookEventName).toBe('UserPromptSubmit');
@@ -697,7 +697,7 @@ describe('hook-handlers registry', () => {
 
   // ── Change 3: votes-sync stash branch (STOP_STDOUT_UNSUPPORTED_TOOLS) ──
 
-  it('votes-sync stashes nudge via stashVotesHint for codebuddy (stdout ignored)', async () => {
+  it.each(['codebuddy', 'codex'])('votes-sync stashes nudge via stashVotesHint for %s (stdout ignored)', async (tool) => {
     const registry = buildHandlerRegistry();
     const handler = registry.find(
       (r) => r.event === 'stop' && r.handler.name === 'votes-sync',
@@ -710,7 +710,7 @@ describe('hook-handlers registry', () => {
 
     const result = await handler.execute(
       { session_id: 'sid-votes-stash', cwd: '/x', transcript_path: '/t/transcript.jsonl' },
-      'codebuddy',
+      tool,
     );
     // Stash path returns null (hint goes to the votes-hint sidecar)
     expect(result).toBeNull();
@@ -781,7 +781,7 @@ describe('hook-handlers registry', () => {
 
   // ── Change 3: pending-hint replays and merges the votes hint ──
 
-  it('pending-hint merges contribute hint and votes hint for codebuddy', async () => {
+  it.each(['codebuddy', 'codex'])('pending-hint merges contribute hint and votes hint for %s', async (tool) => {
     const registry = buildHandlerRegistry();
     const handler = registry.find(
       (r) => r.event === 'prompt-submit' && r.handler.name === 'pending-hint',
@@ -790,7 +790,7 @@ describe('hook-handlers registry', () => {
     mockTakePendingHint.mockResolvedValueOnce('[teamai] contribute hint');
     mockTakePendingVotesHint.mockResolvedValueOnce('[teamai] votes hint');
 
-    const result = await handler.execute({ session_id: 'sid-merge', cwd: '/x' }, 'codebuddy');
+    const result = await handler.execute({ session_id: 'sid-merge', cwd: '/x' }, tool);
     expect(result).not.toBeNull();
     const parsed = JSON.parse(result!);
     const ctx = parsed.hookSpecificOutput.additionalContext;

--- a/src/__tests__/hook-output.test.ts
+++ b/src/__tests__/hook-output.test.ts
@@ -25,7 +25,7 @@ describe('formatStopHookOutput', () => {
   });
 
   it('unknown tool: defaults to hookSpecificOutput (Claude schema)', () => {
-    const result = formatStopHookOutput('x', 'codex');
+    const result = formatStopHookOutput('x', 'unknown');
     const parsed = JSON.parse(result);
     expect(parsed.hookSpecificOutput.additionalContext).toBe('x');
   });
@@ -52,4 +52,8 @@ describe('formatStopHookOutput', () => {
     const parsed = JSON.parse(result);
     expect(parsed.hookSpecificOutput.additionalContext).toBe('');
   });
+});
+
+it.each(['codex', 'Codex'])('%s Stop uses a non-blocking common output field', (tool) => {
+  expect(JSON.parse(formatStopHookOutput('hint', tool))).toEqual({ systemMessage: 'hint' });
 });

--- a/src/contribute-check.ts
+++ b/src/contribute-check.ts
@@ -707,19 +707,17 @@ export async function contributeCheck(toolArg?: string): Promise<void> {
     return;
   }
 
-  // This standalone CLI path always writes the hint to Stop stdout (no stashing).
-  // It is NOT wired for codebuddy/workbuddy — those route through hook-dispatch's
-  // contributeCheckHandler, which stashes instead. If a future tool whose Stop
-  // hook ignores stdout is ever pointed at this command directly, the hint would
-  // be silently dropped; such a tool must go through the stashing handler.
+  const { STOP_STDOUT_UNSUPPORTED_TOOLS } = await import('./utils/tool-names.js');
+  const tool = toolArg?.toLowerCase() ?? 'claude';
   const { hint } = await contributeCheckForSession(
     stdinData.sessionId,
     stdinData.cwd,
     stdinData.transcriptPath,
+    STOP_STDOUT_UNSUPPORTED_TOOLS.has(tool),
   );
   if (hint !== null) {
     const { formatStopHookOutput } = await import('./utils/hook-output.js');
-    process.stdout.write(formatStopHookOutput(hint, toolArg ?? 'claude'));
+    process.stdout.write(formatStopHookOutput(hint, tool));
   }
 }
 

--- a/src/hook-handlers.ts
+++ b/src/hook-handlers.ts
@@ -221,7 +221,7 @@ const contributeCheckHandler: HookHandler = {
     const sessionId = deriveSessionId(stdin, { includeCwd: true });
     const cwd = resolveHookCwd(stdin);
     const transcriptPath = typeof stdin.transcript_path === 'string' ? stdin.transcript_path : undefined;
-    // Tools whose Stop hook ignores stdout: the hint is stashed (within the same
+    // Tools whose Stop hook cannot deliver model context: stash the hint (in the same
     // single state write inside contributeCheckForSession) for delivery on the
     // next UserPromptSubmit, so contributeCheckForSession returns null here.
     const stash = STOP_STDOUT_UNSUPPORTED_TOOLS.has(tool);

--- a/src/utils/hook-output.ts
+++ b/src/utils/hook-output.ts
@@ -3,7 +3,8 @@
  *
  * Schema choice per tool:
  * - Cursor: `{ followup_message }`  (Cursor stop hook docs)
- * - Everyone else (Claude / CodeBuddy / WorkBuddy / Codex / unknown):
+ * - Codex: `{ systemMessage }` (UI notice; model context is deferred to prompt-submit)
+ * - Everyone else (Claude / CodeBuddy / WorkBuddy / unknown):
  *   `{ hookSpecificOutput: { hookEventName: 'Stop', additionalContext } }`
  *   (Claude Code stop hook docs — the "additional context that continues
  *   the conversation" branch, NOT top-level `stopReason`, which requires
@@ -11,6 +12,10 @@
  */
 export function formatStopHookOutput(message: string, tool: string): string {
   const normalized = tool?.toLowerCase() ?? '';
+
+  if (normalized === 'codex') {
+    return JSON.stringify({ systemMessage: message });
+  }
 
   if (normalized === 'cursor') {
     return JSON.stringify({ followup_message: message });

--- a/src/utils/tool-names.ts
+++ b/src/utils/tool-names.ts
@@ -34,8 +34,8 @@ export function normalizeAgentType(name: string): string {
 }
 
 /**
- * Tools whose Stop hook is fire-and-forget: the host executes the command but
- * does not consume its stdout, so a Stop-hook hint printed to stdout is dropped.
+ * Tools whose Stop hook cannot deliver non-blocking model context.
+ * CodeBuddy/WorkBuddy ignore stdout; Codex rejects Stop additionalContext.
  * For these tools the share-learnings hint is stashed as pending state at Stop
  * and injected on the next UserPromptSubmit instead (which they DO consume).
  *
@@ -44,4 +44,4 @@ export function normalizeAgentType(name: string): string {
  * "codebuddy-internal") would miss this Set and fall back to the dropped-stdout
  * Stop path, so add such variants here explicitly.
  */
-export const STOP_STDOUT_UNSUPPORTED_TOOLS = new Set(['codebuddy', 'workbuddy']);
+export const STOP_STDOUT_UNSUPPORTED_TOOLS = new Set(['codebuddy', 'workbuddy', 'codex']);


### PR DESCRIPTION
## Summary

Codex rejects Stop hookSpecificOutput.additionalContext when a contribution hint is emitted, after the session is already marked hinted. Defer contribution and votes reminders to the next UserPromptSubmit, preserving one-time delivery without forcing another turn. Use the supported systemMessage field in the shared Codex Stop formatter and adapt the standalone contribute-check entry point.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Plan

Tested commit 09a2efd542d709a15893458026c9eb553fa33afb on upstream 1d4da26 in an isolated macOS / Node 22.22.3 worktree.

- [x] npm run typecheck
- [x] npm run build
- [x] npm run test:coverage: 198 files, 2737 passed; line coverage 63.90%.
- [x] git diff --check
- [x] Regression tests cover no hint, pending state, repeated Stop, next-prompt delivery and deduplication, contribution before delivery, votes and standalone CLI.
- [x] Built CLI Stop and duplicate-suppression checks: Claude/Codex/CodeBuddy/OpenCode across local git/gitlab/github configurations (12 combinations). These are local CLI checks, not live provider or host-agent integrations.

npm run test:e2e: **81 passed, 25 skipped**. The skipped tests need a remote fixture/token (22) or CNB/GitCode/GitLab live credentials (3). No remote fixture writes were performed.

## Related Issues

Fixes #440

## Notes for Reviewers

**Draft: the requested zero-failure, zero-skip acceptance bar is not yet met.** Full CI OS/Node matrix, the 25 remote/live tests, and a real Codex desktop session remain unverified. Previously lost hints with hinted=true are not automatically replayed.

Preserves the latest upstream contribution-hint opt-out behavior. English/Chinese usage guides updated. GPT-6 Astra (high) reviewed the implementation and updated upstream diff without finding a blocking issue.
