### PR TITLE
docs: align public usage guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Insight into how the team actually uses its AI tools, and a starting point for t
 | `teamai recall enable/disable/status` | Toggle or check recall state |
 | `teamai recall promote [learningId]` | Promote a high-confidence learning to formal knowledge (skills/rules/docs) |
 | `teamai recall maintenance` | Maintain knowledge base health: prune low-confidence learnings, writeback confidence scores, flag stale entries |
-| `teamai import` | Import knowledge (`--dir`, `--from-repo`, `--from-org`, `--from-repo-list`, `--from-mr`, `--from-iwiki`) |
+| `teamai import` | Import knowledge (`--dir`, `--from-repo`, `--from-org`, `--from-repo-list`, `--from-mr`) |
 | `teamai codebase --lint` | Knowledge graph health check |
 | `teamai ci extract-mr --url <url>` | CI: extract knowledge from MR, post comments, write after merge |
 | `teamai members` | List team members |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -266,7 +266,7 @@ WASM 解析器是纯 JavaScript 依赖，无需任何原生编译工具链。若
 | `teamai recall enable/disable/status` | 开关或查看 recall 状态 |
 | `teamai recall promote [learningId]` | 将高置信度 learning 晋升为正式知识（skills/rules/docs） |
 | `teamai recall maintenance` | 维护知识库健康：清理低置信度 learnings、回写置信度、标记过时条目 |
-| `teamai import` | 导入知识（`--dir`、`--from-repo`、`--from-org`、`--from-repo-list`、`--from-mr`、`--from-iwiki`） |
+| `teamai import` | 导入知识（`--dir`、`--from-repo`、`--from-org`、`--from-repo-list`、`--from-mr`） |
 | `teamai codebase --lint` | 知识图谱健康检查 |
 | `teamai ci extract-mr --url <url>` | CI：从 MR 提取知识、发评论、合并后写入 |
 | `teamai members` | 查看团队成员 |

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -4,7 +4,7 @@
 
 > **teamai-cli** — the team collaboration layer for AI agents
 >
-> **Make every team continuously smarter with AI.** Define how agents work (Team Execution), give them team knowledge (Team Context), and turn real sessions into shared capability (Team Improvement). Skills, Rules, Docs, Env, MCP, and more sync automatically to Claude Code, CodeBuddy, Cursor, Codex, OpenCode, Gemini CLI, Windsurf, and others.
+> **Make every team continuously smarter with AI.** Define how agents work (Team Execution), give them team knowledge (Team Context), and turn real sessions into shared capability (Team Improvement). TeamAI manages Skills, Rules, Docs, Env, MCP, and more across Claude Code, Codex, CodeBuddy, WorkBuddy, OpenCode, Cursor, and other supported agents.
 
 ---
 
@@ -23,6 +23,8 @@
 - [Day-to-Day Use](#day-to-day-use)
 - [Sharing Team Resources](#sharing-team-resources)
 - [Knowledge Capture & Retrieval](#knowledge-capture--retrieval)
+- [Knowledge Base Health Report](#knowledge-base-health-report)
+- [Commit Co-Author Attribution](#commit-co-author-attribution)
 - [Team Culture](#team-culture)
 - [Advanced Features](#advanced-features)
 - [Configuration Reference](#configuration-reference)
@@ -89,7 +91,7 @@ npm install -g teamai-cli
 teamai --version
 ```
 
-**Prerequisites:** Node.js ≥ 18, Git (TGit users also need the `gf` CLI, and CNB users the `cnb` CLI — `teamai init` installs either automatically)
+**Prerequisites:** Node.js ≥ 20, Git (TGit users also need the `gf` CLI, and CNB users the `cnb` CLI — `teamai init` installs either automatically)
 
 ---
 
@@ -97,7 +99,7 @@ teamai --version
 
 > Only one admin needs to do this — other members can skip to [Member Onboarding](#member-onboarding).
 
-Create an empty repository on GitHub, GitLab (gitlab.com or a self-hosted instance), GitCode (gitcode.com), CNB (cnb.cool), TGit (Tencent's internal Git host), or any private/self-hosted Git service (suggested naming: `TeamAi-<team-name>`), or simply run `teamai init` — if the repo doesn't exist yet, you'll be prompted to create it automatically.
+Create an empty repository on GitHub, GitLab (gitlab.com or a self-hosted instance), GitCode (gitcode.com), CNB (cnb.cool), TGit, or any private/self-hosted Git service (suggested naming: `TeamAi-<team-name>`), or simply run `teamai init` — if the repo doesn't exist yet, you'll be prompted to create it automatically.
 
 ### Project Scope (default)
 
@@ -106,8 +108,8 @@ Resources are installed under the project directory (`<project>/.claude/skills/`
 ```bash
 # project is the default — --scope can be omitted
 cd /path/to/my-project
-teamai init <group>/TeamAi-<team>
-# equivalent alias: teamai init --repo <group>/TeamAi-<team>
+teamai init https://github.com/yourorg/yourrepo
+# equivalent alias: teamai init --repo https://github.com/yourorg/yourrepo
 ```
 
 Resulting directory structure:
@@ -122,7 +124,7 @@ Resulting directory structure:
 └── src/
 ```
 
-`teamai init` writes `.teamai/` only. Per-agent project roots (`.claude/`, `.cursor/`, `.codebuddy/`, …) are created on **SessionStart** for the tool that just opened (`--tool claude` creates `.claude/`, then pull writes into it). A bare `teamai pull` still skips tools whose project root does not exist, so it never invents agent directories for tools you have not opened in this project.
+`teamai init` writes `.teamai/` only. Per-agent project roots (`.claude/`, `.cursor/`, `.codebuddy/`, …) are created on **SessionStart** for the tool that just opened. For example, opening Claude Code creates `.claude/`, then pull writes into it. A bare `teamai pull` still skips tools whose project root does not exist, so it never invents agent directories for tools you have not opened in this project.
 
 If the repo has role-based skills enabled (i.e. `manifest/roles.yaml` exists), `teamai init` will also interactively ask you to choose:
 
@@ -132,7 +134,7 @@ If the repo has role-based skills enabled (i.e. `manifest/roles.yaml` exists), `
 You can also skip the interactive prompts via CLI flags for a fully non-interactive init (suitable for CI/CD or AI agents):
 
 ```bash
-teamai init <group>/TeamAi-<team> --scope project --role hai_dev --force
+teamai init https://github.com/yourorg/yourrepo --scope project --role hai_dev --force
 ```
 
 | Flag | Description |
@@ -165,7 +167,7 @@ resourceProfileVersion: 1
 Resources are installed into your home directory (`~/.claude/skills/`, etc.), suited for general team conventions and cross-project skills.
 
 ```bash
-teamai init <group>/TeamAi-<team> --scope user
+teamai init https://github.com/yourorg/yourrepo --scope user
 ```
 
 Resulting directory structure:
@@ -266,7 +268,7 @@ Once the admin shares the team repo URL with members:
 ```bash
 npm install -g teamai-cli
 cd /path/to/my-project
-teamai init <group>/TeamAi-<team>
+teamai init https://github.com/yourorg/yourrepo
 # Done! AI tools now automatically have access to team resources
 ```
 
@@ -274,7 +276,7 @@ teamai init <group>/TeamAi-<team>
 
 ```bash
 npm install -g teamai-cli
-teamai init <group>/TeamAi-<team> --scope user
+teamai init https://github.com/yourorg/yourrepo --scope user
 ```
 
 **HTTP mode (read-only consumer):**
@@ -438,7 +440,7 @@ Choose namespace [1-3] (default: 1 = common):
 
 - If `primaryRole` is set, the list of available namespaces is expanded from the manifest
 - If `primaryRole` is not set, the team repo's directory structure is scanned automatically
-- A single namespace is auto-selected; `--silent` mode uses the default
+- A single namespace is auto-selected; use `--role <id>` to choose one explicitly
 - Modifying an existing skill automatically keeps its original namespace
 
 **Updating an open PR instead of duplicating it:** If a resource is already waiting in an unmerged PR, re-running `teamai push` on it updates that existing PR in place (by force-pushing its branch) rather than opening a duplicate. Keep the resource selected to update its PR; deselect it to leave the PR untouched. Unrelated resources selected in the same run go into their own new PR. Once the PR merges (or its branch is removed from the remote), the record is cleared and the next push opens a fresh PR as usual.
@@ -492,6 +494,18 @@ teamai pull
 ```
 
 > **Safe degradation:** If an admin removes a role that a member is still configured with, `pull` won't error out — it falls back to a full sync and prints a warning prompting the member to choose a new role.
+
+### Tag subscriptions
+
+Tags let members subscribe to selected skills and rules outside their role's default namespaces.
+
+```bash
+teamai tags list
+teamai tags subscribe frontend testing
+teamai tags unsubscribe testing
+```
+
+Admins can manage resource tags with `teamai tags add` and `teamai tags remove`. Run `teamai pull` after changing your subscriptions.
 
 ---
 
@@ -957,116 +971,7 @@ When using `teamai init --http <baseUrl>`, the endpoint must implement the follo
 }
 ```
 
-The backend may push an **`apply_model_config`** task whose `cmd` is JSON. Both
-the documented candidate-set shape and the legacy single-model shape are accepted.
-`{"models":[...]}` is a full snapshot; a direct model object is an incremental upsert.
-`max_tokens` is optional (CodeBuddy `maxOutputTokens`); omitted or `0` defaults to `4096`. Claude does not use it.
-
-```jsonc
-{ "id": 16, "type": "apply_model_config",
-  "cmd": "{\"models\":[{\"provider\":\"openai\",\"model_id\":\"gpt-4o\",\"name\":\"GPT-4o\",\"base_url\":\"https://proxy.example.com/v1\",\"api_key\":\"<ProxyToken>\",\"max_tokens\":4096,\"context_window\":128000}]}" }
-```
-
-The candidate set is applied only to the agent that reported the task. CodeBuddy uses
-its user-level `~/.codebuddy/models.json`; user-owned entries with the same model ID
-are preserved. Claude gets an explicit profile at `~/.claude/teamai-models.json` and
-also receives the gateway environment in `~/.claude/settings.json` when it has no
-conflicting user-owned Anthropic gateway configuration. Unsupported agents acknowledge
-the task as failed instead of writing another agent's config. Symlinked user config
-files remain symlinks. These files are mode `0600`. A successful write is acknowledged with
-`type: "apply_model_config"`; malformed payloads are acknowledged as `failed`. Unknown
-future task types are silently skipped for protocol compatibility.
-
-The reverse direction is reported through the existing `report` call: models that
-TeamAI recorded in its model manifest and can still identify by model ID and provider
-on disk are sent as `user_level.models`. Normal agent-added metadata does not suppress
-the report. A successful apply triggers this report immediately in the same sync run.
-User-owned models are omitted because the backend cannot resolve them. The server
-requires both `provider` and `model_id`. Like skills and rules, the field is omitted
-entirely when nothing qualifies, because a present array is treated as a full
-snapshot. Only CodeBuddy (`~/.codebuddy/models.json`) and Claude (the
-`ANTHROPIC_CUSTOM_MODEL_OPTION` gateway in `~/.claude/settings.json`) expose a
-discoverable model config; other tools report nothing. Reported entries always use
-`source: "enterprise"`. **`api_key` is never reported back** — the ProxyToken stays
-on disk.
-
-```jsonc
-{ "agent_type": "codebuddy", "local_agent_id": "...",
-  "user_level": { "models": [
-    { "provider": "tokenhub", "model_id": "gpt-4o", "name": "GPT-4o", "source": "enterprise" }
-  ] } }
-```
-
-The backend may also push an **`uninstall_teamai`** command to remove the local agent. It carries a `cmd` (a single `teamai` subcommand) that runs once on the client, with the result reported back through the same ack channel:
-
-```json
-{ "id": 42, "type": "uninstall_teamai", "cmd": "teamai uninstall --force --agent codebuddy" }
-```
-
-Security boundary for the executed `cmd`:
-
-- **teamai subcommands only** — the first token must be exactly `teamai`; anything else is rejected (acked `failed`) and never executed. There is no arbitrary-shell surface.
-- **No shell** — the command is run via `execFile` with the current Node binary and teamai entry script, so shell metacharacters (`;`, `|`, `&`, `$`, …) are treated as literals and there is no PATH dependency (works inside sandboxes with a bundled Node).
-- **On by default** — like install/uninstall commands, it runs automatically. Set `TEAMAI_DISABLE_REMOTE_CMD=1` on the client to reject it (acked `failed` with `remote cmd disabled by client`).
-- **Timeout** — a hung command is killed after 120s and acked `failed`.
-
-The backend may also push **`install_hook_rule`** / **`uninstall_hook_rule`** commands to remotely
-manage a session hook in the **current reporting tool**'s settings, keyed by `slug`. The result is
-reported over the same ack channel:
-
-```jsonc
-// install (or replace) a hook keyed by slug
-{ "id": 50, "type": "install_hook_rule", "handle_type": "hook", "slug": "my-hook",
-  "event": "SessionStart", "cmd": "echo hi", "timeout": 10 }
-
-// uninstall the hook previously installed under slug
-{ "id": 51, "type": "uninstall_hook_rule", "handle_type": "hook", "slug": "my-hook" }
-```
-
-Rules for agent hooks:
-
-- **Current tool only** — the hook is written to the tool that is reporting (e.g. under Claude ⇒
-  only `.claude/settings.json`). Other tools are never touched.
-- **Supported tools** — `claude` / `codex` / `workbuddy` / `codebuddy` (plus their internal
-  variants). **Cursor and OpenClaw-family tools are rejected** → acked `failed` (`unsupported tool`).
-- **Event whitelist** — `SessionStart` / `UserPromptSubmit` / `PreToolUse` / `PostToolUse` / `Stop`.
-  Any other event → acked `failed` (`unsupported event`).
-- **Optional `matcher`** — a tool-name filter for `PreToolUse` / `PostToolUse`; defaults to `*`
-  (all tools) when omitted.
-- **Default timeout 10s** when `timeout` is omitted; the backend value is honored when present.
-- **Idempotent** — re-installing the same `slug` replaces the existing hook rather than duplicating
-  it; `uninstall_hook_rule` for a missing `slug` is acked `success`.
-- **Isolation** — agent hooks use a dedicated `[teamai:agent-hook:<slug>]` marker, so a team pull
-  never deletes them and installing one never disturbs built-in or team hooks.
-- **Teardown** — agent hooks are removed by `uninstall_hook_rule`, `teamai source remove`, and
-  `teamai uninstall` (no residue in any tool's settings).
-- **Kill-switch** — an agent hook is a backend-supplied command the tool auto-runs on its events,
-  so it shares the `uninstall_teamai` trust model: setting `TEAMAI_DISABLE_REMOTE_CMD=1` on the
-  client rejects `install_hook_rule` / `uninstall_hook_rule` too (acked `failed`).
-- **Codex matching** — codex settings carry no description field, so codex agent hooks are matched
-  by their exact command and the local-agent manifest is the authoritative record for their
-  teardown. Backends should use a **unique `cmd` per codex `slug`** so replace/remove stay precise.
-
-Configurable environment variables:
-
-| Variable | Purpose |
-|------|------|
-| `TEAMAI_API_TOKEN` | API key (alternative to `--token`) |
-| `TEAMAI_REPORT_ENDPOINT` | Reporter base URL (defaults to the `--http` address) |
-| `TEAMAI_REPORT_PATHS` | JSON `{ "report", "sync", "ack" }`, overrides the three paths |
-| `TEAMAI_REPORT_AGENTS` | Comma-separated list of agents that report (default `workbuddy,codebuddy`) |
-| `TEAMAI_SKILL_DOWNLOAD_HOSTS` | Allowlist of hosts for skill `download_url` (empty = allow all) |
-| `TEAMAI_ALLOW_SANDBOX_REPORT` | Set to `1` to force report/sync inside a CloudStudio sandbox (see note below) |
-| `TEAMAI_DISABLE_REMOTE_CMD` | Set to `1` to reject server-pushed `uninstall_teamai`, `install_hook_rule`, and `uninstall_hook_rule` commands (they are acked `failed`) |
-| `TEAMAI_SKIP_AST` | Set to `1` to force heuristic-only code extraction, skipping the WASM tree-sitter AST track |
-
-> **Privacy:** The install path and machine id are only hashed locally to derive `local_agent_id` — they are never reported.
-
-> **CloudStudio sandbox:** When WorkBuddy runs teamai hooks inside a CloudStudio container, that container has a
-> different machine id than the macOS host and would report a duplicate agent card. The duplicate report is therefore
-> skipped automatically inside a CloudStudio sandbox (sync still runs, so pushed commands are still received) —
-> detected via `X_IDE_IS_CLOUDSTUDIO=TRUE` or the `/var/run/cloudstudio` directory.
-> Set `TEAMAI_ALLOW_SANDBOX_REPORT=1` to opt back in if you run teamai exclusively inside CloudStudio.
+The HTTP contract is intended for custom integrations. End users only need the `teamai init --http` command described in [Member Onboarding](#member-onboarding).
 
 ### Codebase Knowledge Graph
 
@@ -1087,9 +992,6 @@ teamai import --from-repo-list repos.yaml
 
 # Extract learnings from a merged MR/PR
 teamai import --from-mr https://github.com/org/repo/pull/123
-
-# Import docs from iWiki
-teamai import --from-iwiki 12345
 
 # Incremental mode (skip unchanged files)
 teamai import --from-repo https://github.com/org/repo --incremental
@@ -1173,13 +1075,14 @@ Hooks automatically injected by `teamai init`:
 | `Stop` | CLI update check + report session end |
 
 ```bash
+teamai hooks list      # Show effective built-in and team hooks
 teamai hooks inject    # Re-inject
 teamai hooks remove    # Remove
 ```
 
-Both commands only touch tools you actually have installed (i.e. whose `~/.<tool>/` root directory already exists). They never create root directories for tools listed in `toolPaths` but not installed.
+The inject and remove commands only touch tools you actually have installed (i.e. whose `~/.<tool>/` root directory already exists). They never create root directories for tools listed in `toolPaths` but not installed.
 
-> **Codex trust gate** — Codex (the OpenAI / ChatGPT Codex app, tool id `codex`) gates non-managed hooks behind an explicit user trust step. After teamai writes `~/.codex/hooks.json`, Codex may skip a newly added or changed hook until you review/trust it in `/hooks` or Settings → Hooks. `teamai hooks inject` and `teamai doctor` print a reminder when Codex hooks are installed; teamai never edits Codex's `[hooks.state]` to auto-trust — trusting is left to you. (The internal variants `codex-internal` / `tcodex` share the hooks.json format but have no trust gate, so no reminder is shown for them.)
+> **Codex trust gate** — Codex (the OpenAI / ChatGPT Codex app, tool id `codex`) gates non-managed hooks behind an explicit user trust step. After teamai writes `~/.codex/hooks.json`, Codex may skip a newly added or changed hook until you review/trust it in `/hooks` or Settings → Hooks. `teamai hooks inject` and `teamai doctor` print a reminder when Codex hooks are installed; teamai never edits Codex's `[hooks.state]` to auto-trust — trusting is left to you.
 
 ### Team Hooks Declaration
 
@@ -1274,10 +1177,13 @@ Upgrading from an earlier version: `.cursor/rules/*.md` copies written by the ol
 ```bash
 teamai doctor          # Config diagnostics
 teamai stats           # Skill usage stats
-teamai update          # CLI update
+teamai update --check  # Check for a CLI update without installing it
+teamai update          # Check for and install a CLI update
+teamai digest          # Generate the weekly team activity digest
 teamai remove skills <name>   # Remove a resource
 teamai remove rules <name>
-teamai remove wiki <name>
+teamai remove agents <name>
+teamai remove mcp <name>
 ```
 
 Auto-update runs in the Stop hook and is controlled by two tiers:
@@ -1373,6 +1279,8 @@ packages:
 sharing:
   rules:
     enforced: [code-review-guide]
+  recall:
+    enabled: false             # optional; members can override locally
   docs:
     localDir: ./.teamai/docs
   env:
@@ -1438,7 +1346,7 @@ The exclusion is durable: `uninstall --agent <tool>` drops the tool from `enable
 To rejoin after uninstalling:
 
 ```bash
-teamai init --repo <group>/TeamAi-<team> --scope user --role <role_id> --force
+teamai init --repo https://github.com/yourorg/yourrepo --scope user --role <role_id> --force
 teamai pull
 ```
 
@@ -1455,7 +1363,7 @@ Yes, but project scope remains isolated by default. When the current working dir
 In interactive mode, you'll be asked whether to overwrite — type `y` to confirm. You can also use `--force` to skip the confirmation:
 
 ```bash
-teamai init --repo <group>/<repo> --force
+teamai init --repo https://github.com/yourorg/yourrepo --force
 ```
 
 **Q: After `teamai init` in a project, there is no `.claude/` (or `.cursor/`, `.codebuddy/`) directory?**

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -2,9 +2,9 @@
 
 > [English](usage-guide.md) | [简体中文](usage-guide.zh-CN.md)
 
-> **@tencent/teamai-cli** — AI Agents 的团队协作层
+> **teamai-cli** — AI Agents 的团队协作层
 >
-> **让每个团队通过 AI 持续变得更聪明。** 统一工作方式（Team Execution）、共享团队 Context（Team Context），并把真实 Session 沉淀成团队能力（Team Improvement）。Skills、Rules、Docs、Env、MCP 等会自动同步到 Claude Code、CodeBuddy、Cursor、Codex、OpenCode、Gemini CLI、Windsurf 等工具。
+> **让每个团队通过 AI 持续变得更聪明。** 统一工作方式（Team Execution）、共享团队 Context（Team Context），并把真实 Session 沉淀成团队能力（Team Improvement）。TeamAI 统一管理 Claude Code、Codex、CodeBuddy、WorkBuddy、OpenCode、Cursor 及其他受支持 Agent 的 Skills、Rules、Docs、Env、MCP 等资源。
 
 ---
 
@@ -23,9 +23,12 @@
 - [日常使用](#日常使用)
 - [共享团队资源](#共享团队资源)
 - [知识沉淀与检索](#知识沉淀与检索)
-- [团队文化](#团队文化culture)
+- [知识库健康报告](#知识库健康报告)
+- [提交 Co-Author 署名](#提交-co-author-署名)
+- [团队文化](#团队文化)
 - [进阶功能](#进阶功能)
 - [配置文件参考](#配置文件参考)
+- [卸载](#卸载)
 - [常见问题 FAQ](#常见问题-faq)
 
 ---
@@ -81,13 +84,13 @@ TeamAI 的产品是一条闭环，而不是三个独立产品：
 ## 安装
 
 ```bash
-npm install -g @tencent/teamai-cli --registry=http://r.tnpm.oa.com
+npm install -g teamai-cli
 
 # 验证
 teamai --version
 ```
 
-**前置依赖：** Node.js ≥ 18、Git（TGit 用户还需 `gf` CLI、CNB 用户还需 `cnb` CLI，`teamai init` 时都会自动安装）
+**前置依赖：** Node.js ≥ 20、Git（TGit 用户还需 `gf` CLI、CNB 用户还需 `cnb` CLI，`teamai init` 时都会自动安装）
 
 ---
 
@@ -95,7 +98,7 @@ teamai --version
 
 > 只需一位管理员完成，其他成员跳到[成员接入](#成员接入)。
 
-在 GitHub、GitLab（gitlab.com 或自建实例）、GitCode（gitcode.com）、CNB（cnb.cool）、TGit（腾讯工蜂），或任意私有/自建 Git 服务上创建一个空仓库（命名建议：`TeamAi-<团队名>`），或者直接执行 `teamai init`，不存在时会提示自动创建。
+在 GitHub、GitLab（gitlab.com 或自建实例）、GitCode（gitcode.com）、CNB（cnb.cool）、TGit，或任意私有/自建 Git 服务上创建一个空仓库（命名建议：`TeamAi-<团队名>`），或者直接执行 `teamai init`，不存在时会提示自动创建。
 
 ### 项目级（Project Scope，默认）
 
@@ -104,8 +107,8 @@ teamai --version
 ```bash
 # project 是默认值，可省略 --scope
 cd /path/to/my-project
-teamai init <group>/TeamAi-<team>
-# 等价别名：teamai init --repo <group>/TeamAi-<team>
+teamai init https://github.com/yourorg/yourrepo
+# 等价别名：teamai init --repo https://github.com/yourorg/yourrepo
 ```
 
 生成的目录结构：
@@ -120,7 +123,7 @@ teamai init <group>/TeamAi-<team>
 └── src/
 ```
 
-`teamai init` 只写入 `.teamai/`。各 Agent 的项目根目录（`.claude/`、`.cursor/`、`.codebuddy/` 等）会在 **SessionStart** 时按刚打开的工具创建（`--tool claude` 会建 `.claude/`，再 pull 写入）。单独执行 `teamai pull` 仍会跳过项目里还不存在根目录的工具，因此不会给尚未在本项目打开过的 Agent 凭空建目录。
+`teamai init` 只写入 `.teamai/`。各 Agent 的项目根目录（`.claude/`、`.cursor/`、`.codebuddy/` 等）会在 **SessionStart** 时按刚打开的工具创建。例如，打开 Claude Code 时会创建 `.claude/`，再由 pull 写入。单独执行 `teamai pull` 仍会跳过项目里还不存在根目录的工具，因此不会给尚未在本项目打开过的 Agent 凭空建目录。
 
 如果仓库启用了角色化 skills（存在 `manifest/roles.yaml`），`teamai init` 还会交互式要求你选择：
 
@@ -130,7 +133,7 @@ teamai init <group>/TeamAi-<team>
 也可以通过 CLI 参数跳过交互，实现完全非交互式初始化（适合 CI/CD 或 AI agent）：
 
 ```bash
-teamai init <group>/TeamAi-<team> --scope project --role hai_dev --force
+teamai init https://github.com/yourorg/yourrepo --scope project --role hai_dev --force
 ```
 
 | 参数 | 说明 |
@@ -147,7 +150,7 @@ teamai init <group>/TeamAi-<team> --scope project --role hai_dev --force
 ```yaml
 repo:
   localPath: /path/to/my-project/.teamai/team-repo
-  remote: https://git.woa.com/group/repo.git
+  remote: https://github.com/yourorg/yourrepo.git
 username: alice
 scope: project
 projectRoot: /path/to/my-project
@@ -163,7 +166,7 @@ resourceProfileVersion: 1
 资源安装到用户主目录（`~/.claude/skills/` 等），适用于通用团队规范、跨项目技能。
 
 ```bash
-teamai init <group>/TeamAi-<team> --scope user
+teamai init https://github.com/yourorg/yourrepo --scope user
 ```
 
 生成的目录结构：
@@ -197,14 +200,14 @@ teamai init <group>/TeamAi-<team> --scope user
 ```bash
 cd /path/to/my-project
 teamai init .                        # 交互式：选择要启用哪些 AI 工具
-teamai init . --agent claude,codex   # 非交互:启用 Claude Code + Codex
+teamai init . --agent claude,codex   # 非交互：启用 Claude Code + Codex
 ```
 
-**选择启用哪些 AI 工具。** 单仓模式会在你的仓库里为每个工具创建一个目录（如 `.claude/`、`.codex/`）—— 建好 skills 目录、注入 teamai hooks,并把该工具的 settings 提交到 main,让队友 clone 后即可获得。由你决定启用哪些工具:
+**选择启用哪些 AI 工具。** 单仓模式会在你的仓库里为每个工具创建一个目录（如 `.claude/`、`.codex/`）——建好 skills 目录、注入 teamai hooks，并把该工具的 settings 提交到 main，让队友 clone 后即可获得。由你决定启用哪些工具：
 
-- **`--agent <name...>`** —— 显式列表,可重复或逗号分隔:`--agent claude`、`--agent claude,codex`、`--agent claude --agent cursor`。支持的 id 包括 `claude`、`codex`、`cursor`、`joycode`、`codebuddy`、`workbuddy`、`dsh`（DeepSeek Harness）。
-- **交互式（无 `--agent`、有终端）** —— teamai 弹出多选列表。第 1 项是 **Auto**,会列出你本机已安装的 AI 工具（`~/.claude`、`~/.codex`……）并作为回车默认项;其余各项是具体工具。Auto 与具体工具可以组合勾选。
-- **非交互（无 `--agent`、无终端 —— CI、hook、clone 时自愈 bootstrap）** —— teamai 会按你本机 home 目录下已装的工具（`~/.claude`、`~/.codex`……）来建。若一个都没检测到,则什么都不建（你仍拿到知识,可稍后运行 `teamai init .` 再选工具）。
+- **`--agent <name...>`** —— 显式列表，可重复或逗号分隔：`--agent claude`、`--agent claude,codex`、`--agent claude --agent cursor`。常用 id 包括 `claude`、`codex`、`cursor`、`joycode`、`codebuddy`、`workbuddy`、`dsh`（DeepSeek Harness）。
+- **交互式（无 `--agent`、有终端）** —— teamai 弹出多选列表。第 1 项是 **Auto**，会列出你本机已安装的 AI 工具（`~/.claude`、`~/.codex`……）并作为回车默认项；其余各项是具体工具。Auto 与具体工具可以组合勾选。
+- **非交互（无 `--agent`、无终端 —— CI、hook、clone 时自愈 bootstrap）** —— teamai 会按你本机 home 目录下已装的工具（`~/.claude`、`~/.codex`……）来建。若一个都没检测到，则什么都不建（你仍拿到知识，可稍后运行 `teamai init .` 再选工具）。
 
 **数据如何在分支间拆分：**
 
@@ -222,19 +225,19 @@ teamai init . --agent claude,codex   # 非交互:启用 Claude Code + Codex
 
 1. `teamai init .` 已经帮你把 `.teamai/`（skills、rules、docs、learnings、`teamai.yaml`、`.gitignore`）以及每个所选工具的 settings（如 `.claude/settings.json`、`.codex/hooks.json`）提交到当前分支。
 2. 推送 main，供团队成员 clone。
-3. 之后新增资源用 `teamai push` —— 它会（通过隔离 worktree）向你的仓库开 PR，而不是直接改动你的工作区。单仓模式下，你既可以在 AI 工具目录（如 `~/.claude/skills/`）里编写,**也可以**直接把资源放进仓库里的 `.teamai/`：
+3. 之后新增资源用 `teamai push` —— 它会（通过隔离 worktree）向你的仓库开 PR，而不是直接改动你的工作区。单仓模式下，你既可以在 AI 工具目录（如 `~/.claude/skills/`）里编写，**也可以**直接把资源放进仓库里的 `.teamai/`：
    - `.teamai/skills/` —— 团队 skills
    - `.teamai/rules/` —— 共享 rules
-   - `.teamai/agents/` —— subagent 定义（`<name>.yaml`,或旧版 `<name>.md`）
+   - `.teamai/agents/` —— subagent 定义（`<name>.yaml`，或旧版 `<name>.md`）
    - `.teamai/env/env.yaml` —— 共享环境变量
 
-   `teamai push` 会同时扫描这些目录和你的 AI 工具目录,只呈现真正的新增或修改（已提交的内容会被跳过）。如果你改了某个 agent 的扩展名（如 `helper.md` → `helper.yaml`）,请手动删掉旧文件 —— `teamai push` 不会替你删除,同 stem 的两个文件会在 pull 时冲突。
-4. **docs / hooks / mcp** 通过直接编辑对应文件来贡献 —— 它们不走 `teamai push`,用普通的 `git commit` + push 即可分发：
+   `teamai push` 会同时扫描这些目录和你的 AI 工具目录，只呈现真正的新增或修改（已提交的内容会被跳过）。如果你改了某个 agent 的扩展名（如 `helper.md` → `helper.yaml`），请手动删掉旧文件 —— `teamai push` 不会替你删除，同 stem 的两个文件会在 pull 时冲突。
+4. **docs / hooks / mcp** 通过直接编辑对应文件来贡献 —— 它们不走 `teamai push`，用普通的 `git commit` + push 即可分发：
    - `.teamai/docs/` —— 团队文档
    - `.teamai/hooks/hooks.yaml` —— 团队 hooks
    - `.teamai/mcp/mcp.yaml` —— 共享 MCP servers
 
-> **关于 `env` 的提醒。** 单仓模式下 `.teamai/env/env.yaml` **会被提交到 main**（不同于独立模式的每机本地 env），因此会随 clone 分发给所有人。`env.yaml` 存的是明文键值对 —— 只放非敏感的共享配置,真正的密钥请留在你自己未追踪的环境里。
+> **关于 `env` 的提醒。** 单仓模式下 `.teamai/env/env.yaml` **会被提交到 main**（不同于独立模式的每机本地 env），因此会随 clone 分发给所有人。`env.yaml` 存的是明文键值对 —— 只放非敏感的共享配置，真正的密钥请留在你自己未追踪的环境里。
 
 > **限制。** 单仓模式把一套团队配置绑定到一个业务仓。如果需要一套团队知识库被多个业务仓共享，请改用独立团队仓（`teamai init <repo>`）。
 
@@ -262,17 +265,17 @@ teamai init https://github.com/yourorg/java-service-teamai --inherit-user-scope
 **项目级团队（默认）：**
 
 ```bash
-npm install -g @tencent/teamai-cli --registry=http://r.tnpm.oa.com
+npm install -g teamai-cli
 cd /path/to/my-project
-teamai init <group>/TeamAi-<team>
+teamai init https://github.com/yourorg/yourrepo
 # 完成！AI 工具已自动获得团队资源
 ```
 
 **用户级团队：**
 
 ```bash
-npm install -g @tencent/teamai-cli --registry=http://r.tnpm.oa.com
-teamai init <group>/TeamAi-<team> --scope user
+npm install -g teamai-cli
+teamai init https://github.com/yourorg/yourrepo --scope user
 ```
 
 **HTTP 模式（只读消费者）：**
@@ -436,7 +439,7 @@ Choose namespace [1-3] (default: 1 = common):
 
 - 有 `primaryRole` 时，从 manifest 展开可用 namespace 列表
 - 无 `primaryRole` 时，自动扫描团队仓库目录结构
-- 单一命名空间时自动选中；`--silent` 模式使用默认值
+- 单一命名空间时自动选中；也可用 `--role <id>` 显式指定
 - 修改已有 skill 时自动保持原 namespace
 
 **更新已存在的 PR 而非重复创建：** 如果某个资源已在一个未合并的 PR 中等待评审，再次对它执行 `teamai push` 会就地更新那个已存在的 PR（通过 force-push 其分支），而不是新开一个重复的 PR。保持该资源被选中即更新其 PR；取消勾选则不动它。同一次运行中选中的其他无关资源会进入各自新开的 PR。一旦该 PR 合并（或其分支从远端删除），记录会被清除，下次 push 照常新开 PR。
@@ -490,6 +493,18 @@ teamai pull
 ```
 
 > **安全降级：** 如果管理员删除了某个角色，仍然配置了该角色的成员在 pull 时不会报错，而是回退到全量同步并输出警告，提示重新选择角色。
+
+### 标签订阅
+
+标签让成员订阅默认角色 namespace 之外的指定 skills 和 rules。
+
+```bash
+teamai tags list
+teamai tags subscribe frontend testing
+teamai tags unsubscribe testing
+```
+
+管理员可通过 `teamai tags add` 和 `teamai tags remove` 管理资源标签。修改订阅后运行 `teamai pull`。
 
 ---
 
@@ -603,9 +618,9 @@ Codex 支持 `stdio` 与 `http`，`sse` 会被跳过。Qoder 使用对应作用�
 
 **密钥**：在 `mcp.yaml` 里写 `${VAR}`，不要写明文。取值优先来自环境变量，其次是 `env/env.yaml` → `~/.teamai/env`。变量无法解析则跳过并提示。
 
-teamai 会**把每个 `${VAR}` 解析成取值后原样写入**各工具的配置文件(新建文件权限为 `0600`)。它不依赖任何工具自身的环境变量展开——因为那种展开很脆弱:最典型的是,以 GUI 方式(Dock/Launchpad)启动的 IDE 不会继承你 shell 中 `export` 的变量,`${VAR}` 占位符会展开为空、导致服务端 401。解析成明文可以保证无论工具如何启动,token 都在。
+teamai 会**把每个 `${VAR}` 解析成取值后原样写入**各工具的配置文件（新建文件权限为 `0600`）。它不依赖任何工具自身的环境变量展开——因为那种展开很脆弱：最典型的是，以 GUI 方式（Dock/Launchpad）启动的 IDE 不会继承你 shell 中 `export` 的变量，`${VAR}` 占位符会展开为空、导致服务端 401。解析成明文可以保证无论工具如何启动，token 都在。
 
-> ⚠️ **解析后的 token 会落盘。** 项目级 MCP 配置(`.mcp.json`、`.cursor/mcp.json`、`.codebuddy/mcp.json`、`.codex/config.toml`、`opencode.json`)因此含有明文密钥——请把它们加入 `.gitignore`,切勿提交。
+> ⚠️ **解析后的 token 会落盘。** 项目级 MCP 配置（`.mcp.json`、`.cursor/mcp.json`、`.codebuddy/mcp.json`、`.codex/config.toml`、`opencode.json`）因此含有明文密钥——请把它们加入 `.gitignore`，切勿提交。
 
 Claude Code 可能把来自仓库的 `.mcp.json` 标为待批准，需在交互式会话中确认一次。
 
@@ -791,7 +806,7 @@ teamai push   # 将清理后的知识库分享给团队
 
 ---
 
-## 提交 Co-Author 署名（Commit Co-Author Attribution）
+## 提交 Co-Author 署名
 
 AI 编码工具会在它生成的提交上打一个 `Co-Authored-By:` / attribution 尾注。希望保持干净历史的团队可以为全员关闭它，成员仍可在自己机器上覆盖。`teamai pull` 会把最终生效的意图写入每个已安装工具各自的配置文件。
 
@@ -820,7 +835,7 @@ AI 编码工具会在它生成的提交上打一个 `Co-Authored-By:` / attribut
 
 ---
 
-## 团队文化（Culture）
+## 团队文化
 
 TeamAI 支持将团队文化注入到 AI 工具中，让 AI 编码助手在每次会话中都能感知你的团队文化、价值观和编码准则。
 
@@ -955,107 +970,7 @@ cat ~/.claude/CLAUDE.md
 }
 ```
 
-后端可下发 **`apply_model_config`** 任务，其 `cmd` 为 JSON。客户端同时兼容设计文档中的候选集结构和
-旧版单模型结构：`{"models":[...]}` 按完整快照处理，直接模型对象按增量 upsert 处理。
-`max_tokens` 可选（对应 CodeBuddy 的 `maxOutputTokens`）；缺省或 `0` 时默认 `4096`。Claude 不使用该字段。
-
-```jsonc
-{ "id": 16, "type": "apply_model_config",
-  "cmd": "{\"models\":[{\"provider\":\"openai\",\"model_id\":\"gpt-4o\",\"name\":\"GPT-4o\",\"base_url\":\"https://proxy.example.com/v1\",\"api_key\":\"<ProxyToken>\",\"max_tokens\":4096,\"context_window\":128000}]}" }
-```
-
-候选集只会写入当前上报任务的 agent。CodeBuddy 使用用户级 `~/.codebuddy/models.json`；若同一
-模型 ID 已由用户配置，则保留用户条目。Claude 侧会生成独立配置
-`~/.claude/teamai-models.json`；仅当 `~/.claude/settings.json` 中不存在冲突的用户 Anthropic
-网关配置时，才把网关环境变量写入默认 settings。不支持的 agent 会回执失败，不会误写其他
-agent 的配置。用户配置文件是符号链接时会保留链接。以上含凭证文件权限均为 `0600`。落盘成功后以
-`type: "apply_model_config"` 回执；
-非法 payload 回执 `failed`。未来未知任务类型会静默跳过，以保持协议向后兼容。
-
-反向的模型上报走已有的 `report` 接口：仅上报 TeamAI manifest 已记录、且磁盘上的模型 ID 和
-provider 仍可识别的模型，放在 `user_level.models` 中。agent 正常补充元数据不会导致漏报；
-模型落盘成功后会在同一次 sync 中立即补一次 report，无需等待下一次 session。用户自有模型不上报，
-因为后台无法识别。服务端要求 `provider` 与
-`model_id` 同时存在。与 skills/rules 一致，没有任何符合条件的模型时该字段整体省略——因为
-存在的数组会被当作全量快照。只有 CodeBuddy（`~/.codebuddy/models.json`）和 Claude
-（`~/.claude/settings.json` 里的 `ANTHROPIC_CUSTOM_MODEL_OPTION` 网关）有可发现的模型配置，
-其余工具不上报。上报条目的 `source` 固定为 `enterprise`。
-**`api_key` 不会被回传** —— ProxyToken 只留在本地磁盘。
-
-```jsonc
-{ "agent_type": "codebuddy", "local_agent_id": "...",
-  "user_level": { "models": [
-    { "provider": "tokenhub", "model_id": "gpt-4o", "name": "GPT-4o", "source": "enterprise" }
-  ] } }
-```
-
-后端也可下发 **`uninstall_teamai`** 命令来移除本地 agent。它携带一个 `cmd`（一条 `teamai` 子命令），让客户端执行一次，执行结果经同一 ack 通道回报：
-
-```json
-{ "id": 42, "type": "uninstall_teamai", "cmd": "teamai uninstall --force --agent codebuddy" }
-```
-
-执行 `cmd` 的安全边界：
-
-- **仅限 teamai 子命令** —— 第一个 token 必须严格等于 `teamai`；其它一律拒绝（ack `failed`）且不执行，不存在任意 shell 面。
-- **无 shell** —— 命令经 `execFile` 用当前 Node 二进制与 teamai 入口脚本运行，shell 元字符（`;`、`|`、`&`、`$` 等）按字面处理，且不依赖 PATH（沙箱内自带 Node 也可运行）。
-- **默认开启** —— 与 install/uninstall 命令一致，会自动执行。客户端设 `TEAMAI_DISABLE_REMOTE_CMD=1` 可拒绝（ack `failed`，错误为 `remote cmd disabled by client`）。
-- **超时** —— 命令卡住 120s 后被杀掉并 ack `failed`。
-
-后端还可下发 **`install_hook_rule`** / **`uninstall_hook_rule`** 命令，按 `slug` 远程管理**当前上报工具**
-settings 里的一个 session hook。结果经同一 ack 通道回报：
-
-```jsonc
-// 按 slug 安装（或替换）一个 hook
-{ "id": 50, "type": "install_hook_rule", "handle_type": "hook", "slug": "my-hook",
-  "event": "SessionStart", "cmd": "echo hi", "timeout": 10 }
-
-// 卸载此前以该 slug 安装的 hook
-{ "id": 51, "type": "uninstall_hook_rule", "handle_type": "hook", "slug": "my-hook" }
-```
-
-agent hook 规则：
-
-- **仅当前工具** —— hook 只写入正在上报的工具（如在 Claude 下运行 ⇒ 只写 `.claude/settings.json`），
-  绝不触碰其它工具。
-- **支持的工具** —— `claude` / `codex` / `workbuddy` / `codebuddy`（含其内部变体）。**Cursor 与 OpenClaw
-  家族被拒绝** → ack `failed`（`unsupported tool`）。
-- **事件白名单** —— `SessionStart` / `UserPromptSubmit` / `PreToolUse` / `PostToolUse` / `Stop`。
-  其它事件 → ack `failed`（`unsupported event`）。
-- **可选 `matcher`** —— `PreToolUse` / `PostToolUse` 的工具名过滤；省略时默认为 `*`（全部工具）。
-- **默认超时 10s** —— 省略 `timeout` 时用 10s；后端给了值则以后端为准。
-- **幂等** —— 用相同 `slug` 重装会替换已有 hook 而非重复追加；对不存在的 `slug` 执行
-  `uninstall_hook_rule` 也 ack `success`。
-- **隔离** —— agent hook 使用专属 marker `[teamai:agent-hook:<slug>]`，团队 pull 不会删除它，
-  安装它也不会扰动 built-in 或团队 hook。
-- **清理** —— agent hook 会被 `uninstall_hook_rule`、`teamai source remove` 和 `teamai uninstall`
-  彻底移除（不在任何工具 settings 里留残留）。
-- **关闭开关** —— agent hook 是后端下发、由工具在其事件上自动执行的命令，因此与 `uninstall_teamai`
-  共用信任模型：客户端设 `TEAMAI_DISABLE_REMOTE_CMD=1` 也会拒绝 `install_hook_rule` /
-  `uninstall_hook_rule`（ack `failed`）。
-- **Codex 匹配** —— codex settings 无 description 字段，因此 codex agent hook 按其确切命令匹配，
-  且以 local-agent manifest 作为卸载的权威记录。后端应为**每个 codex `slug` 使用唯一的 `cmd`**，
-  以保证替换/删除的精确性。
-
-可配置环境变量：
-
-| 变量 | 作用 |
-|------|------|
-| `TEAMAI_API_TOKEN` | API key（`--token` 的替代） |
-| `TEAMAI_REPORT_ENDPOINT` | reporter 基础 URL（默认 = `--http` 地址） |
-| `TEAMAI_REPORT_PATHS` | JSON `{ "report", "sync", "ack" }`，覆盖三个路径 |
-| `TEAMAI_REPORT_AGENTS` | 参与上报的 agent，逗号分隔（默认 `workbuddy,codebuddy`） |
-| `TEAMAI_SKILL_DOWNLOAD_HOSTS` | skill `download_url` host 白名单（空 = 全部放行） |
-| `TEAMAI_ALLOW_SANDBOX_REPORT` | 设为 `1` 可强制在 CloudStudio 沙箱内 report/sync（见下方说明） |
-| `TEAMAI_DISABLE_REMOTE_CMD` | 设为 `1` 可拒绝服务端下发的 `uninstall_teamai`、`install_hook_rule`、`uninstall_hook_rule` 命令（会 ack `failed`） |
-| `TEAMAI_SKIP_AST` | 设为 `1` 时强制仅用启发式提取，跳过 WASM tree-sitter AST 轨 |
-
-> **隐私**：install path 和 machine id 仅在本地哈希以派生 `local_agent_id`，不会上报。
-
-> **CloudStudio 沙箱**：当 WorkBuddy 在 CloudStudio 容器内运行 teamai hook 时，该容器的 machine id 与 macOS
-> 宿主不同，会上报一张重复的 agent 卡片。因此在 CloudStudio 沙箱内会自动跳过重复的 report（sync 仍会执行，因此仍能收到下发命令）——
-> 通过 `X_IDE_IS_CLOUDSTUDIO=TRUE` 或 `/var/run/cloudstudio` 目录检测。若你只在 CloudStudio 内使用 teamai，可设
-> `TEAMAI_ALLOW_SANDBOX_REPORT=1` 重新开启上报。
+HTTP 契约用于自建集成。普通用户只需使用[成员接入](#成员接入)中的 `teamai init --http` 命令。
 
 ### 代码知识图谱
 
@@ -1076,9 +991,6 @@ teamai import --from-repo-list repos.yaml
 
 # 从已合并的 MR/PR 提取经验
 teamai import --from-mr https://github.com/org/repo/pull/123
-
-# 从 iWiki 导入文档
-teamai import --from-iwiki 12345
 
 # 增量模式（跳过未变更文件）
 teamai import --from-repo https://github.com/org/repo --incremental
@@ -1162,13 +1074,14 @@ teamai session save --push --include-prompt  # 额外带上（脱敏后的）首
 | `Stop` | CLI 更新检查 + 上报会话结束 |
 
 ```bash
+teamai hooks list      # 查看生效的内置和团队 hooks
 teamai hooks inject    # 重新注入
 teamai hooks remove    # 移除
 ```
 
-这两个命令只会操作你实际已安装的工具（即 `~/.<tool>/` 根目录已存在的工具）。对于 `toolPaths` 中已配置但未安装的工具，命令不会为其凭空创建根目录。
+inject 和 remove 只会操作你实际已安装的工具（即 `~/.<tool>/` 根目录已存在的工具）。对于 `toolPaths` 中已配置但未安装的工具，命令不会为其凭空创建根目录。
 
-> **Codex 信任门槛** — Codex（OpenAI / ChatGPT Codex 应用，工具 id 为 `codex`）对非托管 hooks 设有显式的用户信任机制。teamai 写入 `~/.codex/hooks.json` 后，对于新增或变更的 hook，Codex 可能会跳过执行，直到你在 `/hooks` 或 Settings → Hooks 中 review/trust。当检测到 Codex hooks 已安装时，`teamai hooks inject` 与 `teamai doctor` 会输出提示；teamai 从不修改 Codex 的 `[hooks.state]` 来自动信任 —— 信任操作交由你手动完成。（内部变体 `codex-internal` / `tcodex` 共用 hooks.json 格式但没有信任门槛，因此不会为它们输出提示。）
+> **Codex 信任门槛** — Codex（OpenAI / ChatGPT Codex 应用，工具 id 为 `codex`）对非托管 hooks 设有显式的用户信任机制。teamai 写入 `~/.codex/hooks.json` 后，对于新增或变更的 hook，Codex 可能会跳过执行，直到你在 `/hooks` 或 Settings → Hooks 中 review/trust。当检测到 Codex hooks 已安装时，`teamai hooks inject` 与 `teamai doctor` 会输出提示；teamai 从不修改 Codex 的 `[hooks.state]` 来自动信任 —— 信任操作交由你手动完成。
 
 ### 团队 Hooks 声明
 
@@ -1240,7 +1153,7 @@ JoyCode 规则清理采用保守策略：不在团队规则列表中的本地 `.
 
 对于以 YAML 保存的团队 Agent，push 会将本地文件与对应工具的渲染结果比较，只将真实编辑合并回原始配置。部署范围 `targets`、其他工具的元数据，以及本地格式未输出的字段都会保留。遇到冲突或无法解析的编辑时跳过回写，不会替换团队源文件。
 
-**Hooks 与手动同步**：JoyCode 当前没有提供生命周期 Hooks 机制或专用启动适配器（无类似 `settings.json` hooks 数组或 `hooks.json` 的事件配置）。因此，打开或启动 JoyCode 不会触发 TeamAI 的 `SessionStart` 事件，无法进行后台自动拉取（auto-pull）、使用指标上报（auto-report/track）或自动更新检测。JoyCode 用户需要通过在终端手动运行 `teamai pull` 来同步团队最新技能、规则与 Agent，通过 `teamai push` 贡献变更。若 JoyCode 后续版本提供了 Hooks 或插件生命周期机制，将通过专用适配器接入。
+**Hooks 与手动同步**：JoyCode 当前没有提供生命周期 Hooks 机制或专用启动适配器（无类似 `settings.json` hooks 数组或 `hooks.json` 的事件配置）。因此，打开或启动 JoyCode 不会触发 TeamAI 的 `SessionStart` 事件，无法进行后台自动拉取、使用指标上报（`teamai track`）或自动更新检测。JoyCode 用户需要通过在终端手动运行 `teamai pull` 来同步团队最新技能、规则与 Agent，通过 `teamai push` 贡献变更。若 JoyCode 后续版本提供了 Hooks 或插件生命周期机制，将通过专用适配器接入。
 
 ### Cursor
 
@@ -1263,10 +1176,13 @@ Cursor 的项目规则必须以 **`.mdc`** 文件形式放在 `.cursor/rules/` �
 ```bash
 teamai doctor          # 配置诊断
 teamai stats           # skill 使用统计
-teamai update          # CLI 更新
+teamai update --check  # 仅检查 CLI 更新，不安装
+teamai update          # 检查并安装 CLI 更新
+teamai digest          # 生成团队活动周报
 teamai remove skills <name>   # 删除资源
 teamai remove rules <name>
-teamai remove wiki <name>
+teamai remove agents <name>
+teamai remove mcp <name>
 ```
 
 自动更新在 Stop hook 中执行，可通过两层控制：
@@ -1307,7 +1223,7 @@ teamai ci extract-mr --url "$MR_URL" --mode write --team-repo ./team-repo --indi
 
 ```bash
 # 添加订阅源
-teamai source add https://git.woa.com/other-team/teamai-public.git --name other-team
+teamai source add https://github.com/other-team/teamai-public.git --name other-team
 
 # 查看订阅列表
 teamai source list
@@ -1347,8 +1263,8 @@ HTTP 源通过 hook dispatch 在每次 session 中上报状态并拉取 skill �
 ```yaml
 team: my-team
 description: 团队 AI 资源仓库
-repo: https://git.woa.com/group/repo.git
-provider: tgit
+repo: https://github.com/yourorg/yourrepo.git
+provider: github
 # scope: 若存在则忽略——本机安装位置由 `teamai init --scope` 决定
 
 reviewers:
@@ -1362,6 +1278,8 @@ packages:
 sharing:
   rules:
     enforced: [code-review-guide]
+  recall:
+    enabled: false             # 可选；成员可在本地覆盖
   docs:
     localDir: ./.teamai/docs
   env:
@@ -1377,7 +1295,7 @@ sharing:
 ```yaml
 repo:
   localPath: /path/to/.teamai/team-repo
-  remote: https://git.woa.com/group/repo.git
+  remote: https://github.com/yourorg/yourrepo.git
 username: your-name
 updatePolicy: auto
 scope: project                 # project（init 默认）或 user
@@ -1427,7 +1345,7 @@ teamai uninstall --agent claude
 卸载后如需重新加入：
 
 ```bash
-teamai init --repo <group>/TeamAi-<team> --scope user --role <role_id> --force
+teamai init --repo https://github.com/yourorg/yourrepo --scope user --role <role_id> --force
 teamai pull
 ```
 
@@ -1444,7 +1362,7 @@ teamai pull
 交互模式下会提示是否覆盖，输入 `y` 即可。也可用 `--force` 跳过确认：
 
 ```bash
-teamai init --repo <group>/<repo> --force
+teamai init --repo https://github.com/yourorg/yourrepo --force
 ```
 
 **Q: 在项目里执行 `teamai init` 后没有 `.claude/`（或 `.cursor/`、`.codebuddy/`）目录？**
@@ -1471,5 +1389,5 @@ teamai remove rules <name>
 
 ---
 
-> **仓库**: https://git.woa.com/teamai/teamai-cli
-> **问题反馈**: 提交 Issue 到仓库
+> **仓库**：https://github.com/Tencent/teamai-cli
+> **问题反馈**：https://github.com/Tencent/teamai-cli/issues


### PR DESCRIPTION
## Summary

- align the Chinese usage guide with the public npm package and GitHub examples
- remove internal-only registry, repository, tool-variant, sandbox, and backend protocol details from public-facing guides
- correct documented Node requirements and CLI examples
- add missing tags, hooks, digest, recall configuration, and table-of-contents coverage
- keep the English and Chinese README command summaries in sync

## Test Plan

- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [x] Built CLI help smoke test for `init`, `push`, `tags`, `hooks`, `remove`, `update`, and `digest`
- [x] `npx vitest run src/__tests__/push-team-config.test.ts --testTimeout=30000`
- [x] `git diff --check`

## Notes

The full default-timeout Vitest run completed 2,726/2,728 tests; two existing `push-team-config` tests exceeded the 15-second default in this environment. The complete failing file passes when rerun with a 30-second timeout.