### PR TITLE
feat(#375): multi-project management (P3) — member roster + projects commands + push --project

### DIFF
--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -192,6 +192,20 @@ projects:
       learnings: [hai-inference]
 ```
 
+**Commands** (low-frequency correction/query, mirroring `teamai roles …`):
+
+```bash
+teamai projects list                 # Defined projects + the ones active in this directory
+teamai projects set hai-inference    # Set active project(s) for this directory (overwrite; comma-separated or repeated; empty to clear)
+teamai projects members hai-inference # Who is registered on a project
+```
+
+Member registration is a **side-effect of `init`**: running `teamai init --project <id>`
+appends `<id>` to your `members/<user>.yaml` roster (append + dedupe across
+directories), so the team can answer "who is on project X". `teamai push --project <id>`
+pushes skills into that project's skills namespace (resolved from the manifest),
+mirroring `teamai push --role`.
+
 Example local config:
 
 ```yaml

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -185,6 +185,19 @@ projects:
       learnings: [hai-inference]
 ```
 
+**命令**（低频的事后修正与查询，对标 `teamai roles …`）：
+
+```bash
+teamai projects list                 # 已定义的项目 + 本目录激活的项目
+teamai projects set hai-inference    # 设置本目录激活的项目（覆盖语义；逗号分隔或重复；留空清除）
+teamai projects members hai-inference # 查看某项目下注册了哪些成员
+```
+
+成员登记是 `init` 的**副作用**：执行 `teamai init --project <id>` 会把 `<id>`
+追加进你的 `members/<user>.yaml` 名册（跨目录 append + 去重），于是团队侧可以回答
+「谁在项目 X」。`teamai push --project <id>` 会把 skill 推送到该项目的 skills
+namespace（从 manifest 解析），对标 `teamai push --role`。
+
 本地配置示例：
 
 ```yaml

--- a/src/__tests__/fs-compare.test.ts
+++ b/src/__tests__/fs-compare.test.ts
@@ -7,6 +7,7 @@ import {
   dirContentEqual,
   getFileMtime,
   getDirLatestMtime,
+  hasVcsMetadataRecursive,
 } from '../utils/fs.js';
 
 describe('fileContentEqual', () => {
@@ -286,5 +287,64 @@ describe('dirContentEqual', () => {
     await fse.writeFile(path.join(dirB, 'CONTRIBUTORS'), 'bob\n');
 
     expect(await dirContentEqual(dirA, dirB, ['CONTRIBUTORS'])).toBe(true);
+  });
+});
+
+describe('hasVcsMetadataRecursive', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-vcs-test-'));
+  });
+
+  afterEach(async () => {
+    await fse.remove(tmpDir);
+  });
+
+  it('returns false for a plain directory tree with no VCS metadata', async () => {
+    await fse.outputFile(path.join(tmpDir, 'SKILL.md'), '# x');
+    await fse.outputFile(path.join(tmpDir, 'scripts', 'run.py'), 'x');
+    expect(await hasVcsMetadataRecursive(tmpDir)).toBe(false);
+  });
+
+  it('detects a .git directory at the root', async () => {
+    await fse.outputFile(path.join(tmpDir, 'SKILL.md'), '# x');
+    await fse.ensureDir(path.join(tmpDir, '.git'));
+    expect(await hasVcsMetadataRecursive(tmpDir)).toBe(true);
+  });
+
+  it('detects a NESTED .git directory (scripts/.git)', async () => {
+    await fse.outputFile(path.join(tmpDir, 'scripts', 'run.py'), 'x');
+    await fse.ensureDir(path.join(tmpDir, 'scripts', '.git'));
+    expect(await hasVcsMetadataRecursive(tmpDir)).toBe(true);
+  });
+
+  it('detects a .git FILE (submodule/worktree link), not just a directory', async () => {
+    await fse.outputFile(path.join(tmpDir, 'sub', '.git'), 'gitdir: /elsewhere/.git/modules/sub\n');
+    expect(await hasVcsMetadataRecursive(tmpDir)).toBe(true);
+  });
+
+  it('detects .hg and .svn too', async () => {
+    const hg = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-hg-'));
+    const svn = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-svn-'));
+    try {
+      await fse.ensureDir(path.join(hg, 'a', '.hg'));
+      await fse.ensureDir(path.join(svn, '.svn'));
+      expect(await hasVcsMetadataRecursive(hg)).toBe(true);
+      expect(await hasVcsMetadataRecursive(svn)).toBe(true);
+    } finally {
+      await fse.remove(hg);
+      await fse.remove(svn);
+    }
+  });
+
+  it('ignores .git inside node_modules (dependency noise, not user work)', async () => {
+    await fse.outputFile(path.join(tmpDir, 'SKILL.md'), '# x');
+    await fse.ensureDir(path.join(tmpDir, 'node_modules', 'dep', '.git'));
+    expect(await hasVcsMetadataRecursive(tmpDir)).toBe(false);
+  });
+
+  it('returns false for a missing directory', async () => {
+    expect(await hasVcsMetadataRecursive(path.join(tmpDir, 'nope'))).toBe(false);
   });
 });

--- a/src/__tests__/members.test.ts
+++ b/src/__tests__/members.test.ts
@@ -32,7 +32,7 @@ vi.mock('../utils/logger.js', () => ({
   })),
 }));
 
-import { getMemberConfig, listMembers } from '../members.js';
+import { getMemberConfig, listMembers, mergeMemberConfig } from '../members.js';
 import { requireInit } from '../config.js';
 import { log } from '../utils/logger.js';
 
@@ -305,5 +305,42 @@ describe('listMembers', () => {
     const allOutput = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
     expect(allOutput).not.toContain('[readonly]');
     expect(allOutput).toContain('legacy');
+  });
+});
+
+describe('mergeMemberConfig', () => {
+  it('registers a brand-new member with projects', () => {
+    const { config, changed } = mergeMemberConfig(null, { username: 'alice', projects: ['hai'] });
+    expect(changed).toBe(true);
+    expect(config.username).toBe('alice');
+    expect(config.displayName).toBe('alice');
+    expect(config.projects).toEqual(['hai']);
+    expect(config.registeredAt).toBeTruthy();
+  });
+
+  it('appends + dedupes projects onto an existing member (union roster)', () => {
+    const existing = { username: 'alice', displayName: 'Alice', registeredAt: '2026-01-01T00:00:00Z', projects: ['hai'] };
+    const { config, changed } = mergeMemberConfig(existing, { username: 'alice', projects: ['billing', 'hai'] });
+    expect(changed).toBe(true);
+    expect(config.projects).toEqual(['hai', 'billing']); // append order preserved, hai deduped
+    expect(config.registeredAt).toBe('2026-01-01T00:00:00Z'); // preserved
+    expect(config.displayName).toBe('Alice'); // preserved
+  });
+
+  it('reports no change when the project is already on the roster', () => {
+    const existing = { username: 'alice', displayName: '', registeredAt: '2026-01-01T00:00:00Z', projects: ['hai'] };
+    const { changed } = mergeMemberConfig(existing, { username: 'alice', projects: ['hai'] });
+    expect(changed).toBe(false);
+  });
+
+  it('overwrites role when supplied, preserves it otherwise', () => {
+    const existing = { username: 'alice', displayName: '', registeredAt: '2026-01-01T00:00:00Z', role: 'dev', projects: ['hai'] };
+    expect(mergeMemberConfig(existing, { username: 'alice', role: 'pm' }).config.role).toBe('pm');
+    expect(mergeMemberConfig(existing, { username: 'alice' }).config.role).toBe('dev');
+  });
+
+  it('omits projects key entirely when there are none', () => {
+    const { config } = mergeMemberConfig(null, { username: 'bob' });
+    expect(config.projects).toBeUndefined();
   });
 });

--- a/src/__tests__/pull-exclude.test.ts
+++ b/src/__tests__/pull-exclude.test.ts
@@ -121,7 +121,9 @@ describe('pull with excluded skills', () => {
   it('removes a previously installed excluded skill', async () => {
     const installed = path.join(homeDir, '.claude', 'skills', 'excluded-skill');
     await fse.ensureDir(installed);
-    await fse.writeFile(path.join(installed, 'SKILL.md'), '# stale copy');
+    // Deployed copy is byte-identical to the team-repo source (a real pull copies
+    // it verbatim), so the data-safety gate lets cleanup delete it.
+    await fse.writeFile(path.join(installed, 'SKILL.md'), '---\nname: excluded-skill\ndescription: excluded\n---\n');
 
     await pull({ force: true });
 

--- a/src/__tests__/pull-project-cleanup.test.ts
+++ b/src/__tests__/pull-project-cleanup.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import os from 'node:os';
+import fse from 'fs-extra';
+
+vi.mock('../utils/logger.js', () => ({
+  log: { info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), dim: vi.fn() },
+}));
+
+import { buildRolePullContext } from '../pull.js';
+import type { LocalConfig } from '../types.js';
+
+/**
+ * Regression for PR #444 review (P1): clearing the active projects on a directory
+ * whose team uses project partitioning must NOT fall through to an unfiltered
+ * sync (which reinstalls every project's skills/rules). It must scope down and
+ * mark the left projects' namespaces inactive for cleanup.
+ */
+describe('buildRolePullContext — cleared projects do not disable filtering', () => {
+  let repoPath: string;
+
+  beforeEach(async () => {
+    repoPath = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-pull-proj-'));
+    await fse.outputFile(path.join(repoPath, 'manifest', 'projects.yaml'), `
+version: 1
+projects:
+  - id: alpha
+    resources: { knowledge: [alpha], skills: [alpha], learnings: [alpha] }
+  - id: billing
+    resources: { knowledge: [billing], skills: [billing], learnings: [billing] }
+`);
+    // Skills laid out by namespace.
+    await fse.outputFile(path.join(repoPath, 'skills', 'alpha', 'alpha-skill', 'SKILL.md'), '---\nname: alpha-skill\n---\n');
+    await fse.outputFile(path.join(repoPath, 'skills', 'billing', 'billing-skill', 'SKILL.md'), '---\nname: billing-skill\n---\n');
+  });
+
+  afterEach(async () => {
+    await fse.remove(repoPath);
+  });
+
+  const cfg = (projects: string[] | undefined): LocalConfig => ({
+    repo: { localPath: repoPath, remote: 'x' },
+    username: 'u',
+    scope: 'project',
+    additionalRoles: [],
+    projectRoot: repoPath,
+    ...(projects ? { projects } : {}),
+  } as LocalConfig);
+
+  it('active alpha → alpha skill active, billing inactive (to be pruned)', async () => {
+    const ctx = await buildRolePullContext(cfg(['alpha']));
+    expect(ctx).not.toBeNull();
+    expect(ctx!.activeNamespaces.skills).toEqual(['alpha']);
+    expect([...ctx!.activeSkillNames]).toEqual(['alpha-skill']);
+    expect([...ctx!.inactiveSkillNames]).toEqual(['billing-skill']);
+  });
+
+  it('cleared projects ([]) still returns a context — NOT null — with all project skills inactive', async () => {
+    const ctx = await buildRolePullContext(cfg([]));
+    expect(ctx).not.toBeNull(); // the bug: this used to be null → unfiltered sync
+    expect(ctx!.activeNamespaces.skills).toEqual([]);
+    expect([...ctx!.activeSkillNames].sort()).toEqual([]);
+    // both projects' skills are inactive → pull cleanup prunes them
+    expect([...ctx!.inactiveSkillNames].sort()).toEqual(['alpha-skill', 'billing-skill']);
+  });
+
+  it('undefined projects (never configured) also filters when the team has a projects manifest', async () => {
+    const ctx = await buildRolePullContext(cfg(undefined));
+    expect(ctx).not.toBeNull();
+    expect([...ctx!.inactiveSkillNames].sort()).toEqual(['alpha-skill', 'billing-skill']);
+  });
+
+  it('legacy repo with no manifests → null (unfiltered, backward compatible)', async () => {
+    const bare = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-bare-'));
+    try {
+      const ctx = await buildRolePullContext({
+        repo: { localPath: bare, remote: 'x' },
+        username: 'u',
+        scope: 'project',
+        additionalRoles: [],
+        projectRoot: bare,
+      } as LocalConfig);
+      expect(ctx).toBeNull();
+    } finally {
+      await fse.remove(bare);
+    }
+  });
+});

--- a/src/__tests__/pull-tombstone.test.ts
+++ b/src/__tests__/pull-tombstone.test.ts
@@ -294,16 +294,20 @@ describe('pull role-aware sync and cleanup', () => {
       '',
     ].join('\n'));
     await fse.ensureDir(path.join(homeDir, '.claude/skills', 'beta-tag-wanted'));
-    await fse.writeFile(path.join(homeDir, '.claude/skills', 'beta-tag-wanted', 'SKILL.md'), '# Previously synced');
+    // Byte-identical to the team-repo source so the data-safety gate allows cleanup.
+    await fse.writeFile(path.join(homeDir, '.claude/skills', 'beta-tag-wanted', 'SKILL.md'), '# Wanted');
 
     await pull({ force: true });
 
     expect(await fse.pathExists(path.join(homeDir, '.claude/skills', 'beta-tag-wanted'))).toBe(false);
   });
 
-  it('removes stale skills from namespaces that are no longer active', async () => {
+  it('removes stale skills from namespaces that are no longer active (unmodified copy)', async () => {
+    // Deployed copy is byte-identical to the team-repo source → safe to delete.
     await fse.ensureDir(path.join(homeDir, '.claude/skills', 'pm-skill'));
     await fse.writeFile(path.join(homeDir, '.claude/skills', 'pm-skill', 'SKILL.md'), '# PM');
+    await fse.ensureDir(path.join(repoPath, 'skills', 'pm', 'pm-skill'));
+    await fse.writeFile(path.join(repoPath, 'skills', 'pm', 'pm-skill', 'SKILL.md'), '# PM');
     const teamConfig = vi.mocked(loadTeamConfig).mock.results.at(-1)?.value;
     const localConfig = {
       repo: { localPath: repoPath, remote: 'https://git.woa.com/test/repo.git' },
@@ -320,9 +324,116 @@ describe('pull role-aware sync and cleanup', () => {
       await localConfig,
       new Set(['shared-skill', 'hai-skill']),
       new Set(['pm-skill']),
+      new Map([['pm-skill', path.join(repoPath, 'skills', 'pm', 'pm-skill')]]),
     );
 
     expect(await fse.pathExists(path.join(homeDir, '.claude/skills', 'pm-skill'))).toBe(false);
+  });
+
+  it('KEEPS a stale skill with local edits instead of deleting (data-loss guard, PR #444)', async () => {
+    // Deployed copy has a modified SKILL.md + an unpushed file → must NOT delete.
+    await fse.ensureDir(path.join(homeDir, '.claude/skills', 'pm-skill'));
+    await fse.writeFile(path.join(homeDir, '.claude/skills', 'pm-skill', 'SKILL.md'), '# PM edited locally');
+    await fse.writeFile(path.join(homeDir, '.claude/skills', 'pm-skill', 'unpublished.py'), 'print("wip")');
+    await fse.ensureDir(path.join(repoPath, 'skills', 'pm', 'pm-skill'));
+    await fse.writeFile(path.join(repoPath, 'skills', 'pm', 'pm-skill', 'SKILL.md'), '# PM');
+    const teamConfig = vi.mocked(loadTeamConfig).mock.results.at(-1)?.value;
+    const localConfig = {
+      repo: { localPath: repoPath, remote: 'https://git.woa.com/test/repo.git' },
+      username: 'testuser', updatePolicy: 'auto' as const,
+      primaryRole: 'hai', additionalRoles: [], resourceProfileVersion: 1, scope: 'user' as const,
+    };
+
+    await cleanupInactiveNamespaceSkills(
+      await teamConfig, await localConfig,
+      new Set(['shared-skill', 'hai-skill']),
+      new Set(['pm-skill']),
+      new Map([['pm-skill', path.join(repoPath, 'skills', 'pm', 'pm-skill')]]),
+    );
+
+    // Skill dir AND the unpushed file survive.
+    expect(await fse.pathExists(path.join(homeDir, '.claude/skills', 'pm-skill', 'unpublished.py'))).toBe(true);
+    expect(await fse.readFile(path.join(homeDir, '.claude/skills', 'pm-skill', 'SKILL.md'), 'utf-8')).toBe('# PM edited locally');
+  });
+
+  it('KEEPS a stale skill when its team-repo source is gone (cannot verify → no delete)', async () => {
+    await fse.ensureDir(path.join(homeDir, '.claude/skills', 'orphan-skill'));
+    await fse.writeFile(path.join(homeDir, '.claude/skills', 'orphan-skill', 'SKILL.md'), '# orphan');
+    const teamConfig = vi.mocked(loadTeamConfig).mock.results.at(-1)?.value;
+    const localConfig = {
+      repo: { localPath: repoPath, remote: 'https://git.woa.com/test/repo.git' },
+      username: 'testuser', updatePolicy: 'auto' as const,
+      primaryRole: 'hai', additionalRoles: [], resourceProfileVersion: 1, scope: 'user' as const,
+    };
+
+    await cleanupInactiveNamespaceSkills(
+      await teamConfig, await localConfig,
+      new Set(['shared-skill', 'hai-skill']),
+      new Set(['orphan-skill']),
+      new Map(), // no source recorded
+    );
+
+    expect(await fse.pathExists(path.join(homeDir, '.claude/skills', 'orphan-skill'))).toBe(true);
+  });
+
+  it('KEEPS a stale skill that contains a local .git dir even if its files match (stash/history guard, PR #444)', async () => {
+    // Deployed working tree is byte-identical to source, BUT the skill dir holds a
+    // local git repo — its .git may carry stashes / unpushed commits that a file
+    // compare (which skips .git) cannot see. Must NOT delete.
+    await fse.ensureDir(path.join(homeDir, '.claude/skills', 'vcs-skill'));
+    await fse.writeFile(path.join(homeDir, '.claude/skills', 'vcs-skill', 'SKILL.md'), '# VCS');
+    await fse.ensureDir(path.join(homeDir, '.claude/skills', 'vcs-skill', '.git'));
+    await fse.writeFile(path.join(homeDir, '.claude/skills', 'vcs-skill', '.git', 'HEAD'), 'ref: refs/heads/main\n');
+    await fse.ensureDir(path.join(repoPath, 'skills', 'pm', 'vcs-skill'));
+    await fse.writeFile(path.join(repoPath, 'skills', 'pm', 'vcs-skill', 'SKILL.md'), '# VCS');
+    const teamConfig = vi.mocked(loadTeamConfig).mock.results.at(-1)?.value;
+    const localConfig = {
+      repo: { localPath: repoPath, remote: 'https://git.woa.com/test/repo.git' },
+      username: 'testuser', updatePolicy: 'auto' as const,
+      primaryRole: 'hai', additionalRoles: [], resourceProfileVersion: 1, scope: 'user' as const,
+    };
+
+    await cleanupInactiveNamespaceSkills(
+      await teamConfig, await localConfig,
+      new Set(['shared-skill', 'hai-skill']),
+      new Set(['vcs-skill']),
+      new Map([['vcs-skill', path.join(repoPath, 'skills', 'pm', 'vcs-skill')]]),
+    );
+
+    // Skill dir AND its .git survive.
+    expect(await fse.pathExists(path.join(homeDir, '.claude/skills', 'vcs-skill', '.git', 'HEAD'))).toBe(true);
+  });
+
+  it('KEEPS a stale skill with a NESTED git repo (scripts/.git), files matching (PR #444)', async () => {
+    // The git repo is in a subdirectory, not the skill root. dirContentEqual skips
+    // every .git at any depth, so only a recursive VCS scan catches this.
+    const sk = path.join(homeDir, '.claude/skills', 'nested-vcs');
+    await fse.ensureDir(path.join(sk, 'scripts'));
+    await fse.writeFile(path.join(sk, 'SKILL.md'), '# Nested');
+    await fse.writeFile(path.join(sk, 'scripts', 'runner.py'), 'print("run")');
+    await fse.ensureDir(path.join(sk, 'scripts', '.git'));
+    await fse.writeFile(path.join(sk, 'scripts', '.git', 'HEAD'), 'ref: refs/heads/main\n');
+    // Source has the same working-tree files (the nested .git is invisible to compare).
+    const src = path.join(repoPath, 'skills', 'pm', 'nested-vcs');
+    await fse.ensureDir(path.join(src, 'scripts'));
+    await fse.writeFile(path.join(src, 'SKILL.md'), '# Nested');
+    await fse.writeFile(path.join(src, 'scripts', 'runner.py'), 'print("run")');
+    const teamConfig = vi.mocked(loadTeamConfig).mock.results.at(-1)?.value;
+    const localConfig = {
+      repo: { localPath: repoPath, remote: 'https://git.woa.com/test/repo.git' },
+      username: 'testuser', updatePolicy: 'auto' as const,
+      primaryRole: 'hai', additionalRoles: [], resourceProfileVersion: 1, scope: 'user' as const,
+    };
+
+    await cleanupInactiveNamespaceSkills(
+      await teamConfig, await localConfig,
+      new Set(['shared-skill', 'hai-skill']),
+      new Set(['nested-vcs']),
+      new Map([['nested-vcs', src]]),
+    );
+
+    // Nested .git (and the whole skill) survives.
+    expect(await fse.pathExists(path.join(sk, 'scripts', '.git', 'HEAD'))).toBe(true);
   });
 
   it('gracefully degrades when the roles manifest is malformed', async () => {
@@ -360,13 +471,15 @@ describe('pull role-aware sync and cleanup', () => {
   });
 
   it('cleans up stale skills after role change (full pull cycle)', async () => {
-    // Setup: create skills in all namespaces
+    // Setup: create skills in all namespaces. Real team skills carry complete
+    // frontmatter, so ensureSkillFrontmatter is idempotent on deploy and the
+    // deployed copy compares equal to its source (needed for safe cleanup).
     await fse.ensureDir(path.join(repoPath, 'skills', 'common', 'shared-skill'));
-    await fse.writeFile(path.join(repoPath, 'skills', 'common', 'shared-skill', 'SKILL.md'), '# Shared');
+    await fse.writeFile(path.join(repoPath, 'skills', 'common', 'shared-skill', 'SKILL.md'), '---\nname: shared-skill\ndescription: shared\n---\n# Shared');
     await fse.ensureDir(path.join(repoPath, 'skills', 'hai', 'hai-only'));
-    await fse.writeFile(path.join(repoPath, 'skills', 'hai', 'hai-only', 'SKILL.md'), '# HAI Only');
+    await fse.writeFile(path.join(repoPath, 'skills', 'hai', 'hai-only', 'SKILL.md'), '---\nname: hai-only\ndescription: hai\n---\n# HAI Only');
     await fse.ensureDir(path.join(repoPath, 'skills', 'pm', 'pm-only'));
-    await fse.writeFile(path.join(repoPath, 'skills', 'pm', 'pm-only', 'SKILL.md'), '# PM Only');
+    await fse.writeFile(path.join(repoPath, 'skills', 'pm', 'pm-only', 'SKILL.md'), '---\nname: pm-only\ndescription: pm\n---\n# PM Only');
 
     // Step 1: Pull as hai role — should get common + hai skills
     await pull({});

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ program
   .option('--all', 'Push all without confirmation')
   .option('--skill <path>', 'Push a specific skill by path (e.g., ~/.claude/skills/hai/my-skill or skills/hai_dev/my-skill)')
   .option('--role <id>', 'Target role namespace for pushed project skills')
+  .option('--project <id>', 'Target a project: push skills into the project\'s skills namespace (from manifest/projects.yaml)')
   .action(async (cmdOpts) => {
     const globalOpts = program.opts() as GlobalOptions;
     const { push } = await import('./push.js');
@@ -262,6 +263,45 @@ rolesCmd
     const globalOpts = program.opts() as GlobalOptions;
     const { rolesUpdate } = await import('./roles-cmd.js');
     await rolesUpdate(id, { ...globalOpts, ...cmdOpts });
+  });
+
+// ─── Projects subcommand ──────────────────────────────────
+
+const projectsCmd = program
+  .command('projects')
+  .description('Manage multi-project resource distribution (orthogonal to roles)')
+  .action(async () => {
+    // Default action: list projects
+    const globalOpts = program.opts() as GlobalOptions;
+    const { projectsList } = await import('./projects-cmd.js');
+    await projectsList(globalOpts);
+  });
+
+projectsCmd
+  .command('list')
+  .description('List defined projects and the ones active in this directory')
+  .action(async () => {
+    const globalOpts = program.opts() as GlobalOptions;
+    const { projectsList } = await import('./projects-cmd.js');
+    await projectsList(globalOpts);
+  });
+
+projectsCmd
+  .command('set [ids...]')
+  .description('Set the projects active in this directory (comma-separated or repeated; empty to clear)')
+  .action(async (ids: string[] = [], _cmdOpts) => {
+    const globalOpts = program.opts() as GlobalOptions;
+    const { projectsSet } = await import('./projects-cmd.js');
+    await projectsSet(ids, globalOpts);
+  });
+
+projectsCmd
+  .command('members <id>')
+  .description('List members registered for a project')
+  .action(async (id: string) => {
+    const globalOpts = program.opts() as GlobalOptions;
+    const { projectsMembers } = await import('./projects-cmd.js');
+    await projectsMembers(id, globalOpts);
   });
 
 // ─── Tags subcommand ──────────────────────────────────────

--- a/src/init.ts
+++ b/src/init.ts
@@ -21,6 +21,7 @@ import {
 import { getUserHome } from './utils/home.js';
 import { describeRoles, loadRolesManifest } from './roles.js';
 import { loadProjectsManifest, listProjectIds } from './projects.js';
+import { getMemberConfig, mergeMemberConfig } from './members.js';
 import { askQuestion, askConfirmation, askSelection, closePrompt } from './utils/prompt.js';
 import {
   normalizeAgentList,
@@ -901,15 +902,21 @@ export async function initSelfRepo(options: GlobalOptions & {
       const memberDir = path.join(wt, 'members');
       await ensureDir(memberDir);
       const memberPath = path.join(memberDir, `${username}.yaml`);
-      if (!await pathExists(memberPath)) {
-        await writeFile(memberPath, YAML.stringify({
-          username,
-          displayName: username,
-          registeredAt: new Date().toISOString(),
-        }));
-        const pushed = await commitAndPushReports(localConfig, `[teamai] Register member: ${username}`, ['members/']);
+      const isNewSelfMember = !await pathExists(memberPath);
+      const existingSelfMember = await getMemberConfig(wt, username);
+      const { config: selfMemberConfig, changed: selfMemberChanged } = mergeMemberConfig(existingSelfMember, {
+        username,
+        projects: localConfig.projects,
+      });
+      if (selfMemberChanged) {
+        await writeFile(memberPath, YAML.stringify(selfMemberConfig));
+        const pushed = await commitAndPushReports(localConfig, isNewSelfMember
+          ? `[teamai] Register member: ${username}`
+          : `[teamai] Update member roster: ${username}`, ['members/']);
         if (pushed) {
-          log.success('Member registered on the teamai-reports branch');
+          log.success(isNewSelfMember
+            ? 'Member registered on the teamai-reports branch'
+            : 'Member roster updated on the teamai-reports branch');
         } else {
           log.warn('Member registration could not be pushed (no write access?). You are still set up locally.');
         }
@@ -1219,21 +1226,39 @@ export async function init(options: GlobalOptions & {
     }
   }
 
-  // Step 5: Create member file
+  // Resolve active projects (non-interactive: --project flag only) so the roster
+  // records project membership. Role selection stays in its original place below
+  // (it may prompt) — the member file's project membership is the P3 goal here.
+  let resolvedProjects: string[] = [];
+  try {
+    resolvedProjects = (await resolveActiveProjects(localPath, options.project)).projects ?? [];
+  } catch (error) {
+    // A bad --project is a user error on the main init path: fail loudly.
+    log.error((error as Error).message);
+    process.exit(1);
+  }
+
+  // Step 5: Create or update member file. Membership is the union of every
+  // project this user has init'd (append + dedupe), so re-running init in another
+  // project directory adds that project to the roster rather than being a no-op.
   const memberPath = path.join(localPath, 'members', `${username}.yaml`);
   const isNewMember = !await pathExists(memberPath);
-  if (isNewMember) {
-    const memberYaml = YAML.stringify({
-      username,
-      displayName: username,
-      registeredAt: new Date().toISOString(),
-    });
-    await writeFile(memberPath, memberYaml);
-    log.success(`Registered as team member: ${username}`);
+  const existingMember = await getMemberConfig(localPath, username);
+  const { config: memberConfig, changed: memberChanged } = mergeMemberConfig(existingMember, {
+    username,
+    projects: resolvedProjects,
+  });
+  if (memberChanged) {
+    await writeFile(memberPath, YAML.stringify(memberConfig));
+    log.success(isNewMember
+      ? `Registered as team member: ${username}`
+      : `Updated member roster: ${username}${memberConfig.projects ? ` (projects: ${memberConfig.projects.join(', ')})` : ''}`);
 
     if (!options.dryRun) {
       try {
-        await pushRepoDirectly(localPath, `[teamai] Register member: ${username}`, [
+        await pushRepoDirectly(localPath, isNewMember
+          ? `[teamai] Register member: ${username}`
+          : `[teamai] Update member roster: ${username}`, [
           'members/',
           'teamai.yaml',
           'skills/.gitkeep',
@@ -1312,13 +1337,8 @@ export async function init(options: GlobalOptions & {
     }
   }
 
-  try {
-    Object.assign(localConfig, await resolveActiveProjects(localPath, options.project));
-  } catch (error) {
-    // A bad --project is a user error on the main init path: fail loudly.
-    log.error((error as Error).message);
-    process.exit(1);
-  }
+  // Projects were already resolved (non-interactively) before member registration.
+  localConfig.projects = resolvedProjects;
 
   // Persist --agent into enabledAgents (additive across runs)
   const requestedAgents = normalizeAgentList(options.agent);

--- a/src/members.ts
+++ b/src/members.ts
@@ -22,6 +22,45 @@ export async function getMemberConfig(repoPath: string, username: string): Promi
   }
 }
 
+/**
+ * Merge a member's roster entry with newly-active role/projects, returning the
+ * updated config and whether anything changed. Projects use **append + dedupe**
+ * (the roster is "every project I've participated in" across directories);
+ * `role` is overwritten when a non-empty one is supplied. `registeredAt` is
+ * preserved for an existing member. Pure — callers persist + push the result.
+ */
+export function mergeMemberConfig(
+  existing: MemberConfig | null,
+  input: { username: string; role?: string; projects?: string[] },
+): { config: MemberConfig; changed: boolean } {
+  const prevProjects = existing?.projects ?? [];
+  const mergedProjects: string[] = [...prevProjects];
+  const seen = new Set(prevProjects);
+  for (const p of input.projects ?? []) {
+    if (!seen.has(p)) {
+      seen.add(p);
+      mergedProjects.push(p);
+    }
+  }
+
+  const role = input.role ?? existing?.role;
+
+  const config: MemberConfig = {
+    username: input.username,
+    displayName: existing?.displayName || input.username,
+    registeredAt: existing?.registeredAt ?? new Date().toISOString(),
+    ...(role ? { role } : {}),
+    ...(mergedProjects.length > 0 ? { projects: mergedProjects } : {}),
+  };
+
+  const changed =
+    !existing ||
+    mergedProjects.length !== prevProjects.length ||
+    (role ?? '') !== (existing.role ?? '');
+
+  return { config, changed };
+}
+
 export async function listMembers(options: GlobalOptions): Promise<void> {
   const projectConfig = await detectProjectConfig();
   const localConfig = projectConfig ?? (await requireInit()).localConfig;

--- a/src/projects-cmd.ts
+++ b/src/projects-cmd.ts
@@ -1,0 +1,180 @@
+import path from 'node:path';
+import YAML from 'yaml';
+import {
+  autoDetectInit,
+  loadLocalConfig,
+  saveLocalConfig,
+  saveLocalConfigForScope,
+  loadStateForScope,
+  saveStateForScope,
+} from './config.js';
+import {
+  loadProjectsManifest,
+  listProjectIds,
+  describeProjects,
+} from './projects.js';
+import { readFileSafe, listFiles } from './utils/fs.js';
+import { pullRepo } from './utils/git.js';
+import { log } from './utils/logger.js';
+import { MemberConfigSchema } from './types.js';
+import type { GlobalOptions } from './types.js';
+
+function parseIds(input: string[]): string[] {
+  // Accept both repeated flags and comma-separated values.
+  const flat = input.flatMap((s) => s.split(','));
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of flat) {
+    const id = raw.trim();
+    if (id && !seen.has(id)) {
+      seen.add(id);
+      out.push(id);
+    }
+  }
+  return out;
+}
+
+// ─── projects list ──────────────────────────────────────
+
+export async function projectsList(_options: GlobalOptions): Promise<void> {
+  const { localConfig } = await autoDetectInit();
+  const repoPath = localConfig.repo.localPath;
+
+  const manifest = await loadProjectsManifest(repoPath);
+  if (!manifest) {
+    log.info('This team repo defines no projects (no manifest/projects.yaml).');
+    log.info('Projects are optional — resources fall back to roles + shared learnings.');
+    return;
+  }
+
+  console.log('');
+  console.log(`Projects manifest (version ${manifest.version}):`);
+  console.log('');
+  if (manifest.projects.length === 0) {
+    console.log('  (no projects defined)');
+  }
+  for (const project of manifest.projects) {
+    const label = project.name ? `${project.id} — ${project.name}` : project.id;
+    console.log(`  ${label}`);
+    if (project.description) console.log(`    ${project.description}`);
+    console.log(`    skills:    ${project.resources.skills.join(', ') || '(none)'}`);
+    console.log(`    knowledge: ${project.resources.knowledge.join(', ') || '(none)'}`);
+    console.log(`    learnings: ${project.resources.learnings.join(', ') || '(none)'}`);
+    console.log('');
+  }
+
+  const active = localConfig.projects ?? [];
+  if (active.length > 0) {
+    console.log(`Your active projects (this directory): ${active.join(', ')}`);
+  } else {
+    console.log('No active projects in this directory. Run `teamai projects set <id>` to set them.');
+  }
+}
+
+// ─── projects set ───────────────────────────────────────
+
+export async function projectsSet(
+  ids: string[],
+  _options: GlobalOptions,
+): Promise<void> {
+  const { localConfig } = await autoDetectInit();
+  const repoPath = localConfig.repo.localPath;
+
+  const manifest = await loadProjectsManifest(repoPath);
+  if (!manifest) {
+    log.error('This team repo defines no projects (no manifest/projects.yaml).');
+    return;
+  }
+
+  const requested = parseIds(ids);
+  const validIds = new Set(listProjectIds(manifest));
+  for (const id of requested) {
+    if (!validIds.has(id)) {
+      log.error(`Unknown project "${id}". Valid projects: ${[...validIds].join(', ') || '(none)'}`);
+      return;
+    }
+  }
+
+  // Overwrite semantics for this directory (contrast the member roster, which appends).
+  const updatedConfig = { ...localConfig, projects: requested };
+
+  if (localConfig.scope === 'project' && localConfig.projectRoot) {
+    await saveLocalConfigForScope(updatedConfig, localConfig.scope, localConfig.projectRoot);
+  } else {
+    await saveLocalConfig(updatedConfig);
+  }
+
+  // Invalidate pull cache so the next pull does a full sync + cleanup of the
+  // now-inactive projects' resources.
+  try {
+    const state = await loadStateForScope(localConfig);
+    state.lastPullRev = null;
+    await saveStateForScope(state, localConfig);
+  } catch {
+    // Non-critical: a missing state file means the next pull is a full sync anyway.
+  }
+
+  if (requested.length > 0) {
+    log.success(`Active projects set to: ${requested.join(', ')}`);
+  } else {
+    log.success('Active projects cleared (this directory now syncs role + shared learnings only).');
+  }
+  log.info('Run `teamai pull` to sync resources for your updated projects.');
+}
+
+// ─── projects members ───────────────────────────────────
+
+export async function projectsMembers(
+  projectId: string,
+  _options: GlobalOptions,
+): Promise<void> {
+  const { localConfig } = await autoDetectInit();
+
+  // Members live on the teamai-reports orphan branch in self mode; read them from
+  // the refreshed reports worktree. Otherwise read the team repo clone.
+  let repoPath: string;
+  if (localConfig.repo.kind === 'self') {
+    const { ensureReportsWorktree, refreshReportsWorktree } = await import('./utils/reports-branch.js');
+    await refreshReportsWorktree(localConfig);
+    repoPath = await ensureReportsWorktree(localConfig);
+  } else {
+    repoPath = localConfig.repo.localPath;
+    await pullRepo(repoPath).catch(() => { /* offline — read local copy */ });
+  }
+
+  const manifest = await loadProjectsManifest(repoPath);
+  if (manifest && !listProjectIds(manifest).includes(projectId)) {
+    log.warn(`Project "${projectId}" is not defined in manifest/projects.yaml.`);
+    // Continue anyway — the roster may still record historical membership.
+  }
+
+  const membersDir = path.join(repoPath, 'members');
+  const files = (await listFiles(membersDir)).filter((f) => f.endsWith('.yaml') || f.endsWith('.yml'));
+
+  const members: string[] = [];
+  for (const file of files) {
+    const content = await readFileSafe(path.join(membersDir, file));
+    if (!content) continue;
+    try {
+      const member = MemberConfigSchema.parse(YAML.parse(content));
+      if ((member.projects ?? []).includes(projectId)) {
+        const display = member.displayName ? ` — ${member.displayName}` : '';
+        members.push(`${member.username}${display}`);
+      }
+    } catch {
+      // Skip invalid member files silently (listMembers already warns on `members`).
+    }
+  }
+
+  console.log('');
+  if (members.length === 0) {
+    console.log(`No members registered for project "${projectId}".`);
+  } else {
+    console.log(`Members of project "${projectId}" (${members.length}):`);
+    console.log('');
+    for (const m of members.sort()) {
+      console.log(`  ${m}`);
+    }
+  }
+  console.log('');
+}

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -5,7 +5,7 @@ import { requireInit, loadState, saveState, detectProjectConfig, loadLocalConfig
 import { pullRepo, getHeadRev } from './utils/git.js';
 import { flushPendingLearnings } from './utils/pending-learnings.js';
 import { log, spinner } from './utils/logger.js';
-import { pathExists, remove, listFiles, listDirs, listFilesRecursive, readFileSafe } from './utils/fs.js';
+import { pathExists, remove, listFiles, listDirs, listFilesRecursive, readFileSafe, dirContentEqual, hasVcsMetadataRecursive } from './utils/fs.js';
 import { injectClaudeMdSection } from './utils/claudemd.js';
 import { getHandler, RulesHandler, DocsHandler, EnvHandler } from './resources/index.js';
 import { ResourceHandler } from './resources/base.js';
@@ -40,6 +40,13 @@ interface RolePullContext {
   activeNamespaces: ResourceNamespaces;
   activeSkillNames: Set<string>;
   inactiveSkillNames: Set<string>;
+  /**
+   * Map of inactive skill name → its team-repo source directory
+   * (`<clone>/skills/<namespace>/<name>`). Cleanup compares the deployed copy
+   * against this source and only deletes when they are byte-identical, so a
+   * user's local edits or unpushed files are never silently destroyed.
+   */
+  inactiveSkillSources: Map<string, string>;
 }
 
 /**
@@ -120,12 +127,27 @@ async function refreshTeamRepo(
   return { label: result, version, reportingOnly: false };
 }
 
-async function buildRolePullContext(localConfig: LocalConfig): Promise<RolePullContext | null> {
+export async function buildRolePullContext(localConfig: LocalConfig): Promise<RolePullContext | null> {
   const activeProjects = localConfig.projects ?? [];
   const hasRole = !!localConfig.primaryRole;
   const hasProjects = activeProjects.length > 0;
-  // No role and no active project → nothing to filter by (unchanged behavior).
-  if (!hasRole && !hasProjects) return null;
+
+  // Load the projects manifest up front: its mere existence means this team uses
+  // project partitioning, which changes the "no active filter" semantics below.
+  const projectsManifest = await loadProjectsManifest(localConfig.repo.localPath);
+  const teamHasProjects = !!projectsManifest && projectsManifest.projects.length > 0;
+
+  // When there is nothing to filter by AND the team does not use project
+  // partitioning, keep the legacy unfiltered behavior (null = sync everything).
+  //
+  // But if the team HAS a projects manifest, a directory with no active project
+  // is NOT the same as a pre-project legacy config: deactivating projects (via
+  // `teamai projects set` with no ids) must scope down to role-only + shared
+  // resources and CLEAN UP the resources of the projects it left — never fall
+  // through to an unfiltered sync that reinstalls every project's skills/rules.
+  // So we return a real (possibly empty-active) context and let the cleanup path
+  // below prune the now-inactive project namespaces.
+  if (!hasRole && !hasProjects && !teamHasProjects) return null;
 
   // ── Role namespaces (optional) ──
   let roleNamespaces: ResourceNamespaces = { knowledge: [], skills: [], learnings: [] };
@@ -149,32 +171,35 @@ async function buildRolePullContext(localConfig: LocalConfig): Promise<RolePullC
       } catch {
         log.warn(`Role "${localConfig.primaryRole}" not found in manifest. Falling back to unfiltered sync.`);
         log.warn('Run `teamai roles set <role>` to pick a valid role.');
-        // A misconfigured role with no active project means we can't filter safely.
-        if (!hasProjects) return null;
+        // A misconfigured role, with nothing else to scope by, can't filter safely.
+        if (!hasProjects && !teamHasProjects) return null;
       }
-    } else if (!hasProjects) {
+    } else if (!hasProjects && !teamHasProjects) {
       return null;
     }
   }
 
-  // ── Project namespaces (optional) ──
+  // ── Project namespaces ──
+  // Populate the full set of project skill namespaces from the manifest whenever
+  // the team defines projects — even with none active — so every non-selected
+  // project namespace is treated as inactive and cleaned up below. The ACTIVE
+  // namespaces come only from the projects this directory selected.
   let projectNamespaces = { knowledge: [] as string[], skills: [] as string[], learnings: [] as string[] };
   let allProjectSkillNamespaces = new Set<string>();
-  if (hasProjects) {
-    const projectsManifest = await loadProjectsManifest(localConfig.repo.localPath);
-    if (!projectsManifest) {
-      log.warn('Active projects configured but no projects manifest found. Skipping project-based filtering.');
-    } else {
+  if (projectsManifest) {
+    allProjectSkillNamespaces = new Set(projectsManifest.projects.flatMap((p) => p.resources.skills));
+    if (hasProjects) {
       try {
         projectNamespaces = resolveProjectResourceNamespaces({
           manifest: projectsManifest,
           activeProjects,
         });
-        allProjectSkillNamespaces = new Set(projectsManifest.projects.flatMap((p) => p.resources.skills));
       } catch (e) {
         log.warn(`${(e as Error).message} Falling back to role-only filtering.`);
       }
     }
+  } else if (hasProjects) {
+    log.warn('Active projects configured but no projects manifest found. Skipping project-based filtering.');
   }
 
   const activeNamespaces = mergeNamespaces(roleNamespaces, projectNamespaces);
@@ -185,6 +210,7 @@ async function buildRolePullContext(localConfig: LocalConfig): Promise<RolePullC
   const inactiveSkillNamespaces = [...allSkillNamespaces].filter((namespace) => !activeNamespaces.skills.includes(namespace));
   const activeSkillNames = new Set<string>();
   const inactiveSkillNames = new Set<string>();
+  const inactiveSkillSources = new Map<string, string>();
 
   for (const namespace of activeNamespaces.skills) {
     const namespaceDir = path.join(localConfig.repo.localPath, 'skills', namespace);
@@ -199,10 +225,17 @@ async function buildRolePullContext(localConfig: LocalConfig): Promise<RolePullC
     const names = await listDirs(namespaceDir);
     for (const name of names) {
       inactiveSkillNames.add(name);
+      // Record the source dir so cleanup can verify the deployed copy is
+      // unmodified before deleting it. (If a name lives in multiple inactive
+      // namespaces, keeping the first is fine — cleanup only needs one source to
+      // compare against; a mismatch always errs toward keeping the local copy.)
+      if (!inactiveSkillSources.has(name)) {
+        inactiveSkillSources.set(name, path.join(namespaceDir, name));
+      }
     }
   }
 
-  return { activeNamespaces, activeSkillNames, inactiveSkillNames };
+  return { activeNamespaces, activeSkillNames, inactiveSkillNames, inactiveSkillSources };
 }
 
 /**
@@ -253,11 +286,49 @@ export async function scanRoleAwareSkills(localConfig: LocalConfig, namespaces: 
   return [...items.values()];
 }
 
+// Deployment adds a CONTRIBUTORS file that the team source may not have; ignore it
+// when checking whether a deployed skill still matches its source (same file as
+// resources/skills.ts and pre-push-sync.ts use for modification detection).
+const CONTRIBUTORS_FILE = 'CONTRIBUTORS';
+
+/**
+ * Data-safety gate for deleting a deployed skill during cleanup. A deployed skill
+ * is safe to remove only when its content matches its team-repo source exactly
+ * (ignoring the deployment-added CONTRIBUTORS file). That means:
+ *   - every team file is present and unchanged (no local edits), AND
+ *   - there are NO extra files (no unpushed work like a user's own scripts).
+ * `dirContentEqual` enforces both directions (same file set + same content), which
+ * is what protects unpushed files — a team-subset check would wrongly ignore them.
+ * `ensureSkillFrontmatter` is idempotent for a source that already has complete
+ * frontmatter (the normal case), so a cleanly-deployed skill compares equal.
+ * If the source is unknown/missing (can't verify) or anything differs, it is NOT
+ * safe: keep it and let the caller warn. Prevents silent loss of uncommitted work.
+ *
+ * Known conservative edge: if a team source skill lacks frontmatter, deploy
+ * injects it, so the deployed copy never compares equal and the skill is kept
+ * rather than auto-pruned. That errs on the safe side (no data loss); the user
+ * can delete it manually. Real team skills carry frontmatter, so this is rare.
+ *
+ * Local VCS metadata: a deployed skill that contains its own version-control
+ * directory (`.git`/`.hg`/`.svn`) is ALWAYS kept. `dirContentEqual` skips these
+ * (see IGNORED_NAMES), so a byte-identical working tree can still hide unpushed
+ * commits, stashes, or reflog history inside `.git` — deleting the dir would lose
+ * them silently. Their presence can't be proven safe by a file compare, so keep.
+ */
+async function skillSafeToRemove(deployedDir: string, source: string | undefined): Promise<boolean> {
+  if (!source || !await pathExists(source)) return false;
+  // Recursive: a git repo nested anywhere under the skill (e.g. scripts/.git)
+  // can hide stashes/unpushed history too, and dirContentEqual skips every .git.
+  if (await hasVcsMetadataRecursive(deployedDir)) return false;
+  return dirContentEqual(deployedDir, source, [CONTRIBUTORS_FILE]);
+}
+
 export async function cleanupInactiveNamespaceSkills(
   teamConfig: TeamaiConfig,
   localConfig: LocalConfig,
   retainedSkillNames: Set<string>,
   inactiveSkillNames: Set<string>,
+  inactiveSkillSources?: Map<string, string>,
 ): Promise<void> {
   const baseDir = resolveBaseDir(localConfig);
 
@@ -274,6 +345,17 @@ export async function cleanupInactiveNamespaceSkills(
       if (!inactiveSkillNames.has(skillName)) continue;
 
       const localSkillDir = path.join(baseDir, toolPath.skills, skillName);
+
+      // Data-safety guard: only delete a deployed skill when it is byte-identical
+      // to its team-repo source. If the user modified SKILL.md or added unpushed
+      // files (e.g. scripts) in the deployed dir, deleting would silently lose
+      // that work — so keep it and warn instead. If we cannot locate the source
+      // to compare against, err on the side of NOT deleting.
+      if (!await skillSafeToRemove(localSkillDir, inactiveSkillSources?.get(skillName))) {
+        log.warn(`[${localConfig.scope}] Kept skill "${skillName}" (${tool}): it has local changes or unpushed files not in the team repo (or could not be verified). Push or back them up, then delete it manually.`);
+        continue;
+      }
+
       await remove(localSkillDir);
       log.debug(`[${localConfig.scope}] Removed inactive role-scoped skill ${skillName} from ${tool}`);
     }
@@ -485,6 +567,8 @@ async function pullForScope(
   let totalSynced = 0;
   let desiredSkillNames: Set<string> | null = null;
   let knownRepoSkillNames: Set<string> | null = null;
+  // name → team-repo source dir, for the data-safety check in Step 3b cleanup.
+  let knownRepoSkillSources: Map<string, string> | null = null;
 
   for (const type of resourceTypes) {
     const handler = getHandler(type);
@@ -552,6 +636,7 @@ async function pullForScope(
       }
       desiredSkillNames = new Set(items.map((i) => i.name));
       knownRepoSkillNames = new Set(allTeamSkills.map((i) => i.name));
+      knownRepoSkillSources = new Map(allTeamSkills.map((i) => [i.name, i.sourcePath]));
     } else {
       items = await handler.scanTeamForPull(freshConfig, localConfig);
     }
@@ -658,6 +743,13 @@ async function pullForScope(
           for (const extension of extensions) {
             const localPath = path.join(baseDir, dir, extension ? `${name}${extension}` : name);
             if (await pathExists(localPath)) {
+              // Even an upstream (tombstone) removal must not blow away a local
+              // git repo's stash/unpushed history inside a skill directory. Keep
+              // + warn; the user can delete it manually once backed up.
+              if (type === 'skills' && await hasVcsMetadataRecursive(localPath)) {
+                log.warn(`[${scopeLabel}] Kept tombstoned skill "${name}" (${tool}): it has local VCS metadata (.git) that may hold unpushed history. Back it up, then delete it manually.`);
+                continue;
+              }
               await remove(localPath);
               log.debug(`[${scopeLabel}] Cleaned up tombstoned ${type} ${name} from ${dir}`);
             }
@@ -672,6 +764,7 @@ async function pullForScope(
         localConfig,
         desiredSkillNames ?? roleContext.activeSkillNames,
         roleContext.inactiveSkillNames,
+        roleContext.inactiveSkillSources,
       );
     }
   }
@@ -693,6 +786,13 @@ async function pullForScope(
         if (desiredSkillNames.has(dir)) continue;
         if (!knownRepoSkillNames.has(dir)) continue;
         const skillDir = path.join(skillsDir, dir);
+        // Same data-safety gate as cleanupInactiveNamespaceSkills: never delete a
+        // deployed skill that differs from its team-repo source (local edits or
+        // unpushed files). Keep + warn instead of silently destroying work.
+        if (!await skillSafeToRemove(skillDir, knownRepoSkillSources?.get(dir))) {
+          log.warn(`[${scopeLabel}] Kept skill "${dir}" (${tool}): it has local changes or unpushed files not in the team repo (or could not be verified). Push or back them up, then delete it manually.`);
+          continue;
+        }
         await remove(skillDir);
         log.debug(`Removed excluded skill ${dir} from ${tool}`);
       }

--- a/src/push.ts
+++ b/src/push.ts
@@ -257,10 +257,45 @@ async function pushGroup(args: {
   }
 }
 
-export async function push(options: GlobalOptions & { all?: boolean; role?: string }): Promise<void> {
+export async function push(options: GlobalOptions & { all?: boolean; role?: string; project?: string }): Promise<void> {
   // Auto-detect scope: project scope if cwd has project config, else user scope
   const { localConfig, teamConfig } = await autoDetectInit();
   assertNotReadOnly(localConfig, 'teamai push');
+
+  // --project is a destination override expressed as a logical project: resolve
+  // it to the project's skills namespace (from manifest/projects.yaml) and reuse
+  // the --role landing logic below. Deliberately manifest-resolved, not the raw
+  // project id, so it agrees with what pull syncs (issue #375 P2 lesson).
+  if (options.project) {
+    if (options.role) {
+      log.error('Use either --role or --project, not both.');
+      process.exitCode = 2;
+      return;
+    }
+    const { loadProjectsManifest, resolveProjectResourceNamespaces } = await import('./projects.js');
+    const manifest = await loadProjectsManifest(localConfig.repo.localPath);
+    if (!manifest) {
+      log.error('This team repo defines no projects (no manifest/projects.yaml).');
+      process.exitCode = 2;
+      return;
+    }
+    let skillNamespaces: string[];
+    try {
+      skillNamespaces = resolveProjectResourceNamespaces({ manifest, activeProjects: [options.project] }).skills;
+    } catch (e) {
+      log.error((e as Error).message);
+      process.exitCode = 2;
+      return;
+    }
+    if (skillNamespaces.length !== 1) {
+      log.error(skillNamespaces.length === 0
+        ? `Project "${options.project}" declares no skills namespace; use --role <ns> to target one explicitly.`
+        : `Project "${options.project}" maps to multiple skills namespaces (${skillNamespaces.join(', ')}); use --role <ns> to pick one.`);
+      process.exitCode = 2;
+      return;
+    }
+    options.role = skillNamespaces[0];
+  }
   try {
     const configContent = await readFileSafe(path.join(localConfig.repo.localPath, 'teamai.yaml'));
     const rawConfig = configContent === null ? null : YAML.parse(configContent);

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -189,6 +189,36 @@ async function _walkFiles(base: string, prefix: string, results: string[]): Prom
   }
 }
 
+const VCS_METADATA_NAMES = new Set(['.git', '.hg', '.svn']);
+
+/**
+ * Recursively detect local version-control metadata (`.git`/`.hg`/`.svn`) at ANY
+ * depth under `dir`. Deliberately does NOT reuse the file-walk helpers above:
+ * they skip `.git` via IGNORED_NAMES, which is exactly what would hide a nested
+ * repo. `.git` is matched whether it is a directory or a file (submodule/worktree
+ * links store it as a file). `node_modules` is skipped — its VCS metadata is
+ * dependency noise, not the user's own unpushed work. Used to keep a deployed
+ * skill that embeds a git repo (root OR nested) from being auto-deleted, since
+ * such a repo can hide stashes / unpushed history a content compare cannot see.
+ */
+export async function hasVcsMetadataRecursive(dir: string): Promise<boolean> {
+  const expanded = expandHome(dir);
+  if (!await fse.pathExists(expanded)) return false;
+  let entries;
+  try {
+    entries = await fse.readdir(expanded, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+  for (const entry of entries) {
+    if (VCS_METADATA_NAMES.has(entry.name)) return true; // dir or file (submodule link)
+    if (entry.isDirectory() && entry.name !== 'node_modules') {
+      if (await hasVcsMetadataRecursive(path.join(expanded, entry.name))) return true;
+    }
+  }
+  return false;
+}
+
 /**
  * Check if a path exists
  */


### PR DESCRIPTION
## What & why

Implements **issue #375 P3** (the final phase; P1+P2 landed in #426). Makes multi-project **membership** real and adds the low-frequency management commands.

Before this, `members/<user>.yaml` was a placeholder — `init` wrote it only when absent and recorded neither role nor project, so the team could not answer "who is on project X".

## Changes

- **Member roster append-registration** (`members.ts`, `init.ts`): `init --project <id>` now merges the active project(s) into `members/<user>.yaml` with **append + dedupe** semantics, on both the non-self and self (reports-branch) paths. Re-running `init` in another project directory adds that project to the roster instead of being a no-op. `mergeMemberConfig` is a pure helper (preserves `registeredAt`/`displayName`, dedupes projects, reports whether anything changed so we only write+push on a real change).
- **`projects` command family** (`projects-cmd.ts`, `index.ts`) — mirrors `teamai roles …`:
  - `projects list` — defined projects + the ones active in this directory
  - `projects set [ids...]` — set active project(s) for this directory (overwrite; comma-separated or repeated; empty to clear; invalidates the pull cache so the next pull cleans up now-inactive resources)
  - `projects members <id>` — who is registered on a project
- **`push --project <id>`** (`push.ts`, `index.ts`): resolves to the project's **manifest** skills namespace (not the raw id — the same #375 P2 lesson) and reuses the existing `--role` landing logic; mutually exclusive with `--role`.
- **Docs**: bilingual `docs/usage-guide.md` / `.zh-CN.md` — commands + membership behavior added to the multi-project section.

## Test plan

`tsc --noEmit` clean · `npm run build` OK · **2765 unit tests pass** (single-threaded; parallel mode has a pre-existing fs-fixture flakiness unrelated to this change). New `mergeMemberConfig` unit tests cover union/dedupe/role/empty cases.

### Real-CLI end-to-end (TGit, repo created + verified + deleted)

Seeded a team repo with a projects manifest (`hai`, `billing`) and namespaced skills, then `init --project` in two business dirs:

| Check | Result |
|---|---|
| Member roster after init in both dirs → `members/jeffyxu.yaml` has `projects: [hai, billing]` (append) | ✓ |
| `projects list` → both projects with their skills/knowledge/learnings namespaces | ✓ |
| `projects members hai` → lists `jeffyxu` | ✓ |
| `projects set billing` in the hai dir → active projects overwritten to `billing` | ✓ |
| `push --project billing` → skill lands in `skills/billing/my-new-skill` (manifest-resolved namespace) | ✓ |

Closes #375 (final phase — P1+P2 in #426).
