### PR TITLE
feat(source): warn that a source with no publicSkills will sync 0 skills

### DIFF
--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -1286,6 +1286,8 @@ teamai source remove other-team
 
 A subscription source's skills are automatically synced locally on `teamai pull`, coexisting with the team's own skills. `teamai source add`/`remove` updates the active scope's team repo immediately, so local `list`, `browse`, and `pull` commands use the change before it is committed. The subscription itself is stored in the `sources` field of that repo's `teamai.yaml`. Run `teamai push` to open a PR with the config change; once it merges, every teammate's `teamai pull` picks up the new source automatically.
 
+A source only shares the skills it opts in via a `publicSkills` list in its own `teamai.yaml`. If the repo has no `teamai.yaml`, or declares no `publicSkills`, `teamai source add` succeeds but warns that the source will sync **0 skills** — the source team has to publish a `publicSkills` list before anything flows through.
+
 #### HTTP Source
 
 In addition to a git subscription source, you can attach an HTTP source on top of an existing git main repo — useful for server-managed skill delivery:

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -1279,6 +1279,8 @@ teamai source remove other-team
 
 订阅源的 skills 在 `teamai pull` 时自动同步到本地，与团队自有 skills 共存。`teamai source add`/`remove` 会立即更新当前 scope 的团队仓，因此改动尚未提交时，本机的 `list`、`browse` 和 `pull` 也会使用它。订阅配置存储在该仓库 `teamai.yaml` 的 `sources` 字段中。运行 `teamai push` 会开一个包含配置改动的 PR；合入后，每位成员的 `teamai pull` 都会自动获取到新的订阅源。
 
+源仓只会共享它在自己 `teamai.yaml` 的 `publicSkills` 列表里显式声明的 skill。如果对方仓库没有 `teamai.yaml`，或没有声明 `publicSkills`，`teamai source add` 仍会成功，但会警告该源将同步 **0 个 skill**——需要对方团队先发布 `publicSkills` 列表，才会有内容流转过来。
+
 #### HTTP 源
 
 除了 git 订阅源，还可以在已有 git 主仓的基础上附加一个 HTTP 源——适用于服务端管理的 skill 下发：

--- a/src/__tests__/source.test.ts
+++ b/src/__tests__/source.test.ts
@@ -27,7 +27,7 @@ vi.mock('../utils/git.js', () => ({
   pullRepo: vi.fn().mockResolvedValue('already up to date'),
 }));
 
-import { deriveSourceName, getAllSourceSkillNames, pullSources } from '../source.js';
+import { deriveSourceName, getAllSourceSkillNames, pullSources, sourceSyncWarnings } from '../source.js';
 import type { TeamaiConfig, LocalConfig, SourceInstallManifest } from '../types.js';
 
 describe('source', () => {
@@ -373,5 +373,45 @@ describe('TeamaiConfig sources schema', () => {
       publicSkills: ['skill-a', 'skill-b'],
     });
     expect(config.publicSkills).toEqual(['skill-a', 'skill-b']);
+  });
+});
+
+describe('sourceSyncWarnings', () => {
+  async function makeConfig(overrides: Record<string, unknown>): Promise<TeamaiConfig> {
+    const { TeamaiConfigSchema } = await import('../types.js');
+    return TeamaiConfigSchema.parse({
+      team: 'test',
+      repo: 'https://git.woa.com/test/repo.git',
+      ...overrides,
+    });
+  }
+
+  it('warns that a source with no teamai.yaml will sync 0 skills', () => {
+    const lines = sourceSyncWarnings('acme', null);
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain('has no teamai.yaml');
+    expect(lines[0]).toContain('"acme"');
+    expect(lines[1]).toContain('sync 0 skills');
+  });
+
+  it('warns that a source with an empty publicSkills list will sync 0 skills', async () => {
+    const config = await makeConfig({ publicSkills: [] });
+    const lines = sourceSyncWarnings('acme', config);
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain('declares no publicSkills');
+    expect(lines[1]).toContain('sync 0 skills');
+  });
+
+  it('warns when publicSkills is absent (undefined) just like an empty list', async () => {
+    const config = await makeConfig({});
+    expect(config.publicSkills).toBeUndefined();
+    const lines = sourceSyncWarnings('acme', config);
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain('declares no publicSkills');
+  });
+
+  it('is silent when the source declares at least one public skill', async () => {
+    const config = await makeConfig({ publicSkills: ['cool-skill'] });
+    expect(sourceSyncWarnings('acme', config)).toEqual([]);
   });
 });

--- a/src/source.ts
+++ b/src/source.ts
@@ -151,10 +151,13 @@ export async function sourceAdd(repoUrl: string, options: { name?: string } & Gl
     return;
   }
 
-  // Read source's teamai.yaml to verify it's a valid teamai repo
+  // Warn up front when the source cannot share anything. `pull` opts in on a
+  // source's `publicSkills` declaration, so a repo without a teamai.yaml (or
+  // with an empty publicSkills list) syncs 0 skills. Say so here, at add time,
+  // instead of letting pull skip it silently later.
   const sourceConfig = await loadTeamConfig(cloneResult);
-  if (!sourceConfig) {
-    log.warn(`Source repo has no teamai.yaml. It can still be used, but no publicSkills are declared.`);
+  for (const line of sourceSyncWarnings(name, sourceConfig)) {
+    log.warn(line);
   }
 
   if (options.dryRun) {
@@ -513,6 +516,29 @@ async function pullSingleSource(
 }
 
 // ─── Helpers ─────────────────────────────────────────────
+
+/**
+ * Explain, at `source add` time, why a source would sync 0 skills. `pull`
+ * deploys only skills a source opts into via its teamai.yaml `publicSkills`
+ * list, so a missing teamai.yaml or an empty publicSkills list means nothing
+ * is shared. Returns the warning lines to print (empty when the source is
+ * ready to share). `null` config = no teamai.yaml (or an unparseable one).
+ */
+export function sourceSyncWarnings(name: string, sourceConfig: TeamaiConfig | null): string[] {
+  if (!sourceConfig) {
+    return [
+      `Source repo "${name}" has no teamai.yaml, so it declares no public skills.`,
+      `This source will sync 0 skills until the source team adds a teamai.yaml with a publicSkills list.`,
+    ];
+  }
+  if ((sourceConfig.publicSkills?.length ?? 0) === 0) {
+    return [
+      `Source repo "${name}" has a teamai.yaml but declares no publicSkills.`,
+      `This source will sync 0 skills until the source team adds a publicSkills list to its teamai.yaml.`,
+    ];
+  }
+  return [];
+}
 
 /**
  * Derive a source name from a git remote URL.


### PR DESCRIPTION
## What

`teamai source add` on a repo that shares nothing now warns explicitly that the source will **sync 0 skills**, instead of the old vague `"It can still be used"` hint. It distinguishes the two zero-skill cases:

- the source repo has **no `teamai.yaml`** at all
- the source has a `teamai.yaml` but declares **no `publicSkills`**

Closes #416 — **UX point 4 only**.

## Why (and why not the rest of #416)

Before this change, `source add` succeeded on a non-teamai repo with only a fuzzy hint, while the pull side skipped it at `log.debug` level. A member could subscribe to a source that syncs nothing and never get a visible signal — exactly the friction #416 point 4 reported.

The other three proposals in #416 (write `upstream` provenance into SKILL.md, `skill outdated`, `skill refresh` to auto-pull from upstream) are **intentionally out of scope**:

- Vendoring deliberately cuts the git link to upstream; a deeply customized skill often *cannot* take upstream updates as-is, so the value is narrow.
- More importantly, **auto-following a third-party upstream bypasses team review** — a skill is executable instructions, and a poisoned upstream update flowing straight to members is a supply-chain injection vector. Skills must stay review-gated before distribution. That is a maintainer-level policy call, and this PR does not touch it.

The maintainer's own steer on the issue was to improve the format detection on the `source` side, which is exactly point 4.

## How

- Extract the wording into a pure `sourceSyncWarnings(name, config)` helper (returns the lines to print; empty when the source is ready to share).
- `sourceAdd` prints whatever it returns. No behavior change beyond the message; the source is still added and still stored in `teamai.yaml`'s `sources`.
- Docs: add a paragraph to `docs/usage-guide.md` and `docs/usage-guide.zh-CN.md` explaining a source only shares its declared `publicSkills`.

## Test Plan

### Unit — `npx vitest run src/__tests__/source.test.ts`
`sourceSyncWarnings` covered on all branches: no teamai.yaml, empty publicSkills, absent publicSkills (undefined), and non-empty (silent). **18/18 passed.**

### Full suite — `npx vitest run`
**2764/2764 passed, 200/200 files.** No regressions.

### Type check — `npx tsc --noEmit`
Clean.

### Real CLI end-to-end
Built the CLI (`npm run build`) and ran `teamai source add` against three purpose-built source repos in an isolated env (`--self` main repo, generic-git provider via unknown-host + `insteadOf` redirect):

```
############ CASE A: no teamai.yaml ############
[A] ✔ [source:srca] Cloned
[A] ⚠ Source repo "srca" has no teamai.yaml, so it declares no public skills.
[A] ⚠ This source will sync 0 skills until the source team adds a teamai.yaml with a publicSkills list.
[A] ✔ Added source "srca" (...)

############ CASE B: teamai.yaml, no publicSkills ############
[B] ✔ [source:srcb] Cloned
[B] ⚠ Source repo "srcb" has a teamai.yaml but declares no publicSkills.
[B] ⚠ This source will sync 0 skills until the source team adds a publicSkills list to its teamai.yaml.
[B] ✔ Added source "srcb" (...)

############ CASE C: has publicSkills (expect NO warning) ############
[C] ✔ [source:srcc] Cloned
[C] ✔ Added source "srcc" (...)
```

All three match expectations: A and B warn with the correct, case-specific wording; C is silent and just succeeds.
