### PR TITLE
fix(codex): reuse existing shared skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ teamai push → create branch + MR → reviewer approves + merges
               SessionStart hook → teamai pull → synced to local AI tools
 ```
 
-Members push changes via `teamai push`, which opens a Merge Request for review. Re-running `teamai push` on a resource that is still waiting in an unmerged PR updates that PR in place instead of opening a duplicate. Once merged, `teamai pull` (triggered automatically on session start via the SessionStart hook) syncs the latest resources locally. Skills sync to `~/.claude/skills/`, `~/.codex/skills/`, `~/.cursor/skills/`, `~/.codebuddy/skills/`, etc. In a **project-scope** install, SessionStart first creates that tool's project root (e.g. `<project>/.claude`) if it is missing, then pulls into it — a bare `teamai pull` still will not invent agent directories.
+Members push changes via `teamai push`, which opens a Merge Request for review. Re-running `teamai push` on a resource that is still waiting in an unmerged PR updates that PR in place instead of opening a duplicate. Once merged, `teamai pull` (triggered automatically on session start via the SessionStart hook) syncs the latest resources locally. Skills sync to `~/.claude/skills/`, `~/.codex/skills/`, `~/.cursor/skills/`, `~/.codebuddy/skills/`, etc. For Codex, an existing skill under `~/.agents/skills/` is updated there instead of duplicated under `~/.codex/skills/`. In a **project-scope** install, SessionStart first creates that tool's project root (e.g. `<project>/.claude`) if it is missing, then pulls into it — a bare `teamai pull` still will not invent agent directories.
 
 ### Team Hooks
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -110,7 +110,7 @@ teamai push → 创建分支 + MR → reviewer 审批合并
            SessionStart hook → teamai pull → 同步到本地 AI 工具
 ```
 
-成员通过 `teamai push` 提交变更并创建合并请求供审核。若某个资源已在未合并的 PR 中等待评审，再次对它执行 `teamai push` 会就地更新该 PR，而非新开一个重复的 PR。合并后，`teamai pull`（由 SessionStart hook 在会话启动时自动触发）将最新资源同步到本地。Skills 会同步到 `~/.claude/skills/`、`~/.codex/skills/`、`~/.cursor/skills/`、`~/.codebuddy/skills/` 等目录。在 **project scope** 安装下，SessionStart 会先为当前工具创建项目根目录（例如 `<project>/.claude`），再 pull 写入；单独执行 `teamai pull` 仍不会凭空创建 Agent 目录。
+成员通过 `teamai push` 提交变更并创建合并请求供审核。若某个资源已在未合并的 PR 中等待评审，再次对它执行 `teamai push` 会就地更新该 PR，而非新开一个重复的 PR。合并后，`teamai pull`（由 SessionStart hook 在会话启动时自动触发）将最新资源同步到本地。Skills 会同步到 `~/.claude/skills/`、`~/.codex/skills/`、`~/.cursor/skills/`、`~/.codebuddy/skills/` 等目录。对于 Codex，若 skill 已存在于 `~/.agents/skills/`，则会在原位置更新，不会在 `~/.codex/skills/` 创建重复副本。在 **project scope** 安装下，SessionStart 会先为当前工具创建项目根目录（例如 `<project>/.claude`），再 pull 写入；单独执行 `teamai pull` 仍不会凭空创建 Agent 目录。
 
 ### 团队 Hooks
 

--- a/docs/designs/data-directory-layout.md
+++ b/docs/designs/data-directory-layout.md
@@ -128,6 +128,6 @@ is a P1 concern. This keeps P0 independently reviewable (issue R7).
 
 ### Explicitly out of scope
 
-`teamai migrate` / `gc` / `--revert` commands; cross-project shared team-repo clone;
-Codex `.agents/skills` landing (separate issue). Downgrade to an older teamai after
+`teamai migrate` / `gc` / `--revert` commands; cross-project shared team-repo clone.
+Downgrade to an older teamai after
 P1 migration is not supported (`.teamai.bak/` is the manual rollback path).

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -17,6 +17,7 @@ vi.mock('../utils/logger.js', () => ({
 
 import { SkillsHandler } from '../resources/skills.js';
 import { scanTeamRepoNamespaces, ensureSkillFrontmatter } from '../resources/skills.js';
+import { log } from '../utils/logger.js';
 import type { TeamaiConfig, LocalConfig } from '../types.js';
 
 describe('SkillsHandler.scanLocalForPush', () => {
@@ -1134,5 +1135,90 @@ describe('SkillsHandler.pullItem honors disabledAgents', () => {
     expect(await fse.pathExists(path.join(homeDir, '.claude', 'skills', 'team-skill'))).toBe(false);
     // codex is not disabled → synced normally
     expect(await fse.pathExists(path.join(homeDir, '.codex', 'skills', 'team-skill'))).toBe(true);
+  });
+});
+
+describe('SkillsHandler.pullItem Codex shared skills', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-skills-pull-codex-'));
+    vi.stubEnv('HOME', path.join(tmpDir, 'home'));
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await fse.remove(tmpDir);
+  });
+
+  it('updates an existing .agents skill and removes an identical TeamAI .codex copy', async () => {
+    const homeDir = path.join(tmpDir, 'home');
+    const sourcePath = path.join(tmpDir, 'team-repo', 'skills', 'team-skill');
+    const sharedSkillPath = path.join(homeDir, '.agents', 'skills', 'team-skill');
+    const codexSkillPath = path.join(homeDir, '.codex', 'skills', 'team-skill');
+    await fse.ensureDir(codexSkillPath);
+    await fse.ensureDir(sharedSkillPath);
+    await fse.ensureDir(sourcePath);
+    const managedContent = '---\nname: team-skill\ndescription: Updated\n---\n';
+    await fse.writeFile(path.join(sharedSkillPath, 'SKILL.md'), managedContent);
+    await fse.writeFile(path.join(codexSkillPath, 'SKILL.md'), managedContent);
+    await fse.writeFile(path.join(sourcePath, 'SKILL.md'), managedContent);
+
+    const teamConfig = {
+      team: 'test',
+      description: '',
+      repo: 'https://example.test/team.git',
+      provider: 'git' as const,
+      reviewers: [],
+      sharing: { skills: {}, rules: { enforced: [] }, docs: { localDir: '' }, env: { injectShellProfile: true } },
+      toolPaths: { codex: { skills: '.codex/skills' } },
+    };
+    const localConfig = {
+      repo: { localPath: path.join(tmpDir, 'team-repo'), remote: 'https://example.test/team.git' },
+      username: 'testuser',
+      updatePolicy: 'auto' as const,
+      additionalRoles: [],
+      scope: 'user' as const,
+    };
+
+    await new SkillsHandler().pullItem({
+      name: 'team-skill',
+      type: 'skills',
+      sourcePath,
+      relativePath: 'skills/team-skill',
+    }, teamConfig, localConfig);
+
+    expect(await fse.readFile(path.join(sharedSkillPath, 'SKILL.md'), 'utf8')).toContain('description: Updated');
+    expect(await fse.pathExists(codexSkillPath)).toBe(false);
+
+    await new SkillsHandler().removeItem('team-skill', teamConfig, localConfig);
+    expect(await fse.pathExists(sharedSkillPath)).toBe(false);
+  });
+
+  it('preserves and reports a different .codex copy', async () => {
+    const homeDir = path.join(tmpDir, 'home');
+    const sourcePath = path.join(tmpDir, 'team-repo', 'skills', 'team-skill');
+    const sharedSkillPath = path.join(homeDir, '.agents', 'skills', 'team-skill');
+    const codexSkillPath = path.join(homeDir, '.codex', 'skills', 'team-skill');
+    await fse.ensureDir(sharedSkillPath);
+    await fse.ensureDir(codexSkillPath);
+    await fse.ensureDir(sourcePath);
+    await fse.writeFile(path.join(sharedSkillPath, 'SKILL.md'), 'shared copy');
+    await fse.writeFile(path.join(codexSkillPath, 'SKILL.md'), 'different copy');
+    await fse.writeFile(path.join(sourcePath, 'SKILL.md'), '---\nname: team-skill\ndescription: Updated\n---\n');
+
+    await new SkillsHandler().pullItem({
+      name: 'team-skill', type: 'skills', sourcePath, relativePath: 'skills/team-skill',
+    }, {
+      team: 'test', description: '', repo: 'https://example.test/team.git', provider: 'git', reviewers: [],
+      sharing: { skills: {}, rules: { enforced: [] }, docs: { localDir: '' }, env: { injectShellProfile: true } },
+      toolPaths: { codex: { skills: '.codex/skills' } },
+    }, {
+      repo: { localPath: path.join(tmpDir, 'team-repo'), remote: 'https://example.test/team.git' },
+      username: 'testuser', updatePolicy: 'auto', additionalRoles: [], scope: 'user',
+    });
+
+    expect(await fse.readFile(path.join(codexSkillPath, 'SKILL.md'), 'utf8')).toBe('different copy');
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining('Codex skill conflict'));
   });
 });

--- a/src/__tests__/skip-uninstalled-tools.test.ts
+++ b/src/__tests__/skip-uninstalled-tools.test.ts
@@ -572,4 +572,33 @@ describe('deployBuiltinSkills — skip uninstalled tools', () => {
     expect(await fse.pathExists(wikiEnrichFile)).toBe(true);
     expect(await fse.pathExists(path.join(homeDir, '.claude/skills/teamai-share-learnings/SKILL.md'))).toBe(false);
   });
+
+  it('deploys a built-in Codex skill to its existing shared location', async () => {
+    const { deployBuiltinSkills } = await import('../builtin-skills.js');
+    const sharedSkill = path.join(homeDir, '.agents', 'skills', 'team-wiki-codebase');
+    await fse.ensureDir(path.join(homeDir, '.codex'));
+    await fse.ensureDir(sharedSkill);
+
+    const teamConfig = {
+      team: 'test',
+      description: '',
+      repo: 'https://example.test/team.git',
+      provider: 'git' as const,
+      reviewers: [],
+      sharing: { skills: {}, rules: { enforced: [] }, docs: { localDir: '' }, env: { injectShellProfile: true } },
+      toolPaths: { codex: { skills: '.codex/skills' } },
+    };
+    const localConfig = {
+      repo: { localPath: path.join(tmpDir, 'repo'), remote: 'https://example.test/team.git' },
+      username: 'testuser',
+      updatePolicy: 'auto' as const,
+      additionalRoles: [],
+      scope: 'user' as const,
+    };
+
+    await deployBuiltinSkills(teamConfig, localConfig);
+
+    expect(await fse.pathExists(path.join(sharedSkill, 'SKILL.md'))).toBe(true);
+    expect(await fse.pathExists(path.join(homeDir, '.codex', 'skills', 'team-wiki-codebase'))).toBe(false);
+  });
 });

--- a/src/__tests__/source.test.ts
+++ b/src/__tests__/source.test.ts
@@ -210,6 +210,42 @@ describe('source', () => {
       expect(manifest.installedSkills).toContain('cool-skill');
     });
 
+    it('deploys a source Codex skill to its existing shared location', async () => {
+      teamConfig.sources = [{ name: 'platform', repo: 'https://example.test/platform/repo.git' }];
+      teamConfig.toolPaths = { codex: { skills: '.codex/skills' } };
+      const sharedSkill = path.join(homeDir, '.agents', 'skills', 'cool-skill');
+      await fse.ensureDir(path.join(homeDir, '.codex'));
+      await fse.ensureDir(sharedSkill);
+
+      const YAML = (await import('yaml')).default;
+      await fse.writeFile(path.join(localConfig.repo.localPath, 'teamai.yaml'), YAML.stringify(teamConfig));
+      const sourceRepoDir = path.join(sourcesDir, 'platform', 'repo');
+      await fse.ensureDir(path.join(sourceRepoDir, 'skills', 'cool-skill'));
+      await fse.writeFile(
+        path.join(sourceRepoDir, 'skills', 'cool-skill', 'SKILL.md'),
+        '---\nname: cool-skill\ndescription: Shared\n---\n',
+      );
+      await fse.writeFile(
+        path.join(sourceRepoDir, 'teamai.yaml'),
+        YAML.stringify({ team: 'platform', repo: 'https://example.test/platform/repo.git', publicSkills: ['cool-skill'] }),
+      );
+
+      await pullSources(localConfig, {});
+
+      expect(await fse.readFile(path.join(sharedSkill, 'SKILL.md'), 'utf8')).toContain('description: Shared');
+      expect(await fse.pathExists(path.join(homeDir, '.codex', 'skills', 'cool-skill'))).toBe(false);
+
+      await fse.ensureDir(path.join(sourceRepoDir, 'skills', 'next-skill'));
+      await fse.writeFile(path.join(sourceRepoDir, 'skills', 'next-skill', 'SKILL.md'), '# Next');
+      await fse.writeFile(
+        path.join(sourceRepoDir, 'teamai.yaml'),
+        YAML.stringify({ team: 'platform', repo: 'https://example.test/platform/repo.git', publicSkills: ['next-skill'] }),
+      );
+      await pullSources(localConfig, {});
+
+      expect(await fse.pathExists(sharedSkill)).toBe(false);
+    });
+
     it('should not deploy source skill that conflicts with local team skill', async () => {
       teamConfig.sources = [{ name: 'platform', repo: 'git@git.woa.com:platform/repo.git' }];
 
@@ -339,6 +375,48 @@ describe('source', () => {
         path.join(homeDir, '.claude', 'skills', 'cool-skill'),
       );
       expect(deployed).toBe(false);
+    });
+
+    it('removes a source skill from its recorded path when a shared Codex skill appears later', async () => {
+      teamConfig.sources = [{ name: 'platform', repo: 'git@git.woa.com:platform/repo.git' }];
+      teamConfig.toolPaths = { codex: { skills: '.codex/skills' } };
+      const YAML = (await import('yaml')).default;
+      await fse.writeFile(path.join(localConfig.repo.localPath, 'teamai.yaml'), YAML.stringify(teamConfig));
+
+      const sourceDir = path.join(sourcesDir, 'platform');
+      await fse.ensureDir(sourceDir);
+      await fse.writeJson(path.join(sourceDir, 'installed.json'), {
+        lastPull: new Date(0).toISOString(),
+        installedSkills: ['old-skill'],
+        installedPaths: { 'old-skill': ['.codex/skills/old-skill'] },
+      } satisfies SourceInstallManifest);
+      await fse.ensureDir(path.join(homeDir, '.codex', 'skills', 'old-skill'));
+      await fse.writeFile(path.join(homeDir, '.codex', 'skills', 'old-skill', 'SKILL.md'), '# Source copy');
+      await fse.ensureDir(path.join(homeDir, '.agents', 'skills', 'old-skill'));
+      await fse.writeFile(path.join(homeDir, '.agents', 'skills', 'old-skill', 'SKILL.md'), '# User copy');
+      await fse.ensureDir(path.join(sourceDir, 'repo', 'skills', 'old-skill'));
+      await fse.writeFile(path.join(sourceDir, 'repo', 'skills', 'old-skill', 'SKILL.md'), '# Updated source');
+      await fse.writeFile(path.join(sourceDir, 'repo', 'teamai.yaml'), YAML.stringify({
+        team: 'platform', repo: 'git@git.woa.com:platform/repo.git', publicSkills: ['old-skill'],
+      }));
+
+      await pullSources(localConfig, { force: true });
+
+      const updatedManifest = await fse.readJson(path.join(sourceDir, 'installed.json')) as SourceInstallManifest;
+      expect(updatedManifest.installedPaths?.['old-skill']).toEqual([
+        '.codex/skills/old-skill', '.agents/skills/old-skill',
+      ]);
+
+      await fse.ensureDir(path.join(sourceDir, 'repo', 'skills', 'new-skill'));
+      await fse.writeFile(path.join(sourceDir, 'repo', 'skills', 'new-skill', 'SKILL.md'), '# New');
+      await fse.writeFile(path.join(sourceDir, 'repo', 'teamai.yaml'), YAML.stringify({
+        team: 'platform', repo: 'git@git.woa.com:platform/repo.git', publicSkills: ['new-skill'],
+      }));
+
+      await pullSources(localConfig, { force: true });
+
+      expect(await fse.pathExists(path.join(homeDir, '.codex', 'skills', 'old-skill'))).toBe(false);
+      expect(await fse.pathExists(path.join(homeDir, '.agents', 'skills', 'old-skill'))).toBe(false);
     });
   });
 });

--- a/src/builtin-skills.ts
+++ b/src/builtin-skills.ts
@@ -7,7 +7,7 @@ import { log } from './utils/logger.js';
 import type { TeamaiConfig, LocalConfig } from './types.js';
 import { resolveBaseDir, isAgentDisabled, scopedToolPaths } from './types.js';
 import { ResourceHandler } from './resources/base.js';
-import { ensureSkillFrontmatter } from './resources/skills.js';
+import { ensureSkillFrontmatter, resolveSkillDestination } from './resources/skills.js';
 import { getUserHome } from './utils/home.js';
 
 // ─── Built-in skills deployment ──────────────────────────
@@ -117,11 +117,9 @@ export async function deployBuiltinSkills(teamConfig: TeamaiConfig, localConfig?
     }
     if (localConfig && isAgentDisabled(localConfig, tool)) continue;
 
-    const targetSkillsDir = path.join(baseDir, toolPath.skills);
-
     for (const skillName of skillNames) {
       const srcDir = path.join(builtinDir, skillName);
-      const destDir = path.join(targetSkillsDir, skillName);
+      const destDir = await resolveSkillDestination(tool, toolPath.skills, baseDir, skillName, srcDir);
 
       try {
         await copyBuiltinSkillDir(srcDir, destDir);

--- a/src/resources/skills.ts
+++ b/src/resources/skills.ts
@@ -3,7 +3,7 @@ import YAML from 'yaml';
 import { ResourceHandler } from './base.js';
 import type { ResourceItem, ResourceItemStatus, TeamaiConfig, LocalConfig } from '../types.js';
 import { resolveBaseDir, getPushignorePath, isAgentDisabled, scopedToolPaths } from '../types.js';
-import { listDirs, pathExists, copyDir, remove, dirTeamSubsetEqual, getDirLatestMtime, readFileSafe, writeFile } from '../utils/fs.js';
+import { listDirs, pathExists, copyDir, remove, dirContentEqual, dirTeamSubsetEqual, getDirLatestMtime, readFileSafe, writeFile } from '../utils/fs.js';
 import { log } from '../utils/logger.js';
 import { BUILTIN_SKILL_NAMES } from '../builtin-skills.js';
 import { resolveOpenclawWorkspaceDir } from '../openclaw-hooks.js';
@@ -15,6 +15,35 @@ import { splitFrontmatter, stringifyFrontmatter } from '../utils/frontmatter.js'
 /** File name used to track who has contributed (pushed) a skill. */
 const CONTRIBUTORS_FILE = 'CONTRIBUTORS';
 const SKILL_MD = 'SKILL.md';
+const CODEX_TOOL = 'codex';
+const SHARED_AGENT_SKILLS_PATH = '.agents/skills';
+
+/** Prefer Codex's shared skill when that skill already lives there. */
+export async function resolveSkillDestination(
+  tool: string,
+  configuredSkillsPath: string,
+  baseDir: string,
+  skillName: string,
+  sourcePath?: string,
+): Promise<string> {
+  const configuredDestination = path.join(baseDir, configuredSkillsPath, skillName);
+  if (tool === CODEX_TOOL) {
+    const sharedDestination = path.join(baseDir, SHARED_AGENT_SKILLS_PATH, skillName);
+    if (await pathExists(sharedDestination)) {
+      if (await pathExists(configuredDestination)) {
+        if (sourcePath && await dirContentEqual(sharedDestination, configuredDestination) && await dirContentEqual(configuredDestination, sourcePath)) {
+          await remove(configuredDestination);
+          log.debug(`Removed identical TeamAI skill ${skillName} from ${configuredSkillsPath}`);
+        } else {
+          log.warn(`Codex skill conflict for ${skillName}: keeping different copies in ${SHARED_AGENT_SKILLS_PATH} and ${configuredSkillsPath}`);
+        }
+      }
+      return sharedDestination;
+    }
+  }
+
+  return configuredDestination;
+}
 
 /** Add fields immediately before the closing delimiter without reformatting existing YAML. */
 function appendFrontmatterFields(raw: string, fields: Record<string, string>): string {
@@ -458,7 +487,7 @@ export class SkillsHandler extends ResourceHandler {
           log.debug(`Skipping skill sync for ${tool}: tool not installed`);
           continue;
         }
-        dest = path.join(baseDir, toolPath.skills, item.name);
+        dest = await resolveSkillDestination(tool, toolPath.skills, baseDir, item.name, item.sourcePath);
       }
 
       try {
@@ -508,7 +537,12 @@ export class SkillsHandler extends ResourceHandler {
         if (!wsDir) continue;
         skillDir = path.join(wsDir, 'skills', name);
       } else {
-        skillDir = path.join(baseDir, toolPath.skills, name);
+        const configuredDir = path.join(baseDir, toolPath.skills, name);
+        skillDir = await resolveSkillDestination(tool, toolPath.skills, baseDir, name);
+        if (skillDir !== configuredDir && await pathExists(configuredDir) && await dirContentEqual(skillDir, configuredDir)) {
+          await remove(configuredDir);
+          removed.push(configuredDir);
+        }
       }
       if (await pathExists(skillDir)) {
         await remove(skillDir);

--- a/src/source.ts
+++ b/src/source.ts
@@ -18,9 +18,10 @@ import {
 } from './utils/fs.js';
 import { getHandler } from './resources/index.js';
 import { ResourceHandler } from './resources/base.js';
+import { resolveSkillDestination } from './resources/skills.js';
 import { BUILTIN_SKILL_NAMES } from './builtin-skills.js';
 import { getUserHome } from './utils/home.js';
-import { assertSafeResourceName } from './utils/path-safety.js';
+import { assertSafeResourceName, assertWithinRoot } from './utils/path-safety.js';
 import type {
   TeamaiConfig,
   LocalConfig,
@@ -450,6 +451,7 @@ async function pullSingleSource(
 
   // Deploy skills to tool paths
   const deployed: string[] = [];
+  const installedPaths: Record<string, string[]> = { ...oldManifest?.installedPaths };
   let newCount = 0;
   let updatedCount = 0;
 
@@ -468,12 +470,15 @@ async function pullSingleSource(
     }
 
     // Deploy to each tool's skills directory
-    for (const [_tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
+    for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
       if (!toolPath.skills) continue;
       if (!await ResourceHandler.isToolInstalled(toolPath.skills, baseDir)) continue;
 
-      const targetDir = path.join(baseDir, toolPath.skills, skill.name);
+      const targetDir = await resolveSkillDestination(tool, toolPath.skills, baseDir, skill.name, skill.sourcePath);
       await copyDir(skill.sourcePath, targetDir);
+      const relativeTarget = path.relative(baseDir, targetDir);
+      const skillPaths = installedPaths[skill.name] ??= [];
+      if (!skillPaths.includes(relativeTarget)) skillPaths.push(relativeTarget);
     }
 
     if (oldInstalled.has(skill.name)) {
@@ -489,8 +494,9 @@ async function pullSingleSource(
     const deployedSet = new Set(deployed);
     for (const oldSkill of oldInstalled) {
       if (!deployedSet.has(oldSkill) && !localTeamSkills.has(oldSkill)) {
-        await removeSkillFromToolPaths(oldSkill, teamConfig, localConfig, baseDir);
+        await removeSkillFromToolPaths(oldSkill, teamConfig, localConfig, baseDir, oldManifest?.installedPaths?.[oldSkill]);
         log.debug(`[source:${source.name}] Removed "${oldSkill}" (no longer public)`);
+        delete installedPaths[oldSkill];
       }
     }
   }
@@ -500,6 +506,7 @@ async function pullSingleSource(
     await saveSourceManifest(source.name, {
       lastPull: new Date().toISOString(),
       installedSkills: deployed,
+      installedPaths,
     });
   }
 
@@ -600,8 +607,17 @@ async function getLocalTeamSkillNames(teamConfig: TeamaiConfig, localConfig: Loc
 /**
  * Remove a skill from all tool paths.
  */
-async function removeSkillFromToolPaths(skillName: string, teamConfig: TeamaiConfig, localConfig: LocalConfig, baseDir: string): Promise<void> {
-  for (const [_tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
+async function removeSkillFromToolPaths(skillName: string, teamConfig: TeamaiConfig, localConfig: LocalConfig, baseDir: string, installedPaths?: string[]): Promise<void> {
+  if (installedPaths) {
+    for (const installedPath of installedPaths) {
+      const skillDir = path.resolve(baseDir, installedPath);
+      assertWithinRoot(baseDir, skillDir);
+      if (await pathExists(skillDir)) await remove(skillDir);
+    }
+    return;
+  }
+
+  for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
     if (!toolPath.skills) continue;
     const skillDir = path.join(baseDir, toolPath.skills, skillName);
     if (await pathExists(skillDir)) {
@@ -619,7 +635,7 @@ async function cleanupSourceSkills(sourceName: string, teamConfig: TeamaiConfig,
 
   const baseDir = resolveBaseDir(localConfig);
   for (const skillName of manifest.installedSkills) {
-    await removeSkillFromToolPaths(skillName, teamConfig, localConfig, baseDir);
+    await removeSkillFromToolPaths(skillName, teamConfig, localConfig, baseDir, manifest.installedPaths?.[skillName]);
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -203,6 +203,8 @@ export interface SourceInstallManifest {
   lastPull: string;
   /** Skill names currently deployed from this source. */
   installedSkills: string[];
+  /** Per-skill deployment paths, relative to the configured scope root. */
+  installedPaths?: Record<string, string[]>;
 }
 
 /** TTL for source repo pull: don't re-pull within this duration (ms). */


### PR DESCRIPTION
## Summary

- make Codex reuse an existing per-skill `.agents/skills/<name>` directory
- keep `.codex/skills` as the default for new Codex skills
- reconcile only duplicates proven identical to the incoming TeamAI payload, and track source deployment paths for safe cleanup

## Testing

- RED: `expected 'old' to contain 'description: Updated'`
- GREEN: focused Codex shared-skill regression passed
- full local suite via `./run-ci.sh` on Node 22 and pinned Node 20: 197 files, 2,733 tests passed on each runtime
- build, OpenCode recall E2E, and changed-line coverage gate passed
- built CLI pull E2E passed against a local Git remote

Fixes #435
