### PR TITLE
fix(gitlab): diagnose unconfigured self-hosted instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ npm install -g teamai-cli
 
 Create a shared-experience repo on your git host (GitHub, GitLab, GitCode, CNB, TGit, or a private Git service), **grant write access to team members**, then run `teamai init https://github.com/yourorg/yourrepo`.
 
+For self-hosted GitLab, set `GITLAB_URL` to your instance URL and `GITLAB_TOKEN` to a token with `api` scope before initializing. If `init` recognizes an unconfigured GitLab instance, it stops with setup instructions. Existing repos with `provider: git` also need `provider: gitlab` in the team repo's `teamai.yaml` to create MRs. See [GitLab setup](docs/providers.md#gitlab-provider含自托管).
+
 > **No team repo yet?** Start from a template pre-loaded with production-ready skills, rules, and review agents. Browse the [teamai-hub](https://github.com/teamai-hub) org, click **Use this template**, then `teamai init` against your new repo.
 
 ### Team members

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -25,6 +25,8 @@ npm install -g teamai-cli
 
 在 Git 托管平台（GitHub、GitLab、GitCode、CNB、TGit，或私有 Git 服务）创建共享经验仓库，**授予团队成员写权限**，然后运行 `teamai init https://github.com/yourorg/yourrepo`。
 
+使用自建 GitLab 时，先将 `GITLAB_URL` 设为实例地址，并配置具有 `api` 权限的 `GITLAB_TOKEN`。若 `init` 探测到尚未配置的 GitLab 实例，会停止并提示配置方法。已有仓库若为 `provider: git`，还需把团队仓库 `teamai.yaml` 中的值改为 `provider: gitlab`，才能创建 MR。详见 [GitLab 配置](docs/providers.md#gitlab-provider含自托管)。
+
 > **还没有团队仓库？** 可以从内置了成套 skills、rules、review agents 的模板起步。浏览 [teamai-hub](https://github.com/teamai-hub) org，点 **Use this template** 生成自己的仓库，再对它执行 `teamai init`。
 
 ### 团队成员

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -27,15 +27,17 @@ https://gitlab.com/org/repo(.git)       → gitlab
 git@gitlab.com:org/repo.git             → gitlab
 https://gitcode.com/org/repo(.git)      → gitcode
 git@gitcode.com:org/repo.git            → gitcode
-https://git.example.com/group/repo.git  → git
-git@git.example.com:group/repo.git      → git
+https://git.example.com/group/repo.git  → 检查 GitLab，未确认则 git
+git@git.example.com:group/repo.git      → 检查 GitLab，未确认则 git
 ```
 
-provider 选择会写入 team 仓库的 `teamai.yaml` 的 `provider` 字段，后续 `push` / `pull` 都按这个值来。
+已知 host 和显式配置的 GitLab 实例优先。对于未知 host，`init` 会匿名探测 GitLab 登录页；确认是未配置的 GitLab 实例时，先提示设置 `GITLAB_URL` 和 `GITLAB_TOKEN` 后重试，不会直接把探测结果写入配置。未确认则继续使用 `git`。
+
+初始化成功后，provider 选择会写入 team 仓库的 `teamai.yaml` 的 `provider` 字段，后续 `push` / `pull` 都按这个值来。探测不会自动修改已有的 provider。
 
 ## 通用 Git Provider（自建/私有仓库）
 
-不在已知 host 列表中的完整 HTTPS 或 SSH URL 会自动选择 `git` provider。例如：
+完整 HTTPS 或 SSH URL 的 host 若不在已知列表、不匹配显式 GitLab 配置，且探测未确认 GitLab，就会选择 `git` provider。例如：
 
 ```bash
 teamai init https://code.qschou.com/Enterprise/arb-workflow-kit.git --scope user
@@ -49,6 +51,8 @@ teamai init git@code.qschou.com:Enterprise/arb-workflow-kit.git --scope user
 - SSH：预先配置 SSH Key，并确保 `ssh-agent` 能访问私钥。
 
 clone、pull、push 均可正常使用。平台 API 操作（自动建仓、自动创建 MR/PR）无法跨不同服务统一实现，因此暂不支持；`teamai push` 会先推送分支，再提示用户到对应平台手动创建 MR，并以非零退出码表明自动 PR/MR 创建未完成。
+
+若已有 `provider: git` 的仓库在创建 PR 时失败，CLI 会额外检查该 host；确认是 GitLab 后，会提示设置实例地址和 token，并将团队仓库 `teamai.yaml` 的 `provider` 改为 `gitlab`。这个提示不会自动修改配置，也不会撤回已经推送的分支。
 
 ## GitHub Provider
 
@@ -185,16 +189,18 @@ token 变量支持三个名字（按优先级）：`GITLAB_TOKEN` > `GITLAB_PRIV
 ### 自托管实例检测
 
 - **公有 gitlab.com**：URL host 直接命中，自动选择 gitlab provider。
-- **自托管实例**：设置 `GITLAB_URL` 后，URL host 与 `GITLAB_URL` 的 host 相同时自动识别为 gitlab；也可用 `TEAMAI_GITLAB_HOST` 直接指定 host。两种方式都不需要写完整 URL：
+- **自托管实例**：设置 `GITLAB_URL` 后，URL host 与 `GITLAB_URL` 的 host 相同时自动识别为 gitlab；也可用 `TEAMAI_GITLAB_HOST` 直接指定 host。仓库参数需使用完整 HTTP(S) 或 SSH URL：
   ```bash
   export GITLAB_URL=https://git.example.com
-  teamai init git.example.com/yourgroup/yourrepo     # → gitlab
+  teamai init https://git.example.com/yourgroup/yourrepo     # → gitlab
   ```
-- 也可以在 team 仓库的 `teamai.yaml` 显式写 `provider: gitlab` 强制切换。
+- **未配置的未知 host**：`init` 会匿名请求根路径下的 `/users/sign_in?auto_sign_in=false`，仅在响应包含明确的 GitLab 页面特征时确认。确认后，在认证、克隆和写入配置前停止，提示设置 `GITLAB_URL` 和具有 `api` 权限的 `GITLAB_TOKEN` 后重试。实例 URL 不会自动持久化。
+- **探测边界**：请求总超时为三秒，不发送 token、不跟随重定向、不关闭 TLS 校验。HTTP(S) 仓库 URL 保留其 scheme 和 Web 端口；SSH 仓库 URL 使用 HTTPS 的默认 443 端口探测，不会把 SSH 端口当作 Web 端口。超时、网络错误、代理拦截、重定向和无法确认的页面都继续回落到 `git`。子路径部署、SSO 遮蔽的登录页，以及 Web 地址与 SSH host 不同的实例，需要显式配置 `GITLAB_URL`。
+- **已有 `provider: git`**：设置实例地址和 token 后，还需在团队仓库的 `teamai.yaml` 中将 `provider` 改为 `gitlab`。仅补设环境变量不会覆盖配置中的 provider。创建 PR 失败后的 GitLab 探测只提供修复提示，不会自动切换。
 
 ### 与 `git` 通用 Provider 的分工
 
-未知 host 默认落到 `git` 通用 Provider——它只做传输（clone/pull/push 走系统 Git 凭据），`createRepo` 和创建 MR 都会直接报「不支持」。GitLab Provider 的价值就在这里：把自托管实例识别出来后，建仓、建 MR、拉 MR 数据、列 group 仓库这些平台能力才可用。检测顺序是 **已知 host → 自托管 GitLab → `git` 通用回落**。
+检测顺序是 **已知 host → 显式配置的自托管 GitLab → 匿名 GitLab 探测 → `git` 通用回落**。匿名探测只用于 `init` 的配置提示，以及通用 provider 创建 PR 失败后的诊断，只确认具有明确特征的 GitLab 页面，不会自动配置实例或 token。未确认的 host 使用 `git` 通用 Provider，clone/pull/push 走系统 Git 凭据，自动建仓和创建 MR 则不受支持。配置好 GitLab Provider 后，才可使用建仓、建 MR、拉 MR 数据、列 group 仓库等平台能力。
 
 ### 多级命名空间
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -99,7 +99,19 @@ teamai --version
 
 > Only one admin needs to do this — other members can skip to [Member Onboarding](#member-onboarding).
 
-Create an empty repository on GitHub, GitLab (gitlab.com or a self-hosted instance), GitCode (gitcode.com), CNB (cnb.cool), TGit, or any private/self-hosted Git service (suggested naming: `TeamAi-<team-name>`), or simply run `teamai init` — if the repo doesn't exist yet, you'll be prompted to create it automatically.
+Create an empty repository on GitHub, GitLab (gitlab.com or a self-hosted instance), GitCode (gitcode.com), CNB (cnb.cool), TGit, or any private/self-hosted Git service (suggested naming: `TeamAi-<team-name>`). For providers that support repository creation, you can also run `teamai init` and create a missing repo when prompted.
+
+For self-hosted GitLab, configure the instance and a Personal Access Token with `api` scope first:
+
+```bash
+export GITLAB_URL=https://git.example.com
+export GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxx
+teamai init https://git.example.com/yourgroup/yourrepo
+```
+
+For an unknown host, `init` makes an anonymous GitLab sign-in page check with a three-second total timeout. If confirmed as GitLab, it stops before authentication, cloning, or writing configuration and asks you to set the instance URL and token, then retry. The check does not send tokens or follow redirects. If it cannot confirm GitLab, initialization continues with the generic `git` provider, which supports Git transport but cannot create repos or PRs/MRs automatically. Set `GITLAB_URL` explicitly for instances behind SSO, deployed under a subpath, or otherwise inaccessible to the check.
+
+**Already initialized with `provider: git`?** Set the variables above and change `provider` to `gitlab` in the team repo's `teamai.yaml`. Setting the environment variables alone does not change an existing provider selection. A failed `teamai push` may already have pushed the branch; if its diagnostic detects GitLab, it prints these recovery steps. See [provider configuration](providers.md#gitlab-provider含自托管).
 
 ### Project Scope (default)
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -98,7 +98,19 @@ teamai --version
 
 > 只需一位管理员完成，其他成员跳到[成员接入](#成员接入)。
 
-在 GitHub、GitLab（gitlab.com 或自建实例）、GitCode（gitcode.com）、CNB（cnb.cool）、TGit，或任意私有/自建 Git 服务上创建一个空仓库（命名建议：`TeamAi-<团队名>`），或者直接执行 `teamai init`，不存在时会提示自动创建。
+在 GitHub、GitLab（gitlab.com 或自建实例）、GitCode（gitcode.com）、CNB（cnb.cool）、TGit，或任意私有/自建 Git 服务上创建一个空仓库（命名建议：`TeamAi-<团队名>`）。对于支持自动建仓的 provider，也可直接执行 `teamai init`，按提示创建尚不存在的仓库。
+
+使用自建 GitLab 时，先配置实例地址和具有 `api` 权限的 Personal Access Token：
+
+```bash
+export GITLAB_URL=https://git.example.com
+export GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxx
+teamai init https://git.example.com/yourgroup/yourrepo
+```
+
+对于未知 host，`init` 会匿名检查 GitLab 登录页，总超时为三秒。确认是 GitLab 后，会在认证、克隆或写入配置前停止，提示设置实例地址和 token 后重试。探测不发送 token，也不跟随重定向。无法确认时，初始化继续使用通用 `git` provider；它支持 Git 传输，但不能自动建仓或创建 PR/MR。实例若由 SSO 遮蔽、部署在子路径下，或无法被探测访问，请显式设置 `GITLAB_URL`。
+
+**已经初始化为 `provider: git`？** 设置上述环境变量，并把团队仓库 `teamai.yaml` 中的 `provider` 改为 `gitlab`。仅设置环境变量不会改变已有 provider 选择。失败的 `teamai push` 可能已经推送了分支；若其诊断探测到 GitLab，会输出这些修复步骤。详见 [Provider 配置](providers.md#gitlab-provider含自托管)。
 
 ### 项目级（Project Scope，默认）
 

--- a/src/__tests__/gitlab-detection-e2e.test.ts
+++ b/src/__tests__/gitlab-detection-e2e.test.ts
@@ -1,0 +1,103 @@
+import { execFileSync, spawn } from 'node:child_process';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const CLI = fileURLToPath(new URL('../../dist/index.js', import.meta.url));
+const agents = ['claude', 'codex', 'codebuddy', 'opencode'];
+
+function runCLI(args: string[], cwd: string, home: string, env: Record<string, string> = {}) {
+  return new Promise<{ code: number | null; output: string }>((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI, ...args], {
+      cwd,
+      env: {
+        ...process.env, HOME: home, FORCE_COLOR: '0',
+        GITLAB_URL: '', TEAMAI_GITLAB_HOST: '', TEAMAI_DEFAULT_PROVIDER: '',
+        GITLAB_TOKEN: 'must-not-be-sent-by-probe', GITLAB_PRIVATE_TOKEN: '', GITLAB_PAT: '',
+        ...env,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let output = '';
+    child.stdout.on('data', (chunk) => { output += chunk; });
+    child.stderr.on('data', (chunk) => { output += chunk; });
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ code, output }));
+  });
+}
+
+describe('self-hosted GitLab detection through the built CLI', () => {
+  const requests: http.IncomingMessage[] = [];
+  let server: http.Server;
+  let baseUrl: string;
+  let sandbox: string;
+
+  beforeAll(async () => {
+    expect(fs.existsSync(CLI), 'Run npm run build first').toBe(true);
+    sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-gitlab-detection-'));
+    server = http.createServer((request, response) => {
+      requests.push(request);
+      response.writeHead(200, { 'Content-Type': 'text/html' });
+      response.end('<html><head><meta content="GitLab" property="og:site_name">'
+        + '<script>window.gon={};gon.api_version="v4";</script></head></html>');
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('Missing server address');
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server?.close(() => resolve()));
+    if (sandbox) fs.rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  for (const mode of ['team', 'self'] as const) {
+    it.each(agents)(`${mode} init for %s identifies GitLab before authentication or writing configuration`, async (agent) => {
+      const dir = fs.mkdtempSync(path.join(sandbox, `${mode}-${agent}-`));
+      const home = path.join(dir, 'home');
+      const project = path.join(dir, 'project');
+      fs.mkdirSync(home);
+      fs.mkdirSync(project);
+      execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: project });
+      execFileSync('git', ['remote', 'add', 'origin', `${baseUrl}/team/repo.git`], { cwd: project });
+      const before = requests.length;
+      const result = await runCLI(
+        ['init', mode === 'self' ? '.' : `${baseUrl}/team/repo.git`, '--agent', agent, '--force'],
+        project, home,
+      );
+      expect(result.code, result.output).toBe(1);
+      expect(result.output).toContain(`Detected self-hosted GitLab at ${baseUrl}`);
+      expect(result.output).toContain(`Set GITLAB_URL=${baseUrl}`);
+      expect(result.output).toContain('GITLAB_TOKEN');
+      expect(result.output).not.toContain('Authenticated as');
+      expect(result.output).not.toContain('must-not-be-sent-by-probe');
+      expect(result.output).not.toContain('at detectProviderForInit');
+      expect(result.output).not.toContain('node:internal');
+      expect(fs.existsSync(path.join(project, '.teamai', 'config.yaml'))).toBe(false);
+      expect(fs.existsSync(path.join(project, '.teamai', 'teamai.yaml'))).toBe(false);
+      expect(fs.existsSync(path.join(project, '.teamai', 'team-repo'))).toBe(false);
+      expect(requests.slice(before).map((request) => request.url)).toEqual(['/users/sign_in?auto_sign_in=false']);
+      for (const request of requests.slice(before)) {
+        expect(request.headers.authorization).toBeUndefined();
+        expect(request.headers['private-token']).toBeUndefined();
+        expect(request.headers.cookie).toBeUndefined();
+      }
+    });
+  }
+
+  it('uses explicit GitLab configuration without probing and still requires a token', async () => {
+    const dir = fs.mkdtempSync(path.join(sandbox, 'explicit-'));
+    const before = requests.length;
+    const result = await runCLI(['init', `${baseUrl}/team/repo.git`, '--force'], dir, dir, {
+      GITLAB_URL: baseUrl, GITLAB_TOKEN: '',
+    });
+    expect(result.code, result.output).toBe(1);
+    expect(result.output).toContain('GitLab authentication unavailable');
+    expect(result.output).not.toContain('Detected self-hosted GitLab');
+    expect(requests).toHaveLength(before);
+  });
+});

--- a/src/__tests__/gitlab-probe.test.ts
+++ b/src/__tests__/gitlab-probe.test.ts
@@ -1,0 +1,274 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { probeSelfHostedGitLab } from '../providers/gitlab/probe.js';
+import { detectProviderForInit } from '../providers/registry.js';
+
+const repoUrl = 'https://code.example.com/group/project.git';
+const gitlabMeta = JSON.stringify({ correlation_id: '01TESTREQUEST', version: '1' });
+const gitlabPage = '<html><head><meta property="og:site_name" content="GitLab">'
+  + '<script>window.gon = {}; gon.api_version = "v4";</script></head></html>';
+
+function htmlResponse(body = gitlabPage, status = 200): Response {
+  return new Response(body, { status, headers: { 'content-type': 'text/html; charset=utf-8' } });
+}
+
+describe('anonymous self-hosted GitLab probe', () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it.each([
+    ['https://code.example.com/group/project.git', 'https://code.example.com'],
+    ['http://code.example.com:8080/group/subgroup/project', 'http://code.example.com:8080'],
+    ['https://code.example.com:8443/group/project.git', 'https://code.example.com:8443'],
+    ['git@code.example.com:group/project.git', 'https://code.example.com'],
+    ['ssh://git@code.example.com:2222/group/project.git', 'https://code.example.com'],
+  ])('probes the web origin for %s', async (input, baseUrl) => {
+    fetchMock.mockResolvedValue(htmlResponse());
+
+    await expect(probeSelfHostedGitLab(input)).resolves.toEqual({ baseUrl });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toBe(`${baseUrl}/users/sign_in?auto_sign_in=false`);
+    expect(fetchMock.mock.calls[0][1]).toEqual(expect.objectContaining({
+      redirect: 'manual',
+      credentials: 'omit',
+      signal: expect.any(AbortSignal),
+    }));
+    expect(fetchMock.mock.calls[0][1]?.method ?? 'GET').toBe('GET');
+  });
+
+  it('does not send environment credentials during discovery', async () => {
+    vi.stubEnv('GITLAB_TOKEN', 'gitlab-secret');
+    vi.stubEnv('GITHUB_TOKEN', 'github-secret');
+    vi.stubEnv('TEAMAI_GITLAB_TOKEN', 'teamai-secret');
+    fetchMock.mockResolvedValue(htmlResponse());
+
+    await expect(probeSelfHostedGitLab(repoUrl)).resolves.toEqual({ baseUrl: 'https://code.example.com' });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe('https://code.example.com/users/sign_in?auto_sign_in=false');
+    const headers = new Headers(init?.headers);
+    expect([...headers.keys()].some((name) => /authorization|token|cookie|key/i.test(name))).toBe(false);
+    expect(JSON.stringify([...headers.entries()])).not.toMatch(/gitlab-secret|github-secret|teamai-secret/);
+    expect(init?.body).toBeUndefined();
+    expect(init?.credentials).toBe('omit');
+  });
+
+  it.each([
+    '',
+    'group/project',
+    'https://code.example.com',
+    'https://code.example.com/group',
+    'file:///tmp/group/project.git',
+    'ftp://code.example.com/group/project.git',
+    'https://oauth2:secret@code.example.com/group/project.git',
+    'https://user@code.example.com/group/project.git',
+    'ssh://git:secret@code.example.com/group/project.git',
+    'oauth2:secret@code.example.com:group/project.git',
+    'https://code.example.com/group/project.git?token=secret',
+    'https://code.example.com/group/project.git#secret',
+    'ssh://git@code.example.com/group/project.git?token=secret',
+    'git@code.example.com:group/project.git#secret',
+  ])('rejects unsafe or non-repository input without making a request: %s', async (input) => {
+    await expect(probeSelfHostedGitLab(input)).resolves.toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([200, 204, 401, 403])('accepts a structured GitLab metadata header on HTTP %i', async (status) => {
+    fetchMock.mockResolvedValue(new Response(null, {
+      status,
+      headers: { 'X-Gitlab-Meta': gitlabMeta },
+    }));
+
+    await expect(probeSelfHostedGitLab(repoUrl)).resolves.toEqual({ baseUrl: 'https://code.example.com' });
+  });
+
+  it.each([
+    'GitLab',
+    '{invalid json}',
+    '{}',
+    '{"correlation_id":"request"}',
+    '{"version":"1"}',
+    '{"correlation_id":"","version":"1"}',
+    '{"correlation_id":"request","version":""}',
+    '{"correlation_id":123,"version":"1"}',
+    '{"correlation_id":"request","version":1}',
+    '[{"correlation_id":"request","version":"1"}]',
+  ])('does not identify GitLab from an invalid metadata header: %s', async (header) => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 401, headers: { 'x-gitlab-meta': header } }));
+
+    await expect(probeSelfHostedGitLab(repoUrl)).resolves.toBeNull();
+  });
+
+  it.each([401, 403])('does not identify GitLab from HTTP %i alone', async (status) => {
+    fetchMock.mockResolvedValue(new Response('Unauthorized', { status }));
+
+    await expect(probeSelfHostedGitLab(repoUrl)).resolves.toBeNull();
+  });
+
+  it.each([
+    '<meta content="GitLab" property="og:site_name"><script>gon.api_version="v4";</script>',
+    "<meta property='og:site_name' content='GitLab'><script>gon.api_version = 'v4';</script>",
+    "<meta data-other='value' content='GitLab' property='og:site_name' /><script nonce='abc'>gon.api_version = 'v4';</script>",
+  ])('recognizes independent HTML fingerprints with different attribute ordering and quoting', async (body) => {
+    fetchMock.mockResolvedValue(htmlResponse(body));
+
+    await expect(probeSelfHostedGitLab(repoUrl)).resolves.toEqual({ baseUrl: 'https://code.example.com' });
+  });
+
+  it.each([
+    '<html><h1>GitLab hosting guide</h1></html>',
+    '<meta property="og:site_name" content="GitLab">',
+    '<script>gon.api_version="v4";</script>',
+    '<meta property="og:site_name" content="GitLab"><p>gon.api_version="v4";</p>',
+    '<meta property="og:site_name" content="Not GitLab"><script>gon.api_version="v4";</script>',
+    '<meta property="og:site_name" content="GitLab"><script>gon.api_version="v3";</script>',
+    '&lt;meta property="og:site_name" content="GitLab"&gt;<script>gon.api_version="v4";</script>',
+    '<!-- <meta property="og:site_name" content="GitLab"> --><script>gon.api_version="v4";</script>',
+    '<script>const template = `<meta property="og:site_name" content="GitLab">`; gon.api_version="v4";</script>',
+  ])('does not mistake partial fingerprints or GitLab mentions for a GitLab instance', async (body) => {
+    fetchMock.mockResolvedValue(htmlResponse(body));
+
+    await expect(probeSelfHostedGitLab(repoUrl)).resolves.toBeNull();
+  });
+
+  it('requires HTML content type for the HTML fingerprint', async () => {
+    fetchMock.mockResolvedValue(new Response(gitlabPage, { headers: { 'content-type': 'text/plain' } }));
+
+    await expect(probeSelfHostedGitLab(repoUrl)).resolves.toBeNull();
+  });
+
+  it.each([201, 401, 403])('does not use HTML fingerprints on HTTP %i', async (status) => {
+    fetchMock.mockResolvedValue(htmlResponse(gitlabPage, status));
+
+    await expect(probeSelfHostedGitLab(repoUrl)).resolves.toBeNull();
+  });
+
+  it.each([302, 500])('rejects HTTP %i even when a response contains GitLab fingerprints', async (status) => {
+    fetchMock.mockResolvedValue(new Response(gitlabPage, {
+      status,
+      headers: {
+        'x-gitlab-meta': gitlabMeta,
+        'content-type': 'text/html',
+        location: 'https://sso.example.com/login',
+      },
+    }));
+
+    await expect(probeSelfHostedGitLab(repoUrl)).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][1]?.redirect).toBe('manual');
+  });
+
+  it('returns null for certificate or connection failures', async () => {
+    fetchMock.mockRejectedValue(new TypeError('fetch failed: self-signed certificate'));
+
+    await expect(probeSelfHostedGitLab(repoUrl)).resolves.toBeNull();
+  });
+
+  it('aborts when response headers do not arrive before the deadline', async () => {
+    vi.useFakeTimers();
+    fetchMock.mockImplementation((_url, init) => new Promise((_resolve, reject) => {
+      init?.signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')));
+    }));
+
+    const pending = probeSelfHostedGitLab(repoUrl, 25);
+    await vi.advanceTimersByTimeAsync(26);
+
+    await expect(pending).resolves.toBeNull();
+    expect(fetchMock.mock.calls[0][1]?.signal?.aborted).toBe(true);
+  });
+
+  it('enforces the same deadline when headers arrive but the HTML body stalls', async () => {
+    vi.useFakeTimers();
+    const cancel = vi.fn();
+    fetchMock.mockResolvedValue(new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('<html><head>'));
+      },
+      cancel,
+    }), { headers: { 'content-type': 'text/html' } }));
+
+    const pending = probeSelfHostedGitLab(repoUrl, 25);
+    await vi.advanceTimersByTimeAsync(26);
+
+    await expect(pending).resolves.toBeNull();
+    expect(fetchMock.mock.calls[0][1]?.signal?.aborted).toBe(true);
+    expect(cancel).toHaveBeenCalled();
+  });
+
+  it('rejects oversized HTML even when the fingerprint appears before the limit', async () => {
+    fetchMock.mockResolvedValue(htmlResponse(gitlabPage + 'x'.repeat(128 * 1024)));
+
+    await expect(probeSelfHostedGitLab(repoUrl)).resolves.toBeNull();
+  });
+
+  it('limits streamed body bytes without trusting Content-Length', async () => {
+    const cancel = vi.fn();
+    fetchMock.mockResolvedValue(new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(gitlabPage));
+        controller.enqueue(new Uint8Array(128 * 1024));
+      },
+      cancel,
+    }), { headers: { 'content-type': 'text/html', 'content-length': '1' } }));
+
+    await expect(probeSelfHostedGitLab(repoUrl)).resolves.toBeNull();
+    expect(cancel).toHaveBeenCalled();
+  });
+});
+
+describe('provider discovery during initialization', () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubEnv('GITLAB_URL', '');
+    vi.stubEnv('TEAMAI_GITLAB_HOST', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it.each([
+    ['https://github.com/group/project.git', 'github'],
+    ['git@gitlab.com:group/project.git', 'gitlab'],
+    ['https://git.woa.com/group/project.git', 'tgit'],
+    ['https://cnb.cool/group/project.git', 'cnb'],
+  ])('keeps known provider %s without a network request', async (input, provider) => {
+    await expect(detectProviderForInit(input)).resolves.toBe(provider);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('uses explicitly configured self-hosted GitLab without probing', async () => {
+    vi.stubEnv('GITLAB_URL', 'https://code.example.com:8443');
+
+    await expect(detectProviderForInit('git@code.example.com:group/project.git')).resolves.toBe('gitlab');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps generic Git when the host cannot be positively identified', async () => {
+    fetchMock.mockResolvedValue(htmlResponse('<h1>Company Git hosting</h1>'));
+
+    await expect(detectProviderForInit(repoUrl)).resolves.toBe('git');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports the detected instance and required setup before writing a provider choice', async () => {
+    fetchMock.mockResolvedValue(htmlResponse());
+
+    await expect(detectProviderForInit(repoUrl)).rejects.toThrow(
+      /Detected self-hosted GitLab at https:\/\/code\.example\.com\..*GITLAB_URL=https:\/\/code\.example\.com.*GITLAB_TOKEN.*api scope.*teamai init again/,
+    );
+    expect(process.env.GITLAB_URL).toBe('');
+  });
+});

--- a/src/__tests__/gitlab-push-guidance.test.ts
+++ b/src/__tests__/gitlab-push-guidance.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPrWithFallback } from '../push.js';
+import { getDefaultBranch } from '../utils/git.js';
+import { log } from '../utils/logger.js';
+
+const { fail, succeed } = vi.hoisted(() => ({ fail: vi.fn(), succeed: vi.fn() }));
+
+vi.mock('../utils/git.js', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../utils/git.js')>(),
+  getDefaultBranch: vi.fn().mockResolvedValue('main'),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  log: {
+    info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), dim: vi.fn(),
+  },
+  spinner: vi.fn(() => ({ start: vi.fn().mockReturnValue({ fail, succeed }) })),
+}));
+
+const REMOTE = 'https://private-code.example.test/team/project.git';
+const BRANCH = 'teamai/push/member/review';
+const UNSUPPORTED_PR = 'Failed to create PR: Automatic pull/merge request creation is not supported for generic Git hosts.';
+const localConfig = { repo: { remote: REMOTE, localPath: '/tmp/unused-teamai-guidance-repo' } };
+
+describe('GitLab guidance after generic Git PR creation fails', () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubEnv('GITLAB_URL', '');
+    vi.stubEnv('TEAMAI_GITLAB_HOST', '');
+    vi.stubEnv('GITLAB_TOKEN', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it('diagnoses the valid remote used when a nonempty team repo input cannot be parsed', async () => {
+    const teamConfig = { repo: 'team/project', provider: 'git' };
+    const originalConfig = structuredClone(teamConfig);
+    fetchMock.mockResolvedValue(new Response(null, {
+      status: 200,
+      headers: { 'x-gitlab-meta': '{"correlation_id":"guidance-test","version":"1"}' },
+    }));
+
+    await expect(createPrWithFallback(teamConfig, localConfig, BRANCH, 'Title', 'Body')).resolves.toBeNull();
+
+    expect(getDefaultBranch).toHaveBeenCalledWith(localConfig.repo.localPath);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://private-code.example.test/users/sign_in?auto_sign_in=false',
+      expect.objectContaining({ credentials: 'omit', redirect: 'manual' }),
+    );
+    expect(fail).toHaveBeenCalledWith(UNSUPPORTED_PR);
+    expect(log.info).toHaveBeenCalledWith(expect.stringContaining('Change it to provider: gitlab'));
+    expect(log.info).toHaveBeenCalledWith(expect.stringContaining('set GITLAB_URL to https://private-code.example.test'));
+    expect(teamConfig).toEqual(originalConfig);
+    expect(process.env.GITLAB_URL).toBe('');
+  });
+
+  it('uses an explicitly configured GitLab host to explain a saved git provider without network probing', async () => {
+    vi.stubEnv('GITLAB_URL', 'https://private-code.example.test');
+    const teamConfig = { repo: REMOTE, provider: 'git' };
+    const originalConfig = structuredClone(teamConfig);
+
+    await expect(createPrWithFallback(teamConfig, localConfig, BRANCH, 'Title', 'Body')).resolves.toBeNull();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fail).toHaveBeenCalledWith(UNSUPPORTED_PR);
+    expect(log.info).toHaveBeenCalledWith(expect.stringContaining('teamai.yaml has provider: git. Change it to provider: gitlab'));
+    expect(log.info).toHaveBeenCalledWith(expect.stringContaining('configure GITLAB_TOKEN with api scope'));
+    expect(succeed).not.toHaveBeenCalled();
+    expect(teamConfig).toEqual(originalConfig);
+    expect(process.env.GITLAB_URL).toBe('https://private-code.example.test');
+  });
+
+  it('preserves the original failure and manual PR guidance when an unknown host is not GitLab', async () => {
+    const teamConfig = { repo: REMOTE, provider: 'git' };
+    const originalConfig = structuredClone(teamConfig);
+    fetchMock.mockResolvedValue(new Response('<h1>Company Git hosting</h1>', {
+      headers: { 'content-type': 'text/html' },
+    }));
+
+    await expect(createPrWithFallback(teamConfig, localConfig, BRANCH, 'Title', 'Body')).resolves.toBeNull();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fail).toHaveBeenCalledWith(UNSUPPORTED_PR);
+    expect(log.info).toHaveBeenCalledWith(`Branch ${BRANCH} has been pushed. You can create a PR manually.`);
+    expect(log.info).not.toHaveBeenCalledWith(expect.stringContaining('Detected GitLab'));
+    expect(succeed).not.toHaveBeenCalled();
+    expect(teamConfig).toEqual(originalConfig);
+  });
+});

--- a/src/__tests__/push-role-skill-e2e.test.ts
+++ b/src/__tests__/push-role-skill-e2e.test.ts
@@ -9,6 +9,8 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..', '..');
 const CLI = path.join(ROOT, 'dist', 'index.js');
+const PUSH_AGENTS = ['claude', 'codex', 'codebuddy', 'opencode'] as const;
+type PushAgent = (typeof PUSH_AGENTS)[number];
 
 const GIT_ENV = {
   GIT_AUTHOR_NAME: 'TeamAI CI',
@@ -62,8 +64,12 @@ interface PushFixture {
   remote: string;
 }
 
-function makePushFixture(provider: 'github' | 'gitlab', repoUrl: string): PushFixture {
-  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), `teamai-push-${provider}-e2e-`));
+function makePushFixture(
+  provider: 'github' | 'gitlab' | 'git',
+  repoUrl: string,
+  agent: PushAgent,
+): PushFixture {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), `teamai-push-${provider}-${agent}-e2e-`));
   const home = path.join(sandbox, 'home');
   const projectRoot = path.join(sandbox, 'project');
   const seed = path.join(sandbox, 'seed');
@@ -71,7 +77,7 @@ function makePushFixture(provider: 'github' | 'gitlab', repoUrl: string): PushFi
   const teamRepo = path.join(projectRoot, '.teamai', 'team-repo');
 
   fs.mkdirSync(home, { recursive: true });
-  fs.mkdirSync(path.join(projectRoot, '.claude', 'skills'), { recursive: true });
+  fs.mkdirSync(path.join(projectRoot, `.${agent}`, 'skills'), { recursive: true });
   fs.mkdirSync(path.join(seed, 'skills', 'backend', 'beta-proof'), { recursive: true });
   fs.writeFileSync(
     path.join(seed, 'teamai.yaml'),
@@ -81,8 +87,8 @@ function makePushFixture(provider: 'github' | 'gitlab', repoUrl: string): PushFi
       `provider: ${provider}`,
       'reviewers: []',
       'toolPaths:',
-      '  claude:',
-      '    skills: .claude/skills',
+      `  ${agent}:`,
+      `    skills: .${agent}/skills`,
     ].join('\n'),
   );
   fs.writeFileSync(
@@ -114,6 +120,7 @@ function makePushFixture(provider: 'github' | 'gitlab', repoUrl: string): PushFi
 
 async function pullModifyAndPush(
   fixture: PushFixture,
+  agent: PushAgent,
   envOverrides: Record<string, string> = {},
 ): Promise<RunResult> {
   const pullResult = await runCLI(
@@ -123,13 +130,17 @@ async function pullModifyAndPush(
     envOverrides,
   );
   expect(pullResult.code, pullResult.output).toBe(0);
+  const skillPath = `.${agent}/skills/beta-proof`;
+  const skillFile = path.join(fixture.projectRoot, skillPath, 'SKILL.md');
+  expect(fs.existsSync(skillFile), pullResult.output).toBe(true);
+  expect(fs.readFileSync(skillFile, 'utf8')).toContain('# Original');
 
   fs.writeFileSync(
-    path.join(fixture.projectRoot, '.claude', 'skills', 'beta-proof', 'SKILL.md'),
+    skillFile,
     '---\nname: beta-proof\ndescription: modified\n---\n\n# Modified locally\n',
   );
   return runCLI(
-    ['push', '--skill', '.claude/skills/beta-proof', '--role', 'backend', '--all'],
+    ['push', '--skill', skillPath, '--role', 'backend', '--all'],
     fixture.projectRoot,
     fixture.home,
     envOverrides,
@@ -239,8 +250,43 @@ describe('role-scoped skill push e2e (issue #331)', () => {
 });
 
 describe('role-scoped skill provider PR creation e2e (issue #331)', () => {
-  it('commits, pushes, and creates a GitHub PR', async () => {
-    const fixture = makePushFixture('github', 'https://github.com/team/issue-331.git');
+  it.each(PUSH_AGENTS)('explains a saved generic provider when anonymous probing identifies GitLab for %s', async (agent) => {
+    const requests: http.IncomingMessage[] = [];
+    const server = http.createServer((request, response) => {
+      requests.push(request);
+      response.writeHead(200, {
+        'content-type': 'text/html',
+        'x-gitlab-meta': JSON.stringify({ correlation_id: 'probe-test', version: '1' }),
+      });
+      response.end('GitLab sign in');
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('Missing server address');
+    const baseUrl = `http://127.0.0.1:${address.port}`;
+    const fixture = makePushFixture('git', `${baseUrl}/team/issue-331.git`, agent);
+    try {
+      const result = await pullModifyAndPush(fixture, agent, {
+        GITLAB_URL: '', TEAMAI_GITLAB_HOST: '', GITLAB_TOKEN: 'must-not-be-sent',
+      });
+      expect(result.code, result.output).not.toBe(0);
+      expect(result.output).toContain('Pushed branch teamai/push/issue-331-git/');
+      expect(result.output).toContain('Detected GitLab, but teamai.yaml has provider: git.');
+      expect(result.output).toContain('Change it to provider: gitlab');
+      expect(result.output).toContain(`set GITLAB_URL to ${baseUrl}`);
+      expect(result.output).not.toContain('must-not-be-sent');
+      expect(requests.map((request) => request.url)).toEqual(['/users/sign_in?auto_sign_in=false']);
+      expect(requests[0].headers['private-token']).toBeUndefined();
+      const config = fs.readFileSync(path.join(fixture.projectRoot, '.teamai', 'team-repo', 'teamai.yaml'), 'utf8');
+      expect(config).toContain('provider: git\n');
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      fs.rmSync(fixture.sandbox, { recursive: true, force: true });
+    }
+  }, 60_000);
+
+  it.each(PUSH_AGENTS)('commits, pushes, and creates a GitHub PR for %s', async (agent) => {
+    const fixture = makePushFixture('github', 'https://github.com/team/issue-331.git', agent);
     const binDir = path.join(fixture.sandbox, 'bin');
     const ghLog = path.join(fixture.sandbox, 'gh.log');
     fs.mkdirSync(binDir);
@@ -251,7 +297,7 @@ describe('role-scoped skill provider PR creation e2e (issue #331)', () => {
     );
 
     try {
-      const result = await pullModifyAndPush(fixture, {
+      const result = await pullModifyAndPush(fixture, agent, {
         PATH: `${binDir}:${process.env.PATH ?? ''}`,
         TEAMAI_FAKE_GH_LOG: ghLog,
       });
@@ -274,7 +320,7 @@ describe('role-scoped skill provider PR creation e2e (issue #331)', () => {
     }
   }, 60_000);
 
-  it('commits, pushes, and creates a GitLab MR', async () => {
+  it.each(PUSH_AGENTS)('commits, pushes, and creates a GitLab MR for %s', async (agent) => {
     const requestPaths: string[] = [];
     let requestBody = '';
     const server = http.createServer((request, response) => {
@@ -295,10 +341,10 @@ describe('role-scoped skill provider PR creation e2e (issue #331)', () => {
       throw new Error('Failed to start the fake GitLab API server.');
     }
     const gitlabUrl = `http://127.0.0.1:${address.port}`;
-    const fixture = makePushFixture('gitlab', `${gitlabUrl}/team/issue-331.git`);
+    const fixture = makePushFixture('gitlab', `${gitlabUrl}/team/issue-331.git`, agent);
 
     try {
-      const result = await pullModifyAndPush(fixture, {
+      const result = await pullModifyAndPush(fixture, agent, {
         GITLAB_URL: gitlabUrl,
         GITLAB_TOKEN: 'test-token',
       });

--- a/src/init.ts
+++ b/src/init.ts
@@ -5,7 +5,7 @@ import { saveLocalConfig, loadTeamConfig, saveLocalConfigForScope, loadLocalConf
 import { reconcileTeamHooksForConfig } from './hooks.js';
 import { configureGitUser, initRepo, isGitRepo, getRemoteUrl, remotesMatch, redactGitCredentials } from './utils/git.js';
 import { pushRepoDirectly } from './utils/git.js';
-import { getProvider, detectProvider, RepoNotFoundError } from './providers/index.js';
+import { getProvider, detectProviderForInit, RepoNotFoundError } from './providers/index.js';
 import { ensureDir, writeFile, pathExists, expandHome, readFileSafe, remove } from './utils/fs.js';
 import { log, spinner } from './utils/logger.js';
 import {
@@ -708,7 +708,14 @@ export async function initSelfRepo(options: GlobalOptions & {
     process.exit(1);
     return;
   }
-  const providerName = detectProvider(remoteUrl);
+  let providerName: string;
+  try {
+    providerName = await detectProviderForInit(remoteUrl);
+  } catch (e) {
+    log.error((e as Error).message);
+    process.exit(1);
+    return;
+  }
   const provider = getProvider(providerName);
   log.debug(`Detected provider: ${providerName} (from ${remoteUrl})`);
 
@@ -1043,7 +1050,14 @@ export async function init(options: GlobalOptions & {
   }
 
   // Step 1b: Detect and initialize provider from URL
-  const providerName = detectProvider(repoInput);
+  let providerName: string;
+  try {
+    providerName = await detectProviderForInit(repoInput);
+  } catch (e) {
+    log.error((e as Error).message);
+    process.exit(1);
+    return;
+  }
   const provider = getProvider(providerName);
   log.debug(`Detected provider: ${providerName}`);
 

--- a/src/providers/gitlab/probe.ts
+++ b/src/providers/gitlab/probe.ts
@@ -1,0 +1,106 @@
+const PROBE_TIMEOUT_MS = 3_000;
+const MAX_RESPONSE_BYTES = 128 * 1024;
+
+/** Derive a web origin without forwarding URL credentials or SSH ports. */
+function webOrigin(input: string): string | null {
+  const trimmed = input.trim();
+  try {
+    const scp = trimmed.match(/^([^@\s/:]+)@([^:\s/?#]+):(.+)$/);
+    const url = new URL(scp ? `ssh://${scp[1]}@${scp[2]}/${scp[3]}` : trimmed);
+    if (!['https:', 'http:', 'ssh:'].includes(url.protocol)) return null;
+    if (url.password || (url.protocol !== 'ssh:' && url.username)) return null;
+    if (url.search || url.hash || !url.hostname) return null;
+    const segments = url.pathname.replace(/^\/+|\/+$/g, '').split('/');
+    if (segments.length < 2 || segments.some((part) => !part || /[\s\\]/.test(part))) return null;
+    return url.protocol === 'ssh:' ? `https://${url.hostname}` : url.origin;
+  } catch {
+    return null;
+  }
+}
+
+function hasGitLabHeader(response: Response): boolean {
+  const value = response.headers.get('x-gitlab-meta');
+  if (!value) return false;
+  try {
+    const meta = JSON.parse(value);
+    return typeof meta?.correlation_id === 'string' && meta.correlation_id.length > 0
+      && typeof meta?.version === 'string' && meta.version.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/** Match structured login-page markers, not a page that merely mentions GitLab. */
+function hasGitLabHtml(html: string): boolean {
+  const markup = html.replace(/<!--[\s\S]*?-->/g, '');
+  const scripts = [...markup.matchAll(/<script\b[^>]*>([\s\S]*?)<\/script\s*>/gi)];
+  const hasApiVersion = scripts.some((match) => /\bgon\.api_version\s*=\s*(["'])v4\1/.test(match[1]));
+  if (!hasApiVersion) return false;
+  const withoutScripts = markup.replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, '');
+  return [...withoutScripts.matchAll(/<meta\b[^>]*>/gi)].some(([tag]) => {
+    const attributes = new Map(
+      [...tag.matchAll(/\s([\w:-]+)\s*=\s*(["'])(.*?)\2/g)].map((match) => [match[1].toLowerCase(), match[3]]),
+    );
+    return attributes.get('property') === 'og:site_name' && attributes.get('content') === 'GitLab';
+  });
+}
+
+/**
+ * Best-effort anonymous identification of a self-hosted GitLab web root.
+ * This is a configuration hint, not permission to send a token to this host.
+ * Custom web ports for SSH remotes and relative-URL-root deployments still
+ * require an explicit GITLAB_URL. Never follow redirects to an SSO service.
+ */
+export async function probeSelfHostedGitLab(
+  input: string,
+  timeoutMs = PROBE_TIMEOUT_MS,
+): Promise<{ baseUrl: string } | null> {
+  const baseUrl = webOrigin(input);
+  if (!baseUrl) return null;
+  const controller = new AbortController();
+  let response: Response | undefined;
+  let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<null>((resolve) => {
+    timer = setTimeout(() => {
+      controller.abort();
+      resolve(null);
+    }, timeoutMs);
+  });
+  const probe = async (): Promise<{ baseUrl: string } | null> => {
+    try {
+      response = await fetch(`${baseUrl}/users/sign_in?auto_sign_in=false`, {
+        method: 'GET',
+        credentials: 'omit',
+        redirect: 'manual',
+        signal: controller.signal,
+        headers: { Accept: 'text/html' },
+      });
+      if (!response.ok && response.status !== 401 && response.status !== 403) return null;
+      if (hasGitLabHeader(response)) return { baseUrl };
+      if (response.status !== 200 || !response.headers.get('content-type')?.toLowerCase().includes('text/html')) return null;
+      reader = response.body?.getReader();
+      if (!reader) return null;
+      const chunks: Uint8Array[] = [];
+      let size = 0;
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        size += value.byteLength;
+        if (size > MAX_RESPONSE_BYTES) return null;
+        chunks.push(value);
+      }
+      return hasGitLabHtml(Buffer.concat(chunks).toString('utf8')) ? { baseUrl } : null;
+    } catch {
+      return null;
+    }
+  };
+  try {
+    return await Promise.race([probe(), timeout]);
+  } finally {
+    clearTimeout(timer!);
+    controller.abort();
+    // Cancellation must not extend the overall timeout for a stalled body.
+    void (reader ? reader.cancel() : response?.body?.cancel())?.catch(() => {});
+  }
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,6 +1,6 @@
 export type { GitProvider, RepoInfo, PrCreateOptions } from './types.js';
 export { RepoNotFoundError } from './types.js';
-export { getProvider, getProviderFromUrl, detectProvider } from './registry.js';
+export { getProvider, getProviderFromUrl, detectProvider, detectProviderForInit } from './registry.js';
 export { TGitProvider } from './tgit/index.js';
 export { GitHubProvider } from './github/index.js';
 export { GitLabProvider } from './gitlab/index.js';

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -6,6 +6,7 @@ import { GitLabProvider } from './gitlab/index.js';
 import { GitCodeProvider } from './gitcode/index.js';
 import { GenericGitProvider } from './git/index.js';
 import { getCurrentPackageName } from '../package-info.js';
+import { probeSelfHostedGitLab } from './gitlab/probe.js';
 
 // ─── Provider Detection ──────────────────────────────────
 //
@@ -106,6 +107,25 @@ export function detectProvider(input: string): string {
 
   // Bare owner/repo — use distribution-based default.
   return getDefaultProvider();
+}
+
+/**
+ * Interactive initialization can probe an otherwise unknown host. Do not just
+ * return "gitlab": its API client needs an explicitly configured instance URL
+ * on subsequent runs too, otherwise it would silently target gitlab.com.
+ */
+export async function detectProviderForInit(input: string): Promise<string> {
+  const provider = detectProvider(input);
+  if (provider !== 'git') return provider;
+  const detected = await probeSelfHostedGitLab(input);
+  if (detected) {
+    throw new Error(
+      `Detected self-hosted GitLab at ${detected.baseUrl}. `
+      + `Set GITLAB_URL=${detected.baseUrl} (use the full instance base URL for a subpath deployment) `
+      + 'and GITLAB_TOKEN (a Personal Access Token with api scope), then run teamai init again.',
+    );
+  }
+  return provider;
 }
 
 /**

--- a/src/push.ts
+++ b/src/push.ts
@@ -95,12 +95,14 @@ async function createPrWithFallback(
 ): Promise<string | null> {
   const provider = getProvider(teamConfig.provider);
   const mrSpin = spinner('Creating Pull Request...').start();
+  let repoInput = teamConfig.repo;
   try {
     let repoInfo;
     try {
       repoInfo = provider.parseRepoInput(teamConfig.repo);
     } catch {
       repoInfo = provider.parseRepoInput(localConfig.repo.remote);
+      repoInput = localConfig.repo.remote;
     }
 
     const targetBranch = await getDefaultBranch(localConfig.repo.localPath);
@@ -118,6 +120,20 @@ async function createPrWithFallback(
   } catch (e) {
     mrSpin.fail(`Failed to create PR: ${(e as Error).message}`);
     log.info(`Branch ${branchName} has been pushed. You can create a PR manually.`);
+    if (provider.name === 'git') {
+      const { detectProvider } = await import('./providers/registry.js');
+      const { probeSelfHostedGitLab } = await import('./providers/gitlab/probe.js');
+      const repoUrl = repoInput || localConfig.repo.remote;
+      const detected = detectProvider(repoUrl) === 'gitlab'
+        ? { baseUrl: 'your GitLab instance base URL' }
+        : await probeSelfHostedGitLab(repoUrl);
+      if (detected) {
+        log.info(
+          'Detected GitLab, but teamai.yaml has provider: git. Change it to provider: gitlab, '
+          + `set GITLAB_URL to ${detected.baseUrl}, and configure GITLAB_TOKEN with api scope.`,
+        );
+      }
+    }
     return null;
   }
 }


### PR DESCRIPTION
## Summary

An unconfigured self-hosted GitLab URL can be initialized with `provider: git`, then fail at `teamai push` with `Automatic pull/merge request creation is not supported for generic Git hosts.` after the branch has already been pushed. This change anonymously identifies recognizable GitLab instances during initialization and reports the required instance URL/token configuration before authentication, cloning, or writing configuration. Existing repositories with `provider: git` receive specific GitLab recovery guidance after PR creation fails, including when parsing falls back to the local remote.

Known-host and explicitly configured GitLab detection keep their existing precedence. README and usage-guide translations, plus provider documentation, describe the behavior and correct an existing self-hosted URL example.

## Type of Change

- [x] Bug fix

## Test Plan

All checked items were run on the final change (macOS, Node.js v22.15.0, Vitest 2.1.9).

- [x] `npm run build` — passed.
- [x] `npx tsc --noEmit` — passed.
- [x] `npx vitest run` — **203 files / 2,850 tests passed**, using a canonical temporary HOME for isolation.
- [x] `npx vitest run --config vitest.e2e.config.ts src/__tests__/gitlab-detection-e2e.test.ts src/__tests__/push-role-skill-e2e.test.ts --reporter=verbose` — **2 files / 23 tests passed**, after building the CLI.
- [x] `git diff --check` — passed.
- [x] Added regressions for anonymous fingerprints, ordinary 401 responses, redirects, invalid/credential-bearing URLs, HTTPS/SSH port handling, network/TLS errors, response-body limits, total timeout and cancellation, explicit-config precedence, and remote fallback.

### CLI test report

Each matrix cell runs the built CLI to pull a skill into that agent's configured directory, verifies its contents, modifies it, and pushes through a real local Git remote. The generic Git case checks the GitLab setup guidance and preserved provider configuration; GitLab and GitHub cases check successful MR/PR creation through their respective provider interfaces.

| Agent configuration | `git`: GitLab recovery guidance | `gitlab`: MR creation | `github`: PR creation |
| --- | --- | --- | --- |
| Claude | PASS | PASS | PASS |
| Codex | PASS | PASS | PASS |
| CodeBuddy | PASS | PASS | PASS |
| OpenCode | PASS | PASS | PASS |

Additional CLI cases: team-repo and self-repo initialization for all four agent options (8), explicit GitLab configuration without a token (1), and the existing generic Git branch/error assertions (2). Total: 12 matrix cases + 11 additional cases = 23.

GitLab HTTP responses are served by a loopback fixture; GitHub `gh` output is stubbed. These tests exercise the real built TeamAI CLI and Git operations, not live hosted API credentials or the agent applications themselves.

## Related Issues

Reported self-hosted GitLab initialization/push failure; no existing issue linked.

## Notes for Reviewers

- This is detection and configuration guidance, not automatic migration or zero-configuration GitLab access. Positive detection during `init` now stops with instructions instead of saving the generic provider. The GitLab API client still requires an explicitly configured instance so a later process cannot silently target gitlab.com.
- The probe is limited to an anonymous request to `/users/sign_in?auto_sign_in=false`, with a 3-second total timeout and a 128 KiB HTML limit. It uses a structured `X-Gitlab-Meta` header or paired GitLab HTML markers; a plain 401 or a page mentioning GitLab is insufficient.
- No tokens/cookies are sent during probing, redirects are not followed, and TLS verification stays enabled. Unknown or inaccessible services retain the generic fallback. Subpath deployments, SSO-hidden pages, and SSH hosts with a different web endpoint still require explicit `GITLAB_URL` configuration.
- Existing `provider: git` values and pushed branches remain intact. The diagnostic tells users to configure the instance/token and update the provider themselves.
