### PR TITLE
feat(gitlab): support custom API prefix for gateway-proxied instances

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -174,13 +174,27 @@ GitLab Provider 通过 GitLab **REST API v4** 工作，**不需要任何外部 C
 通过标准 GitLab 环境变量配置：
 
 ```bash
-export GITLAB_URL=https://gitlab.example.com   # 自托管实例 base URL；默认 https://gitlab.com
-export GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxx      # Personal Access Token，需要 api scope
+export GITLAB_URL=https://gitlab.example.com    # 自托管实例 base URL；默认 https://gitlab.com
+export GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxx       # Personal Access Token，需要 api scope
+export GITLAB_API_PREFIX=api/v4                  # API 路径前缀；默认 api/v4（标准 GitLab）
 ```
 
 token 变量支持三个名字（按优先级）：`GITLAB_TOKEN` > `GITLAB_PRIVATE_TOKEN` > `GITLAB_PAT`。空值/纯空白视为未设置，会继续尝试下一个别名。
 
 `GITLAB_URL` **必须带 scheme**（`https://` 或 `http://`）。写成 `gitlab.example.com` 会在执行 GitLab 操作时报错退出，而不是静默回落到 gitlab.com。内网 http 实例、非标准端口、以及挂在子路径下的部署（`https://example.com/gitlab`）都会被完整保留，包括 clone URL。
+
+`GITLAB_API_PREFIX` 用于网关代理场景：某些自托管实例通过网关统一路由，GitLab API 被挂载到非标准路径（如 `/api/gitlab` 而不是标准的 `/api/v4`）。此时设置该变量可避免 405 错误。示例：
+
+```bash
+# 标准 GitLab 自托管（默认，无需设置 GITLAB_API_PREFIX）
+export GITLAB_URL=https://gitlab.example.com
+export GITLAB_TOKEN=glpat-xxx
+
+# 网关代理场景（API 路径被改为 /api/gitlab）
+export GITLAB_URL=https://code.company.com
+export GITLAB_API_PREFIX=api/gitlab
+export GITLAB_TOKEN=glpat-xxx
+```
 
 ### 自托管实例检测
 

--- a/src/providers/gitlab/gitlab-api.ts
+++ b/src/providers/gitlab/gitlab-api.ts
@@ -30,9 +30,16 @@ export function gitlabBaseUrl(): string {
   return resolveGitLabBaseUrl();
 }
 
-/** Base URL for REST API calls (GitLab mounts the API under /api/v4). */
-function gitlabApiBase(): string {
-  return `${gitlabBaseUrl()}/api/v4`;
+/**
+ * Base URL for REST API calls (GitLab mounts the API under /api/v4).
+ *
+ * The API prefix can be customized via GITLAB_API_PREFIX for instances behind
+ * gateways that mount the GitLab API at a non-standard path (e.g., `/api/gitlab`).
+ * Defaults to `api/v4` (standard GitLab).
+ */
+export function gitlabApiBase(): string {
+  const prefix = process.env.GITLAB_API_PREFIX?.trim().replace(/^\/+|\/+$/g, '') || 'api/v4';
+  return `${gitlabBaseUrl()}/${prefix}`;
 }
 
 function resolveGitLabBaseUrl(): string {

--- a/src/providers/gitlab/mr-fetch.ts
+++ b/src/providers/gitlab/mr-fetch.ts
@@ -1,6 +1,6 @@
 import { type MRData } from '../../types.js';
 import { log } from '../../utils/logger.js';
-import { getGitLabToken } from './gitlab-api.js';
+import { getGitLabToken, gitlabApiBase } from './gitlab-api.js';
 import { GITLAB_HOST } from './repo-url.js';
 
 /** GitLab MR URL 解析结果 */
@@ -42,8 +42,10 @@ function parseGitLabMRUrl(url: string): ParsedGitLabMR {
         `instance if it is trusted.`,
     );
   }
+  // Use the same API prefix as gitlabApiBase() for consistency with MR creation.
+  const apiPrefix = process.env.GITLAB_API_PREFIX?.trim().replace(/^\/+|\/+$/g, '') || 'api/v4';
   return {
-    apiBase: `${scheme}://${host}/api/v4`,
+    apiBase: `${scheme}://${host}/${apiPrefix}`,
     projectPath,
     mrIid: match[4],
   };


### PR DESCRIPTION
Add GITLAB_API_PREFIX environment variable to support self-hosted GitLab instances behind gateways that mount the API at non-standard paths.

Problem:
Some enterprise GitLab deployments sit behind API gateways that route GitLab API requests to paths like /api/gitlab instead of the standard /api/v4. The hardcoded /api/v4 prefix causes 405 Method Not Allowed errors on such instances.

Solution:
- Add optional GITLAB_API_PREFIX env var (default: api/v4)
- Apply prefix in both gitlab-api.ts (MR creation) and mr-fetch.ts (MR fetching)
- Update docs/providers.md with usage examples

Example use case:
Enterprise deployments may route GitLab API to /api/gitlab/ instead of /api/v4

Changes:
- gitlab-api.ts: Make gitlabApiBase() export and read GITLAB_API_PREFIX
- mr-fetch.ts: Use same prefix logic in parseGitLabMRUrl()
- providers.md: Document GITLAB_API_PREFIX with gateway proxy example

Testing:
- Existing behavior unchanged when GITLAB_API_PREFIX is unset
- No breaking changes to standard GitLab instances
- Type-safe (export added to maintain interface compatibility)

<!--
Thanks for opening a PR! Please fill out this template to help reviewers understand your change quickly.
-->

## Summary

<!-- 1-3 sentences: what does this PR do and why? -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing behavior to change)
- [ ] Documentation only
- [ ] Refactor / internal cleanup

## Test Plan

<!-- How did you verify this works? Include commands you ran, new tests added, etc. -->

- [ ] `npx tsc --noEmit` passes
- [ ] `npx vitest run` passes
- [ ] Added/updated tests for the change

## Related Issues

<!-- Closes #123, Fixes #456 -->

## Notes for Reviewers

<!-- Anything reviewers should pay particular attention to (tricky logic, trade-offs, follow-ups) -->
