### PR TITLE
feat(local-agent): apply WorkBuddy model configs from ClawPro

### DIFF
--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -1037,6 +1037,53 @@ When using `teamai init --http <baseUrl>`, the endpoint must implement the follo
 }
 ```
 
+The backend may push an **`apply_model_config`** task whose `cmd` is JSON. Both
+the documented candidate-set shape and the legacy single-model shape are accepted.
+`{"models":[...]}` is a full snapshot; a direct model object is an incremental upsert.
+`max_tokens` is optional (CodeBuddy / WorkBuddy `maxOutputTokens`); omitted or `0` defaults to `4096`. Claude does not use it.
+
+```jsonc
+{ "id": 16, "type": "apply_model_config",
+  "cmd": "{\"models\":[{\"provider\":\"openai\",\"model_id\":\"gpt-4o\",\"name\":\"GPT-4o\",\"base_url\":\"https://proxy.example.com/v1\",\"api_key\":\"<ProxyToken>\",\"max_tokens\":4096,\"context_window\":128000}]}" }
+```
+
+The candidate set is applied only to the agent that reported the task. CodeBuddy uses
+user-level `~/.codebuddy/models.json` (`{ "models": [...] }`). WorkBuddy uses
+`~/.workbuddy/models.json`; both the current `{ "models": [...] }` shape and the legacy
+top-level array are accepted, and an existing file keeps its shape. A workspace-scoped
+CodeBuddy or WorkBuddy task uses `<workspace>/.codebuddy/models.json`, matching the
+embedded model loader; that credential-bearing file is added to
+`<workspace>/.codebuddy/.gitignore`. Workspace delivery is accepted only for a path
+already present in the reporter's workspace bindings. User-owned entries with the same
+model ID are preserved. Claude
+gets an explicit profile at `~/.claude/teamai-models.json`
+and also receives the gateway environment in `~/.claude/settings.json` when it has no
+conflicting user-owned Anthropic gateway configuration. Unsupported agents acknowledge
+the task as failed instead of writing another agent's config. Symlinked user config
+files remain symlinks. These files are mode `0600`. A successful write is acknowledged with
+`type: "apply_model_config"`; malformed payloads are acknowledged as `failed`. Unknown
+future task types are silently skipped for protocol compatibility.
+
+The reverse direction is reported through the existing `report` call: models that
+TeamAI recorded in its model manifest and can still identify by model ID and provider
+on disk are sent as `user_level.models` or, for workspace-scoped deliveries, the
+matching `workspaces[].models`. Normal agent-added metadata does not suppress
+the report. A successful apply triggers this report immediately in the same sync run.
+User-owned models are omitted because the backend cannot resolve them. The server
+requires both `provider` and `model_id`. Like skills and rules, the field is omitted
+entirely when nothing qualifies, because a present array is treated as a full
+snapshot. CodeBuddy, WorkBuddy, and Claude (the `ANTHROPIC_CUSTOM_MODEL_OPTION`
+gateway in `~/.claude/settings.json`) expose a discoverable model config; other tools
+report nothing. Reported entries always use `source: "enterprise"`. **`api_key` is
+never reported back** — the ProxyToken stays on disk.
+
+```jsonc
+{ "agent_type": "codebuddy", "local_agent_id": "...",
+  "user_level": { "models": [
+    { "provider": "tokenhub", "model_id": "gpt-4o", "name": "GPT-4o", "source": "enterprise" }
+  ] } }
+```
+
 The HTTP contract is intended for custom integrations. End users only need the `teamai init --http` command described in [Member Onboarding](#member-onboarding).
 
 ### Codebase Knowledge Graph

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -1025,6 +1025,43 @@ cat ~/.claude/CLAUDE.md
 }
 ```
 
+后端可下发 **`apply_model_config`** 任务，其 `cmd` 为 JSON。客户端同时兼容设计文档中的候选集结构和
+旧版单模型结构：`{"models":[...]}` 按完整快照处理，直接模型对象按增量 upsert 处理。
+`max_tokens` 可选（对应 CodeBuddy / WorkBuddy 的 `maxOutputTokens`）；缺省或 `0` 时默认 `4096`。Claude 不使用该字段。
+
+```jsonc
+{ "id": 16, "type": "apply_model_config",
+  "cmd": "{\"models\":[{\"provider\":\"openai\",\"model_id\":\"gpt-4o\",\"name\":\"GPT-4o\",\"base_url\":\"https://proxy.example.com/v1\",\"api_key\":\"<ProxyToken>\",\"max_tokens\":4096,\"context_window\":128000}]}" }
+```
+
+候选集只会写入当前上报任务的 agent。CodeBuddy 使用用户级 `~/.codebuddy/models.json`（`{ "models": [...] }`）；
+WorkBuddy 使用 `~/.workbuddy/models.json`；当前 `{ "models": [...] }` 和旧版顶层数组两种结构都支持，
+已有文件保持原结构。CodeBuddy 或 WorkBuddy 的 workspace 级任务写入
+`<workspace>/.codebuddy/models.json`，与产品内嵌模型加载器一致；该含凭证文件会被加入
+`<workspace>/.codebuddy/.gitignore`。仅当目标路径已存在于 reporter 的 workspace bindings 中时，
+才接受 workspace 级下发。若同一模型 ID 已由用户配置，则保留用户条目。
+Claude 侧会生成独立配置 `~/.claude/teamai-models.json`；仅当 `~/.claude/settings.json` 中不存在冲突的用户
+Anthropic 网关配置时，才把网关环境变量写入默认 settings。不支持的 agent 会回执失败，不会误写其他
+agent 的配置。用户配置文件是符号链接时会保留链接。以上含凭证文件权限均为 `0600`。落盘成功后以
+`type: "apply_model_config"` 回执；非法 payload 回执 `failed`。未来未知任务类型会静默跳过，以保持协议向后兼容。
+
+反向的模型上报走已有的 `report` 接口：仅上报 TeamAI manifest 已记录、且磁盘上的模型 ID 和
+provider 仍可识别的模型，用户级放在 `user_level.models`，workspace 级放在对应的
+`workspaces[].models`。agent 正常补充元数据不会导致漏报；
+模型落盘成功后会在同一次 sync 中立即补一次 report，无需等待下一次 session。用户自有模型不上报，
+因为后台无法识别。服务端要求 `provider` 与 `model_id` 同时存在。与 skills/rules 一致，没有任何符合条件的
+模型时该字段整体省略——因为存在的数组会被当作全量快照。CodeBuddy、WorkBuddy 和 Claude
+（`~/.claude/settings.json` 里的 `ANTHROPIC_CUSTOM_MODEL_OPTION` 网关）有可发现的模型配置，
+其余工具不上报。上报条目的 `source` 固定为 `enterprise`。
+**`api_key` 不会被回传** —— ProxyToken 只留在本地磁盘。
+
+```jsonc
+{ "agent_type": "codebuddy", "local_agent_id": "...",
+  "user_level": { "models": [
+    { "provider": "tokenhub", "model_id": "gpt-4o", "name": "GPT-4o", "source": "enterprise" }
+  ] } }
+```
+
 HTTP 契约用于自建集成。普通用户只需使用[成员接入](#成员接入)中的 `teamai init --http` 命令。
 
 ### 代码知识图谱

--- a/src/__tests__/local-agent-model-config.test.ts
+++ b/src/__tests__/local-agent-model-config.test.ts
@@ -287,6 +287,40 @@ describe('local-agent: apply_model_config', () => {
     expect(await fse.pathExists(path.join(home, '.claude/teamai-models.json'))).toBe(false);
   });
 
+  it('rejects reserved model IDs used by object prototypes', async () => {
+    const acks = stubSync({
+      id: 49,
+      type: 'apply_model_config',
+      cmd: JSON.stringify({ ...deliveredModel, model_id: '__proto__' }),
+    });
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ tool: 'workbuddy', status: 'running' });
+
+    expect(acks[0]).toMatchObject({
+      id: 49,
+      status: 'failed',
+      error: expect.stringMatching(/reserved model_id/i),
+    });
+  });
+
+  it('redacts the home directory from model parse errors sent in acks', async () => {
+    const configPath = path.join(home, '.workbuddy/models.json');
+    await fse.outputFile(configPath, '{ invalid json');
+    const acks = stubSync({
+      id: 50,
+      type: 'apply_model_config',
+      cmd: JSON.stringify(deliveredModel),
+    });
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ tool: 'workbuddy', status: 'running' });
+
+    expect(acks[0]?.status).toBe('failed');
+    expect(String(acks[0]?.error)).toContain('~/.workbuddy/models.json');
+    expect(String(acks[0]?.error)).not.toContain(home);
+  });
+
   it('silently skips unknown task types without acknowledging failure', async () => {
     const acks = stubSync({ id: 21, type: 'future_model_task', cmd: '{}' });
 
@@ -328,6 +362,163 @@ describe('local-agent: apply_model_config', () => {
     ]);
   });
 
+  it('persists a direct model payload for WorkBuddy as a top-level array', async () => {
+    await fse.outputJson(path.join(home, '.workbuddy/models.json'), [
+      { id: 'hai-glm5-2', name: 'hai-glm5-2', vendor: 'Custom' },
+    ]);
+    const acks = stubSync({
+      id: 35,
+      type: 'apply_model_config',
+      cmd: JSON.stringify(deliveredModel),
+    });
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ tool: 'workbuddy', status: 'running' });
+
+    const workbuddy = await fse.readJson(path.join(home, '.workbuddy/models.json'));
+    expect(Array.isArray(workbuddy)).toBe(true);
+    expect(workbuddy).toEqual([
+      { id: 'hai-glm5-2', name: 'hai-glm5-2', vendor: 'Custom' },
+      {
+        id: 'deepseek-v3-0324',
+        name: 'DeepSeek V3 0324',
+        vendor: 'tokenhub',
+        apiKey: 'proxy-token',
+        maxInputTokens: 128000,
+        maxOutputTokens: 5555,
+        url: 'https://proxy.example.com/v1/chat/completions',
+        supportsToolCall: true,
+      },
+    ]);
+    expect(await fse.pathExists(path.join(home, '.codebuddy/models.json'))).toBe(false);
+    expect(acks).toContainEqual(expect.objectContaining({
+      id: 35,
+      type: 'apply_model_config',
+      status: 'success',
+    }));
+    expect((await fs.promises.stat(path.join(home, '.workbuddy/models.json'))).mode & 0o777).toBe(0o600);
+  });
+
+  it('creates the documented object-wrapped WorkBuddy format when the file is absent', async () => {
+    const acks = stubSync({
+      id: 43,
+      type: 'apply_model_config',
+      cmd: JSON.stringify(deliveredModel),
+    });
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ tool: 'workbuddy', status: 'running' });
+
+    const workbuddy = await fse.readJson(path.join(home, '.workbuddy/models.json'));
+    expect(workbuddy).toEqual({
+      models: [expect.objectContaining({ id: 'deepseek-v3-0324' })],
+    });
+    expect(acks[0]?.status).toBe('success');
+  });
+
+  it('preserves an object-wrapped WorkBuddy file and its availableModels filter', async () => {
+    await fse.outputJson(path.join(home, '.workbuddy/models.json'), {
+      models: [{ id: 'personal-model', name: 'Personal' }],
+      availableModels: ['personal-model'],
+    });
+    stubSync({
+      id: 44,
+      type: 'apply_model_config',
+      cmd: JSON.stringify(deliveredModel),
+    });
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ tool: 'workbuddy', status: 'running' });
+
+    const workbuddy = await fse.readJson(path.join(home, '.workbuddy/models.json'));
+    expect(workbuddy.models.map((entry: { id: string }) => entry.id)).toEqual([
+      'personal-model',
+      'deepseek-v3-0324',
+    ]);
+    expect(workbuddy.availableModels).toEqual(['personal-model', 'deepseek-v3-0324']);
+  });
+
+  it('writes a workspace-scoped WorkBuddy model to the project models file', async () => {
+    const workspace = path.join(home, 'project');
+    await fse.ensureDir(workspace);
+    const configPath = path.join(home, '.teamai/local-agent/config.json');
+    const config = await fse.readJson(configPath);
+    config.workspaceBindings[workspace] = {
+      projectId: 5,
+      projectName: 'Project 5',
+      boundAt: '2026-09-09T00:00:00.000Z',
+      ideType: 'workbuddy',
+    };
+    await fse.writeJson(configPath, config);
+    const acks = stubSync({
+      id: 45,
+      type: 'apply_model_config',
+      scope: 'workspace',
+      workspace_path: workspace,
+      cmd: JSON.stringify(deliveredModel),
+    });
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ cwd: workspace, tool: 'workbuddy', status: 'running' });
+
+    const projectConfig = await fse.readJson(path.join(workspace, '.codebuddy/models.json'));
+    expect(projectConfig.models[0].id).toBe('deepseek-v3-0324');
+    expect(await fse.readFile(path.join(workspace, '.codebuddy/.gitignore'), 'utf8')).toContain('models.json');
+    expect(await fse.pathExists(path.join(home, '.workbuddy/models.json'))).toBe(false);
+    expect(acks[0]?.status).toBe('success');
+  });
+
+  it('rejects a workspace-scoped model for an unbound path', async () => {
+    const workspace = path.join(home, 'unbound');
+    await fse.ensureDir(workspace);
+    const acks = stubSync({
+      id: 47,
+      type: 'apply_model_config',
+      scope: 'workspace',
+      workspace_path: workspace,
+      cmd: JSON.stringify(deliveredModel),
+    });
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ cwd: workspace, tool: 'workbuddy', status: 'running' });
+
+    expect(acks[0]).toMatchObject({
+      id: 47,
+      status: 'failed',
+      error: expect.stringMatching(/not a registered binding/i),
+    });
+    expect(await fse.pathExists(path.join(workspace, '.codebuddy/models.json'))).toBe(false);
+  });
+
+  it('supports a workspace-scoped CodeBuddy model without writing WorkBuddy user config', async () => {
+    const workspace = path.join(home, 'code-project');
+    await fse.ensureDir(workspace);
+    const configPath = path.join(home, '.teamai/local-agent/config.json');
+    const config = await fse.readJson(configPath);
+    config.workspaceBindings[workspace] = {
+      projectId: 6,
+      projectName: 'Project 6',
+      boundAt: '2026-09-09T00:00:00.000Z',
+      ideType: 'codebuddy',
+    };
+    await fse.writeJson(configPath, config);
+    const acks = stubSync({
+      id: 48,
+      type: 'apply_model_config',
+      scope: 'workspace',
+      workspace_path: workspace,
+      cmd: JSON.stringify(deliveredModel),
+    });
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ cwd: workspace, tool: 'codebuddy', status: 'running' });
+
+    const projectConfig = await fse.readJson(path.join(workspace, '.codebuddy/models.json'));
+    expect(projectConfig.models[0].id).toBe('deepseek-v3-0324');
+    expect(await fse.pathExists(path.join(home, '.workbuddy/models.json'))).toBe(false);
+    expect(acks[0]?.status).toBe('success');
+  });
+
   it('fails apply_model_config for an unsupported reporting agent', async () => {
     const acks = stubSync({
       id: 27,
@@ -336,7 +527,7 @@ describe('local-agent: apply_model_config', () => {
     });
 
     const { reportAndSyncLocalAgent } = await import('../local-agent.js');
-    await reportAndSyncLocalAgent({ tool: 'workbuddy', status: 'running' });
+    await reportAndSyncLocalAgent({ tool: 'cursor', status: 'running' });
 
     expect(acks[0]).toMatchObject({
       id: 27,
@@ -345,6 +536,7 @@ describe('local-agent: apply_model_config', () => {
       error: expect.stringMatching(/unsupported agent/i),
     });
     expect(await fse.pathExists(path.join(home, '.codebuddy/models.json'))).toBe(false);
+    expect(await fse.pathExists(path.join(home, '.workbuddy/models.json'))).toBe(false);
     expect(await fse.pathExists(path.join(home, '.claude/settings.json'))).toBe(false);
   });
 
@@ -366,6 +558,26 @@ describe('local-agent: apply_model_config', () => {
     expect(acks[0]?.status).toBe('success');
     expect((await fse.lstat(link)).isSymbolicLink()).toBe(true);
     expect((await fse.readJson(target)).models[0].id).toBe('deepseek-v3-0324');
+  });
+
+  it('preserves a symlinked WorkBuddy models file', async () => {
+    const target = path.join(home, 'dotfiles', 'workbuddy-models.json');
+    const link = path.join(home, '.workbuddy', 'models.json');
+    await fse.outputJson(target, []);
+    await fse.ensureDir(path.dirname(link));
+    await fse.symlink(target, link);
+    const acks = stubSync({
+      id: 36,
+      type: 'apply_model_config',
+      cmd: JSON.stringify(deliveredModel),
+    });
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ tool: 'workbuddy', status: 'running' });
+
+    expect(acks[0]?.status).toBe('success');
+    expect((await fse.lstat(link)).isSymbolicLink()).toBe(true);
+    expect((await fse.readJson(target))[0].id).toBe('deepseek-v3-0324');
   });
 
   it('preserves a symlinked Claude settings file', async () => {
@@ -421,6 +633,18 @@ describe('local-agent: report local model inventory', () => {
       user_level: { models?: Array<Record<string, unknown>> };
     };
     return payload.user_level.models;
+  }
+
+  async function reportedWorkspaceModels(
+    tool: string,
+    cwd: string,
+  ): Promise<Array<Record<string, unknown>> | undefined> {
+    const { buildReportPayload, loadLocalAgentConfig } = await import('../local-agent.js');
+    const config = await loadLocalAgentConfig();
+    const payload = (await buildReportPayload(config!, { cwd, tool })) as {
+      workspaces?: Array<{ models?: Array<Record<string, unknown>> }>;
+    };
+    return payload.workspaces?.find((workspace) => workspace.models)?.models;
   }
 
   it('omits models entirely when the tool has no model config on disk', async () => {
@@ -498,6 +722,132 @@ describe('local-agent: report local model inventory', () => {
     await reportAndSyncLocalAgent({ tool: 'claude', status: 'running' });
 
     expect(await reportedModels('codebuddy')).toEqual([
+      {
+        provider: 'tokenhub',
+        model_id: 'deepseek-v3-0324',
+        name: 'DeepSeek V3 0324',
+        source: 'enterprise',
+      },
+    ]);
+  });
+
+  it('keeps CodeBuddy report ownership after WorkBuddy receives a different full snapshot', async () => {
+    stubSync({
+      id: 37,
+      type: 'apply_model_config',
+      cmd: JSON.stringify({ models: [deliveredModel] }),
+    });
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ tool: 'codebuddy', status: 'running' });
+
+    stubSync({
+      id: 38,
+      type: 'apply_model_config',
+      cmd: JSON.stringify({
+        models: [{
+          ...deliveredModel,
+          provider: 'Custom',
+          model_id: 'hai',
+          name: 'hai',
+        }],
+      }),
+    });
+    await reportAndSyncLocalAgent({ tool: 'workbuddy', status: 'running' });
+
+    expect(await reportedModels('codebuddy')).toEqual([
+      {
+        provider: 'tokenhub',
+        model_id: 'deepseek-v3-0324',
+        name: 'DeepSeek V3 0324',
+        source: 'enterprise',
+      },
+    ]);
+    expect(await reportedModels('workbuddy')).toEqual([
+      {
+        provider: 'Custom',
+        model_id: 'hai',
+        name: 'hai',
+        source: 'enterprise',
+      },
+    ]);
+  });
+
+  it('replaces a previously managed WorkBuddy model on a full snapshot', async () => {
+    stubSync({ id: 40, type: 'apply_model_config', cmd: JSON.stringify(deliveredModel) });
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ tool: 'workbuddy', status: 'running' });
+
+    stubSync({
+      id: 41,
+      type: 'apply_model_config',
+      cmd: JSON.stringify({
+        models: [{
+          ...deliveredModel,
+          provider: 'Custom',
+          model_id: 'hai',
+          name: 'hai',
+        }],
+      }),
+    });
+    await reportAndSyncLocalAgent({ tool: 'workbuddy', status: 'running' });
+
+    const file = await fse.readJson(path.join(home, '.workbuddy/models.json'));
+    expect(file.models.map((entry: { id: string }) => entry.id)).toEqual(['hai']);
+    expect(await reportedModels('workbuddy')).toEqual([
+      {
+        provider: 'Custom',
+        model_id: 'hai',
+        name: 'hai',
+        source: 'enterprise',
+      },
+    ]);
+  });
+
+  it('still reports a delivered WorkBuddy model after WorkBuddy adds metadata', async () => {
+    stubSync({ id: 42, type: 'apply_model_config', cmd: JSON.stringify(deliveredModel) });
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ tool: 'workbuddy', status: 'running' });
+
+    const configPath = path.join(home, '.workbuddy', 'models.json');
+    const config = await fse.readJson(configPath);
+    config.models[0].supportsImages = false;
+    await fse.writeJson(configPath, config);
+
+    expect(await reportedModels('workbuddy')).toEqual([
+      {
+        provider: 'tokenhub',
+        model_id: 'deepseek-v3-0324',
+        name: 'DeepSeek V3 0324',
+        source: 'enterprise',
+      },
+    ]);
+  });
+
+  it('reports a workspace-scoped WorkBuddy model under that workspace', async () => {
+    const workspace = path.join(home, 'project');
+    await fse.ensureDir(workspace);
+    const configPath = path.join(home, '.teamai/local-agent/config.json');
+    const config = await fse.readJson(configPath);
+    config.workspaceBindings[workspace] = {
+      projectId: 5,
+      projectName: 'Project 5',
+      boundAt: '2026-09-09T00:00:00.000Z',
+      ideType: 'workbuddy',
+    };
+    await fse.writeJson(configPath, config);
+    stubSync({
+      id: 46,
+      type: 'apply_model_config',
+      scope: 'workspace',
+      workspace_path: workspace,
+      cmd: JSON.stringify(deliveredModel),
+    });
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ cwd: workspace, tool: 'workbuddy', status: 'running' });
+
+    expect(await reportedModels('workbuddy')).toBeUndefined();
+    expect(await reportedWorkspaceModels('workbuddy', workspace)).toEqual([
       {
         provider: 'tokenhub',
         model_id: 'deepseek-v3-0324',

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -239,8 +239,13 @@ interface DeliveredModel {
   context_window?: number;
 }
 
-interface ModelConfigManifest {
+interface BuddyModelManifest {
   codebuddy?: Record<string, string>;
+  workbuddy?: Record<string, string>;
+  providersByAgent?: Record<string, Record<string, string>>;
+}
+
+interface ModelConfigManifest extends BuddyModelManifest {
   claudeEnv?: Record<string, string>;
   /**
    * model_id → provider for every model this reporter has applied. Claude
@@ -248,12 +253,16 @@ interface ModelConfigManifest {
    * so this is the only way to report back the provider the server sent.
    */
   providers?: Record<string, string>;
-  providersByAgent?: Record<string, Record<string, string>>;
+  workspaceModels?: Record<string, BuddyModelManifest>;
 }
 
-function modelAgentKind(tool: string | undefined): 'codebuddy' | 'claude' | undefined {
+type ModelAgentKind = 'codebuddy' | 'workbuddy' | 'claude';
+type BuddyAgentKind = 'codebuddy' | 'workbuddy';
+
+function modelAgentKind(tool: string | undefined): ModelAgentKind | undefined {
   const normalized = normalizeAgentType(tool ?? '');
   if (normalized === 'codebuddy' || normalized === 'codebuddy-internal') return 'codebuddy';
+  if (normalized === 'workbuddy') return 'workbuddy';
   if (normalized === 'claude') return 'claude';
   return undefined;
 }
@@ -1353,30 +1362,54 @@ interface ReportedModel {
  * are dropped rather than reported as incomplete. `source` is derived from the
  * model manifest, mirroring how skills/rules classify enterprise vs local.
  *
- * Only CodeBuddy and Claude keep a discoverable model config; every other tool
- * reports nothing. User-owned models are omitted: the backend cannot resolve
- * them, so only entries still matching a TeamAI delivery are reported.
+ * Only CodeBuddy, WorkBuddy, and Claude keep a discoverable model config;
+ * every other tool reports nothing. User-owned models are omitted: the
+ * backend cannot resolve them, so only entries still matching a TeamAI
+ * delivery are reported.
  */
-async function scanModelsFromDisk(tool: string): Promise<ReportedModel[]> {
+function buddyModelsPath(agentKind: BuddyAgentKind, workspacePath?: string): string {
+  return workspacePath
+    ? path.join(workspacePath, '.codebuddy', 'models.json')
+    : path.join(getUserHome(), `.${agentKind}`, 'models.json');
+}
+
+function modelConfigDisplayPath(filePath: string): string {
+  if (filePath.endsWith(`${path.sep}.codebuddy${path.sep}models.json`)) {
+    return '.codebuddy/models.json';
+  }
+  if (filePath.endsWith(`${path.sep}.workbuddy${path.sep}models.json`)) {
+    return '~/.workbuddy/models.json';
+  }
+  return path.basename(filePath);
+}
+
+async function scanModelsFromDisk(tool: string, workspacePath?: string): Promise<ReportedModel[]> {
   const manifest = (await readJson<ModelConfigManifest>(getModelManifestPath())) ?? {};
   const agentKind = modelAgentKind(tool);
-  const providers = (agentKind && manifest.providersByAgent?.[agentKind]) ?? manifest.providers ?? {};
 
-  if (agentKind === 'codebuddy') {
-    const doc = await readJson<{ models?: unknown }>(
-      path.join(getUserHome(), '.codebuddy', 'models.json'),
-    );
-    const entries = Array.isArray(doc?.models) ? doc.models : [];
-    const owned = manifest.codebuddy ?? {};
+  if (agentKind === 'codebuddy' || agentKind === 'workbuddy') {
+    const scopeManifest = workspacePath ? manifest.workspaceModels?.[workspacePath] : manifest;
+    const providers = scopeManifest?.providersByAgent?.[agentKind]
+      ?? (!workspacePath && agentKind !== 'workbuddy' ? manifest.providers : undefined)
+      ?? {};
+    const raw = await readJson<unknown>(buddyModelsPath(agentKind, workspacePath));
+    const entries = Array.isArray(raw)
+      ? raw
+      : (Array.isArray((raw as { models?: unknown } | null)?.models)
+        ? (raw as { models: unknown[] }).models
+        : []);
+    const owned = (agentKind === 'codebuddy'
+      ? scopeManifest?.codebuddy
+      : scopeManifest?.workbuddy) ?? {};
     const results: ReportedModel[] = [];
     for (const entry of entries) {
       if (typeof entry !== 'object' || entry === null) continue;
       const { id, vendor, name } = entry as Record<string, unknown>;
       if (typeof id !== 'string' || !id) continue;
       if (typeof vendor !== 'string' || !vendor) continue;
-      // CodeBuddy may normalize a model entry by adding capability metadata.
-      // The manifest's model id is the durable proof that TeamAI delivered it;
-      // requiring an exact object hash would incorrectly hide such entries.
+      // CodeBuddy / WorkBuddy may normalize a model entry by adding capability
+      // metadata. The manifest's model id is the durable proof that TeamAI
+      // delivered it; requiring an exact object hash would hide such entries.
       if (owned[id] === undefined || providers[id] !== vendor) continue;
       results.push({
         provider: vendor,
@@ -1388,7 +1421,8 @@ async function scanModelsFromDisk(tool: string): Promise<ReportedModel[]> {
     return results;
   }
 
-  if (agentKind === 'claude') {
+  if (agentKind === 'claude' && !workspacePath) {
+    const providers = manifest.providersByAgent?.claude ?? manifest.providers ?? {};
     const settings = await readJson<{ env?: unknown }>(
       path.join(getUserHome(), '.claude', 'settings.json'),
     );
@@ -1561,6 +1595,8 @@ export async function buildReportPayload(
         if (wsScope.rules.length > 0) workspace.rules = wsScope.rules;
         const wsMcps = await scanMcpFromManifest('project', tool, wsPath);
         if (wsMcps.length > 0) workspace.mcps = wsMcps;
+        const wsModels = await scanModelsFromDisk(tool, wsPath);
+        if (wsModels.length > 0) workspace.models = wsModels;
         return workspace;
       }),
     );
@@ -2145,9 +2181,13 @@ function parseDeliveredModels(raw: string | undefined): { models: DeliveredModel
       throw new Error('apply_model_config: each model must be an object');
     }
     const input = value as Record<string, unknown>;
+    const modelId = requireModelString(input.model_id, 'model_id');
+    if (modelId === '__proto__' || modelId === 'prototype' || modelId === 'constructor') {
+      throw new Error(`apply_model_config: reserved model_id "${modelId}"`);
+    }
     const model: DeliveredModel = {
       provider: requireModelString(input.provider, 'provider'),
-      model_id: requireModelString(input.model_id, 'model_id'),
+      model_id: modelId,
       name: requireModelString(input.name, 'name'),
       base_url: requireModelString(input.base_url, 'base_url'),
       api_key: requireModelString(input.api_key, 'api_key'),
@@ -2172,7 +2212,7 @@ function parseDeliveredModels(raw: string | undefined): { models: DeliveredModel
   return { models, fullSnapshot };
 }
 
-function codebuddyModelEntry(model: DeliveredModel): Record<string, unknown> {
+function buddyModelEntry(model: DeliveredModel): Record<string, unknown> {
   const baseUrl = model.base_url.replace(/\/+$/, '');
   return {
     id: model.model_id,
@@ -2196,7 +2236,9 @@ async function readJsonObject(filePath: string): Promise<Record<string, unknown>
     }
     return parsed as Record<string, unknown>;
   } catch (error) {
-    throw new Error(`apply_model_config: cannot parse ${filePath}: ${(error as Error).message}`);
+    throw new Error(
+      `apply_model_config: cannot parse ${modelConfigDisplayPath(filePath)}: ${(error as Error).message}`,
+    );
   }
 }
 
@@ -2215,19 +2257,56 @@ async function writeModelJson(filePath: string, data: unknown): Promise<void> {
   await writeJsonAtomic(targetPath, data, { mode: 0o600 });
 }
 
-async function reconcileCodebuddyModels(
+async function ensureWorkspaceModelGitignore(workspacePath: string): Promise<void> {
+  const gitignorePath = path.join(workspacePath, '.codebuddy', '.gitignore');
+  const existing = await readFileSafe(gitignorePath);
+  if (existing === null) {
+    await writeFile(gitignorePath, '# Local model credentials\nmodels.json\n');
+    return;
+  }
+  if (existing.split(/\r?\n/).some((line) => line.trim() === 'models.json')) return;
+  await writeFile(gitignorePath, `${existing.trimEnd()}\nmodels.json\n`);
+}
+
+async function readBuddyModelEntries(
+  filePath: string,
+): Promise<{ existing: unknown[]; doc?: Record<string, unknown> }> {
+  const source = await readFileSafe(filePath);
+  // The current WorkBuddy / CodeBuddy documentation uses an object wrapper.
+  // Product releases also accept the legacy top-level array, so preserve that
+  // shape when a user already has one instead of forcing a migration.
+  if (source === null) return { existing: [], doc: {} };
+  try {
+    const parsed = JSON.parse(source);
+    if (Array.isArray(parsed)) return { existing: parsed };
+    if (typeof parsed !== 'object' || parsed === null) {
+      throw new Error('root must be an object or array');
+    }
+    const doc = parsed as Record<string, unknown>;
+    const existing = doc.models === undefined ? [] : doc.models;
+    if (!Array.isArray(existing)) {
+      throw new Error('models must be an array');
+    }
+    return { existing, doc };
+  } catch (error) {
+    throw new Error(
+      `apply_model_config: cannot parse ${modelConfigDisplayPath(filePath)}: ${(error as Error).message}`,
+    );
+  }
+}
+
+async function reconcileBuddyModels(
   models: DeliveredModel[],
   fullSnapshot: boolean,
-  manifest: ModelConfigManifest,
+  scopeManifest: BuddyModelManifest,
+  agentKind: BuddyAgentKind,
+  workspacePath?: string,
 ): Promise<void> {
-  const targetFile = path.join(getUserHome(), '.codebuddy', 'models.json');
-  const doc = await readJsonObject(targetFile);
-  const existing = doc.models === undefined ? [] : doc.models;
-  if (!Array.isArray(existing)) {
-    throw new Error(`apply_model_config: models must be an array in ${targetFile}`);
-  }
-
-  const previouslyManaged = manifest.codebuddy ?? {};
+  const targetFile = buddyModelsPath(agentKind, workspacePath);
+  const { existing, doc } = await readBuddyModelEntries(targetFile);
+  const previouslyManaged = (agentKind === 'codebuddy'
+    ? scopeManifest.codebuddy
+    : scopeManifest.workbuddy) ?? {};
   const nextManaged: Record<string, string> = fullSnapshot ? {} : { ...previouslyManaged };
   const incomingIds = new Set(models.map((model) => model.model_id));
   const removedManaged = new Set<string>();
@@ -2253,24 +2332,29 @@ async function reconcileCodebuddyModels(
 
   for (const model of models) {
     if (occupiedIds.has(model.model_id)) continue;
-    const entry = codebuddyModelEntry(model);
+    const entry = buddyModelEntry(model);
     preserved.push(entry);
     nextManaged[model.model_id] = entryHash(entry);
   }
-  doc.models = preserved;
 
-  if (Array.isArray(doc.availableModels) && doc.availableModels.length > 0) {
-    const available = doc.availableModels.filter(
-      (id): id is string => typeof id === 'string' && !removedManaged.has(id),
-    );
-    for (const id of Object.keys(nextManaged)) {
-      if (!available.includes(id)) available.push(id);
+  if (workspacePath) await ensureWorkspaceModelGitignore(workspacePath);
+  if (doc) {
+    doc.models = preserved;
+    if (Array.isArray(doc.availableModels) && doc.availableModels.length > 0) {
+      const available = doc.availableModels.filter(
+        (id): id is string => typeof id === 'string' && !removedManaged.has(id),
+      );
+      for (const id of Object.keys(nextManaged)) {
+        if (!available.includes(id)) available.push(id);
+      }
+      doc.availableModels = available;
     }
-    doc.availableModels = available;
+    await writeModelJson(targetFile, doc);
+  } else {
+    await writeModelJson(targetFile, preserved);
   }
-
-  await writeModelJson(targetFile, doc);
-  manifest.codebuddy = nextManaged;
+  if (agentKind === 'codebuddy') scopeManifest.codebuddy = nextManaged;
+  else scopeManifest.workbuddy = nextManaged;
 }
 
 function claudeEnvForModel(model: DeliveredModel): Record<string, string> {
@@ -2341,26 +2425,55 @@ async function reconcileClaudeModels(
   );
 }
 
-async function applyModelConfig(command: LocalAgentCommand, tool: string | undefined): Promise<void> {
+async function applyModelConfig(
+  config: LocalAgentConfig,
+  command: LocalAgentCommand,
+  context: LocalAgentContext,
+): Promise<void> {
   const { models, fullSnapshot } = parseDeliveredModels(command.cmd);
   const manifest = (await readJson<ModelConfigManifest>(getModelManifestPath())) ?? {};
-  const agentKind = modelAgentKind(tool);
+  const agentKind = modelAgentKind(context.tool);
   if (!agentKind) {
-    throw new Error(`apply_model_config: unsupported agent "${tool ?? ''}"`);
+    throw new Error(`apply_model_config: unsupported agent "${context.tool ?? ''}"`);
   }
-  const previousProviders = manifest.providersByAgent?.[agentKind] ?? manifest.providers ?? {};
+
+  const scope = normalizeScope(command.scope);
+  const workspacePath = scope === 'project'
+    ? await resolveWorkspacePath(command.workspace_path ?? context.cwd)
+    : undefined;
+  if (scope === 'project' && !workspacePath) {
+    throw new Error('apply_model_config: workspace command is missing workspace_path');
+  }
+  if (workspacePath && config.workspaceBindings[workspacePath] === undefined) {
+    throw new Error(
+      `apply_model_config: workspace "${path.basename(workspacePath)}" is not a registered binding`,
+    );
+  }
+  if (agentKind === 'claude' && workspacePath) {
+    throw new Error('apply_model_config: workspace scope is unsupported for claude');
+  }
+
+  let scopeManifest: BuddyModelManifest = manifest;
+  if (workspacePath) {
+    manifest.workspaceModels ??= {};
+    manifest.workspaceModels[workspacePath] ??= {};
+    scopeManifest = manifest.workspaceModels[workspacePath];
+  }
+  const previousProviders = scopeManifest.providersByAgent?.[agentKind]
+    ?? (!workspacePath && agentKind !== 'workbuddy' ? manifest.providers : undefined)
+    ?? {};
   const providers = {
     ...(fullSnapshot ? {} : previousProviders),
     ...Object.fromEntries(models.map((model) => [model.model_id, model.provider])),
   };
-  manifest.providersByAgent = {
-    ...manifest.providersByAgent,
+  scopeManifest.providersByAgent = {
+    ...scopeManifest.providersByAgent,
     [agentKind]: providers,
   };
-  if (agentKind === 'codebuddy') {
-    await reconcileCodebuddyModels(models, fullSnapshot, manifest);
-  } else {
+  if (agentKind === 'claude') {
     await reconcileClaudeModels(models, manifest);
+  } else {
+    await reconcileBuddyModels(models, fullSnapshot, scopeManifest, agentKind, workspacePath);
   }
   await writeJsonAtomic(getModelManifestPath(), manifest);
 }
@@ -2824,7 +2937,7 @@ async function executeCommand(
   context: LocalAgentContext,
 ): Promise<string | undefined> {
   if (command.type === 'apply_model_config') {
-    await applyModelConfig(command, context.tool);
+    await applyModelConfig(config, command, context);
     return;
   }
   // uninstall_teamai (clawpro three-phase: cmd = "teamai uninstall --force


### PR DESCRIPTION
## Summary
- Extend `apply_model_config` to WorkBuddy using the product paths: user `~/.workbuddy/models.json`, workspace `<workspace>/.codebuddy/models.json`.
- Accept both `{ "models": [...] }` (documented default for new files) and the legacy top-level array; keep an existing file's shape and user-owned entries.
- Report user-scoped models in `user_level.models` and workspace-scoped models in `workspaces[].models`; never send `api_key` back.
- Reject unbound `workspace_path`, ignore project `models.json` via `.codebuddy/.gitignore`, and redact home paths in ack errors.

## Test plan
- [x] `npx vitest run src/__tests__/local-agent-model-config.test.ts` (34 tests)
- [x] `npx tsc --noEmit`
- [x] `npx vitest run` (201 files / 2792 tests) and `npm run build`
- [x] Isolated HOME + global `teamai hook-dispatch session-start --tool workbuddy`: persist `{ models: [...] }`, ack success, same-run report without leaking proxy token
- [x] Backend re-delivers a WorkBuddy `apply_model_config` (user and, if available, workspace scope) and confirms inventory on report

Live check on 0.24.0-beta.0 (`@tencent/teamai-cli@beta`): WorkBuddy session-start applied `#4516`/`#4517` to `~/.workbuddy/models.json` (kept the existing top-level array and user entries `hai`/`hai-glm5-2`, appended TeamAI models). Report `user_level.models` listed only the managed models; `api_key` was not in the body. Workspace-scope delivery was not in that sync.