### PR TITLE
fix(codebase): preserve local wiki refresh and lint targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Matched: conflict | Missing: port
 teamai import --from-repo https://github.com/org/repo
 teamai import --from-org myorg              # batch import all repos
 teamai codebase --extract /path/to/repo     # local extract into teamwiki/
-teamai codebase --lint                      # health check
+teamai codebase --lint --output /path/to/repo # check the locally extracted graph
 ```
 
 The graph stores components, interfaces, configs, and cross-repo import edges. `teamai recall` uses it for graph-boosted re-ranking.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -227,7 +227,7 @@ Matched: conflict | Missing: port
 teamai import --from-repo https://github.com/org/repo
 teamai import --from-org myorg              # 批量导入所有仓库
 teamai codebase --extract /path/to/repo     # 本地提取到 teamwiki/
-teamai codebase --lint                      # 健康检查
+teamai codebase --lint --output /path/to/repo # 检查本地提取的图谱
 ```
 
 图谱存储组件、接口、配置和跨仓库依赖边。`teamai recall` 利用图谱进行增强排名。

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -1074,8 +1074,11 @@ Dependency edges are extracted by two parallel tracks: a WASM tree-sitter **AST 
 # Extract code facts and the graph from a local repo (writes <repo>/teamwiki/)
 teamai codebase --extract /path/to/repo --project my-service
 
-# Graph health check
-teamai codebase --lint
+# Incremental refresh: reuse the original repository path and project slug
+teamai codebase --extract /path/to/repo --project my-service --incremental
+
+# Check the local graph; --output is the repository root, not teamwiki/
+teamai codebase --lint --output /path/to/repo
 ```
 
 ### Dashboard

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -1062,8 +1062,11 @@ teamai import --from-repo https://github.com/org/repo --skip-enrich
 # 从本地仓库提取代码事实与图谱（写入 <repo>/teamwiki/）
 teamai codebase --extract /path/to/repo --project my-service
 
-# 图谱健康检查
-teamai codebase --lint
+# 增量刷新：复用首次提取的仓库路径和项目名
+teamai codebase --extract /path/to/repo --project my-service --incremental
+
+# 检查本地提取的图谱；--output 指向仓库根目录，而非 teamwiki/
+teamai codebase --lint --output /path/to/repo
 ```
 
 ### Dashboard

--- a/skills/team-wiki-codebase/SKILL.md
+++ b/skills/team-wiki-codebase/SKILL.md
@@ -892,8 +892,8 @@ _review/                                ← 过程文件（不入知识库）
 | K3 后编译进 wiki | Skip. TeamAI does not ship a separate team-wiki CLI. Continue with this skill using `teamai` and the files under this skill directory. No extra plugin is required. |
 | 产品文档入图 | Skip. Same English note as above. |
 | 产品↔代码桥接 | Skip. Same English note as above. |
-| 一键刷新 | Use `teamai codebase --extract --incremental` when updating a repo already extracted. Do not look for another CLI. |
-| 质量评估 | Use `scripts/validate_kb.py` and `teamai codebase --lint` on `teamwiki/`. Skip any extra evaluate binary. |
+| 一键刷新 | Use `teamai codebase --extract <repo> --project <slug> --incremental`, reusing the Phase 0 repository path and project slug even when running from another directory. Do not look for another CLI. |
+| 质量评估 | Use `scripts/validate_kb.py` and `teamai codebase --lint --output <repo>` to check `<repo>/teamwiki/` (`--output` takes the repository root, not the `teamwiki/` directory). Skip any extra evaluate binary. |
 
 **路径约定**（本 skill 安装后）：
 

--- a/src/__tests__/e2e/codebase-extract-cli.test.ts
+++ b/src/__tests__/e2e/codebase-extract-cli.test.ts
@@ -77,4 +77,47 @@ describe('teamai codebase extract CLI (issue #360 slice 1)', () => {
       fs.rmSync(fixture, { recursive: true, force: true });
     }
   });
+
+  it('refreshes and lints the same local graph using the skill commands from another directory', async () => {
+    const fixture = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-local-workflow-'));
+    const caller = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-workflow-caller-'));
+    try {
+      const skill = fs.readFileSync(path.join(ROOT, 'skills/team-wiki-codebase/SKILL.md'), 'utf8');
+      const commands = [...skill.matchAll(/`(teamai codebase [^`]+)`/g)].map(match => match[1]);
+      const refresh = commands.find(command => command.includes('--incremental'));
+      const lint = commands.find(command => command.includes('--lint'));
+      expect(refresh).toBeDefined();
+      expect(lint).toBeDefined();
+      const args = (command: string) => command.split(/\s+/).slice(1)
+        .map(arg => arg === '<repo>' ? fixture : arg === '<slug>' ? 'custom-service' : arg);
+      const source = path.join(fixture, 'greet.ts');
+      fs.writeFileSync(source, 'export function originalGreeting() { return "hello"; }\n');
+      const initial = await runCLI(
+        ['codebase', '--extract', fixture, '--project', 'custom-service', '--json'], caller,
+      );
+      expect(initial.code, initial.output).toBe(0);
+      fs.writeFileSync(source, 'export function updatedGreeting() { return "updated"; }\n');
+
+      const refreshed = await runCLI([...args(refresh!), '--json'], caller);
+      expect(refreshed.code, refreshed.output).toBe(0);
+      expect(JSON.parse(refreshed.stdout)).toMatchObject({ project: 'custom-service', incremental: true });
+      const wiki = path.join(fixture, 'teamwiki');
+      expect(fs.readdirSync(path.join(wiki, 'evidence', 'code'))).toEqual(['custom-service']);
+      const evidence = fs.readFileSync(path.join(wiki, 'evidence', 'code', 'custom-service', 'component.md'), 'utf8');
+      expect(evidence).toContain('updatedGreeting');
+      expect(evidence).not.toContain('originalGreeting');
+      expect(fs.readFileSync(path.join(wiki, 'router.md'), 'utf8')).toContain('evidence/code/custom-service/index');
+      expect(fs.existsSync(path.join(caller, 'teamwiki'))).toBe(false);
+
+      const checked = await runCLI([...args(lint!), '--json'], caller);
+      expect(checked.code, checked.output).toBe(0);
+      const report = JSON.parse(checked.stdout);
+      const graph = JSON.parse(fs.readFileSync(path.join(wiki, '.indices', 'graph-index.json'), 'utf8'));
+      expect(report.graphHealth.nodeCount).toBe(graph.nodes.length);
+      expect(report.graphHealth.nodeCount).toBeGreaterThan(0);
+    } finally {
+      fs.rmSync(fixture, { recursive: true, force: true });
+      fs.rmSync(caller, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

The local wiki workflow introduced in #449 drops the original repository path and custom project slug when refreshing, and its lint command resolves the configured team repository instead of the locally extracted graph. Following those instructions can leave stale evidence under the original project and report success without checking the intended wiki.

Update the builtin skill to reuse `--extract <repo> --project <slug> --incremental` and lint with `--output <repo>` (the parent of `teamwiki/`). Sync the English and Chinese README and usage-guide examples. Add a built-CLI regression test that reads the actual skill commands and executes them from a separate working directory, checking updated evidence, stable project/router targets, and the linted graph's node count.

## Test plan and CLI report

All checks below were run locally on macOS in an isolated worktree based on `origin/main` after #449 merged.

- [x] `npm run build` — passed.
- [x] `npx tsc --noEmit` — passed.
- [x] `npx vitest run` — 202 files / 2785 tests passed.
- [x] `npx vitest run --config vitest.e2e.config.ts src/__tests__/e2e/codebase-extract-cli.test.ts` — 3 tests passed using the built CLI.
- [x] `npx vitest run src/__tests__/team-wiki-codebase-skill.test.ts` — 4 tests passed.
- [x] Skill `quick_validate.py` — passed.
- [x] `git diff --check` and search for obsolete workflow wording, including `docs/designs/` — passed; no affected design instructions found.

| Real CLI check | Result |
| --- | --- |
| Help lists extract; tiny local extraction produces graph and evidence | PASS |
| Extract with a custom slug, edit source, then execute the skill refresh command from another directory | PASS: same project, updated evidence, no stale function or extra project directory |
| Router retains original custom project target | PASS |
| Execute the skill lint command from another directory | PASS: valid JSON with node count matching the extracted graph |
| Restore only the old refresh instruction | Regression test fails as expected |
| Restore only the old lint instruction | Regression test fails as expected |

Agent/provider matrix: this change updates shared skill instructions and local filesystem CLI examples only. Claude, Codex, CodeBuddy, and OpenCode use the same corrected instructions; no agent invocation or git/gitlab/github provider operations are involved in this workflow. Remote integration matrix was not run.

Follow-up to #449. No runtime command semantics or new options are introduced.
