### PR TITLE
fix(gitlab): honor custom API prefix for organization import

### DIFF
--- a/docs/designs/gitcode-provider.md
+++ b/docs/designs/gitcode-provider.md
@@ -17,7 +17,7 @@
 
 | 维度 | GitLab | **GitCode** |
 |---|---|---|
-| API base | `<host>/api/v4`（同域） | `https://api.gitcode.com/api/v5`（独立 API 域名） |
+| API base | `<host>/api/v4`（同域；可通过 `GITLAB_API_PREFIX` 自定义） | `https://api.gitcode.com/api/v5`（独立 API 域名） |
 | REST 认证头 | `PRIVATE-TOKEN` | `Authorization: Bearer` |
 | whoami 字段 | `username` | **`login`** |
 | 建 PR | `POST /projects/{id}/merge_requests` | `POST /repos/{owner}/{repo}/pulls` |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -183,7 +183,7 @@ token 变量支持三个名字（按优先级）：`GITLAB_TOKEN` > `GITLAB_PRIV
 
 `GITLAB_URL` **必须带 scheme**（`https://` 或 `http://`）。写成 `gitlab.example.com` 会在执行 GitLab 操作时报错退出，而不是静默回落到 gitlab.com。内网 http 实例、非标准端口、以及挂在子路径下的部署（`https://example.com/gitlab`）都会被完整保留，包括 clone URL。
 
-`GITLAB_API_PREFIX` 用于网关代理场景：某些自托管实例通过网关统一路由，GitLab API 被挂载到非标准路径（如 `/api/gitlab` 而不是标准的 `/api/v4`）。此时设置该变量可避免 405 错误。示例：
+`GITLAB_API_PREFIX` 用于网关代理场景：某些自托管实例通过网关统一路由，GitLab API 被挂载到非标准路径（如 `/api/gitlab` 而不是标准的 `/api/v4`）。该配置也适用于 `teamai import --from-org` 的 group 仓库列表请求（包括所有分页）；未设置或为空时仍使用 `api/v4`。此时设置该变量可避免 405 错误。示例：
 
 ```bash
 # 标准 GitLab 自托管（默认，无需设置 GITLAB_API_PREFIX）
@@ -231,6 +231,8 @@ git@git.example.com:Group/Subgroup/repo.git
 | 指定 reviewer          | 解析 username → user id，提交 `reviewer_ids`                |
 | 拉取 MR 数据           | `GET /api/v4/projects/:id/merge_requests/:iid` + commits + changes；MR URL 的 host 必须与已配置实例（`GITLAB_URL` / `TEAMAI_GITLAB_HOST`，默认 gitlab.com）一致，否则拒绝请求，避免把 token 发往未配置的 host |
 | 列出 group 仓库        | `GET /api/v4/groups/:path/projects`（分页，`include_subgroups=true` 含子组） |
+
+GitLab API 表中的 `/api/v4` 为默认前缀；设置 `GITLAB_API_PREFIX` 后，API 请求使用配置的前缀。
 
 ### 默认 email 域
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -1066,6 +1066,8 @@ teamai import --from-repo https://github.com/org/repo --incremental
 teamai import --from-repo https://github.com/org/repo --skip-enrich
 ```
 
+For GitLab behind an API gateway, set `GITLAB_URL` and `GITLAB_API_PREFIX=api/gitlab` before running `teamai import --from-org https://gitlab.example.com/myorg`. Organization listing uses the configured prefix on every page; an unset or blank prefix defaults to `api/v4`.
+
 The graph stores components, interfaces, configs, and cross-repo dependencies. `teamai recall` uses the graph for BM25 + graph-boosted ranking.
 
 Dependency edges are extracted by two parallel tracks: a WASM tree-sitter **AST track** (TypeScript/JavaScript, Python, Go) that resolves imports, calls, and TS `implements` clauses to precise file-to-file edges (`code-ast`), and a regex **heuristic track** (all languages, `code-heuristic`) that also covers languages the AST track does not. AST results win on overlap. The AST parser needs no native toolchain; on load failure, extraction falls back to heuristics and records an `AST_UNAVAILABLE` gap. Set `TEAMAI_SKIP_AST=1` to force heuristic-only extraction.

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -1054,6 +1054,8 @@ teamai import --from-repo https://github.com/org/repo --incremental
 teamai import --from-repo https://github.com/org/repo --skip-enrich
 ```
 
+对于 API 网关后的 GitLab，先设置 `GITLAB_URL` 和 `GITLAB_API_PREFIX=api/gitlab`，再运行 `teamai import --from-org https://gitlab.example.com/myorg`。组织仓库列表的每一页请求都会使用配置的前缀；未设置或为空时默认使用 `api/v4`。
+
 图谱存储组件、接口、配置和跨仓库依赖关系。`teamai recall` 利用图谱进行 BM25 + graph-boost 增强排名。
 
 依赖边由两条并行轨道提取：WASM tree-sitter **AST 轨**（TypeScript/JavaScript、Python、Go），将 import、调用、以及 TS `implements` 子句解析为精确的文件到文件边（`code-ast`）；以及正则 **启发式轨**（所有语言，`code-heuristic`），同时覆盖 AST 轨未支持的语言。重叠时 AST 结果优先。AST 解析器无需原生编译工具链；加载失败时提取会降级到启发式并记录一条 `AST_UNAVAILABLE` gap。设置 `TEAMAI_SKIP_AST=1` 可强制仅用启发式提取。

--- a/src/__tests__/gitlab-org-prefix-e2e.test.ts
+++ b/src/__tests__/gitlab-org-prefix-e2e.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse } from 'yaml';
+
+const CLI = fileURLToPath(new URL('../../dist/index.js', import.meta.url));
+let server: Server | undefined;
+let sandbox: string | undefined;
+
+afterEach(async () => {
+  if (server) await new Promise<void>((resolve, reject) => server!.close(err => err ? reject(err) : resolve()));
+  if (sandbox) await fs.rm(sandbox, { recursive: true, force: true });
+});
+
+describe('GitLab organization API prefix (built CLI)', () => {
+  it.each([
+    ['api/gitlab', '', 'api/gitlab'],
+    [' /api/gitlab/ ', '/gitlab', 'api/gitlab'],
+    [undefined, '', 'api/v4'],
+    ['', '', 'api/v4'],
+    ['   ', '', 'api/v4'],
+  ])('imports a paginated whitelist with prefix %j and root %j', async (prefix, root, expected) => {
+    sandbox = await fs.mkdtemp(path.join(os.tmpdir(), 'teamai-gitlab-prefix-'));
+    const seen: string[] = [];
+    server = createServer((req, res) => {
+      seen.push(req.url!);
+      const url = new URL(req.url!, 'http://localhost');
+      if (url.pathname !== `${root}/${expected}/groups/team%2Fsub/projects`) {
+        res.writeHead(405).end('Unexpected API prefix');
+        return;
+      }
+      if (req.headers['private-token'] !== 'local-test-token') {
+        res.writeHead(401).end('Missing token');
+        return;
+      }
+      const page = Number(url.searchParams.get('page'));
+      const projects = Array.from({ length: page === 1 ? 100 : 1 }, (_, i) => {
+        const id = (page - 1) * 100 + i;
+        return {
+          id, name: `repo-${id}`, path_with_namespace: `team/sub/repo-${id}`,
+          http_url_to_repo: `https://gitlab.example.com/team/sub/repo-${id}.git`,
+        };
+      });
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify(projects));
+    });
+    await new Promise<void>(resolve => server!.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('Missing server address');
+    const origin = `http://127.0.0.1:${address.port}`;
+    const env: NodeJS.ProcessEnv = {
+      ...process.env, HOME: sandbox, TEAMAI_HOME: path.join(sandbox, '.teamai'),
+      GITLAB_URL: `${origin}${root}/`, GITLAB_TOKEN: 'local-test-token',
+    };
+    delete env.TEAMAI_GITLAB_HOST;
+    delete env.GITLAB_API_PREFIX;
+    if (prefix !== undefined) env.GITLAB_API_PREFIX = prefix;
+    const result = await new Promise<{ code: number | null; output: string }>((resolve, reject) => {
+      const child = spawn(process.execPath, [CLI, 'import', '--from-org', `${origin}/team/sub`, '--skip-import'], {
+        cwd: sandbox, env, stdio: ['ignore', 'pipe', 'pipe'], timeout: 15_000,
+      });
+      let output = '';
+      child.stdout.on('data', data => { output += data; });
+      child.stderr.on('data', data => { output += data; });
+      child.on('error', reject);
+      child.on('close', code => resolve({ code, output }));
+    });
+    expect(result.code, result.output).toBe(0);
+    expect(result.output).toContain('Fetched 101 repos');
+    expect(seen).toEqual([1, 2].map(page =>
+      `${root}/${expected}/groups/team%2Fsub/projects?per_page=100&page=${page}&include_subgroups=true`,
+    ));
+    const draft = parse(await fs.readFile(path.join(sandbox, '.teamai/repo-whitelist.draft.yaml'), 'utf8'));
+    expect(draft.repos).toHaveLength(101);
+    expect(draft.repos[100].url).toBe('https://gitlab.example.com/team/sub/repo-100.git');
+  });
+});

--- a/src/__tests__/gitlab-provider.test.ts
+++ b/src/__tests__/gitlab-provider.test.ts
@@ -664,6 +664,7 @@ describe('gitlabListOrgRepos', () => {
     vi.clearAllMocks();
     process.env.GITLAB_TOKEN = 'glpat_test';
     delete process.env.GITLAB_URL;
+    delete process.env.GITLAB_API_PREFIX;
   });
   afterEach(() => {
     global.fetch = originalFetch;
@@ -678,6 +679,33 @@ describe('gitlabListOrgRepos', () => {
     archived: false,
     star_count: id,
     last_activity_at: '2026-01-01T00:00:00Z',
+  });
+
+  it.each([
+    [undefined, 'api/v4'],
+    ['', 'api/v4'],
+    ['   ', 'api/v4'],
+    ['api/gitlab', 'api/gitlab'],
+    [' /api/gitlab/ ', 'api/gitlab'],
+  ])('uses API prefix %j on every page and preserves the instance root', async (prefix, expected) => {
+    process.env.GITLAB_URL = 'http://gitlab.example.com:8080/gitlab/';
+    if (prefix !== undefined) process.env.GITLAB_API_PREFIX = prefix;
+    const seen: string[] = [];
+    global.fetch = vi.fn(async (url: string) => {
+      seen.push(String(url));
+      const items = seen.length === 1
+        ? Array.from({ length: 100 }, (_, i) => project(i, `g/sub/repo-${i}`))
+        : [project(100, 'g/sub/last')];
+      return new Response(JSON.stringify(items), { status: 200 });
+    }) as never;
+
+    const repos = await gitlabListOrgRepos('g/sub');
+
+    expect(repos).toHaveLength(101);
+    expect(seen).toEqual([1, 2].map(page =>
+      `http://gitlab.example.com:8080/gitlab/${expected}/groups/g%2Fsub/projects`
+      + `?per_page=100&page=${page}&include_subgroups=true`,
+    ));
   });
 
   it('requests subgroup projects too', async () => {

--- a/src/providers/gitlab/org.ts
+++ b/src/providers/gitlab/org.ts
@@ -1,5 +1,5 @@
 import type { OrgRepoInfo } from '../types.js';
-import { getGitLabToken, gitlabBaseUrl } from './gitlab-api.js';
+import { getGitLabToken, gitlabApiBase } from './gitlab-api.js';
 
 /** 响应体最大 50 MB，防止恶意服务器返回超大响应导致 OOM */
 const MAX_RESPONSE_BYTES = 50 * 1024 * 1024;
@@ -67,7 +67,7 @@ export async function gitlabListOrgRepos(
   while (collected.length < maxRepos) {
     // include_subgroups=true — GitLab defaults it to false, which would silently
     // drop every project nested under a subgroup of the requested group.
-    const url = `${gitlabBaseUrl()}/api/v4/groups/${encodedGroup}/projects`
+    const url = `${gitlabApiBase()}/groups/${encodedGroup}/projects`
       + `?per_page=${perPage}&page=${page}&include_subgroups=true`;
     const resp = await fetch(url, { headers, redirect: 'manual' });
 


### PR DESCRIPTION
## Summary

Follow-up to #450: `teamai import --from-org` still hardcoded `/api/v4`, so a gateway configured with `GITLAB_API_PREFIX=api/gitlab` returned 405 and organization import exited with code 1 even though the custom endpoint was available.

Use `gitlabApiBase()` for group repository listing on every page. This preserves the instance scheme, port and relative root while applying the same prefix normalization and default as other GitLab API operations. Update the bilingual usage guides, provider documentation and the affected provider design comparison.

## Test report

- [x] `npm run build` — passed.
- [x] `npx tsc --noEmit` — passed.
- [x] `npx vitest run` — 202 files, 2,790 tests passed.
- [x] Regression sensitivity: before the fix, both custom-prefix unit cases failed with actual `/api/v4` URLs; the default-prefix cases passed.
- [x] Built CLI E2E: `npx vitest run --config vitest.e2e.config.ts src/__tests__/gitlab-org-prefix-e2e.test.ts src/__tests__/push-role-skill-e2e.test.ts src/__tests__/e2e/managed-resources-uninstall.test.ts` — 3 files, 10 tests passed.

The five new E2E cases run the built CLI against a local HTTP server and verify both requested page URLs, the token header, exit code 0, and a generated whitelist containing 101 repositories. They cover `api/gitlab`, whitespace/slash normalization with an instance subpath, and unset/empty/whitespace default prefixes. The server rejects incorrect API paths with 405.

Compatibility coverage from the existing built-CLI suites:

| Coverage | Verified behavior |
| --- | --- |
| Claude, Codex, CodeBuddy, OpenCode | Pull creates managed agent artifacts; uninstall preview and execution handle them correctly and preserve user resources. |
| `git` | Role-scoped skill push to a local Git remote. |
| `github` | Role-scoped skill commit/push and PR creation through the test fixture. |
| `gitlab` | Role-scoped skill commit/push and MR creation through the local API fixture, plus the new paginated organization import cases. |

All E2E checks use isolated local fixtures; no live provider accounts or real agent sessions are required. `git diff --check` passed, and `git log origin/main..HEAD` contains only this fix.
