### PR TITLE
feat(data-layout): slim self mode — relocate A1 machine data to the partition (#374 P2)

### DIFF
--- a/docs/designs/data-directory-layout.md
+++ b/docs/designs/data-directory-layout.md
@@ -1,8 +1,8 @@
 # Design: teamai data directory layout — global home + per-project partitioning
 
-> Status: **P0 + P1 implemented** (issue #374). P1 shipped as PRs #397 / #402 /
-> #406 / #414 / #417 (partition routing) and the P1-3 auto-migration below.
-> P2–P3 are follow-up phases, tracked below.
+> Status: **P0 + P1 + P2 implemented** (issue #374). P1 shipped as PRs #397 / #402 /
+> #406 / #414 / #417 (partition routing) and #439 (P1-3 auto-migration). P2 (self
+> mode slimming) is below. P3 is a follow-up phase, tracked below.
 
 ## Problem
 
@@ -191,10 +191,54 @@ a raw async-hook rejection.
 **Downgrade is not supported** — an older teamai treats a partitioned install as
 uninitialized; `.teamai.bak/` is the manual rollback. Flag prominently in release notes.
 
+## P2 — self (single-repo) mode slimming (implemented)
+
+Before P2, self mode kept its class-A1 machine data (config, state, env backup,
+search index, managed-mcp, the per-worktree resource cache) inside the business
+repo at `<repo>/.teamai/`, alongside the class-B team knowledge that is committed
+to main. A hand-maintained `.gitignore` blacklist kept `git status` clean — a
+fragile arrangement (the per-worktree `workspaces/` tree and the user-scope
+`managed-mcp.json` were, in fact, never listed, so a self repo running MCP
+reconcile or the local agent leaked them into the working tree).
+
+P2 physically relocates the A1 data to the partition `~/.teamai/projects/<slug>/`,
+leaving `.teamai/` with only class-B knowledge. The lever is the same as non-self
+installs: attach a partition `dataHome` to the self LocalConfig, and every
+`getDataHome()`-based write follows.
+
+**Invariant:** `getKnowledgeDir` / `repo.localPath` stay `<repo>/.teamai` — that is
+the class-B knowledge anchor, committed to main, and the ~230 `path.join(localPath,
+…)` call sites do not change. `reports-wt/` and `knowledge-wt/` stay in the repo
+too (git worktrees must live in the same repo; they anchor on `localPath`, not
+`getDataHome`).
+
+- **init** (`initSelfRepo`): resolves the partition up front, attaches it as
+  `dataHome`, and writes config/state there. The pre-P2 "retire the stale
+  partition" step is gone — self now USES the partition, so there is nothing to
+  retire.
+- **bootstrap** (teammate fresh clone, `bootstrapSelfRepo`): the "already
+  initialized" check and the config write both target the partition (with a legacy
+  fallback so a pre-P2 install is still recognized).
+- **detection seam** (the delicate part): on a fresh clone the partition config
+  does not exist yet, so partition-first misses. The legacy branch runs the
+  self-heal bootstrap — which now writes the config into the PARTITION — then reads
+  it back FROM the partition (`selfHealAndReadPartition`). A pre-P2 install whose
+  config still sits in `<repo>/.teamai` is read via the legacy branch (double-read
+  compat) until migration relocates it.
+- **migration** (`migrate.ts`, `mode: 'self'`): self CANNOT use the git-mode whole
+  directory copy→rename (that would carry the knowledge off and rename `.teamai` to
+  `.bak`, breaking "knowledge on main"). Instead it selectively relocates the A1
+  whitelist (config.yaml, state.json, env.local, env.sh, search-index.json,
+  managed-mcp.json, workspaces/) entry-by-entry, destination-first (copy to the
+  partition, then delete the source), leaving class-B knowledge and the worktrees
+  untouched and never renaming `.teamai/`. self `repo.localPath` is NOT rebased —
+  it must keep pointing at the in-repo knowledge.
+
+Acceptance: after slimming, `git status` is clean (the A1 data is physically gone,
+not merely ignored) and a teammate's fresh clone bootstraps into the partition.
+
 ## Follow-up phases (not in this PR)
 
-- **P2** — self (single-repo) mode slimming: only team knowledge (class B) stays in
-  the repo.
 - **P3** — functionize module-load-time path constants (so tests that swap `$HOME`
   at runtime take effect), then assign A1/A2 ownership per the data-classification
   table. `status --all` across partitions.

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -280,7 +280,14 @@ teamai init . --agent claude,codex   # non-interactive: set up Claude Code + Cod
 |------|----------------|---------------------------|
 | Knowledge: `skills/` `rules/` `docs/` `learnings/`, `teamai.yaml` | `.teamai/` on the **main** branch | ✅ Yes |
 | Reports: `members/` `sessions/` `votes/` `stats/` | `teamai-reports` **orphan branch** | Pushed to `origin` (separate history) |
-| Machine-local: `config.yaml`, `token`, `state.json`, worktrees | `.teamai/` (gitignored) | ❌ No (per-machine) |
+| Machine-local: `config.yaml`, `state.json`, search index, env backup, MCP manifests | `~/.teamai/projects/<slug>/` (**partition**, outside the repo) | ❌ No (per-machine) |
+| Disposable git worktrees (`reports-wt/`, `knowledge-wt/`) | `.teamai/` (gitignored; rebuilt on demand) | ❌ No (per-machine) |
+
+Machine-local data lives in the per-project **partition** outside the repo, so a
+single-repo `.teamai/` holds only the team knowledge committed to main — `git
+status` stays clean. Upgrading an older single-repo install relocates that machine
+data into the partition automatically on the next `init`/`pull`/`push` (the
+knowledge on main is left exactly in place).
 
 **Clone = initialized.** Because knowledge and the `mode: self` marker in `.teamai/teamai.yaml` are committed to main, a teammate who clones the repo is auto-initialized: the next `teamai` command or AI session detects the marker, and (when their git provider is already authenticated) writes their local config, injects hooks, and registers them on the reports branch — no need to re-type repo/role. If they aren't authenticated yet, teamai prompts them to run `teamai init .` once.
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -268,7 +268,12 @@ teamai init . --agent claude,codex   # 非交互：启用 Claude Code + Codex
 |------|----------|---------------------------|
 | 知识资产：`skills/` `rules/` `docs/` `learnings/`、`teamai.yaml` | **main** 分支的 `.teamai/` | ✅ 会 |
 | 上报数据：`members/` `sessions/` `votes/` `stats/` | `teamai-reports` **孤儿分支** | 推送到 `origin`（独立历史） |
-| 本机私有：`config.yaml`、`token`、`state.json`、worktree | `.teamai/`（已 gitignore） | ❌ 不会（每台机器本地） |
+| 本机私有：`config.yaml`、`state.json`、搜索索引、env 备份、MCP manifest | `~/.teamai/projects/<slug>/`（**分区**，在仓库之外） | ❌ 不会（每台机器本地） |
+| 可丢弃的 git worktree（`reports-wt/`、`knowledge-wt/`） | `.teamai/`（已 gitignore；按需重建） | ❌ 不会（每台机器本地） |
+
+本机私有数据存放在仓库之外的按项目**分区**里，因此单仓模式的 `.teamai/` 只保留提交到
+main 的团队知识 —— `git status` 保持干净。旧版单仓装升级后，下一次
+`init`/`pull`/`push` 会自动把这些机器数据搬进分区（main 上的知识原封不动）。
 
 **克隆即初始化。** 由于知识资产和 `.teamai/teamai.yaml` 里的 `mode: self` 标记都提交在 main 上，团队成员 clone 仓库后会被自动初始化：下一条 `teamai` 命令或 AI 会话会识别该标记，并（在其 git provider 已认证的前提下）自动写入本机配置、注入 hooks、在孤儿分支上注册成员 —— 无需手抄 repo/role 参数。若尚未认证，teamai 会提示其运行一次 `teamai init .`。
 

--- a/src/__tests__/migrate.test.ts
+++ b/src/__tests__/migrate.test.ts
@@ -474,6 +474,48 @@ describe('self mode migration (P2)', () => {
     expect(await planMigration(repoRoot)).toBeNull();
   });
 
+  it('merges the workspaces/ tree instead of dropping legacy children when the partition dir already exists', async () => {
+    // Interrupted-run + reconcile race: the partition already has workspaces/wsA
+    // (moved by a crashed run), and a later reconcile wrote workspaces/wsB into the
+    // repo before the retry. A blind remove(src) would drop wsB (data loss); the
+    // merge must carry wsB over while leaving the authoritative wsA untouched.
+    await seedSelfLayout();
+    const partition = projectDataHome(repoRoot);
+    // partition already holds wsA (authoritative)
+    await fse.ensureDir(path.join(partition, 'workspaces', 'wsA'));
+    await fse.writeFile(path.join(partition, 'workspaces', 'wsA', 'managed-mcp.json'), '{"a":1}');
+    // legacy holds a DIFFERENT worktree wsB (+ the seed's ws1) that must not be lost
+    await fse.ensureDir(path.join(legacyDir, 'workspaces', 'wsB'));
+    await fse.writeFile(path.join(legacyDir, 'workspaces', 'wsB', 'managed-mcp.json'), '{"b":2}');
+    // also give partition an authoritative config so the run reaches the merge branch
+    await fse.writeFile(path.join(partition, 'config.yaml'), 'repo:\n  kind: self\n');
+
+    await runMigration((await planMigration(repoRoot))!);
+
+    // wsB (legacy-only) was carried over — NOT dropped.
+    expect(await fse.pathExists(path.join(partition, 'workspaces', 'wsB', 'managed-mcp.json'))).toBe(true);
+    expect(JSON.parse(await fse.readFile(path.join(partition, 'workspaces', 'wsB', 'managed-mcp.json'), 'utf-8'))).toEqual({ b: 2 });
+    // wsA (partition authoritative) was left untouched.
+    expect(JSON.parse(await fse.readFile(path.join(partition, 'workspaces', 'wsA', 'managed-mcp.json'), 'utf-8'))).toEqual({ a: 1 });
+    // the seed's ws1 also made it over.
+    expect(await fse.pathExists(path.join(partition, 'workspaces', 'ws1', 'managed-mcp.json'))).toBe(true);
+    // legacy workspaces drained + removed.
+    expect(await fse.pathExists(path.join(legacyDir, 'workspaces'))).toBe(false);
+  });
+
+  it('does not overwrite an authoritative partition workspaces child during merge', async () => {
+    await seedSelfLayout(); // seeds legacy workspaces/ws1 = {}
+    const partition = projectDataHome(repoRoot);
+    // partition already has ws1 with authoritative content — merge must keep it.
+    await fse.ensureDir(path.join(partition, 'workspaces', 'ws1'));
+    await fse.writeFile(path.join(partition, 'workspaces', 'ws1', 'managed-mcp.json'), '{"authoritative":true}');
+    await fse.writeFile(path.join(partition, 'config.yaml'), 'repo:\n  kind: self\n');
+
+    await runMigration((await planMigration(repoRoot))!);
+
+    expect(JSON.parse(await fse.readFile(path.join(partition, 'workspaces', 'ws1', 'managed-mcp.json'), 'utf-8'))).toEqual({ authoritative: true });
+  });
+
   it('finishes an interrupted relocation where config.yaml already moved but plaintext env.local lingers (C1)', async () => {
     // The dangerous crash: a partial run relocated config.yaml to the partition
     // but died before moving env.local/env.sh. planMigration must NOT go blind on

--- a/src/__tests__/migrate.test.ts
+++ b/src/__tests__/migrate.test.ts
@@ -140,8 +140,21 @@ describe('planMigration', () => {
     expect(await planMigration(repoRoot)).toBeNull();
   });
 
-  it('skips a self-mode legacy config (its .teamai is committed knowledge)', async () => {
+  it('plans a self-mode migration when legacy A1 machine data is in the repo (P2)', async () => {
+    // config.yaml is class-A1, so a self install with it still in <repo>/.teamai
+    // must be planned for selective relocation (not skipped like pre-P2).
     await writeLegacyConfig({ repo: { localPath: legacyDir, remote: '', kind: 'self' } });
+    const plan = await planMigration(repoRoot);
+    expect(plan).not.toBeNull();
+    expect(plan!.mode).toBe('self');
+  });
+
+  it('skips a self-mode config with no A1 machine data left in the repo (P2)', async () => {
+    // A self install whose machine data already lives in the partition leaves only
+    // class-B knowledge (here: teamai.yaml) in the repo — nothing to relocate.
+    await fse.ensureDir(legacyDir);
+    await fse.writeFile(path.join(legacyDir, 'teamai.yaml'), 'team: t\nmode: self\n');
+    // Its config now lives in the partition, so there is no legacy config.yaml.
     expect(await planMigration(repoRoot)).toBeNull();
   });
 
@@ -366,6 +379,160 @@ describe('runMigration', () => {
     expect(await fse.pathExists(partition)).toBe(false);
     // Source untouched.
     expect(await fse.pathExists(legacyDir)).toBe(true);
+    expect(await fse.pathExists(`${legacyDir}.bak`)).toBe(false);
+  });
+});
+
+describe('self mode migration (P2)', () => {
+  /** Build a real self-mode `.teamai/`: class-B knowledge + class-A1 machine data. */
+  async function seedSelfLayout(): Promise<void> {
+    await fse.ensureDir(legacyDir);
+    // config.yaml (A1) — kind: self
+    await fse.writeFile(
+      path.join(legacyDir, 'config.yaml'),
+      YAML.stringify({
+        repo: { localPath: legacyDir, remote: 'git@example.com:t/r.git', kind: 'self', businessRepoRoot: repoRoot },
+        username: 'tester',
+        scope: 'project',
+      }),
+    );
+    // A1 machine data
+    await fse.writeJson(path.join(legacyDir, 'state.json'), { lastSync: 'x' });
+    await fse.writeFile(path.join(legacyDir, 'env.local'), 'SECRET=xyz\n');
+    await fse.writeFile(path.join(legacyDir, 'env.sh'), 'export SECRET=xyz\n');
+    await fse.writeJson(path.join(legacyDir, 'search-index.json'), { docs: [] });
+    await fse.ensureDir(path.join(legacyDir, 'workspaces', 'ws1'));
+    await fse.writeJson(path.join(legacyDir, 'workspaces', 'ws1', 'managed-mcp.json'), {});
+    // class-B knowledge (committed to main — must stay)
+    for (const d of ['skills', 'rules', 'docs', 'learnings', 'agents', 'hooks', 'mcp']) {
+      await fse.ensureDir(path.join(legacyDir, d));
+      await fse.writeFile(path.join(legacyDir, d, '.gitkeep'), '');
+    }
+    await fse.ensureDir(path.join(legacyDir, 'env'));
+    await fse.writeFile(path.join(legacyDir, 'env', 'env.yaml'), 'SHARED: value\n');
+    await fse.writeFile(path.join(legacyDir, 'teamai.yaml'), 'team: t\nmode: self\n');
+    await fse.writeFile(path.join(legacyDir, 'skills', 'team-skill.md'), '# team\n');
+    // a disposable worktree dir (must stay — anchors on the repo)
+    await fse.ensureDir(path.join(legacyDir, 'reports-wt'));
+    await fse.writeFile(path.join(legacyDir, 'reports-wt', 'x'), 'wt\n');
+  }
+
+  it('relocates A1 machine data to the partition and leaves class-B knowledge in the repo', async () => {
+    await seedSelfLayout();
+    const plan = await planMigration(repoRoot);
+    expect(plan!.mode).toBe('self');
+    const result = await runMigration(plan!);
+    expect(result).toBe('migrated');
+
+    const partition = projectDataHome(repoRoot);
+    // A1 moved to the partition...
+    for (const a1 of ['config.yaml', 'state.json', 'env.local', 'env.sh', 'search-index.json']) {
+      expect(await fse.pathExists(path.join(partition, a1))).toBe(true);
+      expect(await fse.pathExists(path.join(legacyDir, a1))).toBe(false);
+    }
+    expect(await fse.pathExists(path.join(partition, 'workspaces', 'ws1', 'managed-mcp.json'))).toBe(true);
+    expect(await fse.pathExists(path.join(legacyDir, 'workspaces'))).toBe(false);
+
+    // ...class-B knowledge stayed in the repo.
+    expect(await fse.pathExists(path.join(legacyDir, 'skills', 'team-skill.md'))).toBe(true);
+    expect(await fse.pathExists(path.join(legacyDir, 'env', 'env.yaml'))).toBe(true);
+    expect(await fse.pathExists(path.join(legacyDir, 'teamai.yaml'))).toBe(true);
+    for (const d of ['rules', 'docs', 'learnings', 'agents', 'hooks', 'mcp']) {
+      expect(await fse.pathExists(path.join(legacyDir, d))).toBe(true);
+    }
+
+    // The .teamai/ dir itself is NEVER renamed (no .bak), and the worktree stays.
+    expect(await fse.pathExists(legacyDir)).toBe(true);
+    expect(await fse.pathExists(`${legacyDir}.bak`)).toBe(false);
+    expect(await fse.pathExists(path.join(legacyDir, 'reports-wt'))).toBe(true);
+  });
+
+  it('does NOT rebase self repo.localPath (it is the class-B knowledge anchor)', async () => {
+    await seedSelfLayout();
+    await runMigration((await planMigration(repoRoot))!);
+    const migrated = YAML.parse(
+      await fse.readFile(path.join(projectDataHome(repoRoot), 'config.yaml'), 'utf-8'),
+    );
+    // localPath must still point at <repo>/.teamai, where the knowledge lives.
+    expect(migrated.repo.localPath).toBe(legacyDir);
+  });
+
+  it('is idempotent and finishes an interrupted relocation without clobbering the partition', async () => {
+    await seedSelfLayout();
+    const partition = projectDataHome(repoRoot);
+    // Simulate a prior partial run: config already in the partition (authoritative),
+    // but a stale copy also lingers in the repo.
+    await fse.ensureDir(partition);
+    await fse.writeFile(path.join(partition, 'config.yaml'), 'repo:\n  kind: self\nAUTHORITATIVE: true\n');
+
+    await runMigration((await planMigration(repoRoot))!);
+    // The authoritative partition config was NOT overwritten by the repo's copy.
+    expect(await fse.readFile(path.join(partition, 'config.yaml'), 'utf-8')).toContain('AUTHORITATIVE');
+    // The stale repo copy was removed.
+    expect(await fse.pathExists(path.join(legacyDir, 'config.yaml'))).toBe(false);
+    // A second plan is null — nothing left to relocate.
+    expect(await planMigration(repoRoot)).toBeNull();
+  });
+
+  it('finishes an interrupted relocation where config.yaml already moved but plaintext env.local lingers (C1)', async () => {
+    // The dangerous crash: a partial run relocated config.yaml to the partition
+    // but died before moving env.local/env.sh. planMigration must NOT go blind on
+    // "no legacy config.yaml" — it must still see the lingering A1 (incl. the
+    // plaintext secrets) and finish, or those secrets stay in the repo forever.
+    await seedSelfLayout();
+    const partition = projectDataHome(repoRoot);
+    await fse.ensureDir(partition);
+    // config.yaml already in the partition (moved by the crashed run)...
+    await fse.move(path.join(legacyDir, 'config.yaml'), path.join(partition, 'config.yaml'));
+    // ...but env.local (plaintext secret) + env.sh still in the repo.
+    expect(await fse.pathExists(path.join(legacyDir, 'env.local'))).toBe(true);
+
+    const plan = await planMigration(repoRoot);
+    expect(plan).not.toBeNull();
+    expect(plan!.mode).toBe('self');
+    await runMigration(plan!);
+
+    // The stranded secrets got relocated and removed from the repo.
+    expect(await fse.pathExists(path.join(partition, 'env.local'))).toBe(true);
+    expect(await fse.pathExists(path.join(legacyDir, 'env.local'))).toBe(false);
+    expect(await fse.pathExists(path.join(legacyDir, 'env.sh'))).toBe(false);
+    expect(await fse.pathExists(path.join(legacyDir, 'search-index.json'))).toBe(false);
+    // Class-B knowledge untouched throughout.
+    expect(await fse.pathExists(path.join(legacyDir, 'skills', 'team-skill.md'))).toBe(true);
+    expect(await planMigration(repoRoot)).toBeNull();
+  });
+
+  it('dry-run relocates nothing', async () => {
+    await seedSelfLayout();
+    const result = await runMigration((await planMigration(repoRoot))!, { dryRun: true });
+    expect(result).toBe('dry-run');
+    expect(await fse.pathExists(projectDataHome(repoRoot))).toBe(false);
+    expect(await fse.pathExists(path.join(legacyDir, 'config.yaml'))).toBe(true);
+  });
+
+  it('refuses to rename a .teamai holding self knowledge, even via the git-mode path (M2 guard)', async () => {
+    // Pathological mix: config.yaml says kind: git (so planMigration takes the
+    // git-mode branch), but the dir also holds committed self knowledge
+    // (teamai.yaml mode: self + skills). The git-mode retire would rename .teamai
+    // to .bak and wipe the knowledge — the guard must refuse instead.
+    await fse.ensureDir(legacyDir);
+    await fse.writeFile(
+      path.join(legacyDir, 'config.yaml'),
+      YAML.stringify({ repo: { localPath: path.join(legacyDir, 'team-repo'), remote: 'r', kind: 'git' }, username: 'u', scope: 'project' }),
+    );
+    await fse.writeFile(path.join(legacyDir, 'teamai.yaml'), 'team: t\nmode: self\n');
+    await fse.ensureDir(path.join(legacyDir, 'skills'));
+    await fse.writeFile(path.join(legacyDir, 'skills', 'team-skill.md'), '# committed knowledge\n');
+    // Partition already built → git-mode plan is 'retire-only' → calls retireLegacy.
+    const partition = projectDataHome(repoRoot);
+    await fse.ensureDir(partition);
+    await fse.writeFile(path.join(partition, 'config.yaml'), 'repo:\n  kind: git\n');
+
+    const plan = await planMigration(repoRoot);
+    expect(plan!.mode).toBe('retire-only');
+    await expect(runMigration(plan!)).rejects.toThrow(/holds single-repo team knowledge/);
+    // Knowledge and the dir are intact — nothing was renamed away.
+    expect(await fse.pathExists(path.join(legacyDir, 'skills', 'team-skill.md'))).toBe(true);
     expect(await fse.pathExists(`${legacyDir}.bak`)).toBe(false);
   });
 });

--- a/src/__tests__/self-worktree-rebind.test.ts
+++ b/src/__tests__/self-worktree-rebind.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import { realpathSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import fse from 'fs-extra';
+import YAML from 'yaml';
+
+import { detectProjectConfig } from '../config.js';
+import { getKnowledgeDir, getDataHome } from '../types.js';
+import { projectDataHome } from '../utils/partition.js';
+
+// ─── P2 cross-worktree self regression (issue #374) ─────────────────────────
+//
+// After P2 a self install's config lives in the SHARED partition (keyed on the
+// main checkout's projectAnchor), read by every worktree. Its persisted
+// repo.localPath / businessRepoRoot name the checkout that first migrated (main).
+// getKnowledgeDir === repo.localPath, so without rebinding, a feature worktree
+// would read MAIN's knowledge and inject it into the FEATURE tree. detection must
+// re-anchor localPath/businessRepoRoot to the current workspace (self's invariant
+// is localPath === <workspaceRoot>/.teamai, businessRepoRoot === <workspaceRoot>).
+
+function git(cwd: string, ...args: string[]): void {
+  execFileSync('git', args, { cwd, stdio: 'pipe' });
+}
+
+let base: string, main: string, home: string;
+
+beforeEach(() => {
+  base = realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'self-wt-')));
+  main = path.join(base, 'main-repo');
+  fs.mkdirSync(main);
+  git(main, 'init', '-q');
+  git(main, 'config', 'user.email', 't@e.com');
+  git(main, 'config', 'user.name', 'T');
+  git(main, 'commit', '--allow-empty', '-q', '-m', 'init');
+  home = path.join(base, 'home');
+  fs.mkdirSync(home);
+  vi.stubEnv('HOME', home);
+});
+afterEach(() => {
+  vi.unstubAllEnvs();
+  try { fs.rmSync(base, { recursive: true, force: true }); } catch { /* noop */ }
+});
+
+/** Write a migrated self config into the shared partition, localPath = MAIN. */
+function seedSharedSelfConfig(): string {
+  const partition = projectDataHome(main);
+  fs.mkdirSync(partition, { recursive: true });
+  fs.writeFileSync(path.join(partition, 'config.yaml'), YAML.stringify({
+    repo: { localPath: path.join(main, '.teamai'), remote: 'r', kind: 'self', businessRepoRoot: main },
+    username: 'e2e', scope: 'project',
+  }));
+  fse.ensureDirSync(path.join(main, '.teamai'));
+  return partition;
+}
+
+describe('P2 self cross-worktree rebind', () => {
+  it('rebinds self repo.localPath/businessRepoRoot to a feature worktree', async () => {
+    const partition = seedSharedSelfConfig();
+    const feat0 = path.join(base, 'feature-wt');
+    git(main, 'worktree', 'add', '-q', feat0, '-b', 'feature');
+    const feat = realpathSync(feat0);
+    fse.ensureDirSync(path.join(feat, '.teamai'));
+
+    const detected = await detectProjectConfig(feat);
+    expect(detected).not.toBeNull();
+    expect(detected!.projectRoot).toBe(feat);
+    // Knowledge + business root track the CURRENT worktree, not main.
+    expect(getKnowledgeDir(detected!)).toBe(path.join(feat, '.teamai'));
+    expect(detected!.repo.businessRepoRoot).toBe(feat);
+    // Machine data still shares the partition across worktrees.
+    expect(getDataHome(detected!)).toBe(partition);
+  });
+
+  it('still resolves correctly from the main checkout', async () => {
+    seedSharedSelfConfig();
+    const detected = await detectProjectConfig(main);
+    expect(detected).not.toBeNull();
+    expect(getKnowledgeDir(detected!)).toBe(path.join(main, '.teamai'));
+    expect(detected!.repo.businessRepoRoot).toBe(main);
+  });
+
+  it('does NOT rebind localPath for a non-self (git-mode) config', async () => {
+    // git-mode localPath is the team-repo clone path (shared across worktrees on
+    // purpose) — it must NOT be rewritten to <workspace>/.teamai.
+    const partition = projectDataHome(main);
+    fs.mkdirSync(partition, { recursive: true });
+    const clonePath = path.join(partition, 'team-repo');
+    fs.writeFileSync(path.join(partition, 'config.yaml'), YAML.stringify({
+      repo: { localPath: clonePath, remote: 'r', kind: 'git' },
+      username: 'e2e', scope: 'project',
+    }));
+    const feat0 = path.join(base, 'feature-wt');
+    git(main, 'worktree', 'add', '-q', feat0, '-b', 'feature');
+    const feat = realpathSync(feat0);
+
+    const detected = await detectProjectConfig(feat);
+    expect(detected!.repo.localPath).toBe(clonePath);
+  });
+});

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -64,9 +64,18 @@ export async function bootstrapSelfRepo(
   const silent = opts?.silent ?? false;
   const info = (msg: string) => { if (!silent) log.info(msg); };
 
-  // Fast path: already initialized.
-  const configPath = getConfigPath('project', businessRepoRoot);
-  if (await pathExists(configPath)) return 'already';
+  // P2 (issue #374): a self install's machine config lives in the per-project
+  // partition, not the repo. Resolve it up front and use it for the "already
+  // initialized" check and as the write target. Also honor the legacy in-repo
+  // location so a pre-P2 self install (config still under <repo>/.teamai) is
+  // recognized as already initialized and not re-bootstrapped.
+  const { resolveProjectDataHome } = await import('./config.js');
+  const partitionHome = await resolveProjectDataHome(businessRepoRoot);
+  const configPath = path.join(partitionHome, 'config.yaml');
+  const legacyConfigPath = getConfigPath('project', businessRepoRoot);
+
+  // Fast path: already initialized (partition or legacy).
+  if ((await pathExists(configPath)) || (await pathExists(legacyConfigPath))) return 'already';
 
   // Only self-mode projects auto-bootstrap.
   const marker = await readSelfModeMarker(businessRepoRoot);
@@ -145,6 +154,10 @@ export async function bootstrapSelfRepo(
       username,
       scope: 'project',
       projectRoot: businessRepoRoot,
+      // P2: machine config/state land in the partition, not the repo. localPath
+      // stays <repo>/.teamai (the class-B knowledge anchor); dataHome routes the
+      // class-A1 writes (config/state) out of the workspace.
+      dataHome: partitionHome,
       additionalRoles: [],
       ...(enabledAgents.length > 0 ? { enabledAgents } : {}),
     };

--- a/src/config.ts
+++ b/src/config.ts
@@ -269,17 +269,19 @@ export async function detectProjectConfig(cwd?: string): Promise<LocalConfig | n
     //    (which may be untracked/unverified) must never hijack it. Switching that
     //    project to single-repo mode is `init --self`'s job (it retires the
     //    partition), not detection's.
-    const fromPartition = await readConfigFrom(
-      projectDataHome(anchors.projectAnchor),
-      anchors.workspaceRoot,
-    );
+    const partitionDir = projectDataHome(anchors.projectAnchor);
+    const fromPartition = await readConfigFrom(partitionDir, anchors.workspaceRoot);
     if (fromPartition) return fromPartition;
-    // 2. No partition yet: a workspace that declares `mode: self` self-heals the
-    //    machine config under <workspaceRoot>/.teamai (issue #198 clone bootstrap).
-    // 3. Otherwise read the legacy `<workspaceRoot>/.teamai` config directly.
-    //    readConfigFrom runs the self-heal bootstrap when the config is missing,
-    //    so both cases funnel through the same call.
-    return readConfigFrom(legacyDir, anchors.workspaceRoot, anchors.workspaceRoot);
+    // 2. No partition config yet. A workspace that declares `mode: self` self-heals
+    //    on a fresh clone (issue #198): bootstrapSelfRepo now writes the machine
+    //    config into the PARTITION (P2), not <workspaceRoot>/.teamai. So run the
+    //    self-heal and, on success, read the config back FROM THE PARTITION.
+    const healed = await selfHealAndReadPartition(anchors.workspaceRoot, partitionDir);
+    if (healed) return healed;
+    // 3. Otherwise read a legacy `<workspaceRoot>/.teamai` config directly — a
+    //    pre-P2 self install (or any un-migrated install) whose config still lives
+    //    in the repo. Double-read compat until migration relocates it.
+    return readConfigFrom(legacyDir, anchors.workspaceRoot);
   }
 
   // Not a git repo: fall back to a legacy `.teamai` directly at `dir` (also runs
@@ -301,6 +303,28 @@ export async function detectProjectConfig(cwd?: string): Promise<LocalConfig | n
  * cheap on the hot path. Only passed for the legacy `<root>/.teamai` shape (the
  * partition is teamai-managed and never bootstrapped).
  */
+/**
+ * Self-heal a freshly-cloned single-repo project (issue #198), then read the
+ * config back from the PARTITION. bootstrapSelfRepo is a no-op ('skip') for any
+ * non-self workspace, so this stays cheap on the hot path; it only writes a
+ * config (into the partition, per P2) when the workspace carries a `mode: self`
+ * marker and the developer's git provider is already authenticated. Returns the
+ * bootstrapped config, or null when nothing was healed.
+ */
+async function selfHealAndReadPartition(
+  workspaceRoot: string,
+  partitionDir: string,
+): Promise<LocalConfig | null> {
+  try {
+    const { bootstrapSelfRepo } = await import('./bootstrap.js');
+    const result = await bootstrapSelfRepo(workspaceRoot, { silent: true });
+    if (result !== 'bootstrapped') return null;
+  } catch {
+    return null;
+  }
+  return readConfigFrom(partitionDir, workspaceRoot);
+}
+
 async function readConfigFrom(
   dataHomeDir: string,
   projectRoot: string,

--- a/src/config.ts
+++ b/src/config.ts
@@ -353,7 +353,24 @@ async function readConfigFrom(
     // projectRoot can be wrong (e.g. a `.teamai/` copied from the main checkout
     // into a worktree names the main checkout); overriding keeps landing tied to
     // the real workspace (also backfills when absent, #85).
-    return { ...config, projectRoot, dataHome: dataHomeDir };
+    const resolved: LocalConfig = { ...config, projectRoot, dataHome: dataHomeDir };
+    // Self mode (P2): the config now lives in the SHARED partition, but its
+    // persisted repo.localPath / businessRepoRoot name the checkout that first
+    // migrated (typically main). Every worktree reads that one config, so without
+    // rebinding, a feature worktree would read main's knowledge
+    // (getKnowledgeDir === repo.localPath) and write it into the feature tree.
+    // Self's invariant is localPath === <workspaceRoot>/.teamai and
+    // businessRepoRoot === <workspaceRoot>, so re-anchor both to THIS workspace.
+    // (Non-self localPath is the team-repo clone path — shared across worktrees on
+    // purpose — so it is left untouched.)
+    if (config.repo.kind === 'self') {
+      resolved.repo = {
+        ...config.repo,
+        localPath: path.join(projectRoot, '.teamai'),
+        businessRepoRoot: projectRoot,
+      };
+    }
+    return resolved;
   } catch {
     return null;
   }

--- a/src/init.ts
+++ b/src/init.ts
@@ -432,12 +432,25 @@ export async function initHttp(
 /**
  * Build the .teamai/.gitignore for single-repo mode. Unlike the standalone
  * project-scope gitignore, knowledge (skills/rules/docs/learnings) is COMMITTED
- * to main here, so it must NOT be ignored. Only machine-local state, worktrees,
- * and orphan-branch report data are ignored.
+ * to main here, so it must NOT be ignored.
+ *
+ * As of P2 (issue #374) a self install's machine data (class A1 —
+ * config/state/env backup/search index/managed-mcp/resource cache) lives in the
+ * per-project partition `~/.teamai/projects/<slug>/`, NOT the repo, so it does
+ * not need ignoring at all. These entries are kept as belt-and-suspenders:
+ *  - a pre-P2 self install still has them in the repo until migration relocates
+ *    them (double-read compat window), and
+ *  - should any A1 path ever fail to route to the partition, the ignore keeps it
+ *    out of a commit rather than leaking (esp. plaintext env.local/token).
+ * `workspaces/` is NEW here — before P2 the user-scope managed-mcp.json and the
+ * per-worktree `workspaces/<id>/` tree were NOT ignored, so a self repo that ran
+ * MCP reconcile or the local agent would leak them into `git status`.
  */
 export function buildSelfModeGitignore(): string {
   return [
-    '# teamai single-repo mode — machine-local state (never commit)',
+    '# teamai single-repo mode — machine-local state (never commit).',
+    '# As of P2 this data lives in ~/.teamai/projects/<slug>/; these entries guard',
+    '# pre-P2 installs (pre-migration) and any un-relocated path.',
     'config.yaml',
     'state.json',
     'token',
@@ -445,6 +458,7 @@ export function buildSelfModeGitignore(): string {
     '.update-lock',
     '.reports-lock',
     '.bootstrap-lock',
+    '.sync-lock',
     // NB: env/ is intentionally NOT ignored in single-repo mode — team env vars
     // (.teamai/env/env.yaml) are committed to main so `teamai push` can carry them
     // and teammates get them on clone. env.yaml holds plaintext key/value pairs, so
@@ -456,6 +470,10 @@ export function buildSelfModeGitignore(): string {
     'usage.jsonl',
     'known-skills.json',
     'search-index.json',
+    'managed-mcp.json',
+    // Per-worktree machine data (managed-mcp.json + the local-agent resource
+    // cache). Not ignored before P2 — a real leak source in self repos.
+    'workspaces/',
     'dashboard/',
     '# git worktrees for reports (orphan branch) and knowledge PRs',
     'reports-wt/',
@@ -670,7 +688,12 @@ export async function initSelfRepo(options: GlobalOptions & {
   }
   const businessRepoRoot = cwd;
   const teamaiHome = path.join(businessRepoRoot, '.teamai');
-  const localPath = teamaiHome; // knowledge lives under <repo>/.teamai (localPath convention)
+  const localPath = teamaiHome; // knowledge (class B) lives under <repo>/.teamai (localPath convention)
+  // P2 self slimming (issue #374): machine data (class A1 — config/state/env
+  // backup/search index/managed-mcp/resource cache) now lands in the per-project
+  // partition, NOT the repo, so `.teamai/` keeps only committed team knowledge.
+  // Attaching dataHome routes every getDataHome()-based write into the partition.
+  const partitionHome = await resolveProjectDataHome(businessRepoRoot);
 
   let inheritUserScope: boolean | undefined;
   try {
@@ -686,9 +709,12 @@ export async function initSelfRepo(options: GlobalOptions & {
   log.info(`  knowledge → ${localPath}/{skills,rules,docs,learnings} (committed to main)`);
   log.info(`  reports   → ${REPORTS_BRANCH} orphan branch (members/sessions/votes/stats)`);
 
-  // Re-init guard
-  const existingConfigPath = getConfigPath('project', businessRepoRoot);
-  if (await pathExists(existingConfigPath)) {
+  // Re-init guard. The machine config now lives in the partition (P2), so check
+  // there; also check the legacy in-repo location so re-running init on a
+  // pre-P2 self install is still recognized as "already initialized".
+  const existingConfigPath = path.join(partitionHome, 'config.yaml');
+  const legacyConfigPath = getConfigPath('project', businessRepoRoot);
+  if ((await pathExists(existingConfigPath)) || (await pathExists(legacyConfigPath))) {
     log.warn(`teamai is already initialized (project scope) at ${existingConfigPath}`);
     if (options.force) {
       log.info('Overwriting existing config (--force)');
@@ -772,12 +798,15 @@ export async function initSelfRepo(options: GlobalOptions & {
     return;
   }
 
-  // Step 4: assemble local config (kind: self).
+  // Step 4: assemble local config (kind: self). dataHome points at the partition
+  // so config/state and every other class-A1 write lands outside the repo (P2);
+  // repo.localPath stays <repo>/.teamai — that is the class-B knowledge anchor.
   const localConfig: LocalConfig = {
     repo: { localPath, remote: repoInfo.httpsUrl, kind: 'self', businessRepoRoot },
     username,
     scope: 'project',
     projectRoot: businessRepoRoot,
+    dataHome: partitionHome,
     additionalRoles: [],
     ...(inheritUserScope !== undefined ? { inheritUserScope } : {}),
   };
@@ -802,28 +831,17 @@ export async function initSelfRepo(options: GlobalOptions & {
     localConfig.disabledAgents = (existing?.disabledAgents ?? []).filter((t) => !selectedAgents.includes(t));
   }
 
-  // Step 5: write local config + single-repo gitignore.
+  // Step 5: write local config (into the partition via dataHome) + single-repo
+  // gitignore. ensureDir both the knowledge dir (class B, in the repo) and the
+  // partition (class A1 machine data). saveLocalConfigForScope writes through
+  // getDataHome, which now resolves to the partition.
   await ensureDir(teamaiHome);
+  await ensureDir(partitionHome);
   await saveLocalConfigForScope(localConfig, 'project', businessRepoRoot);
-  log.success(`Local config saved to ${teamaiHome}/config.yaml`);
-
-  // Retire any stale project partition from an earlier git-mode install: detection
-  // treats an existing partition as authoritative, so leaving it behind would make
-  // this self install unreachable (pull/push would keep hitting the old external
-  // repo). Removing the partition config is enough for detection to fall through to
-  // this self config; the rest of the old partition is left for the user to clean.
-  try {
-    const partition = await resolveProjectDataHome(businessRepoRoot);
-    if (partition !== teamaiHome) {
-      const partitionConfig = path.join(partition, 'config.yaml');
-      if (await pathExists(partitionConfig)) {
-        await remove(partitionConfig);
-        log.info(`Retired stale project partition config at ${partitionConfig}`);
-      }
-    }
-  } catch (e) {
-    log.debug(`partition retire skipped: ${(e as Error).message}`);
-  }
+  log.success(`Local config saved to ${partitionHome}/config.yaml`);
+  // (Pre-P2 this retired any stale partition config so detection fell back to the
+  // in-repo self config. P2 makes self USE the partition, so there is nothing to
+  // retire — the config we just wrote there is the authoritative one.)
 
   const gitignorePath = path.join(teamaiHome, '.gitignore');
   await writeFile(gitignorePath, buildSelfModeGitignore());

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -465,8 +465,19 @@ async function migrateSelfA1(legacyDir: string, partitionDir: string): Promise<v
     if (!(await pathExists(src))) continue;
     const dest = path.join(partitionDir, name);
     if (await pathExists(dest)) {
-      // Partition copy is authoritative (e.g. written by a prior run or init).
-      // Drop the stale source rather than clobbering it.
+      if (await isDirectory(src)) {
+        // A DIRECTORY entry (workspaces/) may hold per-worktree children the
+        // partition copy lacks — e.g. a reconcile wrote `<legacy>/workspaces/<new>`
+        // between an interrupted run and this retry. A blind remove(src) would drop
+        // them (data loss). Merge instead: relocate only the children missing from
+        // the partition (each atomically), and never overwrite an existing child
+        // (the partition copy is authoritative). Then remove the drained source.
+        await mergeDirIntoPartition(src, dest);
+        await remove(src);
+        moved.push(name);
+        continue;
+      }
+      // A FILE entry: the partition copy is authoritative. Drop the stale source.
       await remove(src);
       continue;
     }
@@ -490,6 +501,39 @@ async function migrateSelfA1(legacyDir: string, partitionDir: string): Promise<v
     );
   } else {
     log.debug('self migration: nothing left to relocate');
+  }
+}
+
+/** True when `p` is a directory (following symlinks). Missing path → false. */
+async function isDirectory(p: string): Promise<boolean> {
+  try {
+    return (await fse.stat(p)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Merge a source directory's immediate children into an already-existing
+ * destination directory, without overwriting anything the destination already
+ * has. Used when relocating the `workspaces/` tree and the partition already holds
+ * some worktree subdirs (from an interrupted prior run): the partition copy is
+ * authoritative, but a child present ONLY in the source (e.g. a new worktree's
+ * managed-mcp/resource-cache written after the crash) must be carried over, not
+ * dropped. Each carried child moves via a temp sibling + atomic rename, so a
+ * concurrent reader sees a whole child or none.
+ */
+async function mergeDirIntoPartition(src: string, dest: string): Promise<void> {
+  await fse.ensureDir(dest);
+  const children = await fse.readdir(src);
+  for (const child of children) {
+    const childDest = path.join(dest, child);
+    if (await pathExists(childDest)) continue; // partition child wins; leave it
+    const childSrc = path.join(src, child);
+    const tmp = `${childDest}.${process.pid}.tmp`;
+    await remove(tmp);
+    await fse.copy(childSrc, tmp, { overwrite: true });
+    await fse.rename(tmp, childDest);
   }
 }
 

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -54,8 +54,30 @@ export interface MigrationPlan {
    * "partition exists" check and the legacy dir — including its plaintext `env`
    * — would linger in the workspace forever, breaking the zero-residue promise.
    */
-  mode: 'full' | 'retire-only';
+  mode: 'full' | 'retire-only' | 'self';
 }
+
+/**
+ * Class-A1 machine-data entries under a self install's `<repo>/.teamai/` that P2
+ * relocates to the partition. Everything NOT in this list stays in the repo: the
+ * class-B knowledge (skills/rules/docs/learnings/env/agents/hooks/mcp/teamai.yaml/
+ * .gitignore) committed to main, and the disposable reports-wt/knowledge-wt
+ * worktrees (which anchor on the repo and are rebuilt on demand, never moved).
+ *
+ * ORDER MATTERS: `config.yaml` is the sentinel planMigration keys on, so it is
+ * relocated LAST. If the run crashes partway, config.yaml is still in the repo,
+ * so the next planMigration still sees legacy A1 and finishes the job — the
+ * remaining entries (incl. the plaintext env.local/env.sh) never get stranded.
+ */
+const SELF_A1_ENTRIES = [
+  'state.json',
+  'env.local',
+  'env.sh',
+  'search-index.json',
+  'managed-mcp.json',
+  'workspaces',
+  'config.yaml',
+] as const;
 
 /**
  * Decide whether the current working directory is a legacy install that needs
@@ -78,26 +100,49 @@ export async function planMigration(cwd?: string): Promise<MigrationPlan | null>
   if (!anchors) return null;
 
   const legacyDir = path.join(anchors.workspaceRoot, '.teamai');
+  const partitionDir = projectDataHome(anchors.projectAnchor);
   const legacyConfig = path.join(legacyDir, 'config.yaml');
-  if (!(await pathExists(legacyConfig))) return null;
 
-  // Read the legacy config directly to gate on scope/kind. A malformed config is
-  // treated as "nothing to migrate" rather than crashing a write command.
-  const content = await readFileSafe(legacyConfig);
-  if (!content) return null;
+  // Gate on scope/kind read from config.yaml. It is normally in the repo, but a
+  // self migration that crashed partway may have already relocated config.yaml to
+  // the partition while other A1 (incl. plaintext env.local/env.sh) still lingers
+  // in the repo. So fall back to the partition config to read scope/kind — never
+  // key the whole decision on legacy config.yaml existing (that would go blind and
+  // strand the remaining A1 forever). A malformed config is treated as "nothing to
+  // migrate" rather than crashing a write command.
+  const gateContent =
+    (await readFileSafe(legacyConfig)) ??
+    (await readFileSafe(path.join(partitionDir, 'config.yaml')));
+  if (!gateContent) return null;
   let scope: string | undefined;
   let kind: string | undefined;
   try {
-    const parsed = LocalConfigSchema.parse(YAML.parse(content));
+    const parsed = LocalConfigSchema.parse(YAML.parse(gateContent));
     scope = parsed.scope;
     kind = parsed.repo.kind;
   } catch {
     return null;
   }
   if (scope !== 'project') return null;
-  if (kind === 'self') return null;
 
-  const partitionDir = projectDataHome(anchors.projectAnchor);
+  // Self mode (P2): the legacy `.teamai/` mixes class-B knowledge (committed to
+  // main, must stay) with class-A1 machine data (must move). We CANNOT rename the
+  // whole dir like a git-mode install — that would carry the knowledge off and
+  // rename `.teamai` to `.bak`, breaking "knowledge on main". Instead, selectively
+  // relocate the A1 whitelist and leave everything else in place. Plan whenever
+  // ANY A1 entry still sits in the repo — not just config.yaml — so an interrupted
+  // relocation (config.yaml already moved, env.local not yet) is still finished.
+  if (kind === 'self') {
+    const hasLegacyA1 = await anyExists(legacyDir, SELF_A1_ENTRIES);
+    if (!hasLegacyA1) return null;
+    return { legacyDir, partitionDir, anchor: anchors.projectAnchor, mode: 'self' };
+  }
+
+  // Non-self (git/http): keyed on legacy config.yaml — the git-mode migration
+  // renames the whole dir, so config.yaml being present IS the "un-migrated"
+  // signal (it is moved atomically, never piecemeal).
+  if (!(await pathExists(legacyConfig))) return null;
+
   // If the partition is already built, the copy is done (or was done by a prior
   // run that crashed before retiring the source). Don't re-copy onto the
   // authoritative partition — just finish the job by retiring the leftover
@@ -106,6 +151,14 @@ export async function planMigration(cwd?: string): Promise<MigrationPlan | null>
     (await pathExists(path.join(partitionDir, 'config.yaml'))) ? 'retire-only' : 'full';
 
   return { legacyDir, partitionDir, anchor: anchors.projectAnchor, mode };
+}
+
+/** True if any of `names` exists directly under `dir`. */
+async function anyExists(dir: string, names: readonly string[]): Promise<boolean> {
+  for (const n of names) {
+    if (await pathExists(path.join(dir, n))) return true;
+  }
+  return false;
 }
 
 /**
@@ -132,7 +185,17 @@ export async function runMigration(
   const { legacyDir, partitionDir, anchor, mode } = plan;
 
   if (opts.dryRun) {
-    if (mode === 'retire-only') {
+    if (mode === 'self') {
+      const present = [];
+      for (const n of SELF_A1_ENTRIES) {
+        if (await pathExists(path.join(legacyDir, n))) present.push(n);
+      }
+      log.info(
+        `[dry-run] self mode: would relocate ${present.length} machine-data item(s) ` +
+          `(${present.join(', ')}) from ${legacyDir} to ${partitionDir}, leaving team ` +
+          `knowledge in place.`,
+      );
+    } else if (mode === 'retire-only') {
       log.info(
         `[dry-run] partition already built at ${partitionDir}; would retire the ` +
           `leftover ${legacyDir} to ${legacyDir}.bak`,
@@ -156,6 +219,15 @@ export async function runMigration(
   const staging = `${partitionDir}.staging`;
   let lockReleased = false;
   try {
+    // 'self' (P2): selectively relocate the class-A1 whitelist from the repo's
+    // `.teamai/` into the partition, leaving class-B knowledge and the
+    // reports-wt/knowledge-wt worktrees untouched. The `.teamai/` dir is NEVER
+    // renamed — the knowledge on main must stay exactly where it is.
+    if (mode === 'self') {
+      await migrateSelfA1(legacyDir, partitionDir);
+      return 'migrated';
+    }
+
     // 'retire-only': a prior run already built the partition but crashed before
     // retiring the source. The partition is authoritative — do NOT re-copy onto
     // it — just finish by retiring the leftover legacy dir.
@@ -319,8 +391,23 @@ async function rebasePath(
  *    stage the plaintext `env`/`token` in the backup. We drop a self-contained
  *    `.gitignore` (`*`) INTO the dir BEFORE renaming, so the backup ignores its
  *    own contents regardless of its final name or the repo's ignore rules.
+ *
+ * REFUSES to rename a dir that holds single-repo team knowledge (a `teamai.yaml`
+ * with `mode: self`): that directory is committed to main, and renaming it to
+ * `.bak` would wipe the knowledge from the working tree. Self installs are
+ * relocated selectively (migrateSelfA1), never retired wholesale — reaching here
+ * with a self `.teamai/` means an upstream mode misclassification, so we fail
+ * closed rather than destroy knowledge.
  */
 async function retireLegacy(legacyDir: string): Promise<string> {
+  if (await holdsSelfKnowledge(legacyDir)) {
+    throw new Error(
+      `migration refused to rename ${legacyDir} to .bak: it holds single-repo ` +
+        `team knowledge (teamai.yaml mode: self) committed to main. This is a ` +
+        `guard against wiping knowledge — self installs relocate machine data ` +
+        `selectively, never by renaming the whole directory.`,
+    );
+  }
   // Make the backup ignore everything it contains, independent of repo rules and
   // the backup's eventual name. Written before the rename so there is never a
   // window in which the credentials sit in a non-ignored directory.
@@ -332,6 +419,78 @@ async function retireLegacy(legacyDir: string): Promise<string> {
   }
   await fse.rename(legacyDir, backup);
   return backup;
+}
+
+/**
+ * True when `dir` (a `.teamai/`) carries single-repo team knowledge — a
+ * `teamai.yaml` with `mode: self`. Such a directory is committed to main and must
+ * never be renamed away. Malformed/absent yaml → false (nothing to protect).
+ */
+async function holdsSelfKnowledge(dir: string): Promise<boolean> {
+  const content = await readFileSafe(path.join(dir, 'teamai.yaml'));
+  if (!content) return false;
+  try {
+    const raw = YAML.parse(content) as { mode?: string } | null;
+    return raw?.mode === 'self';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * P2 self-mode selective relocation: move each class-A1 entry from the repo's
+ * `.teamai/` into the partition, leaving class-B knowledge and the worktrees
+ * untouched. The `.teamai/` directory itself is never renamed — the knowledge on
+ * main must stay in place.
+ *
+ * Per-entry durability (destination-first): copy `<legacy>/<item>` into the
+ * partition, then delete the source. A crash mid-way leaves the item readable in
+ * at least one place, never neither. Idempotent:
+ *  - source missing → skip (already relocated, or never existed);
+ *  - destination already present → do NOT overwrite the authoritative partition
+ *    copy; just remove the stale source (finishes an interrupted relocation).
+ *
+ * The copy lands via a temp sibling + atomic rename (`<dest>.<pid>.tmp` → dest),
+ * NOT a direct copy onto `dest`. A concurrent self pull/push does NOT take the
+ * partition `.sync-lock` (lockScope skips non-git kinds), so it can read
+ * `<partition>/env.local` while we relocate: the atomic rename guarantees it sees
+ * either the complete file or nothing, never a half-written one. Uses raw fse.copy
+ * (NOT copyDir) so a nested `.git` under workspaces/ survives.
+ */
+async function migrateSelfA1(legacyDir: string, partitionDir: string): Promise<void> {
+  await fse.ensureDir(partitionDir);
+  const moved: string[] = [];
+  for (const name of SELF_A1_ENTRIES) {
+    const src = path.join(legacyDir, name);
+    if (!(await pathExists(src))) continue;
+    const dest = path.join(partitionDir, name);
+    if (await pathExists(dest)) {
+      // Partition copy is authoritative (e.g. written by a prior run or init).
+      // Drop the stale source rather than clobbering it.
+      await remove(src);
+      continue;
+    }
+    // Destination-first, atomic: copy into a temp sibling, then rename onto dest
+    // (rename is atomic within the partition filesystem). Verify, THEN delete the
+    // source. A leftover .tmp from an earlier crash is cleared first.
+    const tmp = `${dest}.${process.pid}.tmp`;
+    await remove(tmp);
+    await fse.copy(src, tmp, { overwrite: true });
+    await fse.rename(tmp, dest);
+    if (!(await pathExists(dest))) {
+      throw new Error(`self migration: failed to relocate ${name} to the partition`);
+    }
+    await remove(src);
+    moved.push(name);
+  }
+  if (moved.length > 0) {
+    log.success(
+      `Slimmed single-repo .teamai/: relocated ${moved.length} machine-data item(s) ` +
+        `to ${partitionDir} (team knowledge stays in the repo).`,
+    );
+  } else {
+    log.debug('self migration: nothing left to relocate');
+  }
 }
 
 /** Top-level entries under a legacy `.teamai/` that migration will copy. */

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -1346,9 +1346,13 @@ export async function pull(options: GlobalOptions): Promise<void> {
   const contended = new Set<LocalConfig>();
   const heldLocks = new Map<LocalConfig, string>();
   const lockScope = async (config: LocalConfig): Promise<boolean> => {
-    // Only git-mode has a shared team clone to guard. http has no clone; self
-    // mode writes the reports orphan-branch worktree under its own reports-lock.
-    if (config.repo.kind && config.repo.kind !== 'git') return true;
+    // git-mode guards its shared team clone; self mode guards its machine-data
+    // writes (state/env/search-index) against a concurrent P2 migration relocating
+    // the same files — both contend on <getDataHome>/.sync-lock (which, for a
+    // pre-migration self install, is <repo>/.teamai/.sync-lock, exactly the path
+    // migrateSelfA1 takes). http has no clone and no machine-data relocation, so it
+    // needs no lock.
+    if (config.repo.kind === 'http') return true;
     const lock = path.join(getDataHome(config), SYNC_LOCK_FILENAME);
     if (await acquireLock(lock)) {
       heldLocks.set(config, lock);

--- a/src/push.ts
+++ b/src/push.ts
@@ -283,40 +283,55 @@ export async function push(options: GlobalOptions & { all?: boolean; role?: stri
   // branch/commit/reset never touch the user's active tree. withKnowledgeWorktree
   // hands pushCore a config whose localPath is the worktree's .teamai.
   if (localConfig.repo.kind === 'self') {
-    // Self-heal an older .teamai/.gitignore that still ignores `env` (pre-beta.5).
-    // Run against the ACTIVE tree (original localConfig, projectRoot intact) BEFORE
-    // swapping into the worktree, so the fixed .gitignore lets env changes surface.
-    try {
-      const { migrateSelfModeGitignore } = await import('./init.js');
-      await migrateSelfModeGitignore(localConfig);
-    } catch { /* best-effort */ }
-
-    const { withKnowledgeWorktree, EmptyRepoError } = await import('./utils/reports-branch.js');
-    try {
-      const activeConfigPath = path.join(localConfig.repo.localPath, 'teamai.yaml');
-      const activeConfig = await readFileSafe(activeConfigPath);
-      const businessRoot = localConfig.repo.businessRepoRoot ?? localConfig.projectRoot;
-      let pendingTeamConfig: string | null = null;
-      if (activeConfig !== null && businessRoot) {
-        const relativeConfigPath = path.relative(businessRoot, activeConfigPath).split(path.sep).join('/');
-        const committed = await getFileContentAtRev(businessRoot, 'HEAD', relativeConfigPath);
-        if (committed === null || committed.toString() !== activeConfig) {
-          pendingTeamConfig = activeConfig;
-        }
-      }
-      await withKnowledgeWorktree(localConfig, async (wtConfig) => {
-        if (pendingTeamConfig !== null) {
-          await writeFile(path.join(wtConfig.repo.localPath, 'teamai.yaml'), pendingTeamConfig);
-        }
-        await pushCore(wtConfig, teamConfig, options, pendingTeamConfig);
-      });
-    } catch (e) {
-      if (e instanceof EmptyRepoError) {
-        log.error(e.message);
-      } else {
-        log.error(`Push failed: ${(e as Error).message}`);
-      }
+    // Guard self machine-data writes against a concurrent P2 migration relocating
+    // the same files. Contend on <getDataHome>/.sync-lock — the exact path
+    // migrateSelfA1 takes (for a pre-migration self install that is
+    // <repo>/.teamai/.sync-lock). Like git-mode push, error on contention rather
+    // than silently skipping (that would drop the user's changes).
+    const selfSyncLock = path.join(getDataHome(localConfig), SYNC_LOCK_FILENAME);
+    if (!(await acquireLock(selfSyncLock))) {
+      log.error('Another teamai pull/push/migration is in progress for this project. Re-run once it finishes.');
       process.exitCode = 1;
+      return;
+    }
+    try {
+      // Self-heal an older .teamai/.gitignore that still ignores `env` (pre-beta.5).
+      // Run against the ACTIVE tree (original localConfig, projectRoot intact) BEFORE
+      // swapping into the worktree, so the fixed .gitignore lets env changes surface.
+      try {
+        const { migrateSelfModeGitignore } = await import('./init.js');
+        await migrateSelfModeGitignore(localConfig);
+      } catch { /* best-effort */ }
+
+      const { withKnowledgeWorktree, EmptyRepoError } = await import('./utils/reports-branch.js');
+      try {
+        const activeConfigPath = path.join(localConfig.repo.localPath, 'teamai.yaml');
+        const activeConfig = await readFileSafe(activeConfigPath);
+        const businessRoot = localConfig.repo.businessRepoRoot ?? localConfig.projectRoot;
+        let pendingTeamConfig: string | null = null;
+        if (activeConfig !== null && businessRoot) {
+          const relativeConfigPath = path.relative(businessRoot, activeConfigPath).split(path.sep).join('/');
+          const committed = await getFileContentAtRev(businessRoot, 'HEAD', relativeConfigPath);
+          if (committed === null || committed.toString() !== activeConfig) {
+            pendingTeamConfig = activeConfig;
+          }
+        }
+        await withKnowledgeWorktree(localConfig, async (wtConfig) => {
+          if (pendingTeamConfig !== null) {
+            await writeFile(path.join(wtConfig.repo.localPath, 'teamai.yaml'), pendingTeamConfig);
+          }
+          await pushCore(wtConfig, teamConfig, options, pendingTeamConfig);
+        });
+      } catch (e) {
+        if (e instanceof EmptyRepoError) {
+          log.error(e.message);
+        } else {
+          log.error(`Push failed: ${(e as Error).message}`);
+        }
+        process.exitCode = 1;
+      }
+    } finally {
+      await releaseLock(selfSyncLock);
     }
     return;
   }


### PR DESCRIPTION
## What & why

P2 of issue #374. Self (single-repo) mode kept its **class-A1 machine data**
(config, state, env backup, search index, managed-mcp, the per-worktree resource
cache) inside the business repo at `<repo>/.teamai/`, next to the **class-B team
knowledge** committed to main. A hand-maintained `.gitignore` blacklist kept `git
status` clean — and it was already incomplete (the per-worktree `workspaces/` tree
and the user-scope `managed-mcp.json` were never listed, so a self repo running MCP
reconcile or the local agent **leaked them into the working tree**).

P2 physically relocates A1 to the partition `~/.teamai/projects/<slug>/`, leaving
`.teamai/` with only class-B knowledge — `git status` is clean because the machine
data is *gone*, not merely ignored.

## How it works

Same lever as non-self installs: attach a partition `dataHome` to the self
LocalConfig, and every `getDataHome()`-based write follows.

**Invariant kept:** `getKnowledgeDir` / `repo.localPath` stay `<repo>/.teamai` (the
class-B anchor, committed to main), so the ~230 `path.join(localPath, …)` sites
don't change; `reports-wt/` / `knowledge-wt/` stay in the repo (git worktrees must
anchor there).

- **init** (`initSelfRepo`): attaches the partition as `dataHome`, writes
  config/state there; the old "retire the stale partition" step is gone (self now
  USES the partition — an overwrite of the same partition config supersedes any
  prior git-mode one).
- **bootstrap**: the already-initialized check and config write target the
  partition (with a legacy fallback so a pre-P2 install is still recognized).
- **detection seam** (the delicate part): on a fresh clone the partition config
  doesn't exist yet, so partition-first misses; the legacy branch runs the
  self-heal bootstrap (which now writes into the partition) then reads it back
  **from the partition** (`selfHealAndReadPartition`). A pre-P2 install is read via
  the legacy branch (double-read compat) until migration relocates it.
- **migration** (`mode: 'self'`): self CANNOT use the git-mode whole-dir
  copy→rename (that would carry the knowledge off and rename `.teamai` to `.bak`,
  breaking "knowledge on main"). It selectively relocates the A1 whitelist
  entry-by-entry into the partition, leaving class-B knowledge and the worktrees
  untouched and never renaming `.teamai/`. self `repo.localPath` is NOT rebased.
- **gitignore hardened**: `workspaces/` + `managed-mcp.json` + `.sync-lock` added
  (the pre-P2 leak sources); existing entries kept for the pre-migration
  double-read window.

## Adversarial self-review (found + fixed 3 issues, all regression-tested)

- **[C1] non-atomic relocation stranded plaintext secrets.** `config.yaml` was the
  first whitelist entry AND `planMigration` keyed on legacy `config.yaml` existing —
  so a crash after moving `config.yaml` went blind and left `env.local`/`env.sh`
  in the repo forever. Fix: `config.yaml` is relocated **last** (sentinel), and
  `planMigration` gates on **any** A1 entry (reading kind from the partition config
  when legacy `config.yaml` is already gone).
- **[H1] concurrent read could tear env.local.** A self pull/push does NOT take the
  partition `.sync-lock` (`lockScope` skips non-git kinds), so a concurrent
  hook-pull could read a half-copied `env.local`. Fix: relocate each entry via a
  temp sibling + **atomic rename** — a reader sees the complete file or nothing.
- **[M2] a mislabeled dir could wipe knowledge.** A `<repo>/.teamai` carrying self
  knowledge but a `kind: git` config would take the git-mode retire path and rename
  `.teamai` to `.bak`, wiping committed knowledge. Fix: `retireLegacy` **refuses**
  to rename a dir holding a `teamai.yaml` `mode: self` (fail closed).

## Test Plan

### Unit (`src/__tests__/migrate.test.ts`, 28 tests) — all green
Self relocation (A1 moved / class-B kept / `.teamai` not renamed / localPath not
rebased), idempotent + interrupted-run finish, **the C1 crash state** (config in
partition, env.local stranded → finished), **the M2 guard** (refuses to rename a
self-knowledge dir), http-mode, git-mode full/retire-only, dry-run.

### Full suite
`npx tsc --noEmit` clean · `npm run build` OK · `npx vitest run` → **2788 passed**.

### Real-CLI end-to-end (built `dist/index.js`, isolated HOME + real git repos)
| Scenario | Result |
|---|---|
| pre-P2 self install → `pull` relocates A1 | ✅ config/state/env.local/search-index/workspaces → partition |
| class-B knowledge | ✅ skills/rules/env.yaml/teamai.yaml stay in the repo |
| `.teamai/` | ✅ never renamed; self `repo.localPath` not rebased |
| pre-P2 leak (`workspaces/` + `managed-mcp.json` untracked) | ✅ gone after slimming |
| **`git status`** | ✅ **clean** (P2 acceptance) |
| detection: config in partition | ✅ detected via partition-first, workspace stays clean, no write-back |
| fresh clone, `mode:self`, no auth | ✅ bootstrap degrades gracefully (no crash, no partition config, no pollution, knowledge intact) |
| **C1 crash state** (config moved, env.local stranded) | ✅ `pull` finishes the relocation — the plaintext secret is moved out of the repo, not stranded |

## Docs
`docs/designs/data-directory-layout.md` (P2 section) + bilingual
`docs/usage-guide{,.zh-CN}.md` (self data layout table + upgrade note) updated.

## Follow-ups (out of scope, noted for tracking)
- H2 (detection's self-heal can trigger the bootstrap's network auth on the hot
  path) is **pre-existing** (the issue #198 clone-bootstrap mechanism, unchanged by
  P2) — worth a separate issue, not widened here.
- `teamai.lock` still routes through `getTeamaiHome` (pkg subsystem), a pre-existing
  residue not covered by P2's A1 whitelist.
- P3 (constant functionization + `status --all`) remains.