### PR TITLE
docs(readme): tighten README and mark Context/Improvement as beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Each resource is delivered to every agent:
 | **Rules** | `rules/*.md` | |
 | **Docs** | `docs/` | Foundational project docs; not all loaded by default (progressive disclosure) |
 | **Agents** | `agents/<name>.yaml` | |
-| **Culture** | `culture.md` | |
+| **Culture** | `culture.md` | Injected into each agent's CLAUDE.md / AGENTS.md |
 | **CLAUDE.md** | `claudemd/*.md` | |
 | **Env** | `env/` | |
 | **Hooks** | `hooks/hooks.yaml` | |

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Each resource is delivered to every agent:
 | **Rules** | `rules/*.md` | |
 | **Docs** | `docs/` | Foundational project docs; not all loaded by default (progressive disclosure) |
 | **Agents** | `agents/<name>.yaml` | |
-| **Culture** | `culture.md` | Injected into each agent's CLAUDE.md / AGENTS.md |
+| **Culture** | `culture.md` | Team mission, values, and working principles — injected into each agent's CLAUDE.md / AGENTS.md so every session inherits them |
 | **CLAUDE.md** | `claudemd/*.md` | |
 | **Env** | `env/` | Shared team-level environment variables and switches; do not put secrets here |
 | **Hooks** | `hooks/hooks.yaml` | |

--- a/README.md
+++ b/README.md
@@ -110,6 +110,38 @@ teamai push → create branch + MR → reviewer approves + merges
               SessionStart hook → teamai pull → synced to local AI tools
 ```
 
+### Team Skills
+
+A skill is a directory with `SKILL.md`. `teamai push` opens an MR; after merge, `teamai pull` delivers it to every agent.
+
+```markdown
+---
+name: deploy-helper
+description: Deploy the service the team's way
+---
+# Deploy Helper
+1. Run `npm test`
+2. Run `./deploy.sh`
+```
+
+```bash
+teamai push
+```
+
+### Team Rules
+
+Markdown conventions injected into each agent's rules. Same push → review → pull flow.
+
+```markdown
+# Code review
+- Every function needs JSDoc
+- No `any`
+```
+
+```bash
+teamai push
+```
+
 ### Team Hooks
 
 Declare custom hooks in `hooks/hooks.yaml` and `teamai pull` delivers them to every AI tool:

--- a/README.md
+++ b/README.md
@@ -197,6 +197,16 @@ The WASM parser is a pure-JavaScript dependency — no native toolchain is requi
 
 > Every execution makes the entire team smarter.
 
+### Maintenance
+
+As skills and knowledge accumulate, prune what the team no longer uses. `teamai recall maintenance` archives low-confidence learnings and flags stale skills, rules, and docs for cleanup or updates:
+
+```bash
+teamai recall maintenance --prune --dry-run      # preview
+teamai recall maintenance --prune --archive      # archive unused learnings
+teamai recall maintenance --update-quality       # draft updates for stale skills / docs
+```
+
 Insight into how the team actually uses its AI tools, and a starting point for turning session friction into shared skills, rules, and knowledge:
 
 | Capability | Command | What it shows |
@@ -205,7 +215,6 @@ Insight into how the team actually uses its AI tools, and a starting point for t
 | **Sessions** | `teamai session save` | Privacy-scrubbed per-session summaries (tool sequence, prompt turns, interventions) that feed the digest's Session Highlights. |
 | **Dashboard** | `teamai dashboard` | Web dashboard showing team members' live coding-session status, intervention count, and token usage. |
 | **KB Health** | `teamai dashboard` → KB Health | Built-in dashboard page reporting knowledge-base usage & health — coverage by type, top recalled entries, silent entries, recall trend, author contributions, and a maintenance console. |
-| **Maintenance** | `teamai recall maintenance` | Prune low-confidence learnings and identify stale skills, rules, and docs for cleanup or updates. |
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Each resource is delivered to every agent:
 | **CLAUDE.md** | `claudemd/*.md` | |
 | **Env** | `env/` | Shared team-level environment variables and switches; do not put secrets here |
 | **Hooks** | `hooks/hooks.yaml` | |
-| **MCP servers** | `mcp/mcp.yaml` | |
+| **MCP** | `mcp/mcp.yaml` | |
 | **Packages** | `teamai.yaml` | Currently npm packages and Claude Code plugins only |
 | **Models** | — | Not implemented for every provider yet |
 

--- a/README.md
+++ b/README.md
@@ -114,19 +114,19 @@ teamai push → create branch + MR → reviewer approves + merges
 
 Each resource is delivered to every agent:
 
-| Resource | In the team repo | Commands |
-|----------|------------------|----------|
-| **Skills** | `skills/<name>/SKILL.md` | `teamai push` / `pull`, `teamai skill exclude` |
-| **Rules** | `rules/*.md` | `teamai push` / `pull` |
-| **Docs** | `docs/` | `teamai push` / `pull` |
-| **Agents** | `agents/<name>.yaml` | `teamai push` / `pull` |
-| **Culture** | `culture.md` | `teamai push` / `pull` |
-| **CLAUDE.md** | `claudemd/*.md` | `teamai push` / `pull` |
-| **Env** | `env/` | `teamai env` |
-| **Hooks** | `hooks/hooks.yaml` | `teamai hooks list \| inject \| remove` |
-| **MCP servers** | `mcp/mcp.yaml` | `teamai mcp list \| inject \| remove` |
-| **Packages** | `teamai.yaml` | `teamai packages` |
-| **Models** | — | local-agent on session start |
+| Resource | In the team repo | Notes |
+|----------|------------------|-------|
+| **Skills** | `skills/<name>/SKILL.md` | |
+| **Rules** | `rules/*.md` | |
+| **Docs** | `docs/` | Foundational project docs; not all loaded by default (progressive disclosure) |
+| **Agents** | `agents/<name>.yaml` | |
+| **Culture** | `culture.md` | |
+| **CLAUDE.md** | `claudemd/*.md` | |
+| **Env** | `env/` | |
+| **Hooks** | `hooks/hooks.yaml` | |
+| **MCP servers** | `mcp/mcp.yaml` | |
+| **Packages** | `teamai.yaml` | Currently npm packages and Claude Code plugins only |
+| **Models** | — | Not implemented for every provider yet |
 
 For file formats and full workflows, see the [Usage Guide](docs/usage-guide.md).
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Insight into how the team actually uses its AI tools, and a starting point for t
 | **Sessions** | `teamai session save` | Privacy-scrubbed per-session summaries (tool sequence, prompt turns, interventions) that feed the digest's Session Highlights. |
 | **Dashboard** | `teamai dashboard` | Web dashboard showing team members' live coding-session status, intervention count, and token usage. |
 | **KB Health** | `teamai dashboard` → KB Health | Built-in dashboard page reporting knowledge-base usage & health — coverage by type, top recalled entries, silent entries, recall trend, author contributions, and a maintenance console. |
+| **Maintenance** | `teamai recall maintenance` | Prune low-confidence learnings and identify stale skills, rules, and docs for cleanup or updates. |
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ npm install -g teamai-cli
 
 Create a shared-experience repo on your git host (GitHub, GitLab, GitCode, CNB, TGit, or a private Git service), **grant write access to team members**, then run `teamai init https://github.com/yourorg/yourrepo`.
 
-For self-hosted GitLab, set `GITLAB_URL` to your instance URL and `GITLAB_TOKEN` to a token with `api` scope before initializing. If `init` recognizes an unconfigured GitLab instance, it stops with setup instructions. Existing repos with `provider: git` also need `provider: gitlab` in the team repo's `teamai.yaml` to create MRs. See [GitLab setup](docs/providers.md#gitlab-provider含自托管).
-
 > **No team repo yet?** Start from a template pre-loaded with production-ready skills, rules, and review agents. Browse the [teamai-hub](https://github.com/teamai-hub) org, click **Use this template**, then `teamai init` against your new repo.
 
 ### Team members
@@ -48,13 +46,13 @@ Once initialized, every AI session automatically pulls the latest skills / rules
 
 ## Product architecture
 
-**Team Execution × Team Context × Team Improvement**:
+**Team Execution × Team Context (beta) × Team Improvement (beta)**:
 
 | Layer | Job | In this CLI today |
 |-------|-----|-------------------|
 | **Team Execution** | Make every agent work the team's way | `init` / `pull` / `push`, skills, rules, agents, hooks, MCP, env |
-| **Team Context** | Make every agent understand the team | recall, learnings, codebase graph, teamwiki... |
-| **Team Improvement** | Make every execution improve the team | friction-based share-learnings, sessions, digest, dashboard... |
+| **Team Context** (beta) | Make every agent understand the team | recall, learnings, codebase graph, teamwiki... |
+| **Team Improvement** (beta) | Make every execution improve the team | friction-based share-learnings, sessions, digest, dashboard... |
 
 ## Overview
 
@@ -63,8 +61,8 @@ Once initialized, every AI session automatically pulls the latest skills / rules
     <tr>
       <th rowspan="2">Agent</th>
       <th colspan="7">Team Execution</th>
-      <th colspan="3">Team Context</th>
-      <th colspan="3">Team Improvement</th>
+      <th colspan="3">Team Context (beta)</th>
+      <th colspan="3">Team Improvement (beta)</th>
     </tr>
     <tr>
       <th>skills</th><th>rules</th><th>docs</th><th>env</th><th>agents</th><th>hooks</th><th>mcp</th>
@@ -179,7 +177,7 @@ teamai packages    # Install everything declared by the team
 
 See the [Usage Guide](docs/usage-guide.md#team-packages) for the complete workflow and configuration.
 
-## Team Context
+## Team Context (beta)
 
 > Every agent understands how the team works.
 
@@ -242,7 +240,7 @@ Edges come from two tracks that run together, with AST results taking precedence
 
 The WASM parser is a pure-JavaScript dependency — no native toolchain is required. If it fails to load for any reason, extraction falls back to the heuristic track and records an `AST_UNAVAILABLE` gap. Set `TEAMAI_SKIP_AST=1` to force heuristic-only extraction.
 
-## Team Improvement
+## Team Improvement (beta)
 
 > Every execution makes the entire team smarter.
 

--- a/README.md
+++ b/README.md
@@ -110,8 +110,6 @@ teamai push → create branch + MR → reviewer approves + merges
               SessionStart hook → teamai pull → synced to local AI tools
 ```
 
-Members push changes via `teamai push`, which opens a Merge Request for review. Re-running `teamai push` on a resource that is still waiting in an unmerged PR updates that PR in place instead of opening a duplicate. Once merged, `teamai pull` (triggered automatically on session start via the SessionStart hook) syncs the latest resources locally. Skills sync to `~/.claude/skills/`, `~/.codex/skills/`, `~/.cursor/skills/`, `~/.codebuddy/skills/`, etc. For Codex, an existing skill under `~/.agents/skills/` is updated there instead of duplicated under `~/.codex/skills/`. In a **project-scope** install, SessionStart first creates that tool's project root (e.g. `<project>/.claude`) if it is missing, then pulls into it — a bare `teamai pull` still will not invent agent directories.
-
 ### Team Hooks
 
 Declare custom hooks in `hooks/hooks.yaml` and `teamai pull` delivers them to every AI tool:

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ teamai push → create branch + MR → reviewer approves + merges
 
 ### What Gets Shared
 
-Each resource is declared once in the team repo and delivered on `teamai pull`:
+Each resource is delivered to every agent:
 
 | Resource | In the team repo | Commands |
 |----------|------------------|----------|
@@ -120,10 +120,13 @@ Each resource is declared once in the team repo and delivered on `teamai pull`:
 | **Rules** | `rules/*.md` | `teamai push` / `pull` |
 | **Docs** | `docs/` | `teamai push` / `pull` |
 | **Agents** | `agents/<name>.yaml` | `teamai push` / `pull` |
+| **Culture** | `culture.md` | `teamai push` / `pull` |
+| **CLAUDE.md** | `claudemd/*.md` | `teamai push` / `pull` |
 | **Env** | `env/` | `teamai env` |
 | **Hooks** | `hooks/hooks.yaml` | `teamai hooks list \| inject \| remove` |
 | **MCP servers** | `mcp/mcp.yaml` | `teamai mcp list \| inject \| remove` |
 | **Packages** | `teamai.yaml` | `teamai packages` |
+| **Models** | — | local-agent on session start |
 
 For file formats and full workflows, see the [Usage Guide](docs/usage-guide.md).
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@
 
 TeamAI manages your team's skills, rules, MCP, and knowledge across Claude Code, Codex, CodeBuddy, WorkBuddy, OpenCode, Cursor, and other AI agents.
 
+## Contributors
+
+Thanks to everyone who has contributed to TeamAI!
+
+<a href="https://github.com/Tencent/teamai-cli/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=Tencent/teamai-cli" alt="Contributors" />
+</a>
+
+Made with [contrib.rocks](https://contrib.rocks).
+
 ## Quick Start
 
 ### Install
@@ -252,13 +262,3 @@ Insight into how the team actually uses its AI tools, and a starting point for t
 ## Contributing
 
 PRs are welcome! Please read [CONTRIBUTING.md](.github/CONTRIBUTING.md) first.
-
-## Contributors
-
-Thanks to everyone who has contributed to TeamAI!
-
-<a href="https://github.com/Tencent/teamai-cli/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=Tencent/teamai-cli" alt="Contributors" />
-</a>
-
-Made with [contrib.rocks](https://contrib.rocks).

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Each resource is delivered to every agent:
 | **Agents** | `agents/<name>.yaml` | |
 | **Culture** | `culture.md` | Injected into each agent's CLAUDE.md / AGENTS.md |
 | **CLAUDE.md** | `claudemd/*.md` | |
-| **Env** | `env/` | |
+| **Env** | `env/` | Shared team-level environment variables and switches; do not put secrets here |
 | **Hooks** | `hooks/hooks.yaml` | |
 | **MCP servers** | `mcp/mcp.yaml` | |
 | **Packages** | `teamai.yaml` | Currently npm packages and Claude Code plugins only |

--- a/README.md
+++ b/README.md
@@ -110,102 +110,22 @@ teamai push → create branch + MR → reviewer approves + merges
               SessionStart hook → teamai pull → synced to local AI tools
 ```
 
-### Team Skills
+### What Gets Shared
 
-A skill is a directory with `SKILL.md`. `teamai push` opens an MR; after merge, `teamai pull` delivers it to every agent.
+Each resource is declared once in the team repo and delivered on `teamai pull`:
 
-```markdown
----
-name: deploy-helper
-description: Deploy the service the team's way
----
-# Deploy Helper
-1. Run `npm test`
-2. Run `./deploy.sh`
-```
+| Resource | In the team repo | Commands |
+|----------|------------------|----------|
+| **Skills** | `skills/<name>/SKILL.md` | `teamai push` / `pull`, `teamai skill exclude` |
+| **Rules** | `rules/*.md` | `teamai push` / `pull` |
+| **Docs** | `docs/` | `teamai push` / `pull` |
+| **Agents** | `agents/<name>.yaml` | `teamai push` / `pull` |
+| **Env** | `env/` | `teamai env` |
+| **Hooks** | `hooks/hooks.yaml` | `teamai hooks list \| inject \| remove` |
+| **MCP servers** | `mcp/mcp.yaml` | `teamai mcp list \| inject \| remove` |
+| **Packages** | `teamai.yaml` | `teamai packages` |
 
-```bash
-teamai push
-```
-
-### Team Rules
-
-Markdown conventions injected into each agent's rules. Same push → review → pull flow.
-
-```markdown
-# Code review
-- Every function needs JSDoc
-- No `any`
-```
-
-```bash
-teamai push
-```
-
-### Team Hooks
-
-Declare custom hooks in `hooks/hooks.yaml` and `teamai pull` delivers them to every AI tool:
-
-```yaml
-hooks:
-  - id: block-secret
-    description: Scan for secrets before commit
-    event: PreToolUse
-    matcher: Bash
-    command: 'bash -lc "~/.teamai/team-scripts/scan-secret.sh" || true'
-    tools: [claude, cursor]
-```
-
-```bash
-teamai hooks list      # list effective hooks
-teamai hooks inject    # re-reconcile into every installed tool
-teamai hooks remove    # remove all teamai-managed hooks
-```
-
-### Team MCP Servers
-
-Declare once in `mcp/mcp.yaml`; `teamai pull` writes each tool's native config. Use `${VAR}` for secrets.
-
-```yaml
-servers:
-  - name: gpu-analysis
-    transport: http            # stdio | http | sse
-    url: https://example.com/api/mcp
-    headers:
-      Authorization: Bearer ${GPU_ANALYSIS_TOKEN}
-```
-
-```bash
-teamai mcp list | inject | remove
-```
-
-### Skill Subscription Sources
-
-Subscribe to additional skill repos — other teams' public repos, or shared/public repos within your own org:
-
-```bash
-teamai source add https://github.com/other-team/teamai-public.git --name other-team
-teamai source list
-teamai source browse other-team    # browse available skills
-teamai source remove other-team
-```
-
-The add/remove change takes effect locally right away, and subscribed skills sync on the next
-`teamai pull`. Run `teamai push` when you want to share the `teamai.yaml` change with teammates.
-
-### Team Packages
-
-Share and restore the team's npm packages and Claude Code plugins:
-
-```bash
-teamai packages install typescript
-teamai packages install typescript@5.9.2 --npm
-teamai packages install code-review@claude-plugins-official
-teamai push       # Share the declarations
-teamai packages    # Install everything declared by the team
-```
-
-See the [Usage Guide](docs/usage-guide.md#team-packages) for the complete workflow and configuration.
+For file formats and full workflows, see the [Usage Guide](docs/usage-guide.md).
 
 ## Team Context (beta)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -114,19 +114,19 @@ teamai push → 创建分支 + MR → reviewer 审批合并
 
 每类资源分发到每个 Agent：
 
-| 资源 | 团队仓库中的位置 | 命令 |
+| 资源 | 团队仓库中的位置 | 备注 |
 |------|------------------|------|
-| **Skills** | `skills/<name>/SKILL.md` | `teamai push` / `pull`、`teamai skill exclude` |
-| **Rules（规范）** | `rules/*.md` | `teamai push` / `pull` |
-| **Docs** | `docs/` | `teamai push` / `pull` |
-| **Agents** | `agents/<name>.yaml` | `teamai push` / `pull` |
-| **Culture（团队文化）** | `culture.md` | `teamai push` / `pull` |
-| **CLAUDE.md** | `claudemd/*.md` | `teamai push` / `pull` |
-| **Env** | `env/` | `teamai env` |
-| **Hooks** | `hooks/hooks.yaml` | `teamai hooks list \| inject \| remove` |
-| **MCP Server** | `mcp/mcp.yaml` | `teamai mcp list \| inject \| remove` |
-| **Packages** | `teamai.yaml` | `teamai packages` |
-| **Models（模型）** | — | session start 时由 local-agent 下发 |
+| **Skills** | `skills/<name>/SKILL.md` | |
+| **Rules** | `rules/*.md` | |
+| **Docs** | `docs/` | 项目基础文档，默认不全量加载（渐进式披露） |
+| **Agents** | `agents/<name>.yaml` | |
+| **Culture** | `culture.md` | |
+| **CLAUDE.md** | `claudemd/*.md` | |
+| **Env** | `env/` | |
+| **Hooks** | `hooks/hooks.yaml` | |
+| **MCP Server** | `mcp/mcp.yaml` | |
+| **Packages** | `teamai.yaml` | 目前只支持 npm 包和 Claude 插件 |
+| **Models** | — | 暂时没有对全部 provider 实现 |
 
 文件格式与完整工作流见[使用指南](docs/usage-guide.zh-CN.md)。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -120,7 +120,7 @@ teamai push → 创建分支 + MR → reviewer 审批合并
 | **Rules** | `rules/*.md` | |
 | **Docs** | `docs/` | 项目基础文档，默认不全量加载（渐进式披露） |
 | **Agents** | `agents/<name>.yaml` | |
-| **Culture** | `culture.md` | |
+| **Culture** | `culture.md` | 注入到各 Agent 的 CLAUDE.md / AGENTS.md 中的一段文字 |
 | **CLAUDE.md** | `claudemd/*.md` | |
 | **Env** | `env/` | |
 | **Hooks** | `hooks/hooks.yaml` | |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -110,8 +110,6 @@ teamai push → 创建分支 + MR → reviewer 审批合并
            SessionStart hook → teamai pull → 同步到本地 AI 工具
 ```
 
-成员通过 `teamai push` 提交变更并创建合并请求供审核。若某个资源已在未合并的 PR 中等待评审，再次对它执行 `teamai push` 会就地更新该 PR，而非新开一个重复的 PR。合并后，`teamai pull`（由 SessionStart hook 在会话启动时自动触发）将最新资源同步到本地。Skills 会同步到 `~/.claude/skills/`、`~/.codex/skills/`、`~/.cursor/skills/`、`~/.codebuddy/skills/` 等目录。对于 Codex，若 skill 已存在于 `~/.agents/skills/`，则会在原位置更新，不会在 `~/.codex/skills/` 创建重复副本。在 **project scope** 安装下，SessionStart 会先为当前工具创建项目根目录（例如 `<project>/.claude`），再 pull 写入；单独执行 `teamai pull` 仍不会凭空创建 Agent 目录。
-
 ### 团队 Hooks
 
 在 `hooks/hooks.yaml` 中声明自定义 hooks，`teamai pull` 自动分发到所有 AI 工具：

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -25,8 +25,6 @@ npm install -g teamai-cli
 
 在 Git 托管平台（GitHub、GitLab、GitCode、CNB、TGit，或私有 Git 服务）创建共享经验仓库，**授予团队成员写权限**，然后运行 `teamai init https://github.com/yourorg/yourrepo`。
 
-使用自建 GitLab 时，先将 `GITLAB_URL` 设为实例地址，并配置具有 `api` 权限的 `GITLAB_TOKEN`。若 `init` 探测到尚未配置的 GitLab 实例，会停止并提示配置方法。已有仓库若为 `provider: git`，还需把团队仓库 `teamai.yaml` 中的值改为 `provider: gitlab`，才能创建 MR。详见 [GitLab 配置](docs/providers.md#gitlab-provider含自托管)。
-
 > **还没有团队仓库？** 可以从内置了成套 skills、rules、review agents 的模板起步。浏览 [teamai-hub](https://github.com/teamai-hub) org，点 **Use this template** 生成自己的仓库，再对它执行 `teamai init`。
 
 ### 团队成员
@@ -48,13 +46,13 @@ teamai init https://github.com/yourorg/yourrepo --scope user
 
 ## 产品架构
 
-**Team Execution × Team Context × Team Improvement**：
+**Team Execution × Team Context (beta) × Team Improvement (beta)**：
 
 | 层 | 要解决的问题 | 当前 CLI 中的体现 |
 |----|--------------|-------------------|
 | **Team Execution** | 让每个 Agent 按团队的方式工作 | `init` / `pull` / `push`，skills、rules、agents、hooks、MCP、env |
-| **Team Context** | 让每个 Agent 理解整个团队 | recall、learnings、代码知识图谱、teamwiki... |
-| **Team Improvement** | 让每一次执行都成为团队能力的积累 | 基于摩擦信号的经验分享、sessions、digest、dashboard... |
+| **Team Context** (beta) | 让每个 Agent 理解整个团队 | recall、learnings、代码知识图谱、teamwiki... |
+| **Team Improvement** (beta) | 让每一次执行都成为团队能力的积累 | 基于摩擦信号的经验分享、sessions、digest、dashboard... |
 
 ## 功能概览
 
@@ -63,8 +61,8 @@ teamai init https://github.com/yourorg/yourrepo --scope user
     <tr>
       <th rowspan="2">Agent</th>
       <th colspan="7">Team Execution</th>
-      <th colspan="3">Team Context</th>
-      <th colspan="3">Team Improvement</th>
+      <th colspan="3">Team Context (beta)</th>
+      <th colspan="3">Team Improvement (beta)</th>
     </tr>
     <tr>
       <th>skills</th><th>rules</th><th>docs</th><th>env</th><th>agents</th><th>hooks</th><th>mcp</th>
@@ -179,7 +177,7 @@ teamai packages    # 安装团队声明的全部包
 
 完整工作流和配置见[使用指南](docs/usage-guide.zh-CN.md#团队包)。
 
-## Team Context
+## Team Context (beta)
 
 > Every agent understands how the team works.
 
@@ -242,7 +240,7 @@ teamai codebase --lint --output /path/to/repo # 检查本地提取的图谱
 
 WASM 解析器是纯 JavaScript 依赖，无需任何原生编译工具链。若因任何原因加载失败，提取会降级到启发式轨并记录一条 `AST_UNAVAILABLE` gap。设置 `TEAMAI_SKIP_AST=1` 可强制仅使用启发式提取。
 
-## Team Improvement
+## Team Improvement (beta)
 
 > Every execution makes the entire team smarter.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -197,6 +197,16 @@ WASM 解析器是纯 JavaScript 依赖，无需任何原生编译工具链。若
 
 > Every execution makes the entire team smarter.
 
+### Maintenance
+
+随着 skills 和知识积累，可以把团队不再使用的内容清掉。`teamai recall maintenance` 会归档低置信度 learnings，并标出过时的 skills、rules 和 docs，供清理或更新：
+
+```bash
+teamai recall maintenance --prune --dry-run      # 预览
+teamai recall maintenance --prune --archive      # 归档无用 learnings
+teamai recall maintenance --update-quality       # 为过时 skills / docs 生成更新草稿
+```
+
 洞察团队实际如何使用 AI 工具，也是把 session 中的摩擦转化为共享 Skill、Rule 和知识的起点：
 
 | 能力 | 命令 | 呈现内容 |
@@ -205,7 +215,6 @@ WASM 解析器是纯 JavaScript 依赖，无需任何原生编译工具链。若
 | **会话（Sessions）** | `teamai session save` | 脱敏的单会话摘要（工具序列、对话轮次、干预次数），喂给周报的 Session Highlights。 |
 | **看板（Dashboard）** | `teamai dashboard` | Web 看板，实时展示成员的编码会话状态、干预次数和 token 用量。 |
 | **知识库健康（KB Health）** | `teamai dashboard` → KB Health | 内置于看板的报告页面，展示知识库使用情况与健康状态——各类型覆盖率、高频召回条目、沉默条目、召回趋势、作者贡献及维护控制台。 |
-| **维护（Maintenance）** | `teamai recall maintenance` | 清理低置信度 learnings，并识别待清理或更新的过时 skills、rules 和 docs。 |
 
 ## 命令一览
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -120,7 +120,7 @@ teamai push → 创建分支 + MR → reviewer 审批合并
 | **Rules** | `rules/*.md` | |
 | **Docs** | `docs/` | 项目基础文档，默认不全量加载（渐进式披露） |
 | **Agents** | `agents/<name>.yaml` | |
-| **Culture** | `culture.md` | 注入到各 Agent 的 CLAUDE.md / AGENTS.md 中的一段文字 |
+| **Culture** | `culture.md` | 团队使命、价值观与协作准则——注入各 Agent 的 CLAUDE.md / AGENTS.md，成为每次会话的行事底色 |
 | **CLAUDE.md** | `claudemd/*.md` | |
 | **Env** | `env/` | 通用环境变量、团队级开关；不建议直接放密钥 |
 | **Hooks** | `hooks/hooks.yaml` | |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -112,7 +112,7 @@ teamai push → 创建分支 + MR → reviewer 审批合并
 
 ### 分发内容
 
-每类资源在团队仓库声明一次，随 `teamai pull` 分发：
+每类资源分发到每个 Agent：
 
 | 资源 | 团队仓库中的位置 | 命令 |
 |------|------------------|------|
@@ -120,10 +120,13 @@ teamai push → 创建分支 + MR → reviewer 审批合并
 | **Rules（规范）** | `rules/*.md` | `teamai push` / `pull` |
 | **Docs** | `docs/` | `teamai push` / `pull` |
 | **Agents** | `agents/<name>.yaml` | `teamai push` / `pull` |
+| **Culture（团队文化）** | `culture.md` | `teamai push` / `pull` |
+| **CLAUDE.md** | `claudemd/*.md` | `teamai push` / `pull` |
 | **Env** | `env/` | `teamai env` |
 | **Hooks** | `hooks/hooks.yaml` | `teamai hooks list \| inject \| remove` |
 | **MCP Server** | `mcp/mcp.yaml` | `teamai mcp list \| inject \| remove` |
 | **Packages** | `teamai.yaml` | `teamai packages` |
+| **Models（模型）** | — | session start 时由 local-agent 下发 |
 
 文件格式与完整工作流见[使用指南](docs/usage-guide.zh-CN.md)。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,6 +13,16 @@
 
 TeamAI 统一管理团队的 Skills、Rules、MCP 和知识，驾驭 Claude Code、Codex、CodeBuddy、WorkBuddy、OpenCode、Cursor 等 AI Agents。
 
+## 贡献者
+
+感谢每一位为 TeamAI 贡献代码的伙伴！
+
+<a href="https://github.com/Tencent/teamai-cli/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=Tencent/teamai-cli" alt="Contributors" />
+</a>
+
+由 [contrib.rocks](https://contrib.rocks) 生成。
+
 ## 快速开始
 
 ### 安装
@@ -252,13 +262,3 @@ teamai recall maintenance --update-quality       # 为过时 skills / docs 生�
 ## 贡献
 
 欢迎提交 PR！请先阅读 [CONTRIBUTING.md](.github/CONTRIBUTING.md)。
-
-## 贡献者
-
-感谢每一位为 TeamAI 贡献代码的伙伴！
-
-<a href="https://github.com/Tencent/teamai-cli/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=Tencent/teamai-cli" alt="Contributors" />
-</a>
-
-由 [contrib.rocks](https://contrib.rocks) 生成。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -124,7 +124,7 @@ teamai push → 创建分支 + MR → reviewer 审批合并
 | **CLAUDE.md** | `claudemd/*.md` | |
 | **Env** | `env/` | 通用环境变量、团队级开关；不建议直接放密钥 |
 | **Hooks** | `hooks/hooks.yaml` | |
-| **MCP Server** | `mcp/mcp.yaml` | |
+| **MCP** | `mcp/mcp.yaml` | |
 | **Packages** | `teamai.yaml` | 目前只支持 npm 包和 Claude 插件 |
 | **Models** | — | 暂时没有对全部 provider 实现 |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -122,7 +122,7 @@ teamai push → 创建分支 + MR → reviewer 审批合并
 | **Agents** | `agents/<name>.yaml` | |
 | **Culture** | `culture.md` | 注入到各 Agent 的 CLAUDE.md / AGENTS.md 中的一段文字 |
 | **CLAUDE.md** | `claudemd/*.md` | |
-| **Env** | `env/` | |
+| **Env** | `env/` | 通用环境变量、团队级开关；不建议直接放密钥 |
 | **Hooks** | `hooks/hooks.yaml` | |
 | **MCP Server** | `mcp/mcp.yaml` | |
 | **Packages** | `teamai.yaml` | 目前只支持 npm 包和 Claude 插件 |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -110,102 +110,22 @@ teamai push → 创建分支 + MR → reviewer 审批合并
            SessionStart hook → teamai pull → 同步到本地 AI 工具
 ```
 
-### 团队 Skills
+### 分发内容
 
-Skill 是带 `SKILL.md` 的目录。`teamai push` 开 MR，合并后 `teamai pull` 分发到每个 Agent。
+每类资源在团队仓库声明一次，随 `teamai pull` 分发：
 
-```markdown
----
-name: deploy-helper
-description: 按团队方式部署服务
----
-# Deploy Helper
-1. 运行 `npm test`
-2. 运行 `./deploy.sh`
-```
+| 资源 | 团队仓库中的位置 | 命令 |
+|------|------------------|------|
+| **Skills** | `skills/<name>/SKILL.md` | `teamai push` / `pull`、`teamai skill exclude` |
+| **Rules（规范）** | `rules/*.md` | `teamai push` / `pull` |
+| **Docs** | `docs/` | `teamai push` / `pull` |
+| **Agents** | `agents/<name>.yaml` | `teamai push` / `pull` |
+| **Env** | `env/` | `teamai env` |
+| **Hooks** | `hooks/hooks.yaml` | `teamai hooks list \| inject \| remove` |
+| **MCP Server** | `mcp/mcp.yaml` | `teamai mcp list \| inject \| remove` |
+| **Packages** | `teamai.yaml` | `teamai packages` |
 
-```bash
-teamai push
-```
-
-### 团队规范
-
-Markdown 规范，注入到各 Agent 的 rules。同样走 push → 评审 → pull。
-
-```markdown
-# 代码审查
-- 函数需要 JSDoc
-- 禁止 `any`
-```
-
-```bash
-teamai push
-```
-
-### 团队 Hooks
-
-在 `hooks/hooks.yaml` 中声明自定义 hooks，`teamai pull` 自动分发到所有 AI 工具：
-
-```yaml
-hooks:
-  - id: block-secret
-    description: 提交前扫描密钥
-    event: PreToolUse
-    matcher: Bash
-    command: 'bash -lc "~/.teamai/team-scripts/scan-secret.sh" || true'
-    tools: [claude, cursor]
-```
-
-```bash
-teamai hooks list      # 查看生效的 hooks
-teamai hooks inject    # 重新注入到每个已安装的工具
-teamai hooks remove    # 移除所有 teamai 管理的 hooks
-```
-
-### 团队 MCP Server
-
-在 `mcp/mcp.yaml` 中声明一次，`teamai pull` 按各工具原生格式写入。密钥用 `${VAR}`。
-
-```yaml
-servers:
-  - name: gpu-analysis
-    transport: http            # stdio | http | sse
-    url: https://example.com/api/mcp
-    headers:
-      Authorization: Bearer ${GPU_ANALYSIS_TOKEN}
-```
-
-```bash
-teamai mcp list | inject | remove
-```
-
-### Skill 订阅源
-
-订阅额外的 skill 仓库——其他团队的公开仓库，或本团队内的公共/共享仓库：
-
-```bash
-teamai source add https://github.com/other-team/teamai-public.git --name other-team
-teamai source list
-teamai source browse other-team    # 浏览可用 skills
-teamai source remove other-team
-```
-
-添加/移除会立即在本机生效，订阅的 skills 会在下一次 `teamai pull` 时同步。需要将
-`teamai.yaml` 的改动分享给团队成员时，再运行 `teamai push`。
-
-### 团队包
-
-共享并一键恢复团队的 npm 包和 Claude Code 插件：
-
-```bash
-teamai packages install typescript
-teamai packages install typescript@5.9.2 --npm
-teamai packages install code-review@claude-plugins-official
-teamai push       # 分享团队声明
-teamai packages    # 安装团队声明的全部包
-```
-
-完整工作流和配置见[使用指南](docs/usage-guide.zh-CN.md#团队包)。
+文件格式与完整工作流见[使用指南](docs/usage-guide.zh-CN.md)。
 
 ## Team Context (beta)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -205,6 +205,7 @@ WASM 解析器是纯 JavaScript 依赖，无需任何原生编译工具链。若
 | **会话（Sessions）** | `teamai session save` | 脱敏的单会话摘要（工具序列、对话轮次、干预次数），喂给周报的 Session Highlights。 |
 | **看板（Dashboard）** | `teamai dashboard` | Web 看板，实时展示成员的编码会话状态、干预次数和 token 用量。 |
 | **知识库健康（KB Health）** | `teamai dashboard` → KB Health | 内置于看板的报告页面，展示知识库使用情况与健康状态——各类型覆盖率、高频召回条目、沉默条目、召回趋势、作者贡献及维护控制台。 |
+| **维护（Maintenance）** | `teamai recall maintenance` | 清理低置信度 learnings，并识别待清理或更新的过时 skills、rules 和 docs。 |
 
 ## 命令一览
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -110,6 +110,38 @@ teamai push → 创建分支 + MR → reviewer 审批合并
            SessionStart hook → teamai pull → 同步到本地 AI 工具
 ```
 
+### 团队 Skills
+
+Skill 是带 `SKILL.md` 的目录。`teamai push` 开 MR，合并后 `teamai pull` 分发到每个 Agent。
+
+```markdown
+---
+name: deploy-helper
+description: 按团队方式部署服务
+---
+# Deploy Helper
+1. 运行 `npm test`
+2. 运行 `./deploy.sh`
+```
+
+```bash
+teamai push
+```
+
+### 团队规范
+
+Markdown 规范，注入到各 Agent 的 rules。同样走 push → 评审 → pull。
+
+```markdown
+# 代码审查
+- 函数需要 JSDoc
+- 禁止 `any`
+```
+
+```bash
+teamai push
+```
+
 ### 团队 Hooks
 
 在 `hooks/hooks.yaml` 中声明自定义 hooks，`teamai pull` 自动分发到所有 AI 工具：


### PR DESCRIPTION
## Summary
- Keep the README short: drop self-hosted GitLab setup and the long push/pull path paragraph from Quick Start; details stay in `docs/providers.md` and the usage guide.
- Label Team Context and Team Improvement as `(beta)`.
- Replace the per-resource Team Execution sections with one table (skills, rules, docs, agents, culture, CLAUDE.md, env, hooks, MCP, packages, models), with notes only where they matter.
- Add a Maintenance section at the top of Team Improvement (`teamai recall maintenance`).
- Move Contributors above Quick Start. Contributing / License stay at the end.

## Test plan
- [ ] Open `README.md` and `README.zh-CN.md`: Quick Start has no `GITLAB_URL` / skill-path paragraph.
- [ ] Team Context / Team Improvement show `(beta)` in the architecture line, overview headers, and section headings.
- [ ] Team Execution table lists culture / CLAUDE.md / env / packages / models with the intended notes; MCP is named `MCP` in both languages.
- [ ] Maintenance is the first subsection under Team Improvement.
- [ ] Contributors avatars appear above Quick Start; License + Contributing remain at the bottom.
- [ ] GitLab setup is still in `docs/providers.md` and `docs/usage-guide*.md`.