### PR TITLE
docs: stop claiming GitHub push is hardcoded to master

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -43,7 +43,7 @@ See [docs/providers.md](../docs/providers.md) for how to add a new git provider.
 
 ## Making a Change
 
-1. Fork the repo and create a feature branch from `master`.
+1. Fork the repo and create a feature branch from `main`.
 2. Write tests for your change (we target 80%+ coverage).
 3. Run `npx vitest run` and `npx tsc --noEmit` — both must pass.
 4. Use conventional commits where possible: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -101,7 +101,7 @@ token 需要 `repo` 权限。`GH_TOKEN` 作为别名也会被识别。
 
 ### 默认分支
 
-GitHub 新仓库默认分支通常是 `main`。TeamAI 当前实现中 `push` 的目标分支硬编码为 `master`（历史遗留）。如果你的 GitHub 仓库使用 `main`，可以在仓库 **Settings → Branches** 中将默认分支改为 `master`，或等待后续版本支持可配置目标分支。
+GitHub 新仓库默认分支通常是 `main`。TeamAI 会跟随团队仓库的默认分支（`main` / `master` 均可），`push` 不再硬编码 `master`。使用 GitHub 默认的 `main` 即可，无需在仓库 Settings 里把默认分支改成 `master`。
 
 ## TGit Provider（腾讯工蜂）
 


### PR DESCRIPTION
## Summary

GitHub provider notes still said `teamai push` was hardcoded to `master` and told users to rename their GitHub default branch. CONTRIBUTING still said to branch from `master`. Both are stale: the CLI already resolves the team repo default branch (`origin/HEAD`, then `main`, then `master`, fallback `main`).

This PR updates those two docs only. Skill/culture examples that mention `master` as sample content are unchanged.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing behavior to change)
- [x] Documentation only
- [ ] Refactor / internal cleanup

## Test Plan

- [x] `git diff --check` — clean
- [x] Grep for the old claims (`硬编码为 \`master\``, `feature branch from \`master\``) — gone from `docs/providers.md` and `.github/CONTRIBUTING.md`
- [x] Confirmed `src/push.ts` still uses `getDefaultBranch()` and `src/utils/git.ts` documents origin/HEAD → main → master → `main`
- [ ] `npx tsc --noEmit` — not rerun (docs-only; no TypeScript change)
- [ ] `npx vitest run` — not rerun (docs-only; no test change)

## Related Issues

None. Docs hygiene after noticing the GitHub provider page still described the pre-`getDefaultBranch()` behavior.

## Notes for Reviewers

Left alone on purpose:

- usage-guide skill/culture samples ("Check that the current branch is master", "Direct pushes to master are prohibited")
- design-doc headers and CHANGELOG history
- CI trigger list `master` / `main` (still matches `.github/workflows/ci.yml`)