### PR TITLE
feat: add first-class ZCode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Once initialized, every AI session automatically pulls the latest skills / rules
     <tr><td>Hermes</td><td align="center">✓</td><td align="center">—</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">—</td><td align="center">—</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">—</td><td align="center">—</td></tr>
     <tr><td>DeepSeek Harness</td><td align="center">✓</td><td align="center">—</td><td align="center">✓</td><td align="center">—</td><td align="center">—</td><td align="center">—</td><td align="center">—</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">—</td><td align="center">—</td></tr>
     <tr><td>Qoder</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td></tr>
+    <tr><td>ZCode</td><td align="center">✓</td><td align="center">—</td><td align="center">✓</td><td align="center">—</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td></tr>
   </tbody>
 </table>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -91,6 +91,7 @@ teamai init https://github.com/yourorg/yourrepo --scope user
     <tr><td>Hermes</td><td align="center">✓</td><td align="center">—</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">—</td><td align="center">—</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">—</td><td align="center">—</td></tr>
     <tr><td>DeepSeek Harness</td><td align="center">✓</td><td align="center">—</td><td align="center">✓</td><td align="center">—</td><td align="center">—</td><td align="center">—</td><td align="center">—</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">—</td><td align="center">—</td><td align="center">—</td></tr>
     <tr><td>Qoder</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td></tr>
+    <tr><td>ZCode</td><td align="center">✓</td><td align="center">—</td><td align="center">✓</td><td align="center">—</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td><td align="center">✓</td></tr>
   </tbody>
 </table>
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -1293,6 +1293,15 @@ team-repo/
 
 Qoder is available as a built-in target. TeamAI deploys skills, rules, and subagents to `.qoder/skills/`, `.qoder/rules/`, and `.qoder/agents/`. Hooks and MCP servers are merged into the scope-specific `.qoder/settings.json`, preserving unrelated user settings. The paths match Qoder's user and project configuration contracts.
 
+### ZCode
+
+ZCode is available as a built-in target. Skills deploy to `.zcode/skills/` (ZCode also reads the central `~/.agents/skills/`, which the `agents` entry covers), and subagents deploy as Claude-style Markdown to `.zcode/agents/`. Hooks are merged into the shared `~/.zcode/cli/config.json`, preserving unrelated keys such as plugin state. Two ZCode specifics the writer handles for you:
+
+- Config-file hooks are **disabled by default** in ZCode — TeamAI forces `hooks.enabled: true` so the entries it writes actually fire.
+- Hook entries use the `process` type (`bash -lc <dispatch>` as an argv vector) rather than a shell string, which sidesteps Windows PATH resolution landing on the WSL `bash.exe` instead of Git Bash.
+
+These paths are verified against the ZCode desktop app: profiles created in its Subagents settings page land in `~/.zcode/agents/*.md`, and files placed there (e.g. by TeamAI) show up in the page's installed list. MCP servers deploy to `~/.agents/mcp.json` (user scope, Claude `mcpServers` shape — the same file ZCode's own MCP settings page reads). Project scope is not wired: ZCode stores workspace MCP under a different key (`mcp.servers` inside `.zcode/config.json`), which the Claude writer cannot emit. ZCode has no user-level rules directory convention, so rules are not synced.
+
 ### JoyCode
 
 JoyCode is available as a built-in target. Skills, rules, and subagents are deployed to `.joycode/skills/`, `.joycode/rules/`, and `.joycode/agents/`. Rules use Cursor-compatible `.mdc` files, including the same derived frontmatter and body-only round-trip behavior described below. Subagents use Markdown with YAML frontmatter.

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -1270,6 +1270,15 @@ team-repo/
 
 Qoder 已作为内置目标支持。TeamAI 会将 Skills、Rules 和 Subagents 分别下发到 `.qoder/skills/`、`.qoder/rules/` 和 `.qoder/agents/`。Hooks 与 MCP Server 会合并进对应作用域的 `.qoder/settings.json`，并保留用户已有的其他设置；这些路径与 Qoder 的用户级和项目级配置约定一致。
 
+### ZCode
+
+ZCode 已作为内置目标支持。Skills 下发到 `.zcode/skills/`（ZCode 同时会读取中央目录 `~/.agents/skills/`，该目录由 `agents` 条目覆盖），Subagents 以 Claude 风格 Markdown 下发到 `.zcode/agents/`。Hooks 会合并进共享的 `~/.zcode/cli/config.json`，并保留插件状态等无关键值。写入器为你处理了两个 ZCode 特有的细节：
+
+- ZCode 的配置文件钩子**默认禁用**——TeamAI 会强制置 `hooks.enabled: true`，确保写入的条目真正生效。
+- 钩子条目使用 `process` 类型（`bash -lc <dispatch>` 以 argv 向量执行）而非 shell 字符串，规避 Windows 下 PATH 解析命中 WSL `bash.exe` 而非 Git Bash 的陷阱。
+
+以上路径已对照 ZCode 桌面端实测验证：设置页「新建子智能体」写入的就是 `~/.zcode/agents/*.md`，反向放入的文件也会出现在页面的已安装列表中。MCP Server 下发到 `~/.agents/mcp.json`（用户级，Claude 的 `mcpServers` 结构——正是 ZCode 自己的 MCP 设置页读取的文件）。项目级暂未接入：ZCode 的工作区 MCP 使用不同的键（`.zcode/config.json` 内的 `mcp.servers`），Claude 写入器无法生成该结构。ZCode 暂无用户级 Rules 目录约定，因此 Rules 不同步。
+
 ### JoyCode
 
 JoyCode 已作为内置目标支持。Skills、Rules 和 Subagents 分别下发到 `.joycode/skills/`、`.joycode/rules/` 和 `.joycode/agents/`。Rules 使用与 Cursor 兼容的 `.mdc` 格式，包括下文所述的派生 frontmatter 和仅正文往返同步；Subagents 使用带 YAML frontmatter 的 Markdown 文件。

--- a/src/__tests__/zcode.test.ts
+++ b/src/__tests__/zcode.test.ts
@@ -1,0 +1,134 @@
+import os from 'node:os';
+import path from 'node:path';
+import fse from 'fs-extra';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { builtinHookDefs } from '../builtin-hooks.js';
+import { KNOWN_AGENTS } from '../known-agents.js';
+import { getHookStatus, hasTeamaiHooks, reconcileHooks } from '../hooks.js';
+import { agentFileExtensionForTool, ALL_SUPPORTED_TOOLS } from '../resources/agent-format.js';
+import { detectMcpFormat } from '../resources/mcp-format.js';
+import { TeamaiConfigSchema } from '../types.js';
+
+describe('ZCode support', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('ships ZCode resource paths for user and project scopes', () => {
+    const config = TeamaiConfigSchema.parse({ team: 'test', repo: 'test/repo' });
+
+    expect(config.toolPaths.zcode).toEqual({
+      skills: '.zcode/skills',
+      agents: '.zcode/agents',
+      settings: '.zcode/cli/config.json',
+      mcp: '.agents/mcp.json',
+    });
+  });
+
+  it('registers ZCode for discovery and Claude-style resources', () => {
+    expect(KNOWN_AGENTS.find((agent) => agent.id === 'zcode')).toMatchObject({
+      displayName: 'ZCode',
+      skillsPath: '.zcode/skills',
+    });
+    expect(ALL_SUPPORTED_TOOLS).toContain('zcode');
+    expect(agentFileExtensionForTool('zcode')).toBe('.md');
+    expect(detectMcpFormat('zcode')).toBe('claude');
+  });
+
+  it('generates raw (unwrapped) dispatch commands for ZCode', () => {
+    const defs = builtinHookDefs('zcode');
+
+    expect(defs.length).toBeGreaterThan(0);
+    for (const def of defs) {
+      // Process-type entries get their shell wrapper added by the ZCode writer
+      // (bash + args), so the command itself must be wrapper-free.
+      expect(def.command.startsWith('teamai hook-dispatch ')).toBe(true);
+      expect(def.command).toContain('--tool zcode');
+      expect(def.command).not.toContain('bash -lc');
+      expect(def.timeout).toBeDefined();
+    }
+    const events = new Set(defs.map((d) => d.event));
+    expect(events).toEqual(new Set(['SessionStart', 'Stop', 'PostToolUse', 'UserPromptSubmit']));
+  });
+
+  it('injects hooks into ZCode config.json, forcing the runner enabled and preserving unrelated keys', async () => {
+    const home = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-zcode-test-'));
+    try {
+      const configPath = path.join(home, '.zcode', 'cli', 'config.json');
+      await fse.ensureDir(path.dirname(configPath));
+      await fse.writeJson(configPath, { plugins: { official: true }, unrelated: 'keep-me' });
+
+      await reconcileHooks(configPath, 'zcode');
+
+      const cfg = await fse.readJson(configPath);
+      expect(cfg.unrelated).toBe('keep-me');
+      expect(cfg.plugins).toEqual({ official: true });
+      expect(cfg.hooks.enabled).toBe(true);
+      const events = cfg.hooks.events as Record<string, Array<{ matcher?: string; hooks: Array<{ type: string; command: string; args?: string[]; timeoutMs?: number }> }>>;
+      expect(Object.keys(events).sort()).toEqual(
+        ['PostToolUse', 'SessionStart', 'Stop', 'UserPromptSubmit'].sort(),
+      );
+      for (const entries of Object.values(events)) {
+        for (const group of entries) {
+          // ZCode matchers are regexes: '*' would be an invalid pattern that
+          // never matches, so wildcard groups must omit the matcher entirely.
+          if (group.hooks[0].args?.[1]?.includes('--matcher')) {
+            expect(group.matcher).toBeDefined();
+          } else {
+            expect(group.matcher).toBeUndefined();
+          }
+          expect(group.hooks[0].type).toBe('process');
+          expect(group.hooks[0].command).toBe('bash');
+          expect(group.hooks[0].args?.[0]).toBe('-lc');
+          expect(group.hooks[0].args?.[1]).toContain('teamai hook-dispatch');
+          expect(group.hooks[0].args?.[1]).toContain('--tool zcode');
+          expect(group.hooks[0].timeoutMs).toBeGreaterThan(0);
+        }
+      }
+
+      expect(await getHookStatus(configPath, 'zcode')).toBe('installed');
+    } finally {
+      await fse.remove(home);
+    }
+  });
+
+  it('reconciles idempotently', async () => {
+    const home = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-zcode-test-'));
+    try {
+      const configPath = path.join(home, '.zcode', 'cli', 'config.json');
+      await fse.ensureDir(path.dirname(configPath));
+      await reconcileHooks(configPath, 'zcode');
+      const afterFirst = await fse.readFile(configPath, 'utf-8');
+
+      await reconcileHooks(configPath, 'zcode');
+      const afterSecond = await fse.readFile(configPath, 'utf-8');
+
+      expect(afterSecond).toBe(afterFirst);
+    } finally {
+      await fse.remove(home);
+    }
+  });
+
+  it('removeAll strips teamai entries but keeps the runner and unrelated keys', async () => {
+    const home = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-zcode-test-'));
+    try {
+      const configPath = path.join(home, '.zcode', 'cli', 'config.json');
+      await fse.ensureDir(path.dirname(configPath));
+      await fse.writeJson(configPath, { unrelated: 'keep-me' });
+
+      await reconcileHooks(configPath, 'zcode');
+      expect(await hasTeamaiHooks(configPath, 'zcode')).toBe(true);
+
+      await reconcileHooks(configPath, 'zcode', [], { removeAll: true });
+
+      const cfg = await fse.readJson(configPath);
+      expect(cfg.unrelated).toBe('keep-me');
+      expect(cfg.hooks.enabled).toBe(true);
+      for (const entries of Object.values(cfg.hooks.events) as Array<unknown[]>) {
+        expect(entries).toEqual([]);
+      }
+      expect(await hasTeamaiHooks(configPath, 'zcode')).toBe(false);
+      expect(await getHookStatus(configPath, 'zcode')).toBe('missing');
+    } finally {
+      await fse.remove(home);
+    }
+  });
+});

--- a/src/__tests__/zcode.test.ts
+++ b/src/__tests__/zcode.test.ts
@@ -190,4 +190,30 @@ describe('ZCode support', () => {
       await fse.remove(home);
     }
   });
+
+  it('removeAll preserves a user-disabled hooks.enabled while stripping entries', async () => {
+    const home = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-zcode-test-'));
+    try {
+      const configPath = path.join(home, '.zcode', 'cli', 'config.json');
+      await fse.ensureDir(path.dirname(configPath));
+
+      await reconcileHooks(configPath, 'zcode');
+      const disabled = await fse.readJson(configPath);
+      disabled.hooks.enabled = false;
+      await fse.writeJson(configPath, disabled);
+
+      await reconcileHooks(configPath, 'zcode', [], { removeAll: true });
+
+      const cfg = await fse.readJson(configPath);
+      // Removal strips the managed entries but must not flip the user's
+      // explicit runner choice back on.
+      expect(cfg.hooks.enabled).toBe(false);
+      for (const entries of Object.values(cfg.hooks.events) as Array<unknown[]>) {
+        expect(entries).toEqual([]);
+      }
+      expect(await hasTeamaiHooks(configPath, 'zcode')).toBe(false);
+    } finally {
+      await fse.remove(home);
+    }
+  });
 });

--- a/src/__tests__/zcode.test.ts
+++ b/src/__tests__/zcode.test.ts
@@ -7,7 +7,7 @@ import { KNOWN_AGENTS } from '../known-agents.js';
 import { getHookStatus, hasTeamaiHooks, reconcileHooks } from '../hooks.js';
 import { agentFileExtensionForTool, ALL_SUPPORTED_TOOLS } from '../resources/agent-format.js';
 import { detectMcpFormat } from '../resources/mcp-format.js';
-import { TeamaiConfigSchema } from '../types.js';
+import { HookDef, TeamaiConfigSchema } from '../types.js';
 
 describe('ZCode support', () => {
   afterEach(() => vi.unstubAllEnvs());
@@ -127,6 +127,65 @@ describe('ZCode support', () => {
       }
       expect(await hasTeamaiHooks(configPath, 'zcode')).toBe(false);
       expect(await getHookStatus(configPath, 'zcode')).toBe('missing');
+    } finally {
+      await fse.remove(home);
+    }
+  });
+
+  it('manages custom team hooks: single entry across reinjection, clean removal', async () => {
+    const home = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-zcode-test-'));
+    try {
+      const configPath = path.join(home, '.zcode', 'cli', 'config.json');
+      const manifestPath = path.join(home, 'managed-hooks.json');
+      const teamDefs: HookDef[] = [
+        {
+          source: 'team',
+          key: 'audit',
+          event: 'SessionStart',
+          command: 'sh /tmp/audit.sh',
+          description: '[teamai:hook:audit] audit',
+        },
+      ];
+      const countAudit = async () => {
+        const cfg = await fse.readJson(configPath);
+        const groups = cfg.hooks.events.SessionStart as Array<{ hooks: Array<{ args?: string[] }> }>;
+        return groups.filter((g) => g.hooks[0].args?.[1] === 'sh /tmp/audit.sh').length;
+      };
+
+      await reconcileHooks(configPath, 'zcode', teamDefs, { manifestPath });
+      expect(await countAudit()).toBe(1);
+
+      // Reinjection must recognize the stored entry via the manifest (its
+      // command carries no teamai marker) instead of appending a duplicate.
+      await reconcileHooks(configPath, 'zcode', teamDefs, { manifestPath });
+      expect(await countAudit()).toBe(1);
+
+      // Removal must strip the team entry, not just its manifest record.
+      await reconcileHooks(configPath, 'zcode', [], { removeAll: true, manifestPath });
+      expect(await countAudit()).toBe(0);
+      expect(await hasTeamaiHooks(configPath, 'zcode', manifestPath)).toBe(false);
+    } finally {
+      await fse.remove(home);
+    }
+  });
+
+  it('re-enables hooks.enabled when reinjecting an otherwise up-to-date disabled config', async () => {
+    const home = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-zcode-test-'));
+    try {
+      const configPath = path.join(home, '.zcode', 'cli', 'config.json');
+      await fse.ensureDir(path.dirname(configPath));
+
+      await reconcileHooks(configPath, 'zcode');
+      const disabled = await fse.readJson(configPath);
+      disabled.hooks.enabled = false;
+      await fse.writeJson(configPath, disabled);
+
+      await reconcileHooks(configPath, 'zcode');
+
+      const cfg = await fse.readJson(configPath);
+      expect(cfg.hooks.enabled).toBe(true);
+      expect(Object.keys(cfg.hooks.events).length).toBeGreaterThan(0);
+      expect(await getHookStatus(configPath, 'zcode')).toBe('installed');
     } finally {
       await fse.remove(home);
     }

--- a/src/builtin-hooks.ts
+++ b/src/builtin-hooks.ts
@@ -192,6 +192,17 @@ export function getDispatchCommand(event: string, tool: string, matcher?: string
 }
 
 /**
+ * Raw dispatch command without a shell wrapper. Used by ZCode, whose hook
+ * entries are `process`-typed (an executable plus an argv vector): the writer
+ * puts `bash -lc <raw>` into `args` itself, so the wrapper must not be baked
+ * into the command string.
+ */
+export function getRawDispatchCommand(event: string, tool: string, matcher?: string): string {
+  const matcherArg = matcher && matcher !== '*' ? ` --matcher ${matcher}` : '';
+  return `teamai hook-dispatch ${event} --tool ${tool}${matcherArg}`;
+}
+
+/**
  * Build a hook command that prepends `$HOME/.teamai/bin` to PATH so the
  * wrapper script is found even without the user's login shell PATH.
  * Used by GUI tools (WorkBuddy, CodeBuddy) that spawn hook subprocesses
@@ -241,8 +252,10 @@ const BUILTIN_HOOK_SPECS: BuiltinHookSpec[] = [
 const WRAPPER_TOOLS = SHELL_DEPENDENT_TOOLS;
 
 export function builtinHookDefs(tool: string): HookDef[] {
-  const withTimeout = tool === 'cursor' || tool === 'workbuddy' || tool === 'codebuddy';
-  const buildCommand = WRAPPER_TOOLS.has(tool) ? getWrapperDispatchCommand : getDispatchCommand;
+  const withTimeout = tool === 'cursor' || tool === 'workbuddy' || tool === 'codebuddy' || tool === 'zcode';
+  const buildCommand = tool === 'zcode'
+    ? getRawDispatchCommand
+    : WRAPPER_TOOLS.has(tool) ? getWrapperDispatchCommand : getDispatchCommand;
   return BUILTIN_HOOK_SPECS.map((spec) => ({
     source: 'builtin' as const,
     key: spec.key,

--- a/src/coauthor-reconcile.ts
+++ b/src/coauthor-reconcile.ts
@@ -93,6 +93,9 @@ async function resolveTargets(
   for (const [tool, paths] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
     if (disabled.has(tool)) continue;
     if (whitelist && !whitelist.includes(tool)) continue;
+    // ZCode exposes no documented attribution setting — writing one into its
+    // shared config.json would be an unknown key the tool never reads.
+    if (tool === 'zcode') continue;
     const family = familyOf(tool);
 
     // Installation probe: the tool's root dir (parent of its resource dir), same

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -306,20 +306,25 @@ function toZcodeEntry(def: HookDef): ZcodeHookMatcher {
   const entry: ZcodeHookEntry = {
     type: 'process',
     command: 'bash',
-    args: ['-lc', `${def.command} >/dev/null 2>&1 || true`],
+    // Stored verbatim: the shell payload must equal `def.command` exactly so
+    // managed-entry detection and the managed-hooks manifest share one command
+    // representation (the same invariant the Codex format keeps). teamai
+    // hook-dispatch is silent and failure-tolerant on its success paths, so no
+    // shell redirection is layered on top of the payload.
+    args: ['-lc', def.command],
     ...(def.timeout !== undefined ? { timeoutMs: def.timeout * 1000 } : {}),
   };
   const group: ZcodeHookMatcher = { hooks: [entry] };
   // ZCode's matcher is a case-sensitive regex on the match value; '*' is an
-  // invalid regex that would never match. Omitted matcher matches everything.
+  // invalid pattern that would never match. Omitted matcher matches everything.
   if (def.matcher && def.matcher !== '*') group.matcher = def.matcher;
   return group;
 }
 
-/** Command text of a ZCode hook entry, for teamai-marker matching. */
+/** Shell payload of a ZCode hook entry, for managed-entry matching. */
 function zcodeEntryCommand(entry: ZcodeHookMatcher): string {
   const hook = entry.hooks?.[0];
-  if (hook?.command === 'bash' && hook.args?.length) return hook.args.join(' ');
+  if (hook?.command === 'bash' && hook.args?.[0] === '-lc') return hook.args[1] ?? '';
   return hook?.command ?? '';
 }
 
@@ -536,10 +541,13 @@ async function reconcileZcodeFormat(
   await ensureDir(path.dirname(expanded));
   const cfg: ZcodeHooksJson = (await readJson<ZcodeHooksJson>(expanded)) ?? {};
   if (!cfg.hooks) cfg.hooks = {};
+  let changed = false;
   // Config-file hooks are disabled by default in ZCode; entries we write would
-  // never fire unless the runner is explicitly enabled.
-  if (!cfg.hooks.enabled) {
+  // never fire unless the runner is explicitly enabled. Persist the flip even
+  // when the event arrays are already up to date.
+  if (cfg.hooks.enabled !== true) {
     cfg.hooks.enabled = true;
+    changed = true;
   }
   if (!cfg.hooks.events) cfg.hooks.events = {};
 
@@ -556,7 +564,6 @@ async function reconcileZcodeFormat(
   const eventsMap = cfg.hooks.events;
   const events = [...eventOrder, ...Object.keys(eventsMap).filter((e) => !eventOrder.includes(e))];
 
-  let changed = false;
   for (const event of events) {
     const existing = eventsMap[event] ?? [];
     const untouched = existing.filter((e) => !isManaged(e));

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -544,8 +544,10 @@ async function reconcileZcodeFormat(
   let changed = false;
   // Config-file hooks are disabled by default in ZCode; entries we write would
   // never fire unless the runner is explicitly enabled. Persist the flip even
-  // when the event arrays are already up to date.
-  if (cfg.hooks.enabled !== true) {
+  // when the event arrays are already up to date — but only when installing.
+  // Removal must preserve the runner state the user chose: re-enabling during
+  // uninstall would switch hooks the user explicitly disabled back on.
+  if (!opts.removeAll && cfg.hooks.enabled !== true) {
     cfg.hooks.enabled = true;
     changed = true;
   }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -82,6 +82,35 @@ interface CodexHooksJson {
   [key: string]: unknown;
 }
 
+// ZCode (~/.zcode/cli/config.json): Claude-shaped hooks nested under
+// `hooks.events`, gated by `hooks.enabled` (config-file hooks are disabled by
+// default — the writer must force it on). The file is shared with ZCode's own
+// plugin state, so reconcile merges keys and never replaces the document.
+// Hook entries use the `process` type (argv vector, no shell): spawning the
+// bare string `bash -lc "..."` through ZCode's command-type shell is
+// unreliable on Windows, where PATH order can resolve `bash` to the WSL
+// launcher instead of Git Bash.
+interface ZcodeHookEntry {
+  type: string;
+  command: string;
+  args?: string[];
+  timeoutMs?: number;
+}
+
+interface ZcodeHookMatcher {
+  matcher?: string;
+  hooks: ZcodeHookEntry[];
+}
+
+interface ZcodeHooksJson {
+  hooks?: {
+    enabled?: boolean;
+    description?: string;
+    events?: Record<string, ZcodeHookMatcher[]>;
+  };
+  [key: string]: unknown;
+}
+
 // ─── Unified reconcile engine (issue #19) ───────────────────
 //
 //  A single engine injects BOTH built-in operational hooks (source: 'builtin',
@@ -96,14 +125,16 @@ interface CodexHooksJson {
 //  Reconcile is idempotent and only writes when content actually changes, so an
 //  upgraded CLI re-running over an already-injected file produces a zero-diff.
 
-type ToolFormat = 'claude' | 'cursor' | 'codex';
+type ToolFormat = 'claude' | 'cursor' | 'codex' | 'zcode';
 export type HookStatus = 'installed' | 'missing';
 
 const CURSOR_TOOLS = new Set(['cursor']);
 const CODEX_TOOLS = new Set(['codex', 'codex-internal', 'tcodex']);
+const ZCODE_TOOLS = new Set(['zcode']);
 
 function detectFormat(tool: string): ToolFormat {
   if (CODEX_TOOLS.has(tool)) return 'codex';
+  if (ZCODE_TOOLS.has(tool)) return 'zcode';
   return CURSOR_TOOLS.has(tool) ? 'cursor' : 'claude';
 }
 
@@ -269,6 +300,27 @@ function toCodexEntry(def: HookDef): CodexHookMatcher {
   };
   if (def.matcher && def.matcher !== '*') entry.matcher = def.matcher;
   return entry;
+}
+
+function toZcodeEntry(def: HookDef): ZcodeHookMatcher {
+  const entry: ZcodeHookEntry = {
+    type: 'process',
+    command: 'bash',
+    args: ['-lc', `${def.command} >/dev/null 2>&1 || true`],
+    ...(def.timeout !== undefined ? { timeoutMs: def.timeout * 1000 } : {}),
+  };
+  const group: ZcodeHookMatcher = { hooks: [entry] };
+  // ZCode's matcher is a case-sensitive regex on the match value; '*' is an
+  // invalid regex that would never match. Omitted matcher matches everything.
+  if (def.matcher && def.matcher !== '*') group.matcher = def.matcher;
+  return group;
+}
+
+/** Command text of a ZCode hook entry, for teamai-marker matching. */
+function zcodeEntryCommand(entry: ZcodeHookMatcher): string {
+  const hook = entry.hooks?.[0];
+  if (hook?.command === 'bash' && hook.args?.length) return hook.args.join(' ');
+  return hook?.command ?? '';
 }
 
 /** Ordered, de-duplicated list of events appearing in the desired defs. */
@@ -471,6 +523,59 @@ async function reconcileCodexFormat(
   }
 }
 
+// ─── ZCode (~/.zcode/cli/config.json) reconcile ─────────────
+
+async function reconcileZcodeFormat(
+  settingsPath: string,
+  tool: string,
+  teamDefs: HookDef[],
+  opts: ReconcileHooksOptions,
+  priorTeamCommands: Set<string>,
+): Promise<void> {
+  const expanded = expandHome(settingsPath);
+  await ensureDir(path.dirname(expanded));
+  const cfg: ZcodeHooksJson = (await readJson<ZcodeHooksJson>(expanded)) ?? {};
+  if (!cfg.hooks) cfg.hooks = {};
+  // Config-file hooks are disabled by default in ZCode; entries we write would
+  // never fire unless the runner is explicitly enabled.
+  if (!cfg.hooks.enabled) {
+    cfg.hooks.enabled = true;
+  }
+  if (!cfg.hooks.events) cfg.hooks.events = {};
+
+  // ZCode hook entries carry no description field, so managed-entry detection
+  // relies on the teamai command markers plus the managed-hooks manifest —
+  // same strategy as the Codex format.
+  const isManaged = (entry: ZcodeHookMatcher): boolean => {
+    const cmd = zcodeEntryCommand(entry);
+    return TEAMAI_COMMAND_MARKERS.some((marker) => cmd.includes(marker)) || priorTeamCommands.has(cmd);
+  };
+
+  const defs = opts.removeAll ? [] : desiredDefs(tool, teamDefs, opts.builtinOverride);
+  const eventOrder = desiredEventOrder(defs, (e) => e);
+  const eventsMap = cfg.hooks.events;
+  const events = [...eventOrder, ...Object.keys(eventsMap).filter((e) => !eventOrder.includes(e))];
+
+  let changed = false;
+  for (const event of events) {
+    const existing = eventsMap[event] ?? [];
+    const untouched = existing.filter((e) => !isManaged(e));
+    const desiredEntries = defs.filter((d) => d.event === event).map(toZcodeEntry);
+    const newArr = [...untouched, ...desiredEntries];
+    if (JSON.stringify(existing) !== JSON.stringify(newArr)) {
+      eventsMap[event] = newArr;
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    await writeJson(expanded, cfg);
+    log.success(`${opts.removeAll ? 'Removed' : 'Updated'} teamai hooks in ${settingsPath}`);
+  } else {
+    log.debug(`teamai hooks already up-to-date in ${settingsPath}`);
+  }
+}
+
 // ─── Agent hooks (HTTP-source, issue #238) ──────────────────
 
 /**
@@ -669,6 +774,8 @@ export async function reconcileHooks(
     await reconcileCursorFormat(settingsPath, tool, scopedDefs, opts, priorTeamCommands);
   } else if (format === 'codex') {
     await reconcileCodexFormat(settingsPath, tool, scopedDefs, opts, priorTeamCommands);
+  } else if (format === 'zcode') {
+    await reconcileZcodeFormat(settingsPath, tool, scopedDefs, opts, priorTeamCommands);
   } else {
     await reconcileClaudeFormat(settingsPath, tool, scopedDefs, {
       ...opts,
@@ -747,6 +854,19 @@ export async function getHookStatus(settingsPath: string, tool?: string): Promis
     return present ? 'installed' : 'missing';
   }
 
+  if (format === 'zcode') {
+    const cfg = await readJson<ZcodeHooksJson>(expanded);
+    const eventsMap = cfg?.hooks?.events;
+    if (!eventsMap) return 'missing';
+    const present = defs.every((def) => {
+      const want = toZcodeEntry(def);
+      const wantCmd = zcodeEntryCommand(want);
+      const entries = eventsMap[def.event] ?? [];
+      return entries.some((e) => e.matcher === want.matcher && zcodeEntryCommand(e) === wantCmd);
+    });
+    return present ? 'installed' : 'missing';
+  }
+
   const settings = await readJson<ClaudeSettingsJson>(expanded);
   if (!settings?.hooks) return 'missing';
   const present = defs.every((def) => {
@@ -793,6 +913,18 @@ export async function hasTeamaiHooks(
     return Object.values(j.hooks).some((entries) =>
       (entries ?? []).some((e) => {
         const cmd = e.hooks?.[0]?.command ?? '';
+        return TEAMAI_COMMAND_MARKERS.some((m) => cmd.includes(m)) || priorTeamCommands.has(cmd);
+      }),
+    );
+  }
+
+  if (format === 'zcode') {
+    const j = await readJson<ZcodeHooksJson>(expanded);
+    const eventsMap = j?.hooks?.events;
+    if (!eventsMap) return false;
+    return Object.values(eventsMap).some((entries) =>
+      (entries ?? []).some((e) => {
+        const cmd = zcodeEntryCommand(e);
         return TEAMAI_COMMAND_MARKERS.some((m) => cmd.includes(m)) || priorTeamCommands.has(cmd);
       }),
     );

--- a/src/known-agents.ts
+++ b/src/known-agents.ts
@@ -98,6 +98,7 @@ export const KNOWN_AGENTS: KnownAgent[] = [
   { id: 'trae', displayName: 'Trae', category: 'coding', skillsPath: '.trae/skills' },
   { id: 'trae-cn', displayName: 'Trae CN', category: 'coding', skillsPath: '.trae-cn/skills' },
   { id: 'windsurf', displayName: 'Windsurf', category: 'coding', skillsPath: '.windsurf/skills' },
+  { id: 'zcode', displayName: 'ZCode', category: 'coding', skillsPath: '.zcode/skills' },
 
   // Lobster family
   { id: 'openclaw', displayName: 'OpenClaw', category: 'lobster', skillsPath: '.openclaw/skills' },

--- a/src/resources/agent-format.ts
+++ b/src/resources/agent-format.ts
@@ -5,7 +5,7 @@ import { stringify as stringifyToml, parse as parseToml } from 'smol-toml';
 
 // ─── Tool name type ──────────────────────────────────────────────────────────
 
-export type ToolName = 'claude' | 'claude-internal' | 'tclaude' | 'codebuddy' | 'codex' | 'codex-internal' | 'tcodex' | 'cursor' | 'joycode' | 'qoder' | 'opencode';
+export type ToolName = 'claude' | 'claude-internal' | 'tclaude' | 'codebuddy' | 'codex' | 'codex-internal' | 'tcodex' | 'cursor' | 'joycode' | 'qoder' | 'zcode' | 'opencode';
 
 export const ALL_SUPPORTED_TOOLS: ToolName[] = [
   'claude',
@@ -18,6 +18,7 @@ export const ALL_SUPPORTED_TOOLS: ToolName[] = [
   'cursor',
   'joycode',
   'qoder',
+  'zcode',
   'opencode',
 ];
 
@@ -68,6 +69,7 @@ export interface AgentSpec {
     cursor?: Record<string, unknown>;
     joycode?: Record<string, unknown>;
     qoder?: Record<string, unknown>;
+    zcode?: Record<string, unknown>;
     opencode?: Record<string, unknown>;
   };
   /**
@@ -635,6 +637,7 @@ export function renderForTool(spec: AgentSpec, tool: ToolName): RenderResult {
     case 'cursor': return renderForCursor(spec);
     case 'joycode': return renderForJoycode(spec);
     case 'qoder': return renderForClaude(spec);
+    case 'zcode': return renderForClaude(spec);
     case 'opencode': return renderForOpencode(spec);
   }
 }

--- a/src/resources/agents.ts
+++ b/src/resources/agents.ts
@@ -585,6 +585,8 @@ function reverseByTool(tool: ToolName, filePath: string, content: string): Rever
       return reverseFromJoycode(filePath, content);
     case 'qoder':
       return reverseFromClaude(filePath, content);
+    case 'zcode':
+      return reverseFromClaude(filePath, content);
     case 'opencode':
       return reverseFromOpencode(filePath, content);
   }

--- a/src/resources/mcp-format.ts
+++ b/src/resources/mcp-format.ts
@@ -15,7 +15,7 @@ import type { McpServerDef, McpTransport } from '../types.js';
 
 export type McpFormat = 'claude' | 'cursor' | 'buddy' | 'codex' | 'opencode';
 
-const CLAUDE_TOOLS = new Set(['claude', 'claude-internal', 'tclaude', 'qoder']);
+const CLAUDE_TOOLS = new Set(['claude', 'claude-internal', 'tclaude', 'qoder', 'zcode']);
 const CURSOR_TOOLS = new Set(['cursor']);
 const CODEX_TOOLS = new Set(['codex', 'codex-internal', 'tcodex']);
 const BUDDY_TOOLS = new Set(['codebuddy', 'workbuddy']);

--- a/src/types.ts
+++ b/src/types.ts
@@ -271,6 +271,17 @@ export const TeamaiConfigSchema = z.object({
       mcp: '.qoder/settings.json',
       mcpProject: '.qoder/settings.json',
     },
+    // ZCode: user-level config lives at ~/.zcode/cli/config.json (a shared file
+    // that also carries plugin state — reconcile must merge, never replace).
+    // Hooks are Claude-shaped but nested under `hooks.events` and gated by
+    // `hooks.enabled` (config-file hooks are disabled by default; the writer
+    // must force it on). Subagents deploy to ~/.zcode/agents/ as Claude-style
+    // Markdown (the CLI also reads <project>/.zcode/agents/ per workspace).
+    // User-scope MCP mirrors Claude's shape (`mcpServers` key) in
+    // ~/.agents/mcp.json; project scope writes `mcp.servers` inside
+    // .zcode/config.json (a different key), which the Claude writer cannot
+    // emit — so no mcpProject. ZCode has no user-level rules dir convention.
+    zcode: { skills: '.zcode/skills', agents: '.zcode/agents', settings: '.zcode/cli/config.json', mcp: '.agents/mcp.json' },
     codebuddy: { skills: '.codebuddy/skills', rules: '.codebuddy/rules', settings: '.codebuddy/settings.json', claudemd: '.codebuddy/CODEBUDDY.md', agents: '.codebuddy/agents', mcp: '.codebuddy/mcp.json', mcpProject: '.codebuddy/mcp.json' },
     openclaw: { skills: '.openclaw/skills', rules: '.openclaw/rules', claudemd: '.openclaw/workspace/AGENTS.md' },
     hermes: { skills: '.hermes/skills', claudemd: 'AGENTS.md' },


### PR DESCRIPTION
## Summary

- add ZCode as a first-class TeamAI target: skills → `~/.zcode/skills/`, subagents (Claude-style Markdown) → `~/.zcode/agents/`, user-scope MCP → `~/.agents/mcp.json`, hooks → `~/.zcode/cli/config.json`
- add a dedicated `zcode` hook format: ZCode nests Claude-shaped hooks under `hooks.events` and gates them on `hooks.enabled` (config-file hooks are disabled by default, so the writer forces it on)
- write `process`-type hook entries (`bash -lc <dispatch>` as an argv vector) and omit wildcard matchers (ZCode matchers are case-sensitive regexes; `*` is an invalid pattern that never matches)
- exclude ZCode from co-author reconciliation (no documented attribution setting); rules are not synced (no user-level rules dir convention)
- document the integration in both English and Chinese

Closes #461.

## Why

ZCode was not discoverable as a tool id, so TeamAI could not deploy resources to it nor inject session hooks (no auto pull). Conventions verified against the ZCode desktop app (Windows): user skills live in `~/.zcode/skills` (central `~/.agents/skills` also read — covered by the existing `agents` entry), user subagents in `~/.zcode/agents/*.md` (edited by the desktop Subagents page), user MCP in `~/.agents/mcp.json` (`mcpServers` shape, read by the desktop MCP page), and hooks in the shared `~/.zcode/cli/config.json`.

## Validation

- `npx vitest run src/__tests__/zcode.test.ts` (6/6 passed)
- affected suites: agents / agent-format / coauthor-reconcile (97/97 passed)
- `npm run typecheck`, `npm run build`
- end-to-end `teamai hooks inject` against a sandbox HOME: unrelated config keys (plugin state) preserved, runner forced enabled, second run byte-identical
- dogfooded internally on a second machine: session-start auto pull, subagent deployment, and skill sync all verified against the ZCode desktop app (subagents page lists the deployed profile; hooks fire on session start)
- Windows note: hooks-related suites show identical pass/fail counts before and after this change (only pre-existing platform-sensitive failures, same category as noted in #420)

## Boundary

- no new runtime dependency or CLI command
- rules are not synced (ZCode has no user-level rules dir convention)
- project-scope MCP is not wired (ZCode stores workspace MCP under the `mcp.servers` key inside `.zcode/config.json`, which the Claude writer cannot emit)
- ZCode is excluded from co-author reconciliation

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing behavior to change)
- [ ] Documentation only
- [ ] Refactor / internal cleanup

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` passes (new zcode suite + affected suites green; pre-existing Windows-only failures unchanged, verified against a clean checkout)
- [x] Added/updated tests for the change

## Related Issues

Closes #461

## Notes for Reviewers

- `~/.zcode/cli/config.json` is shared with ZCode's own state (plugins etc.) — `reconcileZcodeFormat` merges the document and only ever touches `hooks.enabled` + `hooks.events.<Event>`.
- Managed-entry detection follows the Codex format's strategy (command markers + manifest) because ZCode hook groups carry no description field.
- Process entries resolve `bash` from PATH; on Windows a host whose PATH resolves the WSL `bash.exe` first would no-op — the same exposure as the existing `bash -lc` Claude commands, called out in the docs.
