### PR TITLE
fix(local-agent): don't override a user's shell-env Claude gateway on model sync

### DIFF
--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -1091,7 +1091,13 @@ already present in the reporter's workspace bindings. User-owned entries with th
 model ID are preserved. Claude
 gets an explicit profile at `~/.claude/teamai-models.json`
 and also receives the gateway environment in `~/.claude/settings.json` when it has no
-conflicting user-owned Anthropic gateway configuration. Unsupported agents acknowledge
+conflicting user-owned Anthropic gateway configuration. The conflict check inspects
+both `settings.json` `env` and the process's shell environment (`export ANTHROPIC_*`),
+so a user who runs Claude via shell env keeps their own gateway — TeamAI skips the write
+and logs the skipped keys to `~/.teamai/reporter/errors.jsonl`. Protected keys are
+`ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_API_KEY`,
+`ANTHROPIC_CUSTOM_HEADERS`, `ANTHROPIC_CUSTOM_MODEL_OPTION{,_NAME}`, and
+`ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL`. Unsupported agents acknowledge
 the task as failed instead of writing another agent's config. Symlinked user config
 files remain symlinks. These files are mode `0600`. A successful write is acknowledged with
 `type: "apply_model_config"`; malformed payloads are acknowledged as `failed`. Unknown

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -1097,7 +1097,10 @@ so a user who runs Claude via shell env keeps their own gateway — TeamAI skips
 and logs the skipped keys to `~/.teamai/reporter/errors.jsonl`. Protected keys are
 `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_API_KEY`,
 `ANTHROPIC_CUSTOM_HEADERS`, `ANTHROPIC_CUSTOM_MODEL_OPTION{,_NAME}`, and
-`ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL`. Unsupported agents acknowledge
+`ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL`. A shell value that matches what TeamAI
+last wrote (Claude re-injects `settings.json` `env` into the hook process) is recognized
+as managed, not a user conflict, so a managed gateway can still be updated or removed on
+later syncs. Unsupported agents acknowledge
 the task as failed instead of writing another agent's config. Symlinked user config
 files remain symlinks. These files are mode `0600`. A successful write is acknowledged with
 `type: "apply_model_config"`; malformed payloads are acknowledged as `failed`. Unknown

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -1076,7 +1076,8 @@ shell 环境变量（`export ANTHROPIC_*`），因此通过 shell 环境变量�
 TeamAI 跳过写入，并把跳过的 key 记入 `~/.teamai/reporter/errors.jsonl`。受保护的 key 包括
 `ANTHROPIC_BASE_URL`、`ANTHROPIC_AUTH_TOKEN`、`ANTHROPIC_API_KEY`、`ANTHROPIC_CUSTOM_HEADERS`、
 `ANTHROPIC_CUSTOM_MODEL_OPTION{,_NAME}` 以及 `ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL`。
-不支持的 agent 会回执失败，不会误写其他
+若某个 shell 值与 TeamAI 上次写入的值一致（Claude 会把 `settings.json` 的 `env` 回注到 hook 进程），
+则识别为托管值而非用户冲突，因此后续同步仍可更新或删除托管网关。不支持的 agent 会回执失败，不会误写其他
 agent 的配置。用户配置文件是符号链接时会保留链接。以上含凭证文件权限均为 `0600`。落盘成功后以
 `type: "apply_model_config"` 回执；非法 payload 回执 `failed`。未来未知任务类型会静默跳过，以保持协议向后兼容。
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -1070,8 +1070,13 @@ WorkBuddy 使用 `~/.workbuddy/models.json`；当前 `{ "models": [...] }` 和�
 `<workspace>/.codebuddy/models.json`，与产品内嵌模型加载器一致；该含凭证文件会被加入
 `<workspace>/.codebuddy/.gitignore`。仅当目标路径已存在于 reporter 的 workspace bindings 中时，
 才接受 workspace 级下发。若同一模型 ID 已由用户配置，则保留用户条目。
-Claude 侧会生成独立配置 `~/.claude/teamai-models.json`；仅当 `~/.claude/settings.json` 中不存在冲突的用户
-Anthropic 网关配置时，才把网关环境变量写入默认 settings。不支持的 agent 会回执失败，不会误写其他
+Claude 侧会生成独立配置 `~/.claude/teamai-models.json`；仅当不存在冲突的用户 Anthropic 网关配置时，
+才把网关环境变量写入默认 settings。冲突检测会**同时**检查 `~/.claude/settings.json` 的 `env` 和当前进程的
+shell 环境变量（`export ANTHROPIC_*`），因此通过 shell 环境变量使用 Claude 的用户会保留自己的网关——
+TeamAI 跳过写入，并把跳过的 key 记入 `~/.teamai/reporter/errors.jsonl`。受保护的 key 包括
+`ANTHROPIC_BASE_URL`、`ANTHROPIC_AUTH_TOKEN`、`ANTHROPIC_API_KEY`、`ANTHROPIC_CUSTOM_HEADERS`、
+`ANTHROPIC_CUSTOM_MODEL_OPTION{,_NAME}` 以及 `ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL`。
+不支持的 agent 会回执失败，不会误写其他
 agent 的配置。用户配置文件是符号链接时会保留链接。以上含凭证文件权限均为 `0600`。落盘成功后以
 `type: "apply_model_config"` 回执；非法 payload 回执 `failed`。未来未知任务类型会静默跳过，以保持协议向后兼容。
 

--- a/src/__tests__/local-agent-model-config.test.ts
+++ b/src/__tests__/local-agent-model-config.test.ts
@@ -17,10 +17,31 @@ vi.mock('../utils/logger.js', () => ({
 let home: string;
 let originalHome: string | undefined;
 
+// The Claude gateway guard treats any user-set ANTHROPIC_* shell var as
+// user-owned config and skips the write. Clear them so a runner's own shell
+// env (a common setup for Claude power users) can't turn these tests flaky.
+const GUARDED_ENV_KEYS = [
+  'ANTHROPIC_BASE_URL',
+  'ANTHROPIC_AUTH_TOKEN',
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_CUSTOM_HEADERS',
+  'ANTHROPIC_CUSTOM_MODEL_OPTION',
+  'ANTHROPIC_CUSTOM_MODEL_OPTION_NAME',
+  'ANTHROPIC_DEFAULT_OPUS_MODEL',
+  'ANTHROPIC_DEFAULT_SONNET_MODEL',
+  'ANTHROPIC_DEFAULT_HAIKU_MODEL',
+];
+let originalGuardedEnv: Record<string, string | undefined>;
+
 beforeEach(async () => {
   home = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-model-config-'));
   originalHome = process.env.HOME;
   process.env.HOME = home;
+  originalGuardedEnv = {};
+  for (const key of GUARDED_ENV_KEYS) {
+    originalGuardedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
   await fse.outputJson(path.join(home, '.teamai/local-agent/config.json'), {
     endpoint: 'https://clawpro.example.com',
     token: 'reporter-token',
@@ -32,6 +53,11 @@ beforeEach(async () => {
 
 afterEach(async () => {
   process.env.HOME = originalHome;
+  for (const key of GUARDED_ENV_KEYS) {
+    const value = originalGuardedEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
   vi.restoreAllMocks();
   await fse.remove(home);
 });
@@ -622,6 +648,50 @@ describe('local-agent: apply_model_config', () => {
     await reportAndSyncLocalAgent({ tool: 'claude', status: 'running' });
 
     expect((await fse.readJson(settingsPath)).env).toEqual(edited.env);
+  });
+
+  it('does not seize the Claude gateway when the user configures it via shell env', async () => {
+    process.env.ANTHROPIC_BASE_URL = 'https://api.model.haihub.cn';
+    process.env.ANTHROPIC_AUTH_TOKEN = 'sk-user-shell-token';
+    const acks = stubSync({
+      id: 32,
+      type: 'apply_model_config',
+      cmd: JSON.stringify(deliveredModel),
+    });
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ tool: 'claude', status: 'running' });
+
+    // The gateway is user-owned via the shell, so settings.json is left alone.
+    expect(await fse.pathExists(path.join(home, '.claude/settings.json'))).toBe(false);
+    expect(await fse.pathExists(path.join(home, '.claude/teamai-models.json'))).toBe(true);
+    expect(acks[0]?.status).toBe('success');
+
+    const errorLog = await fse.readFile(
+      path.join(home, '.teamai/reporter/errors.jsonl'),
+      'utf-8',
+    );
+    expect(errorLog).toContain('skipped claude gateway');
+    expect(errorLog).toContain('ANTHROPIC_BASE_URL');
+  });
+
+  it('does not seize the Claude gateway when the user pins a default model via shell env', async () => {
+    process.env.ANTHROPIC_DEFAULT_OPUS_MODEL = 'claude-opus-4-8';
+    stubSync({
+      id: 33,
+      type: 'apply_model_config',
+      cmd: JSON.stringify(deliveredModel),
+    });
+
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    await reportAndSyncLocalAgent({ tool: 'claude', status: 'running' });
+
+    expect(await fse.pathExists(path.join(home, '.claude/settings.json'))).toBe(false);
+    const errorLog = await fse.readFile(
+      path.join(home, '.teamai/reporter/errors.jsonl'),
+      'utf-8',
+    );
+    expect(errorLog).toContain('ANTHROPIC_DEFAULT_OPUS_MODEL');
   });
 });
 

--- a/src/__tests__/local-agent-model-config.test.ts
+++ b/src/__tests__/local-agent-model-config.test.ts
@@ -693,6 +693,64 @@ describe('local-agent: apply_model_config', () => {
     );
     expect(errorLog).toContain('ANTHROPIC_DEFAULT_OPUS_MODEL');
   });
+
+  // Regression: Claude injects settings.json.env into the hook's own process
+  // environment, so a managed value we wrote last sync reappears in process.env.
+  // The guard must recognise its own re-injected value and NOT treat it as a
+  // user conflict — otherwise every follow-up sync is skipped and the managed
+  // record is wiped, stranding the user on stale gateway/token forever.
+  it('updates a managed gateway even when settings.json.env is re-injected into the hook env', async () => {
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    const settingsPath = path.join(home, '.claude', 'settings.json');
+
+    // First delivery, clean env: seeds the managed gateway.
+    stubSync({ id: 40, type: 'apply_model_config', cmd: JSON.stringify(deliveredModel) });
+    await reportAndSyncLocalAgent({ tool: 'claude', status: 'running' });
+    expect((await fse.readJson(settingsPath)).env.ANTHROPIC_BASE_URL).toBe('https://proxy.example.com');
+
+    // Simulate Claude re-injecting the just-written settings.json.env into the
+    // hook subprocess before the next sync.
+    const written = (await fse.readJson(settingsPath)).env as Record<string, string>;
+    for (const [key, value] of Object.entries(written)) process.env[key] = value;
+
+    // Second delivery: a NEW gateway must go through despite the re-injection.
+    const newModel = {
+      ...deliveredModel,
+      model_id: 'kimi-k2',
+      name: 'Kimi K2',
+      base_url: 'https://new-proxy.example.com/v1',
+      api_key: 'new-proxy-token',
+    };
+    const acks = stubSync({ id: 41, type: 'apply_model_config', cmd: JSON.stringify(newModel) });
+    await reportAndSyncLocalAgent({ tool: 'claude', status: 'running' });
+
+    const after = await fse.readJson(settingsPath);
+    expect(after.env.ANTHROPIC_BASE_URL).toBe('https://new-proxy.example.com');
+    expect(after.env.ANTHROPIC_AUTH_TOKEN).toBe('new-proxy-token');
+    expect(acks[0]?.status).toBe('success');
+
+    // Managed record must survive so future syncs can keep reconciling.
+    const manifest = await fse.readJson(path.join(home, '.teamai/local-agent/model-manifest.json'));
+    expect(Object.keys(manifest.claudeEnv ?? {}).length).toBeGreaterThan(0);
+  });
+
+  it('removes a managed gateway on empty delivery even when it is re-injected into the hook env', async () => {
+    const { reportAndSyncLocalAgent } = await import('../local-agent.js');
+    const settingsPath = path.join(home, '.claude', 'settings.json');
+
+    stubSync({ id: 42, type: 'apply_model_config', cmd: JSON.stringify(deliveredModel) });
+    await reportAndSyncLocalAgent({ tool: 'claude', status: 'running' });
+
+    const written = (await fse.readJson(settingsPath)).env as Record<string, string>;
+    for (const [key, value] of Object.entries(written)) process.env[key] = value;
+
+    stubSync({ id: 43, type: 'apply_model_config', cmd: JSON.stringify({ models: [] }) });
+    await reportAndSyncLocalAgent({ tool: 'claude', status: 'running' });
+
+    const after = await fse.readJson(settingsPath);
+    expect(after.env.ANTHROPIC_BASE_URL).toBeUndefined();
+    expect(after.env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+  });
 });
 
 describe('local-agent: report local model inventory', () => {

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -2401,15 +2401,46 @@ async function reconcileClaudeModels(
   const desired = claudeEnvForModel(models[0]);
   await writeModelJson(profilePath, { env: desired });
 
+  // Any of these keys, if the user already set them, means they have their own
+  // Claude gateway/model config we must not silently take over. Beyond the keys
+  // we write, this also covers auth the gateway swap would break
+  // (ANTHROPIC_API_KEY, ANTHROPIC_CUSTOM_HEADERS) and the user's model choice
+  // (ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL).
   const conflictKeys = new Set([
     ...Object.keys(desired),
     'ANTHROPIC_API_KEY',
+    'ANTHROPIC_CUSTOM_HEADERS',
+    'ANTHROPIC_DEFAULT_OPUS_MODEL',
+    'ANTHROPIC_DEFAULT_SONNET_MODEL',
+    'ANTHROPIC_DEFAULT_HAIKU_MODEL',
   ]);
+  // The guard must see config the user set outside settings.json too. Users who
+  // run Claude via shell `export ANTHROPIC_*` keep no gateway in settings.json,
+  // so a settings-only check reads env[key] === undefined and wrongly seizes the
+  // slot — settings.json then outranks the shell env and breaks their setup.
+  // TeamAI never exports to the shell, so a non-empty process.env value for a
+  // conflict key is always the user's own and can never be reconciled away.
+  const conflictInProcessEnv = (key: string): boolean => {
+    const value = process.env[key];
+    return typeof value === 'string' && value.trim() !== '';
+  };
   const canManage = [...conflictKeys].every((key) => (
-    env[key] === undefined ||
-    (previousHashes[key] !== undefined && entryHash(env[key]) === previousHashes[key])
+    !conflictInProcessEnv(key) && (
+      env[key] === undefined ||
+      (previousHashes[key] !== undefined && entryHash(env[key]) === previousHashes[key])
+    )
   ));
   if (!canManage) {
+    const conflicts = [...conflictKeys].filter(
+      (key) => conflictInProcessEnv(key) || (
+        env[key] !== undefined &&
+        !(previousHashes[key] !== undefined && entryHash(env[key]) === previousHashes[key])
+      ),
+    );
+    await appendErrorLog({
+      apply_model_config: 'skipped claude gateway: user owns conflicting config',
+      conflicts,
+    });
     manifest.claudeEnv = {};
     return;
   }

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -2414,33 +2414,44 @@ async function reconcileClaudeModels(
     'ANTHROPIC_DEFAULT_SONNET_MODEL',
     'ANTHROPIC_DEFAULT_HAIKU_MODEL',
   ]);
+  // A value is TeamAI-managed if it matches what we recorded last time or the
+  // value currently in settings.json (settings.json is our own output, so a
+  // process.env var equal to it is Claude re-injecting settings.json.env into
+  // the hook, not a user's independent shell config).
+  const isManagedValue = (key: string, value: unknown): boolean => (
+    (previousHashes[key] !== undefined && entryHash(value) === previousHashes[key]) ||
+    (env[key] !== undefined && entryHash(value) === entryHash(env[key]))
+  );
   // The guard must see config the user set outside settings.json too. Users who
   // run Claude via shell `export ANTHROPIC_*` keep no gateway in settings.json,
   // so a settings-only check reads env[key] === undefined and wrongly seizes the
   // slot — settings.json then outranks the shell env and breaks their setup.
-  // TeamAI never exports to the shell, so a non-empty process.env value for a
-  // conflict key is always the user's own and can never be reconciled away.
-  const conflictInProcessEnv = (key: string): boolean => {
+  // But Claude injects settings.json.env into the hook's own environment, so we
+  // must NOT treat our own re-injected managed values as a user conflict — doing
+  // so would block every follow-up sync and strand the user on stale config.
+  const userOwnsInShell = (key: string): boolean => {
     const value = process.env[key];
-    return typeof value === 'string' && value.trim() !== '';
+    if (typeof value !== 'string' || value.trim() === '') return false;
+    return !isManagedValue(key, value);
   };
+  const shellConflicts = [...conflictKeys].filter(userOwnsInShell);
+  if (shellConflicts.length > 0) {
+    // The user has their own gateway/model config in the shell. Skip the write,
+    // but keep manifest.claudeEnv intact: this is not the user editing our
+    // managed settings.json entry, so we must stay able to reconcile once the
+    // shell config goes away.
+    await appendErrorLog({
+      apply_model_config: 'skipped claude gateway: user owns conflicting shell env',
+      conflicts: shellConflicts,
+    });
+    return;
+  }
+
   const canManage = [...conflictKeys].every((key) => (
-    !conflictInProcessEnv(key) && (
-      env[key] === undefined ||
-      (previousHashes[key] !== undefined && entryHash(env[key]) === previousHashes[key])
-    )
+    env[key] === undefined ||
+    (previousHashes[key] !== undefined && entryHash(env[key]) === previousHashes[key])
   ));
   if (!canManage) {
-    const conflicts = [...conflictKeys].filter(
-      (key) => conflictInProcessEnv(key) || (
-        env[key] !== undefined &&
-        !(previousHashes[key] !== undefined && entryHash(env[key]) === previousHashes[key])
-      ),
-    );
-    await appendErrorLog({
-      apply_model_config: 'skipped claude gateway: user owns conflicting config',
-      conflicts,
-    });
     manifest.claudeEnv = {};
     return;
   }


### PR DESCRIPTION
## Problem

Users reported that Claude stopped working after a ClawPro sync: their local
model/gateway was overridden and the delivered enterprise gateway either failed
to connect or showed a model name that didn't match what they were using.

Root cause is in `reconcileClaudeModels` (`apply_model_config`). The conflict
guard only inspected `~/.claude/settings.json`'s `env`:

```ts
env[key] === undefined || (previousHashes[key] !== undefined && entryHash(env[key]) === previousHashes[key])
```

A large group of Claude power users configure the gateway **entirely via shell
env** (`export ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN / ANTHROPIC_CUSTOM_HEADERS`
and pin models via `ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL`). They keep **no
gateway in `settings.json`**, so the guard read `env[key] === undefined`, decided
the slot was free, and wrote the enterprise gateway into `settings.json`. Since
`settings.json.env` outranks the shell env in Claude Code, the user's working
gateway was silently overridden — and because `ANTHROPIC_CUSTOM_HEADERS` was
never managed, auth broke outright. These users (often `--dangerously-skip-permissions`)
are exactly the ones hit.

## Fix

- **Guard also inspects `process.env`.** TeamAI never exports to the shell, so any
  non-empty `ANTHROPIC_*` shell value is unambiguously user-owned and is never
  reconciled away — the write is skipped.
- **Widen the conflict key set** to include auth the gateway swap would break
  (`ANTHROPIC_CUSTOM_HEADERS`) and the user's model choice
  (`ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL`).
- **Log skipped keys** to `~/.teamai/reporter/errors.jsonl` so the skip is diagnosable.
- Test env is isolated from the runner's own `ANTHROPIC_*` shell vars for determinism.

No new CLI command/option; behavior-only change to an existing code path.

## Test Plan

All items actually executed on this branch after `npm run build`.

- [x] `npx tsc --noEmit` — clean.
- [x] `npx vitest run` — **206 files / 2915 tests passed**, no regressions.
- [x] `npx vitest run src/__tests__/local-agent-model-config.test.ts` — 36 passed,
      incl. 2 new cases (shell-env `ANTHROPIC_BASE_URL`; shell-env
      `ANTHROPIC_DEFAULT_OPUS_MODEL`).
- [x] **Real CLI E2E** reproducing the reported setup: a local mock ClawPro backend
      delivering a Claude `apply_model_config`, driven through the real
      `teamai hook-dispatch session-start --tool claude` binary from `dist/`, with
      the user's `export ANTHROPIC_BASE_URL=https://api.model.haihub.cn` +
      `ANTHROPIC_AUTH_TOKEN` + `ANTHROPIC_CUSTOM_HEADERS` + `ANTHROPIC_DEFAULT_OPUS_MODEL`
      in the environment.
      - Before this fix: `~/.claude/settings.json` would be written with the
        enterprise gateway.
      - After: `~/.claude/settings.json` is **not written** (user shell gateway
        preserved), and `reporter/errors.jsonl` records:
        ```json
        {"apply_model_config":"skipped claude gateway: user owns conflicting config",
         "conflicts":["ANTHROPIC_BASE_URL","ANTHROPIC_AUTH_TOKEN","ANTHROPIC_CUSTOM_HEADERS",
                      "ANTHROPIC_DEFAULT_OPUS_MODEL","ANTHROPIC_DEFAULT_SONNET_MODEL",
                      "ANTHROPIC_DEFAULT_HAIKU_MODEL"]}
        ```
- [x] Docs updated in both languages (`docs/usage-guide.md`, `docs/usage-guide.zh-CN.md`).
