### PR TITLE
fix(learnings): propagate user-scope deletions (#458)

### DIFF
--- a/src/__tests__/learnings-mirror.test.ts
+++ b/src/__tests__/learnings-mirror.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import fse from 'fs-extra';
+import { mirrorLearnings } from '../utils/learnings-mirror.js';
+import { buildIndex, loadIndex } from '../utils/search-index.js';
+
+describe('mirrorLearnings', () => {
+  let tmpDir: string;
+  let sourceDir: string;
+  let destinationDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-learnings-mirror-'));
+    sourceDir = path.join(tmpDir, 'repo-learnings');
+    destinationDir = path.join(tmpDir, 'local-learnings');
+
+    await fse.outputFile(path.join(sourceDir, 'shared-a.md'), '# shared a');
+    await fse.outputFile(path.join(sourceDir, 'shared-b.md'), '# shared b');
+    await fse.outputFile(path.join(sourceDir, 'alpha', 'keep.md'), '# alpha');
+    await fse.outputFile(path.join(sourceDir, 'beta', 'private.md'), '# beta');
+  });
+
+  afterEach(async () => {
+    await fse.remove(tmpDir);
+  });
+
+  it('copies shared learnings and active namespaces only', async () => {
+    await mirrorLearnings(sourceDir, destinationDir, ['alpha']);
+
+    expect(await fse.pathExists(path.join(destinationDir, 'shared-a.md'))).toBe(true);
+    expect(await fse.pathExists(path.join(destinationDir, 'shared-b.md'))).toBe(true);
+    expect(await fse.pathExists(path.join(destinationDir, 'alpha', 'keep.md'))).toBe(true);
+    expect(await fse.pathExists(path.join(destinationDir, 'beta'))).toBe(false);
+  });
+
+  it('removes deleted shared and active-namespace learnings before reindexing', async () => {
+    await mirrorLearnings(sourceDir, destinationDir, ['alpha']);
+    await fse.remove(path.join(sourceDir, 'shared-b.md'));
+    await fse.remove(path.join(sourceDir, 'alpha', 'keep.md'));
+
+    await mirrorLearnings(sourceDir, destinationDir, ['alpha']);
+
+    expect(await fse.pathExists(path.join(destinationDir, 'shared-b.md'))).toBe(false);
+    expect(await fse.pathExists(path.join(destinationDir, 'alpha', 'keep.md'))).toBe(false);
+
+    const indexPath = path.join(tmpDir, 'search-index.json');
+    await buildIndex({
+      learningsDir: destinationDir,
+      learningsNamespaces: ['alpha'],
+      indexPath,
+    });
+    const index = await loadIndex(indexPath);
+    expect(index?.entries.map((entry) => entry.filename)).toEqual(['shared-a.md']);
+  });
+
+  it('removes stale namespace directories while preserving unrelated root files', async () => {
+    await fse.outputFile(path.join(destinationDir, 'stale.md'), '# stale');
+    await fse.outputFile(path.join(destinationDir, 'old-project', 'note.md'), '# old');
+    await fse.outputFile(path.join(destinationDir, 'README.txt'), 'local metadata');
+
+    await mirrorLearnings(sourceDir, destinationDir, ['alpha']);
+
+    expect(await fse.pathExists(path.join(destinationDir, 'stale.md'))).toBe(false);
+    expect(await fse.pathExists(path.join(destinationDir, 'old-project'))).toBe(false);
+    expect(await fse.readFile(path.join(destinationDir, 'README.txt'), 'utf-8')).toBe('local metadata');
+  });
+});

--- a/src/__tests__/pull-learnings-deletion.test.ts
+++ b/src/__tests__/pull-learnings-deletion.test.ts
@@ -1,0 +1,121 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import fse from 'fs-extra';
+
+const testRoot = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-pull-learnings-delete-'));
+const originalHome = process.env.HOME;
+process.env.HOME = path.join(testRoot, 'home');
+
+vi.mock('../config.js', () => ({
+  requireInit: vi.fn(),
+  loadState: vi.fn().mockResolvedValue({ lastPull: null, lastPullRev: null }),
+  saveState: vi.fn(),
+  loadLocalConfigForScope: vi.fn(),
+  loadTeamConfig: vi.fn(),
+  detectProjectConfig: vi.fn().mockResolvedValue(null),
+  loadStateForScope: vi.fn().mockResolvedValue({ lastPull: null, lastPullRev: null }),
+  saveStateForScope: vi.fn(),
+}));
+
+vi.mock('../utils/git.js', () => ({
+  pullRepo: vi.fn().mockResolvedValue('already up to date'),
+  getHeadRev: vi.fn().mockResolvedValue('abc1234'),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  log: { info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), dim: vi.fn() },
+  spinner: vi.fn(() => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    warn: vi.fn().mockReturnThis(),
+    info: vi.fn().mockReturnThis(),
+    stop: vi.fn().mockReturnThis(),
+  })),
+}));
+
+vi.mock('../source.js', () => ({ pullSources: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../hooks.js', () => ({
+  injectHooksToAllTools: vi.fn().mockResolvedValue(undefined),
+  reconcileTeamHooksForConfig: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('../mcp-reconcile.js', () => ({
+  reconcileMcpForConfig: vi.fn().mockResolvedValue({ changes: [], wrote: false }),
+}));
+vi.mock('../team-push.js', () => ({ reportUsageToTeam: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../usage-tracker.js', () => ({
+  readUsageEvents: vi.fn().mockResolvedValue([]),
+  truncateUsageAfterReport: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../roles.js', () => ({
+  loadRolesManifest: vi.fn().mockResolvedValue({
+    version: 1,
+    roles: [],
+    defaults: { shareTarget: 'primary-role' },
+  }),
+  resolveRoleResourceNamespaces: vi.fn(() => ({ knowledge: [], skills: [], learnings: [] })),
+}));
+vi.mock('../update.js', () => ({
+  acquireLock: vi.fn().mockResolvedValue(true),
+  releaseLock: vi.fn().mockResolvedValue(undefined),
+}));
+
+const { pull } = await import('../pull.js');
+const { loadLocalConfigForScope, loadTeamConfig } = await import('../config.js');
+const { LEARNINGS_LOCAL_DIR, SEARCH_INDEX_PATH } = await import('../types.js');
+const { loadIndex } = await import('../utils/search-index.js');
+import type { LocalConfig, TeamaiConfig } from '../types.js';
+
+const repoPath = path.join(testRoot, 'team-repo');
+const localConfig: LocalConfig = {
+  repo: { localPath: repoPath, remote: 'https://example.test/team/repo.git' },
+  username: 'alice',
+  updatePolicy: 'auto',
+  additionalRoles: [],
+  scope: 'user',
+};
+const teamConfig: TeamaiConfig = {
+  team: 'test',
+  description: '',
+  repo: 'https://example.test/team/repo.git',
+  provider: 'git',
+  reviewers: [],
+  sharing: {
+    skills: {},
+    rules: { enforced: [] },
+    docs: { localDir: '' },
+    env: { injectShellProfile: false },
+  },
+  toolPaths: {},
+};
+
+describe('pull — user-scope learning deletion propagation (issue #458)', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await fse.remove(repoPath);
+    await fse.remove(LEARNINGS_LOCAL_DIR);
+    await fse.remove(SEARCH_INDEX_PATH);
+    await fse.outputFile(path.join(repoPath, 'learnings', 'shared-a.md'), '---\ntitle: shared a\n---\n');
+    await fse.outputFile(path.join(repoPath, 'learnings', 'shared-b.md'), '---\ntitle: shared b\n---\n');
+    vi.mocked(loadLocalConfigForScope).mockResolvedValue(localConfig);
+    vi.mocked(loadTeamConfig).mockResolvedValue(teamConfig);
+  });
+
+  afterAll(async () => {
+    process.env.HOME = originalHome;
+    await fse.remove(testRoot);
+  });
+
+  it('removes a shared Markdown file deleted upstream and drops it from the index', async () => {
+    await pull({ silent: true });
+    expect(await fse.pathExists(path.join(LEARNINGS_LOCAL_DIR, 'shared-b.md'))).toBe(true);
+
+    await fse.remove(path.join(repoPath, 'learnings', 'shared-b.md'));
+    await pull({ silent: true, force: true });
+
+    expect(await fse.pathExists(path.join(LEARNINGS_LOCAL_DIR, 'shared-b.md'))).toBe(false);
+    const index = await loadIndex(SEARCH_INDEX_PATH);
+    expect(index?.entries.map((entry) => entry.title)).toEqual(['shared a']);
+  });
+});

--- a/src/contribute.ts
+++ b/src/contribute.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import fse from 'fs-extra';
 import { requireInit, detectProjectConfig, loadTeamConfig, loadLocalConfigForScope } from './config.js';
 import { assertNotReadOnly } from './read-only.js';
 import { pushRepoDirectly, pullRepo } from './utils/git.js';
@@ -12,6 +11,7 @@ import { savePendingLearning } from './utils/pending-learnings.js';
 import { isSafeNamespaceSegment, resolveActiveLearningsNamespaces } from './projects.js';
 import type { GlobalOptions, LocalConfig } from './types.js';
 import { LEARNINGS_LOCAL_DIR, getDataHome } from './types.js';
+import { mirrorLearnings } from './utils/learnings-mirror.js';
 
 /**
  * Rebuild this scope's local search index so the freshly-written contribution
@@ -59,13 +59,12 @@ async function rebuildIndexAfterContribute(localConfig: LocalConfig): Promise<vo
   // user scope mirrors learnings/ into ~/.teamai/learnings/ (legacy behavior,
   // same as pull.ts); project scope indexes the repo's learnings/ directly.
   let effectiveLearningsDir: string | undefined;
+  const activeLearningsNamespaces = await resolveActiveLearningsNamespaces(
+    repoPath,
+    localConfig.projects ?? [],
+  );
   if (localConfig.scope === 'user') {
-    if (await pathExists(learningsRepoDir)) {
-      await fse.copy(learningsRepoDir, LEARNINGS_LOCAL_DIR, {
-        overwrite: true,
-        filter: (src: string) => !path.basename(src).startsWith('.'),
-      });
-    }
+    await mirrorLearnings(learningsRepoDir, LEARNINGS_LOCAL_DIR, activeLearningsNamespaces);
     effectiveLearningsDir = (await pathExists(LEARNINGS_LOCAL_DIR)) ? LEARNINGS_LOCAL_DIR : undefined;
   } else {
     effectiveLearningsDir = (await pathExists(learningsRepoDir)) ? learningsRepoDir : undefined;
@@ -78,7 +77,7 @@ async function rebuildIndexAfterContribute(localConfig: LocalConfig): Promise<vo
     learningsDir: effectiveLearningsDir,
     // Manifest-resolved namespaces — MUST match what pull indexes by, or a
     // contribute-time rebuild drops the project's other learnings from recall.
-    learningsNamespaces: await resolveActiveLearningsNamespaces(repoPath, localConfig.projects ?? []),
+    learningsNamespaces: activeLearningsNamespaces,
     docsDir: (await pathExists(docsRepoDir)) ? docsRepoDir : undefined,
     rulesDir: (await pathExists(rulesRepoDir)) ? rulesRepoDir : undefined,
     skillsDir: (await pathExists(skillsRepoDir)) ? skillsRepoDir : undefined,
@@ -305,10 +304,11 @@ async function contributeSelf(
       try {
         const { pathExists } = await import('./utils/fs.js');
         const wtLearnings = path.join(wtRepo, 'learnings');
-        await fse.copy(wtLearnings, LEARNINGS_LOCAL_DIR, {
-          overwrite: true,
-          filter: (src: string) => !path.basename(src).startsWith('.'),
-        });
+        const activeLearningsNamespaces = await resolveActiveLearningsNamespaces(
+          localConfig.repo.localPath,
+          localConfig.projects ?? [],
+        );
+        await mirrorLearnings(wtLearnings, LEARNINGS_LOCAL_DIR, activeLearningsNamespaces);
 
         const repoPath = localConfig.repo.localPath; // persistent active-tree .teamai
         const docsDir = path.join(repoPath, 'docs');
@@ -327,7 +327,7 @@ async function contributeSelf(
         const { buildIndex } = await import('./utils/search-index.js');
         await buildIndex({
           learningsDir: await pathExists(LEARNINGS_LOCAL_DIR) ? LEARNINGS_LOCAL_DIR : undefined,
-          learningsNamespaces: await resolveActiveLearningsNamespaces(repoPath, localConfig.projects ?? []),
+          learningsNamespaces: activeLearningsNamespaces,
           docsDir: await pathExists(docsDir) ? docsDir : undefined,
           rulesDir: await pathExists(rulesDir) ? rulesDir : undefined,
           skillsDir: await pathExists(skillsDir) ? skillsDir : undefined,

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -1,5 +1,4 @@
 import path from 'node:path';
-import fse from 'fs-extra';
 import matter from 'gray-matter';
 import { requireInit, loadState, saveState, detectProjectConfig, loadLocalConfigForScope, loadTeamConfig, loadStateForScope, saveStateForScope } from './config.js';
 import { pullRepo, getHeadRev } from './utils/git.js';
@@ -35,6 +34,7 @@ import { loadRolesManifest, resolveRoleResourceNamespaces, type ResourceNamespac
 import { loadProjectsManifest, resolveProjectResourceNamespaces, mergeNamespaces } from './projects.js';
 import { getUserHome } from './utils/home.js';
 import { acquireLock, releaseLock } from './update.js';
+import { mirrorLearnings } from './utils/learnings-mirror.js';
 
 interface RolePullContext {
   activeNamespaces: ResourceNamespaces;
@@ -850,25 +850,6 @@ async function pullForScope(
       // select them. `activeLearningsNamespaces` is the set from role∪project
       // resolution (roles contribute none, so effectively the project set).
       const activeLearningsNamespaces = roleContext?.activeNamespaces.learnings ?? [];
-      const activeLearningsSet = new Set(activeLearningsNamespaces);
-      // Filter for fse.copy: keep the root and any file/dir whose top-level
-      // segment (relative to learningsRepoDir) is either a root-level .md (shared)
-      // or an active-project subdirectory. Everything else (inactive project dirs)
-      // is excluded so no other project's private learnings land on this machine.
-      const learningsCopyFilter = (src: string): boolean => {
-        if (path.basename(src).startsWith('.')) return false;
-        const rel = path.relative(learningsRepoDir, src);
-        if (rel === '') return true; // the root dir itself
-        const top = rel.split(path.sep)[0];
-        // Root-level file (shared) → top has no further segments and is a file.
-        if (!rel.includes(path.sep)) {
-          // Could be a root-level .md (keep) or a subdirectory entry (keep only
-          // if it's an active namespace dir; fse.copy will then recurse into it).
-          return top.endsWith('.md') || activeLearningsSet.has(top);
-        }
-        // Nested path: keep only if under an active namespace.
-        return activeLearningsSet.has(top);
-      };
       const countLearnings = async (baseDir: string): Promise<number> => {
         // Count root-level shared .md + active-namespace .md only.
         let n = (await listFiles(baseDir)).filter((f) => f.endsWith('.md')).length;
@@ -883,20 +864,12 @@ async function pullForScope(
       let learningsCount = 0;
       let effectiveLearningsDir: string | undefined;
       if (localConfig.scope === 'user') {
+        await mirrorLearnings(
+          learningsRepoDir,
+          LEARNINGS_LOCAL_DIR,
+          activeLearningsNamespaces,
+        );
         if (await pathExists(learningsRepoDir)) {
-          // Remove any stale namespace subdirectories no longer active before
-          // re-copying, so deactivating a project cleans up its local learnings.
-          if (await pathExists(LEARNINGS_LOCAL_DIR)) {
-            for (const existing of await listDirs(LEARNINGS_LOCAL_DIR)) {
-              if (!activeLearningsSet.has(existing)) {
-                await fse.remove(path.join(LEARNINGS_LOCAL_DIR, existing));
-              }
-            }
-          }
-          await fse.copy(learningsRepoDir, LEARNINGS_LOCAL_DIR, {
-            overwrite: true,
-            filter: learningsCopyFilter,
-          });
           learningsCount = await countLearnings(learningsRepoDir);
         }
         effectiveLearningsDir = await pathExists(LEARNINGS_LOCAL_DIR) ? LEARNINGS_LOCAL_DIR : undefined;

--- a/src/utils/learnings-mirror.ts
+++ b/src/utils/learnings-mirror.ts
@@ -1,0 +1,83 @@
+import path from 'node:path';
+import fse from 'fs-extra';
+import { ensureDir, listDirs, listFiles, listFilesRecursive, pathExists, remove } from './fs.js';
+
+function visibleMarkdownFiles(files: string[]): string[] {
+  return files.filter((file) =>
+    file.endsWith('.md') && file.split('/').every((segment) => !segment.startsWith('.')),
+  );
+}
+
+/**
+ * Reconcile the machine-local learnings cache with the selected repo content.
+ * Root-level Markdown files are shared; only active namespace directories are
+ * mirrored. The destination is a generated cache, so upstream deletions must
+ * remove the corresponding cached learning before the search index is rebuilt.
+ */
+export async function mirrorLearnings(
+  sourceDir: string,
+  destinationDir: string,
+  activeNamespaces: string[],
+): Promise<void> {
+  const sourceIsDirectory = await pathExists(sourceDir)
+    && (await fse.stat(sourceDir)).isDirectory();
+  const sourceRootFiles = new Set(
+    sourceIsDirectory
+      ? (await listFiles(sourceDir)).filter((file) => file.endsWith('.md') && !file.startsWith('.'))
+      : [],
+  );
+  const sourceNamespaces = new Set(sourceIsDirectory ? await listDirs(sourceDir) : []);
+  const selectedNamespaces = new Set(
+    activeNamespaces.filter((namespace) =>
+      !namespace.startsWith('.') && sourceNamespaces.has(namespace),
+    ),
+  );
+
+  await ensureDir(destinationDir);
+
+  // Root Markdown files are owned by the mirror. Leave unrelated root files
+  // alone, but remove shared learnings that no longer exist upstream.
+  for (const file of await listFiles(destinationDir)) {
+    if (file.endsWith('.md') && !file.startsWith('.') && !sourceRootFiles.has(file)) {
+      await remove(path.join(destinationDir, file));
+    }
+  }
+
+  // Namespace directories are also mirror-owned. This removes both namespaces
+  // that became inactive and active namespaces deleted from the repo.
+  for (const namespace of await listDirs(destinationDir)) {
+    if (!selectedNamespaces.has(namespace)) {
+      await remove(path.join(destinationDir, namespace));
+    }
+  }
+
+  // An active namespace can remain selected while individual learnings are
+  // deleted upstream. Reconcile those files before the overwrite copy.
+  for (const namespace of selectedNamespaces) {
+    const sourceNamespaceDir = path.join(sourceDir, namespace);
+    const destinationNamespaceDir = path.join(destinationDir, namespace);
+    if (!await pathExists(destinationNamespaceDir)) continue;
+
+    const sourceFiles = new Set(visibleMarkdownFiles(await listFilesRecursive(sourceNamespaceDir)));
+    for (const file of visibleMarkdownFiles(await listFilesRecursive(destinationNamespaceDir))) {
+      if (!sourceFiles.has(file)) {
+        await remove(path.join(destinationNamespaceDir, file));
+      }
+    }
+  }
+
+  if (!sourceIsDirectory) return;
+
+  await fse.copy(sourceDir, destinationDir, {
+    overwrite: true,
+    filter: (src: string) => {
+      if (path.basename(src).startsWith('.')) return false;
+      const relative = path.relative(sourceDir, src);
+      if (relative === '') return true;
+      const topLevel = relative.split(path.sep)[0];
+      return relative.includes(path.sep)
+        ? selectedNamespaces.has(topLevel)
+        : sourceRootFiles.has(topLevel) || selectedNamespaces.has(topLevel);
+    },
+  });
+}


### PR DESCRIPTION
## Summary

修复 user scope 下 learnings 的删除同步遗漏：当上游删除顶层共享 `.md` 或命名空间中的 learning 后，`teamai pull` 以及两条 `teamai contribute` 重建索引路径现在会同步清理本地镜像，避免已删除内容继续被索引和召回。

本次改动抽取了一个小型镜像辅助函数，统一复制当前内容并删除已失效的、由 TeamAI 管理的 Markdown 文件与命名空间；无关的本地根目录文件保持不变。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing behavior to change)
- [ ] Documentation only
- [ ] Refactor / internal cleanup

## Test Plan

以下结果均基于最终提交 `b036d83`，运行环境为 macOS、Node.js v22.23.0。

- [x] `npm run build` — 通过。
- [x] `npx tsc --noEmit` — 通过。
- [x] `npx vitest run --minWorkers=4 --maxWorkers=4` — **208 个测试文件、2,917 个测试全部通过**。
- [x] `npx vitest run src/__tests__/pull-learnings-deletion.test.ts src/__tests__/learnings-mirror.test.ts src/__tests__/learnings-namespace.test.ts --coverage` — **3 个测试文件、8 个测试全部通过**；新辅助函数语句覆盖率 98.33%、函数覆盖率 100%。
- [x] `npm run test:e2e` — **21 个测试文件通过、3 个按凭据条件跳过；108 个测试通过、25 个按凭据条件跳过**。
- [x] `git diff --check origin/main...HEAD` — 通过。
- [x] 已新增/更新测试。

### 回归测试敏感度

- RED：将同一个 `pull` 回归测试放到未修复的 `origin/main`（`498a687`）运行，按预期失败：上游删除 `shared-b.md` 后，本地文件仍然存在（`expected false, received true`）。
- GREEN：在本分支运行相同测试，1/1 通过；本地残留文件被删除，索引也只保留仍存在的 learning。

### E2E 覆盖

真实构建产物的角色/技能推送矩阵已通过：

| Agent | `git` | `github` | `gitlab` |
| --- | --- | --- | --- |
| Claude | PASS | PASS | PASS |
| Codex | PASS | PASS | PASS |
| CodeBuddy | PASS | PASS | PASS |
| OpenCode | PASS | PASS | PASS |

需要 CNB、GitLab 或 GitCode 实际凭据的 live suites 按测试配置跳过；本地完整 E2E 与上述 provider 矩阵均通过。

## Related Issues

Fixes #458

## Notes for Reviewers

- 建议重点查看 `mirrorLearnings()` 的删除边界：仅管理顶层 `.md`、当前激活命名空间中的 `.md`，以及已失活/已删除的命名空间目录；不会删除无关的本地根目录文件。
- `pull` 与 `contribute` 的普通模式和 self mode 共用同一镜像逻辑，避免三个入口再次产生行为偏差。
- project scope 直接使用仓库内容，不经过 user-scope 镜像，因此行为不变。
- 未更新文档：这不是新增行为，而是恢复现有 user-scope 镜像与索引语义。

<details>
<summary>English details</summary>

## Summary

Fix incomplete deletion propagation for user-scoped learnings. When a top-level shared `.md` file or a namespaced learning is removed upstream, `teamai pull` and both `teamai contribute` index-rebuild paths now remove the stale local mirror entry so deleted knowledge cannot remain indexed or recalled.

The change introduces a small shared mirror helper that copies current learnings and removes only stale TeamAI-managed Markdown files and namespaces. Unrelated files at the destination root are preserved.

## Test Plan

- `npm run build` — passed.
- `npx tsc --noEmit` — passed.
- Full unit suite with controlled concurrency — 208 files / 2,917 tests passed.
- Focused regression and namespace coverage — 3 files / 8 tests passed; the new helper has 98.33% statement and 100% function coverage.
- Full local E2E — 21 files / 108 tests passed; 3 files / 25 live-credential tests were skipped by configuration.
- Claude, Codex, CodeBuddy, and OpenCode all passed the `git`, `github`, and `gitlab` provider matrix.
- `git diff --check origin/main...HEAD` — passed.

### Regression sensitivity

The exact pull regression failed on unmodified `origin/main` (`498a687`) as expected: after upstream deletion, `shared-b.md` still existed locally (`expected false, received true`). The same test passes on this branch and verifies both filesystem cleanup and index removal.

## Notes for Reviewers

- `mirrorLearnings()` manages only root-level `.md` files, `.md` files in active namespaces, and inactive/deleted namespace directories. It preserves unrelated destination-root files.
- Pull, normal contribute, and self-mode contribute share the same mirror semantics.
- Project scope continues to read directly from the repository and is unchanged.
- No documentation update is included because this restores the already documented user-scope mirror/index behavior rather than introducing a new behavior.

</details>
