### PR TITLE
fix(recall): 同步清理已删除的团队经验

### DIFF
--- a/src/__tests__/learnings-mirror.test.ts
+++ b/src/__tests__/learnings-mirror.test.ts
@@ -1,0 +1,56 @@
+import path from 'node:path';
+import os from 'node:os';
+import fse from 'fs-extra';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { mirrorLearnings } from '../learnings-mirror.js';
+
+describe('mirrorLearnings', () => {
+  const roots: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(roots.splice(0).map((root) => fse.remove(root)));
+  });
+
+  async function fixture(): Promise<{ source: string; destination: string }> {
+    const root = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-learnings-mirror-'));
+    roots.push(root);
+    return {
+      source: path.join(root, 'source'),
+      destination: path.join(root, 'destination'),
+    };
+  }
+
+  it('propagates shared and active-namespace deletions while preserving unrelated local files', async () => {
+    const { source, destination } = await fixture();
+    await fse.outputFile(path.join(source, 'shared-current.md'), 'current');
+    await fse.outputFile(path.join(source, 'project-a', 'current.md'), 'current');
+    await fse.outputFile(path.join(source, 'project-b', 'private.md'), 'private');
+
+    await fse.outputFile(path.join(destination, 'shared-current.md'), 'old');
+    await fse.outputFile(path.join(destination, 'shared-deleted.md'), 'stale');
+    await fse.outputFile(path.join(destination, 'project-a', 'deleted.md'), 'stale');
+    await fse.outputFile(path.join(destination, 'project-b', 'private.md'), 'stale');
+    await fse.outputFile(path.join(destination, 'local-note.txt'), 'keep');
+
+    await mirrorLearnings(source, destination, ['project-a']);
+
+    await expect(fse.readFile(path.join(destination, 'shared-current.md'), 'utf8')).resolves.toBe('current');
+    await expect(fse.readFile(path.join(destination, 'project-a', 'current.md'), 'utf8')).resolves.toBe('current');
+    expect(await fse.pathExists(path.join(destination, 'shared-deleted.md'))).toBe(false);
+    expect(await fse.pathExists(path.join(destination, 'project-a', 'deleted.md'))).toBe(false);
+    expect(await fse.pathExists(path.join(destination, 'project-b'))).toBe(false);
+    await expect(fse.readFile(path.join(destination, 'local-note.txt'), 'utf8')).resolves.toBe('keep');
+  });
+
+  it('clears mirrored markdown when the upstream learnings directory is removed', async () => {
+    const { source, destination } = await fixture();
+    await fse.outputFile(path.join(destination, 'shared-deleted.md'), 'stale');
+    await fse.outputFile(path.join(destination, 'project-a', 'deleted.md'), 'stale');
+
+    await mirrorLearnings(source, destination, ['project-a']);
+
+    expect(await fse.pathExists(path.join(destination, 'shared-deleted.md'))).toBe(false);
+    expect(await fse.pathExists(path.join(destination, 'project-a'))).toBe(false);
+  });
+});

--- a/src/contribute.ts
+++ b/src/contribute.ts
@@ -12,6 +12,7 @@ import { savePendingLearning } from './utils/pending-learnings.js';
 import { isSafeNamespaceSegment, resolveActiveLearningsNamespaces } from './projects.js';
 import type { GlobalOptions, LocalConfig } from './types.js';
 import { LEARNINGS_LOCAL_DIR, getDataHome } from './types.js';
+import { mirrorLearnings } from './learnings-mirror.js';
 
 /**
  * Rebuild this scope's local search index so the freshly-written contribution
@@ -60,12 +61,8 @@ async function rebuildIndexAfterContribute(localConfig: LocalConfig): Promise<vo
   // same as pull.ts); project scope indexes the repo's learnings/ directly.
   let effectiveLearningsDir: string | undefined;
   if (localConfig.scope === 'user') {
-    if (await pathExists(learningsRepoDir)) {
-      await fse.copy(learningsRepoDir, LEARNINGS_LOCAL_DIR, {
-        overwrite: true,
-        filter: (src: string) => !path.basename(src).startsWith('.'),
-      });
-    }
+    const activeNamespaces = await resolveActiveLearningsNamespaces(repoPath, localConfig.projects ?? []);
+    await mirrorLearnings(learningsRepoDir, LEARNINGS_LOCAL_DIR, activeNamespaces);
     effectiveLearningsDir = (await pathExists(LEARNINGS_LOCAL_DIR)) ? LEARNINGS_LOCAL_DIR : undefined;
   } else {
     effectiveLearningsDir = (await pathExists(learningsRepoDir)) ? learningsRepoDir : undefined;
@@ -305,10 +302,11 @@ async function contributeSelf(
       try {
         const { pathExists } = await import('./utils/fs.js');
         const wtLearnings = path.join(wtRepo, 'learnings');
-        await fse.copy(wtLearnings, LEARNINGS_LOCAL_DIR, {
-          overwrite: true,
-          filter: (src: string) => !path.basename(src).startsWith('.'),
-        });
+        const activeNamespaces = await resolveActiveLearningsNamespaces(
+          localConfig.repo.localPath,
+          localConfig.projects ?? [],
+        );
+        await mirrorLearnings(wtLearnings, LEARNINGS_LOCAL_DIR, activeNamespaces);
 
         const repoPath = localConfig.repo.localPath; // persistent active-tree .teamai
         const docsDir = path.join(repoPath, 'docs');

--- a/src/learnings-mirror.ts
+++ b/src/learnings-mirror.ts
@@ -1,0 +1,65 @@
+import path from 'node:path';
+import fse from 'fs-extra';
+
+import { listDirs, listFiles, listFilesRecursive, pathExists } from './utils/fs.js';
+
+function isVisibleMarkdown(relativePath: string): boolean {
+  return relativePath.endsWith('.md')
+    && !relativePath.split(path.sep).some((part) => part.startsWith('.'));
+}
+
+/** Reconcile the user-scope learnings cache with the selected team knowledge. */
+export async function mirrorLearnings(
+  sourceDir: string,
+  destinationDir: string,
+  activeNamespaces: readonly string[],
+): Promise<void> {
+  const sourceExists = await pathExists(sourceDir);
+  const active = new Set(activeNamespaces);
+
+  if (await pathExists(destinationDir)) {
+    const sourceRootFiles = new Set(
+      sourceExists
+        ? (await listFiles(sourceDir)).filter((file) => isVisibleMarkdown(file))
+        : [],
+    );
+    for (const file of await listFiles(destinationDir)) {
+      if (isVisibleMarkdown(file) && !sourceRootFiles.has(file)) {
+        await fse.remove(path.join(destinationDir, file));
+      }
+    }
+
+    for (const namespace of await listDirs(destinationDir)) {
+      const sourceNamespace = path.join(sourceDir, namespace);
+      if (!active.has(namespace) || !sourceExists || !await pathExists(sourceNamespace)) {
+        await fse.remove(path.join(destinationDir, namespace));
+        continue;
+      }
+
+      const sourceFiles = new Set(
+        (await listFilesRecursive(sourceNamespace)).filter(isVisibleMarkdown),
+      );
+      for (const relativePath of await listFilesRecursive(path.join(destinationDir, namespace))) {
+        if (isVisibleMarkdown(relativePath) && !sourceFiles.has(relativePath)) {
+          await fse.remove(path.join(destinationDir, namespace, relativePath));
+        }
+      }
+    }
+  }
+
+  if (!sourceExists) return;
+
+  await fse.ensureDir(destinationDir);
+  for (const file of await listFiles(sourceDir)) {
+    if (!isVisibleMarkdown(file)) continue;
+    await fse.copy(path.join(sourceDir, file), path.join(destinationDir, file), { overwrite: true });
+  }
+  for (const namespace of active) {
+    const sourceNamespace = path.join(sourceDir, namespace);
+    if (!await pathExists(sourceNamespace)) continue;
+    await fse.copy(sourceNamespace, path.join(destinationDir, namespace), {
+      overwrite: true,
+      filter: (sourcePath: string) => !path.basename(sourcePath).startsWith('.'),
+    });
+  }
+}

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -35,6 +35,7 @@ import { loadRolesManifest, resolveRoleResourceNamespaces, type ResourceNamespac
 import { loadProjectsManifest, resolveProjectResourceNamespaces, mergeNamespaces } from './projects.js';
 import { getUserHome } from './utils/home.js';
 import { acquireLock, releaseLock } from './update.js';
+import { mirrorLearnings } from './learnings-mirror.js';
 
 interface RolePullContext {
   activeNamespaces: ResourceNamespaces;
@@ -850,25 +851,6 @@ async function pullForScope(
       // select them. `activeLearningsNamespaces` is the set from role∪project
       // resolution (roles contribute none, so effectively the project set).
       const activeLearningsNamespaces = roleContext?.activeNamespaces.learnings ?? [];
-      const activeLearningsSet = new Set(activeLearningsNamespaces);
-      // Filter for fse.copy: keep the root and any file/dir whose top-level
-      // segment (relative to learningsRepoDir) is either a root-level .md (shared)
-      // or an active-project subdirectory. Everything else (inactive project dirs)
-      // is excluded so no other project's private learnings land on this machine.
-      const learningsCopyFilter = (src: string): boolean => {
-        if (path.basename(src).startsWith('.')) return false;
-        const rel = path.relative(learningsRepoDir, src);
-        if (rel === '') return true; // the root dir itself
-        const top = rel.split(path.sep)[0];
-        // Root-level file (shared) → top has no further segments and is a file.
-        if (!rel.includes(path.sep)) {
-          // Could be a root-level .md (keep) or a subdirectory entry (keep only
-          // if it's an active namespace dir; fse.copy will then recurse into it).
-          return top.endsWith('.md') || activeLearningsSet.has(top);
-        }
-        // Nested path: keep only if under an active namespace.
-        return activeLearningsSet.has(top);
-      };
       const countLearnings = async (baseDir: string): Promise<number> => {
         // Count root-level shared .md + active-namespace .md only.
         let n = (await listFiles(baseDir)).filter((f) => f.endsWith('.md')).length;
@@ -883,20 +865,8 @@ async function pullForScope(
       let learningsCount = 0;
       let effectiveLearningsDir: string | undefined;
       if (localConfig.scope === 'user') {
+        await mirrorLearnings(learningsRepoDir, LEARNINGS_LOCAL_DIR, activeLearningsNamespaces);
         if (await pathExists(learningsRepoDir)) {
-          // Remove any stale namespace subdirectories no longer active before
-          // re-copying, so deactivating a project cleans up its local learnings.
-          if (await pathExists(LEARNINGS_LOCAL_DIR)) {
-            for (const existing of await listDirs(LEARNINGS_LOCAL_DIR)) {
-              if (!activeLearningsSet.has(existing)) {
-                await fse.remove(path.join(LEARNINGS_LOCAL_DIR, existing));
-              }
-            }
-          }
-          await fse.copy(learningsRepoDir, LEARNINGS_LOCAL_DIR, {
-            overwrite: true,
-            filter: learningsCopyFilter,
-          });
           learningsCount = await countLearnings(learningsRepoDir);
         }
         effectiveLearningsDir = await pathExists(LEARNINGS_LOCAL_DIR) ? LEARNINGS_LOCAL_DIR : undefined;


### PR DESCRIPTION
上游删除 learning 后，本地 recall 缓存仍会保留旧文件，导致后续检索继续命中已删除内容。本 PR 将 pull、普通 contribute 和 self contribute 的缓存更新统一为镜像协调：同步新增和更新，同时传播顶层文件及当前项目命名空间中的删除，并保留 TeamAI 不管理的本地文件。

验证：
- `npm run typecheck`
- `npm run build`
- `src/__tests__/learnings-mirror.test.ts`
- `src/__tests__/pull-tombstone.test.ts`

Closes #458