### PR TITLE
fix(learnings): stop self-mode contribute from wiping the local cache

### DIFF
--- a/src/__tests__/contribute-self-learnings.test.ts
+++ b/src/__tests__/contribute-self-learnings.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// Real-git integration test for contributeSelf's local-cache mirroring (#472).
+// Lives in its own file for the same reason as git-commit-paths.test.ts: other
+// suites mock simple-git/config globally.
+
+const testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-contribute-self-'));
+const originalHome = process.env.HOME;
+process.env.HOME = path.join(testRoot, 'home');
+
+const businessRoot = path.join(testRoot, 'business');
+const remote = path.join(testRoot, 'remote.git');
+const localPath = path.join(businessRoot, '.teamai');
+
+const localConfig = {
+  repo: { localPath, kind: 'self' as const, businessRepoRoot: businessRoot, remote },
+  username: 'test',
+  updatePolicy: 'auto' as const,
+  additionalRoles: [],
+  scope: 'project' as const,
+};
+
+vi.mock('../config.js', () => ({
+  requireInit: vi.fn(),
+  detectProjectConfig: vi.fn().mockResolvedValue(localConfig),
+  loadLocalConfigForScope: vi.fn().mockResolvedValue(localConfig),
+  loadTeamConfig: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  log: { info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), dim: vi.fn() },
+  spinner: vi.fn(() => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    warn: vi.fn().mockReturnThis(),
+    info: vi.fn().mockReturnThis(),
+    stop: vi.fn().mockReturnThis(),
+  })),
+}));
+
+const { contribute } = await import('../contribute.js');
+const { LEARNINGS_LOCAL_DIR } = await import('../types.js');
+
+function git(args: string[], cwd: string) {
+  execFileSync('git', args, { cwd, stdio: 'ignore' });
+}
+
+describe('contributeSelf — machine-local learnings cache (issue #472)', () => {
+  beforeEach(async () => {
+    fs.rmSync(businessRoot, { recursive: true, force: true });
+    fs.rmSync(remote, { recursive: true, force: true });
+    fs.rmSync(LEARNINGS_LOCAL_DIR, { recursive: true, force: true });
+
+    fs.mkdirSync(businessRoot, { recursive: true });
+    git(['init', '--bare', remote], testRoot);
+    git(['symbolic-ref', 'HEAD', 'refs/heads/main'], remote);
+    git(['init', '-q', '-b', 'main'], businessRoot);
+    git(['config', 'user.email', 't@t.co'], businessRoot);
+    git(['config', 'user.name', 't'], businessRoot);
+    fs.mkdirSync(localPath, { recursive: true });
+    fs.writeFileSync(path.join(localPath, '.gitkeep'), '');
+    git(['add', '.'], businessRoot);
+    git(['commit', '-qm', 'init'], businessRoot);
+    git(['remote', 'add', 'origin', remote], businessRoot);
+    git(['push', '-u', 'origin', 'main'], businessRoot);
+
+    // Pre-existing cache content this contribution must never touch: another
+    // project's shared root learning, plus a namespace directory unrelated to
+    // this project's own (empty) namespace set.
+    fs.mkdirSync(LEARNINGS_LOCAL_DIR, { recursive: true });
+    fs.writeFileSync(path.join(LEARNINGS_LOCAL_DIR, 'other-team.md'), '# other team knowledge');
+    fs.mkdirSync(path.join(LEARNINGS_LOCAL_DIR, 'other-namespace'), { recursive: true });
+    fs.writeFileSync(path.join(LEARNINGS_LOCAL_DIR, 'other-namespace', 'note.md'), '# unrelated namespace');
+  });
+
+  afterEach(() => {
+    process.env.HOME = originalHome;
+    fs.rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  function cacheFiles(): string[] {
+    return fs.readdirSync(LEARNINGS_LOCAL_DIR).sort();
+  }
+
+  function noteFile(text: string): string {
+    const notePath = path.join(testRoot, `note-${Math.random().toString(36).slice(2)}.md`);
+    fs.writeFileSync(notePath, text);
+    return notePath;
+  }
+
+  it('adds a new contribution without deleting unrelated cache entries', async () => {
+    await contribute({ scope: 'project', title: 'first-pending', file: noteFile('first unique knowledge') });
+
+    expect(fs.existsSync(path.join(LEARNINGS_LOCAL_DIR, 'other-team.md'))).toBe(true);
+    expect(fs.existsSync(path.join(LEARNINGS_LOCAL_DIR, 'other-namespace', 'note.md'))).toBe(true);
+    expect(cacheFiles().some((f) => f.startsWith('first-pending-'))).toBe(true);
+  });
+
+  it('keeps an earlier still-unmerged contribution recallable after a second one', async () => {
+    await contribute({ scope: 'project', title: 'first-pending', file: noteFile('first unique knowledge') });
+    const firstFile = cacheFiles().find((f) => f.startsWith('first-pending-'));
+    expect(firstFile).toBeDefined();
+
+    await contribute({ scope: 'project', title: 'second-pending', file: noteFile('second unique knowledge') });
+    const afterSecond = cacheFiles();
+
+    expect(afterSecond).toContain(firstFile);
+    expect(afterSecond.some((f) => f.startsWith('second-pending-'))).toBe(true);
+    expect(afterSecond).toContain('other-team.md');
+  });
+});

--- a/src/contribute.ts
+++ b/src/contribute.ts
@@ -11,7 +11,7 @@ import { savePendingLearning } from './utils/pending-learnings.js';
 import { isSafeNamespaceSegment, resolveActiveLearningsNamespaces } from './projects.js';
 import type { GlobalOptions, LocalConfig } from './types.js';
 import { LEARNINGS_LOCAL_DIR, getDataHome } from './types.js';
-import { mirrorLearnings } from './utils/learnings-mirror.js';
+import { addLearningToCache, mirrorLearnings } from './utils/learnings-mirror.js';
 
 /**
  * Rebuild this scope's local search index so the freshly-written contribution
@@ -255,10 +255,12 @@ export async function contribute(
  * PR from an isolated knowledge worktree instead of pushing to main directly.
  *
  * The user's active working tree is never written to. For immediate local recall,
- * we mirror the worktree's learnings/ (committed main learnings + the new one)
- * into the machine-local LEARNINGS_LOCAL_DIR and index from there — the same
- * pattern user scope uses. The contribution lands in the active tree only when the
- * PR merges and the user pulls.
+ * we additively copy just the new file into the machine-local LEARNINGS_LOCAL_DIR
+ * and index from there. The worktree is a disposable snapshot scoped to
+ * origin/<default>, not the full cache's source of truth, so it must never drive
+ * a deleting mirror there: doing so wiped out other projects' cached learnings
+ * and any still-unmerged prior contribution (#472). The contribution lands in
+ * the active tree only when the PR merges and the user pulls.
  */
 async function contributeSelf(
   localConfig: LocalConfig,
@@ -303,12 +305,11 @@ async function contributeSelf(
       // This matches the other index-build sites (pull.ts / recall.ts).
       try {
         const { pathExists } = await import('./utils/fs.js');
-        const wtLearnings = path.join(wtRepo, 'learnings');
         const activeLearningsNamespaces = await resolveActiveLearningsNamespaces(
           localConfig.repo.localPath,
           localConfig.projects ?? [],
         );
-        await mirrorLearnings(wtLearnings, LEARNINGS_LOCAL_DIR, activeLearningsNamespaces);
+        await addLearningToCache(destAbs, LEARNINGS_LOCAL_DIR, relPath.slice('learnings/'.length));
 
         const repoPath = localConfig.repo.localPath; // persistent active-tree .teamai
         const docsDir = path.join(repoPath, 'docs');

--- a/src/utils/learnings-mirror.ts
+++ b/src/utils/learnings-mirror.ts
@@ -81,3 +81,19 @@ export async function mirrorLearnings(
     },
   });
 }
+
+/**
+ * Add a single learning file to the machine-local cache without touching
+ * anything else there. Unlike mirrorLearnings, this never deletes: it's for
+ * sources that are only a partial, disposable snapshot (e.g. contributeSelf's
+ * knowledge worktree, checked out at origin/<default>) and would otherwise
+ * wipe out cached entries the snapshot simply doesn't happen to contain, such
+ * as other projects' cache or a still-unmerged prior contribution (#472).
+ */
+export async function addLearningToCache(
+  sourceFile: string,
+  destinationDir: string,
+  relativePath: string,
+): Promise<void> {
+  await fse.copy(sourceFile, path.join(destinationDir, relativePath), { overwrite: true });
+}


### PR DESCRIPTION
## Summary

`teamai contribute --scope project` in self mode wiped other projects' cached learnings and any still-unmerged prior contribution from the machine-local cache, because it mirrored a disposable, narrowly-scoped knowledge worktree into that cache using a function that deletes anything the destination has and the source doesn't.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing behavior to change)
- [ ] Documentation only
- [ ] Refactor / internal cleanup

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` passes
- [x] Added/updated tests for the change

New unit tests in `src/__tests__/contribute-self-learnings.test.ts`, using a real local git remote and business repo (no mocks on the worktree/mirroring machinery). Confirmed red-before-green: both tests fail against unmodified `main` and pass with this fix.

Also ran the real built CLI end to end, following the same reproduction shape as the issue: a self-mode project repo with a local bare remote, an existing `other-team.md` in the machine-local cache, then two consecutive `contribute` calls with neither branch merged.

Before this fix (`git stash` the two source changes, rebuild, rerun):

```
CACHE: ['first-pending-2026-09-10-81o3hu.md']
CACHE: ['second-pending-2026-09-10-dtsf7h.md']
```

`other-team.md` is gone after the first contribution, and the first contribution's own file is gone after the second.

With this fix:

```
CACHE: ['first-pending-2026-09-10-efidol.md', 'other-team.md']
CACHE: ['first-pending-2026-09-10-efidol.md', 'other-team.md', 'second-pending-2026-09-10-or0ocv.md']
```

Both prior entries survive, and both contributions stay locally recallable.

## Related Issues

Fixes #472

## Notes for Reviewers

Root cause: `contributeSelf` (`src/contribute.ts`) calls `mirrorLearnings` with the disposable knowledge worktree's `learnings/` as source and the machine-local `LEARNINGS_LOCAL_DIR` as destination. That worktree is checked out at `origin/<default>`, so it never contains another project's cache or a not-yet-merged branch's contribution, but `mirrorLearnings` treats its source as the destination's complete authoritative content and deletes anything the destination has that the source doesn't.

The fix adds `addLearningToCache` in `src/utils/learnings-mirror.ts`, an additive-only copy of just the one new file, used in place of `mirrorLearnings` at this call site. The other `mirrorLearnings` call site (`rebuildIndexAfterContribute`, used by user scope and by `pull.ts`) is untouched: its source is the full active repo tree, so real upstream-deletion propagation from #465/#458 still works exactly as before, since it never goes through the worktree path this PR changes.
