### PR TITLE
fix(metrics): claw back sessionsSucceeded when a resumed session later fails

### DIFF
--- a/src/__tests__/session-trends.test.ts
+++ b/src/__tests__/session-trends.test.ts
@@ -61,6 +61,29 @@ describe('daily session trends', () => {
     expect(second.delta['2026-09-03']).toMatchObject({ pricedRequests: 1, costMicros: 150, sessionsEnded: 0 });
   });
 
+  it('claws back sessionsSucceeded when a resumed session later fails (#473)', () => {
+    const succeeded = new Map([
+      ['s1', { date: '2026-09-02', prompts: 1, durationMs: 60_000, succeeded: 1 as const, corrected: 0 as const, requestDaily: {} }],
+    ]);
+    const first = computeDailyStatsDelta(succeeded, {});
+    expect(first.delta['2026-09-02']).toMatchObject({ sessionsEnded: 1, sessionsSucceeded: 1 });
+    const merged = mergeDailyStats(undefined, first.delta);
+    expect(merged['2026-09-02']).toMatchObject({ sessionsEnded: 1, sessionsSucceeded: 1 });
+
+    const interrupted = new Map([
+      ['s1', { ...succeeded.get('s1')!, succeeded: 0 as const, corrected: 1 as const }],
+    ]);
+    const second = computeDailyStatsDelta(interrupted, first.nextReported);
+    expect(second.delta['2026-09-02']).toMatchObject({ sessionsEnded: 0, sessionsSucceeded: -1, sessionsCorrected: 1 });
+    const remerged = mergeDailyStats(merged, second.delta);
+    expect(remerged['2026-09-02']).toMatchObject({ sessionsEnded: 1, sessionsSucceeded: 0 });
+
+    // A later, unrelated re-report of the same now-failed state must not
+    // double-subtract: the delta settles back to 0 once the baseline catches up.
+    const third = computeDailyStatsDelta(interrupted, second.nextReported);
+    expect(third.delta['2026-09-02']).toMatchObject({ sessionsEnded: 0, sessionsSucceeded: 0 });
+  });
+
   it('compares the latest seven UTC days with the prior seven days', () => {
     const daily: Record<string, DailyUserStats> = {
       '2026-08-27': { sessionsEnded: 10, sessionsSucceeded: 5, promptTurns: 80, durationMs: 600_000, sessionsCorrected: 4, pricedRequests: 10, costMicros: 1_000_000, cacheReadTokens: 20, cacheEligibleInputTokens: 100 },

--- a/src/session-trends.ts
+++ b/src/session-trends.ts
@@ -104,8 +104,12 @@ export function computeDailyStatsDelta(
     const bucket = delta[date] ?? emptyDaily();
     if (!previous) {
       bucket.sessionsEnded += 1;
-      bucket.sessionsSucceeded += snapshot.succeeded;
     }
+    // Signed, not positiveDelta: unlike the monotonic counters below, a
+    // session can flip from succeeded to failed on a later report (resumed
+    // after an interruption/correction), and that must claw back the earlier
+    // sessionsSucceeded increment, not just skip adding a new one (#473).
+    bucket.sessionsSucceeded += snapshot.succeeded - (previous?.succeeded ?? 0);
     bucket.promptTurns += positiveDelta(snapshot.prompts, previous?.prompts);
     bucket.durationMs += positiveDelta(snapshot.durationMs, previous?.durationMs);
     bucket.sessionsCorrected += positiveDelta(snapshot.corrected, previous?.corrected);

--- a/src/team-push.ts
+++ b/src/team-push.ts
@@ -298,7 +298,10 @@ async function writeReportedDailySessions(data: ReportedDailySessions): Promise<
 
 function hasDailyDelta(delta: ReturnType<typeof computeDailyStatsDelta>['delta']): boolean {
   return Object.values(delta).some((bucket) =>
-    bucket.sessionsEnded > 0 || bucket.sessionsSucceeded > 0 || bucket.promptTurns > 0
+    // sessionsSucceeded can be negative (a resumed session that later failed
+    // claws back an earlier increment), so it must not be checked with the
+    // same "> 0" as the other, purely monotonic counters (#473).
+    bucket.sessionsEnded > 0 || bucket.sessionsSucceeded !== 0 || bucket.promptTurns > 0
     || bucket.durationMs > 0 || bucket.sessionsCorrected > 0 || bucket.pricedRequests > 0
     || bucket.costMicros > 0 || bucket.cacheReadTokens > 0 || bucket.cacheEligibleInputTokens > 0,
   );


### PR DESCRIPTION
## Summary

PR #468 added session success-rate tracking with a bug (issue #473, part 1): a session already reported as succeeded that later fails after being resumed never has that earlier success subtracted back out, so team-wide success rate stays permanently inflated.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing behavior to change)
- [ ] Documentation only
- [ ] Refactor / internal cleanup

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` passes (28 pre-existing failures on this Windows dev box, all Windows-path-specific and unrelated to this change; confirmed identical failure count on unmodified `main`)
- [x] Added/updated tests for the change

New test in `src/__tests__/session-trends.test.ts` exercises the exact scenario: a session reported succeeded, then a second report of the same session now failed, then a third repeat report. Confirmed red-before-green by reverting only the two source changes and rerunning: the new test fails on unmodified `main` (delta stays 0 instead of -1) and passes with this fix. All existing `session-trends`/`team-push` tests still pass, including the one already covering monotonic deltas across a resumed session.

I verified this at the unit level against the real `computeDailyStatsDelta`/`mergeDailyStats`/`hasDailyDelta` functions (no mocking of the algorithm itself), rather than re-running the full hook-to-CLI-to-team-repo pipeline the issue's own report already validated in detail. The fix is scoped to exactly the two lines the issue points at.

## Related Issues

Fixes #473 (part 1 of 2)

## Notes for Reviewers

This issue actually describes two separate problems. This PR only fixes the first (the win-back bug above). The second, in the issue's own words, is a product decision, not a code fix: `session-trends.ts` currently only treats `event.status === 'error'` as a failure, ignoring `event.interventions.toolError`, which the Stop collector does populate on a real tool error. Whether a session that hit a tool error but self-corrected should still count as failed is a definition the maintainers need to make, not something I should guess at in a PR. Left it open rather than picking a side.

Also worth noting per the issue's own "merge and fix scope" section: this fix does not retroactively correct history already written to team YAML files before this lands. Only future reports will compute the correct signed delta going forward.
