### PR TITLE
fix(codebase): reconcile no longer rejects extractor-generated same-file IMPLEMENTS self-loops

### DIFF
--- a/src/__tests__/codebase-reconcile.test.ts
+++ b/src/__tests__/codebase-reconcile.test.ts
@@ -424,4 +424,30 @@ describe('codebase reconciliation', () => {
     expect(result.graphEdges).toHaveLength(2);
     expect(result.mappings).toBe(2);
   });
+
+  it('reconciles a graph containing an extractor-generated same-file IMPLEMENTS self-loop (#475)', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-reconcile-self-loop-'));
+    temporaryDirectories.push(root);
+    fs.mkdirSync(path.join(root, 'src'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'teamwiki', 'product'), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, 'src', 'auth.ts'),
+      'export interface AuthService { login(): void; }\nexport class LocalAuth implements AuthService { login(): void {} }\n',
+    );
+    fs.writeFileSync(path.join(root, 'teamwiki', 'product', 'auth.md'), '# Auth\nUse `AuthService` for login.\n');
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await codebaseCmd({ extract: root, project: 'auth', json: true });
+    const extracted = await loadGraphIndex(path.join(root, 'teamwiki'));
+    expect(extracted?.edges).toContainEqual(
+      expect.objectContaining({ from: 'src/auth.ts', to: 'src/auth.ts', relation: 'IMPLEMENTS', source: 'code-ast' }),
+    );
+
+    await expect(codebaseCmd({ reconcile: true, output: root, json: true })).resolves.toBeUndefined();
+
+    const reconciled = await loadGraphIndex(path.join(root, 'teamwiki'));
+    expect(reconciled?.edges).toContainEqual(
+      expect.objectContaining({ from: 'src/auth.ts', to: 'src/auth.ts', relation: 'IMPLEMENTS' }),
+    );
+  });
 });

--- a/src/wiki-engine/knowledge-reconciler.ts
+++ b/src/wiki-engine/knowledge-reconciler.ts
@@ -8,7 +8,7 @@ import {
   toPageSlug,
   validateGraph,
 } from './core/graph-index.schema.js';
-import type { GraphIndex, GraphNode, GraphEdge, GraphEdgeSource } from './core/graph-index.schema.js';
+import type { GraphIndex, GraphNode, GraphEdge, GraphEdgeSource, RelationType } from './core/graph-index.schema.js';
 import type { WikiConfidence } from './core/wiki-protocol.js';
 import { buildConfidence } from './reconciler-v2-types.js';
 import type {
@@ -81,6 +81,18 @@ const CODE_PAGE_DOMAIN = 'code-knowledge';
 const REPAIRABLE_CODE_EDGE_SOURCES = new Set<GraphEdgeSource>(['code-ast', 'code-heuristic']);
 const MISSING_PATH_ERROR_CODE = 'ENOENT';
 const REPAIRABLE_VALIDATION_ISSUE_CODE = 'edge.missing_node';
+const SELF_LOOP_VALIDATION_ISSUE_CODE = 'edge.self_loop';
+// The extractor deliberately emits a file-level IMPLEMENTS self-loop when a
+// class implements an interface defined in the same file (edges are
+// file-to-file, not symbol-to-symbol). validateGraph flags every self-loop as
+// an issue with no reference back to the edge, so this repeats its own
+// from === to + source/relation check rather than broadening what validateGraph
+// itself treats as fatal for every other caller.
+function isExpectedSelfLoop(edge: GraphEdge): boolean {
+  return edge.from === edge.to
+    && edge.relation === ('IMPLEMENTS' satisfies RelationType)
+    && !!edge.source && REPAIRABLE_CODE_EDGE_SOURCES.has(edge.source);
+}
 
 async function loadReconciliationBase(wikiRoot: string): Promise<GraphIndex> {
   const graphPath = path.join(wikiRoot, '.indices', 'graph-index.json');
@@ -93,7 +105,13 @@ async function loadReconciliationBase(wikiRoot: string): Promise<GraphIndex> {
     graph.nodes,
     graph.edges.filter(edge => edge.source !== BRIDGE_EDGE_SOURCE),
   );
-  if (validateGraph(base).issues.some(issue => issue.code !== REPAIRABLE_VALIDATION_ISSUE_CODE)) {
+  const hasUnexpectedSelfLoop = base.edges.some(edge => edge.from === edge.to && !isExpectedSelfLoop(edge));
+  if (
+    hasUnexpectedSelfLoop
+    || validateGraph(base).issues.some(issue =>
+      issue.code !== REPAIRABLE_VALIDATION_ISSUE_CODE && issue.code !== SELF_LOOP_VALIDATION_ISSUE_CODE,
+    )
+  ) {
     throw new Error(`Cannot reconcile invalid graph index at ${graphPath}`);
   }
   const nodeSlugs = new Set(base.nodes.map(node => node.slug));
@@ -114,7 +132,9 @@ async function loadReconciliationBase(wikiRoot: string): Promise<GraphIndex> {
     }
   }
   const repaired = mergeGraphs(base, createGraphIndex(endpointNodes));
-  if (!validateGraph(repaired).valid) {
+  if (
+    validateGraph(repaired).issues.some(issue => issue.code !== SELF_LOOP_VALIDATION_ISSUE_CODE)
+  ) {
     throw new Error(`Cannot reconcile invalid graph index at ${graphPath}`);
   }
   return repaired;


### PR DESCRIPTION
## Summary

Follow-up to #470. `codebase --reconcile` rejects the graph that `codebase --extract` itself generates for a normal TypeScript file defining an interface and its implementing class in the same file, blocking reconciliation for the entire wiki.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing behavior to change)
- [ ] Documentation only
- [ ] Refactor / internal cleanup

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` passes (one pre-existing unrelated failure on this Windows dev box: a `||` in a test fixture path is an illegal Windows filename character, confirmed identical on unmodified `main`)
- [x] Added/updated tests for the change

New test in `src/__tests__/codebase-reconcile.test.ts` runs a real extract then reconcile in-process against a fixture matching this issue's own reproduction (a same-file `AuthService`/`LocalAuth` pair). Confirmed red-before-green by reverting only `src/wiki-engine/knowledge-reconciler.ts`: the test fails with the exact reported error, `Cannot reconcile invalid graph index at .../graph-index.json`.

Also ran the built CLI directly, following this issue's exact reproduction steps:

```
node dist/index.js codebase --extract "$FIXTURE" --project auth --json
node dist/index.js codebase --reconcile --output "$FIXTURE" --json
```

Reconciliation now exits 0 with `"mappings": 2`, matching the issue's own control-experiment number exactly (its report: "removing only that self-loop edge makes the same reconciliation exit 0 and produce 2 mappings").

## Related Issues

Fixes #475

## Notes for Reviewers

Per the issue's own guidance, I did not broaden what `validateGraph` treats as fatal for every caller, since that would weaken validation of genuinely malformed graphs elsewhere. Instead, `loadReconciliationBase` now separately checks whether every self-loop edge actually in the graph matches the extractor's own criteria for this pattern (`relation === 'IMPLEMENTS'` and `source` in the already-existing `REPAIRABLE_CODE_EDGE_SOURCES` set). Any other self-loop shape, e.g. a manually-authored edge, or a self-loop on a different relation, still fails reconciliation exactly as before. I found this needed to be applied at both of the function's two validation checkpoints (before and after the missing-endpoint-node repair step), since the self-loop edges are still present in the repaired graph and the second checkpoint used the coarser `.valid` boolean rather than filtering by issue code.
