### PR TITLE
docs: require origin/main worktrees and hub-repo dogfood

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,8 +10,6 @@ cd teamai-cli
 npm install
 ```
 
-If you forked first, clone your fork and add `https://github.com/Tencent/teamai-cli.git` as `upstream` so you can branch from its `main`.
-
 ### Common commands
 
 ```bash
@@ -22,30 +20,31 @@ npx vitest run --coverage
 npm run test:e2e       # E2E tests (optional, requires a live test repo)
 ```
 
-### Running your local build (required dogfood)
+### Running your local build
 
-Work in the **CLI clone**. Do **not** run `teamai init .` here — that is single-repo mode and turns this source tree into the team repo (easy to commit by mistake).
+Work in the **CLI clone**, not as `teamai init .`.
 
 ```bash
 npm run build && npm link
-teamai --version
 teamai init https://github.com/teamai-hub/teamai-cli-dev --scope project --role dev
 teamai pull
 git status   # nothing under .teamai/ or tool dirs should be staged for this repo
 ```
 
-Init the **canonical hub URL** above, not a personal fork. `teamai init <url>` treats that URL as the team repo; a fork diverges immediately, and GitHub push/PR today targets the configured remote (no fork-to-upstream flow).
+Documented pitfalls:
 
-`Push failed (you can push manually later)` on member registration is **expected** without write access. Local config is still saved; `teamai pull` still works.
+- Init the **canonical hub URL**, not a personal fork. `teamai init <url>` treats that URL as the team repo; a fork diverges immediately, and GitHub push/PR today targets the configured remote (no fork-to-upstream flow).
+- Do **not** run `teamai init .`. That is single-repo mode: it turns the CLI source tree into the team repo and writes scaffolding at the repo root (easy to commit by mistake).
+- `Push failed (you can push manually later)` on member registration is **expected** without write access. Local config is still saved; `teamai pull` still works.
 
-`git status` after init/pull must not imply committing TeamAI local files into `teamai-cli`. Leave untracked or ignored `.teamai/` directories and AI tool dirs (for example `.claude/`, `.codebuddy/`, `.codex/`, `.cursor/`, `.opencode/`) out of your commits.
-
-The public team repo is read-only for most contributors. `digest` / `dashboard` read `stats/`, `sessions/`, and `members/` from that repo; those files are written via git, so **no write ⇒ not in team stats**. Maintainers do not grant write access to every internet contributor.
+`digest` / `dashboard` read `stats/`, `sessions/`, and `members/` from the team repo. Those files are written via git, so **no write ⇒ not in team stats**. Giving every internet contributor write on the hub repo is not acceptable.
 
 | Who | Hub repo access | Required setup | In team digest |
 | --- | --- | --- | --- |
 | Contributors | read | `init` + `pull` | no |
 | Collaborators (after a few PRs) | write, `main` protected | full, including reports | yes |
+
+`git status` after init does not imply committing TeamAI local files into `teamai-cli`. Do not stage `.teamai/` or tool dirs.
 
 ## Project Layout
 
@@ -63,14 +62,7 @@ See [docs/providers.md](../docs/providers.md) for how to add a new git provider.
 
 ## Making a Change
 
-1. Fork the repo and create a feature branch from the latest `origin/main` (fetch `https://github.com/Tencent/teamai-cli.git` first if your `origin` is a fork). Prefer a git worktree so the main checkout stays clean:
-
-   ```bash
-   git fetch origin
-   git worktree add -b my-feature .worktrees/my-feature origin/main
-   cd .worktrees/my-feature
-   ```
-
+1. Fork the repo and create a feature branch from the latest `origin/main`. Prefer a git worktree for code changes.
 2. Write tests for your change (we target 80%+ coverage).
 3. Run `npx vitest run` and `npx tsc --noEmit` — both must pass.
 4. Use conventional commits where possible: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,6 +10,8 @@ cd teamai-cli
 npm install
 ```
 
+If you forked first, clone your fork and add `https://github.com/Tencent/teamai-cli.git` as `upstream` so you can branch from its `main`.
+
 ### Common commands
 
 ```bash
@@ -20,12 +22,30 @@ npx vitest run --coverage
 npm run test:e2e       # E2E tests (optional, requires a live test repo)
 ```
 
-### Running your local build
+### Running your local build (required dogfood)
+
+Work in the **CLI clone**. Do **not** run `teamai init .` here — that is single-repo mode and turns this source tree into the team repo (easy to commit by mistake).
 
 ```bash
-npm link
+npm run build && npm link
 teamai --version
+teamai init https://github.com/teamai-hub/teamai-cli-dev --scope project --role dev
+teamai pull
+git status   # nothing under .teamai/ or tool dirs should be staged for this repo
 ```
+
+Init the **canonical hub URL** above, not a personal fork. `teamai init <url>` treats that URL as the team repo; a fork diverges immediately, and GitHub push/PR today targets the configured remote (no fork-to-upstream flow).
+
+`Push failed (you can push manually later)` on member registration is **expected** without write access. Local config is still saved; `teamai pull` still works.
+
+`git status` after init/pull must not imply committing TeamAI local files into `teamai-cli`. Leave untracked or ignored `.teamai/` directories and AI tool dirs (for example `.claude/`, `.codebuddy/`, `.codex/`, `.cursor/`, `.opencode/`) out of your commits.
+
+The public team repo is read-only for most contributors. `digest` / `dashboard` read `stats/`, `sessions/`, and `members/` from that repo; those files are written via git, so **no write ⇒ not in team stats**. Maintainers do not grant write access to every internet contributor.
+
+| Who | Hub repo access | Required setup | In team digest |
+| --- | --- | --- | --- |
+| Contributors | read | `init` + `pull` | no |
+| Collaborators (after a few PRs) | write, `main` protected | full, including reports | yes |
 
 ## Project Layout
 
@@ -43,7 +63,14 @@ See [docs/providers.md](../docs/providers.md) for how to add a new git provider.
 
 ## Making a Change
 
-1. Fork the repo and create a feature branch from `master`.
+1. Fork the repo and create a feature branch from the latest `origin/main` (fetch `https://github.com/Tencent/teamai-cli.git` first if your `origin` is a fork). Prefer a git worktree so the main checkout stays clean:
+
+   ```bash
+   git fetch origin
+   git worktree add -b my-feature .worktrees/my-feature origin/main
+   cd .worktrees/my-feature
+   ```
+
 2. Write tests for your change (we target 80%+ coverage).
 3. Run `npx vitest run` and `npx tsc --noEmit` — both must pass.
 4. Use conventional commits where possible: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`.


### PR DESCRIPTION
## Summary

Update `.github/CONTRIBUTING.md` so CLI contributors branch from the latest `origin/main` (prefer a git worktree) and dogfood the public TeamAI team repo instead of only `npm install` / `npm link`.

- Feature branches come from `origin/main`, not `master`.
- Required dogfood in the CLI clone: `npm run build && npm link`, `teamai init https://github.com/teamai-hub/teamai-cli-dev --scope project --role dev`, `teamai pull`.
- Documented pitfalls: canonical hub URL (not a fork), do not `teamai init .`, `Push failed (you can push manually later)` is expected without write access.
- Documented read vs write access and that `git status` after init/pull must not imply committing `.teamai/` or AI tool dirs into `teamai-cli`.

No CLI behavior changes. `docs/providers.md` leftover `master` wording is left alone (out of scope for #479).

`https://github.com/teamai-hub/teamai-cli-dev` currently 404s; creating that repo is org-admin work, not this diff.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing behavior to change)
- [x] Documentation only
- [ ] Refactor / internal cleanup

## Test Plan

- [x] `rg -n 'branch from \`master\`|from \`master\`' .github/CONTRIBUTING.md` — no matches
- [x] `rg -n 'origin/main|worktree' .github/CONTRIBUTING.md` — both present
- [x] CONTRIBUTING contains the exact dogfood sequence, the three pitfalls (including `Push failed (you can push manually later)`), the contributor/collaborator table, and the do-not-commit-local-files note
- [x] `git diff --name-only upstream/main` is only `.github/CONTRIBUTING.md`
- [x] `curl -sI https://github.com/teamai-hub/teamai-cli-dev` — 404 recorded; hub repo creation is out of scope

## Related Issues

Closes #479

## Notes for Reviewers

The hub URL and `--role dev` are kept verbatim from the issue even though `teamai-hub/teamai-cli-dev` does not exist yet.