### PR TITLE
feat(git): route independent-clone reports onto teamai-reports

### DIFF
--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -135,8 +135,11 @@ Resulting directory structure:
 ~/.teamai/projects/my-project-<hash>/   # this project's machine-data partition
 ├── config.yaml
 ├── state.json
-└── team-repo/                           # clone of the team repo
+├── team-repo/                           # clone of the team repo (knowledge on the default branch)
+└── reports-wt/                          # checkout of the `teamai-reports` orphan branch
 ```
+
+Independent git clones use the same reports split as single-repo mode: `members/` `sessions/` `votes/` `stats/` are written to the `teamai-reports` orphan branch (the checkout sits **beside** the clone, not inside it). Knowledge (`skills/` `rules/` `docs/` `learnings/` `teamai.yaml`) stays on the default branch. Leftover report files already on `main` are left in place and ignored.
 
 Project machine-data (config, state, the team-repo clone, search index, MCP
 manifests, resource cache) lives in a per-project partition under
@@ -265,11 +268,12 @@ Resulting directory structure:
 ```
 ~/.teamai/
 ├── config.yaml          # Local config
-├── team-repo/            # Clone of the team repo
+├── team-repo/            # Clone of the team repo (knowledge on the default branch)
 │   ├── teamai.yaml      # Remote team config
-│   ├── skills/ rules/ docs/ env/ members/
+│   ├── skills/ rules/ docs/ env/
 │   ├── manifest/roles.yaml  # Role definitions (when role-based skills are enabled)
 │   └── learnings/       # Team knowledge base
+├── reports-wt/          # Checkout of `teamai-reports` (`members/` `sessions/` `votes/` `stats/`)
 ~/.claude/skills/        # Team skills (auto-synced)
 ~/.claude/rules/         # Team rules (auto-synced)
 ```
@@ -305,7 +309,7 @@ teamai init . --agent claude,codex   # non-interactive: set up Claude Code + Cod
 | Data | Where it lives | Travels with `git clone`? |
 |------|----------------|---------------------------|
 | Knowledge: `skills/` `rules/` `docs/` `learnings/`, `teamai.yaml` | `.teamai/` on the **main** branch | ✅ Yes |
-| Reports: `members/` `sessions/` `votes/` `stats/` | `teamai-reports` **orphan branch** | Pushed to `origin` (separate history) |
+| Reports: `members/` `sessions/` `votes/` `stats/` | `teamai-reports` **orphan branch** | Pushed to `origin` (separate history). Independent git clones use this same split; learnings stay on the default branch. |
 | Machine-local: `config.yaml`, `state.json`, search index, env backup, MCP manifests | `~/.teamai/projects/<slug>/` (**partition**, outside the repo) | ❌ No (per-machine) |
 | Disposable git worktrees (`reports-wt/`, `knowledge-wt/`) | `.teamai/` (gitignored; rebuilt on demand) | ❌ No (per-machine) |
 
@@ -1257,7 +1261,7 @@ teamai session save --push --include-prompt  # also include the (redacted) first
 
 **Local (always):** appends to `~/.teamai/session-logs/<year-month>.md`. Idempotent per session (a session already recorded that month is skipped), and logs older than 90 days are pruned automatically.
 
-**Team (`--push`, opt-in):** commits the summary directly (no PR) to `sessions/<user>/<year-month>.md` in the team repo — the exact path `teamai digest` reads, so the session shows up under **Session Highlights**. Only a **valuable** session is pushed by default: one that shows friction (an interrupt / tool-reject / correction) or substantial tool use (≥ 3 distinct tools). Trivial sessions stay local unless you pass `--force`. On a read-only (HTTP-mode) team, `--push` fails gracefully and the local log is still kept.
+**Team (`--push`, opt-in):** commits the summary directly (no PR) to `sessions/<user>/<year-month>.md` on the `teamai-reports` branch — the exact path `teamai digest` reads, so the session shows up under **Session Highlights**. Only a **valuable** session is pushed by default: one that shows friction (an interrupt / tool-reject / correction) or substantial tool use (≥ 3 distinct tools). Trivial sessions stay local unless you pass `--force`. On a read-only (HTTP-mode) team, `--push` fails gracefully and the local log is still kept.
 
 > Privacy: the team-pushed payload is **counts + tool names only** by default. The first-ask prompt line is opt-in via `--include-prompt`, and even then it is run through the same secret redaction (`ghp_…` → `<REDACTED:…>`) used elsewhere. Local logs keep the redacted first-ask line since they never leave your machine.
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -134,8 +134,11 @@ teamai init https://github.com/yourorg/yourrepo
 ~/.teamai/projects/my-project-<hash>/   # 本项目的机器数据分区
 ├── config.yaml
 ├── state.json
-└── team-repo/                           # 团队仓库克隆
+├── team-repo/                           # 团队仓库克隆（知识资产在默认分支）
+└── reports-wt/                          # `teamai-reports` 孤儿分支的检出
 ```
+
+独立 git clone 与单仓模式使用同一套上报拆分：`members/` `sessions/` `votes/` `stats/` 写到 `teamai-reports` 孤儿分支（检出目录在 clone **旁边**，不嵌在 clone 里）。知识资产（`skills/` `rules/` `docs/` `learnings/` `teamai.yaml`）仍在默认分支。默认分支上已有的上报文件会留在原地并被忽略。
 
 项目的机器数据（config、state、team-repo 克隆、搜索索引、MCP manifest、资源缓存）
 存放在 `~/.teamai/projects/<slug>/` 下的按项目分区里，**不再**放进业务仓库，因此工作区
@@ -252,11 +255,12 @@ teamai init https://github.com/yourorg/yourrepo --scope user
 ```
 ~/.teamai/
 ├── config.yaml          # 本地配置
-├── team-repo/           # 团队仓库克隆
+├── team-repo/           # 团队仓库克隆（知识资产在默认分支）
 │   ├── teamai.yaml      # 远端团队配置
-│   ├── skills/ rules/ docs/ env/ members/
+│   ├── skills/ rules/ docs/ env/
 │   ├── manifest/roles.yaml  # 角色定义（启用角色化 skills 时）
 │   └── learnings/       # 团队知识库
+├── reports-wt/          # `teamai-reports` 检出（`members/` `sessions/` `votes/` `stats/`）
 ~/.claude/skills/        # 团队 skills（自动同步）
 ~/.claude/rules/         # 团队 rules（自动同步）
 ```
@@ -292,7 +296,7 @@ teamai init . --agent claude,codex   # 非交互：启用 Claude Code + Codex
 | 数据 | 存放位置 | 随 `git clone` 一起带走？ |
 |------|----------|---------------------------|
 | 知识资产：`skills/` `rules/` `docs/` `learnings/`、`teamai.yaml` | **main** 分支的 `.teamai/` | ✅ 会 |
-| 上报数据：`members/` `sessions/` `votes/` `stats/` | `teamai-reports` **孤儿分支** | 推送到 `origin`（独立历史） |
+| 上报数据：`members/` `sessions/` `votes/` `stats/` | `teamai-reports` **孤儿分支** | 推送到 `origin`（独立历史）。独立 git clone 使用同一套拆分；learnings 仍在默认分支。 |
 | 本机私有：`config.yaml`、`state.json`、搜索索引、env 备份、MCP manifest | `~/.teamai/projects/<slug>/`（**分区**，在仓库之外） | ❌ 不会（每台机器本地） |
 | 可丢弃的 git worktree（`reports-wt/`、`knowledge-wt/`） | `.teamai/`（已 gitignore；按需重建） | ❌ 不会（每台机器本地） |
 
@@ -1226,7 +1230,7 @@ teamai session save --push --include-prompt  # 额外带上（脱敏后的）首
 
 **本地（始终执行）：** 追加到 `~/.teamai/session-logs/<年-月>.md`。按会话幂等（当月已记录的会话会跳过），且超过 90 天的日志会自动清理。
 
-**团队（`--push`，需显式开启）：** 直接提交（不走 PR）到团队仓库的 `sessions/<user>/<年-月>.md`——正是 `teamai digest` 读取的路径，于是该会话会出现在 **Session Highlights** 板块。默认只推送**有价值**的会话：出现摩擦（interrupt / tool-reject / correction）或工具使用充分（≥ 3 种不同工具）。琐碎会话除非加 `--force`，否则只留本地。对只读（HTTP 模式）的团队，`--push` 会优雅失败并保留本地日志。
+**团队（`--push`，需显式开启）：** 直接提交（不走 PR）到 `teamai-reports` 分支的 `sessions/<user>/<年-月>.md`——正是 `teamai digest` 读取的路径，于是该会话会出现在 **Session Highlights** 板块。默认只推送**有价值**的会话：出现摩擦（interrupt / tool-reject / correction）或工具使用充分（≥ 3 种不同工具）。琐碎会话除非加 `--force`，否则只留本地。对只读（HTTP 模式）的团队，`--push` 会优雅失败并保留本地日志。
 
 > 隐私：推送到团队的内容默认**只含计数 + 工具名**。首个 prompt 行需通过 `--include-prompt` 显式开启，且即便开启也会经过与别处一致的密钥脱敏（`ghp_…` → `<REDACTED:…>`）。本地日志因为不出本机，会保留脱敏后的首个 prompt 行。
 

--- a/src/__tests__/git-kind-reports.test.ts
+++ b/src/__tests__/git-kind-reports.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Real-git coverage for independent clones writing reports to teamai-reports.
+ * No mocks of the units under test.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { simpleGit } from 'simple-git';
+
+import { getReportsDir, REPORTS_WORKTREE_DIRNAME, type LocalConfig } from '../types.js';
+import { commitAndPushReports, ensureReportsWorktree } from '../utils/reports-branch.js';
+import { pushRepoDirectly } from '../utils/git.js';
+import { reportUsageToTeam } from '../team-push.js';
+
+let tmp: string;
+let originalHome: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-git-reports-'));
+  originalHome = process.env.HOME ?? '';
+  process.env.HOME = path.join(tmp, 'home');
+  fs.mkdirSync(process.env.HOME, { recursive: true });
+});
+
+afterEach(() => {
+  process.env.HOME = originalHome;
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+async function configureGit(dir: string): Promise<void> {
+  const git = simpleGit(dir);
+  await git.addConfig('user.email', 't@t.com');
+  await git.addConfig('user.name', 't');
+}
+
+async function seedBareOrigin(): Promise<{ origin: string; clone: string }> {
+  const seed = path.join(tmp, 'seed');
+  fs.mkdirSync(seed, { recursive: true });
+  const seedGit = simpleGit(seed);
+  await seedGit.init(['--initial-branch=main']);
+  await configureGit(seed);
+  fs.writeFileSync(path.join(seed, 'teamai.yaml'), 'team: acme\n');
+  fs.mkdirSync(path.join(seed, 'skills'), { recursive: true });
+  fs.writeFileSync(path.join(seed, 'skills', '.gitkeep'), '');
+  await seedGit.add(['.']);
+  await seedGit.commit('init knowledge');
+
+  const origin = path.join(tmp, 'origin.git');
+  await simpleGit().clone(seed, origin, ['--bare']);
+  const hook = path.join(origin, 'hooks', 'update');
+  fs.writeFileSync(
+    hook,
+    `#!/bin/sh
+ref="$1"
+if [ "$ref" = "refs/heads/main" ] || [ "$ref" = "refs/heads/master" ]; then
+  echo "default branch is protected" >&2
+  exit 1
+fi
+exit 0
+`,
+  );
+  fs.chmodSync(hook, 0o755);
+
+  const clone = path.join(tmp, 'team-repo');
+  await simpleGit().clone(origin, clone);
+  await configureGit(clone);
+  return { origin, clone };
+}
+
+function gitConfig(clone: string, origin: string): LocalConfig {
+  return {
+    repo: { localPath: clone, remote: origin, kind: 'git' },
+    username: 'alice',
+    scope: 'user',
+    additionalRoles: [],
+  };
+}
+
+describe('git-kind reports branch', () => {
+  it('places the reports dir as a sibling of the clone', () => {
+    const clone = '/home/alice/.teamai/team-repo';
+    const cfg = gitConfig(clone, 'https://example.com/team.git');
+    expect(getReportsDir(cfg)).toBe(path.join('/home/alice/.teamai', REPORTS_WORKTREE_DIRNAME));
+    expect(getReportsDir(cfg)).not.toContain(`${path.sep}team-repo${path.sep}`);
+  });
+
+  it('publishes member + stats files on origin/teamai-reports, not on main', async () => {
+    const { origin, clone } = await seedBareOrigin();
+    const cfg = gitConfig(clone, origin);
+
+    const wt = await ensureReportsWorktree(cfg);
+    expect(wt).toBe(path.join(tmp, REPORTS_WORKTREE_DIRNAME));
+    expect(path.dirname(wt)).toBe(path.dirname(clone));
+
+    const memberDir = path.join(wt, 'members');
+    fs.mkdirSync(memberDir, { recursive: true });
+    fs.writeFileSync(path.join(memberDir, 'alice.yaml'), 'username: alice\n');
+    const pushed = await commitAndPushReports(cfg, '[teamai] Register member: alice', ['members/']);
+    expect(pushed).toBe(true);
+
+    const ts = new Date().toISOString();
+    const eventsDir = path.join(process.env.HOME!, '.teamai', 'dashboard');
+    fs.mkdirSync(eventsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(eventsDir, 'events.jsonl'),
+      `${JSON.stringify({ type: 'session_start', timestamp: ts, sessionId: 's1', tool: 'claude', cwd: '/p' })}\n` +
+      `${JSON.stringify({ type: 'stop', timestamp: ts, sessionId: 's1', tool: 'claude', interventions: { interrupt: 1, toolReject: 0 } })}\n`,
+    );
+    await reportUsageToTeam(clone, 'alice', { skipTruncate: true, selfConfig: cfg });
+
+    const originGit = simpleGit(origin);
+    const reportsTree = await originGit.raw(['ls-tree', '-r', '--name-only', 'teamai-reports']);
+    expect(reportsTree).toContain('members/alice.yaml');
+    expect(reportsTree).toContain('stats/alice.yaml');
+
+    const mainTree = await originGit.raw(['ls-tree', '-r', '--name-only', 'main']);
+    expect(mainTree).not.toContain('members/alice.yaml');
+    expect(mainTree).not.toContain('stats/alice.yaml');
+    expect(mainTree).toContain('teamai.yaml');
+
+    expect(fs.existsSync(path.join(clone, 'members', 'alice.yaml'))).toBe(false);
+    expect(fs.existsSync(path.join(clone, 'stats', 'alice.yaml'))).toBe(false);
+  });
+
+  it('ignores leftover default-branch members after the switch and does not copy or delete them', async () => {
+    const { origin, clone } = await seedBareOrigin();
+    const leftover = path.join(clone, 'members', 'stale.yaml');
+    fs.mkdirSync(path.dirname(leftover), { recursive: true });
+    fs.writeFileSync(leftover, 'username: stale\n');
+
+    const cfg = gitConfig(clone, origin);
+    const wt = await ensureReportsWorktree(cfg);
+    fs.mkdirSync(path.join(wt, 'members'), { recursive: true });
+    fs.writeFileSync(path.join(wt, 'members', 'alice.yaml'), 'username: alice\n');
+    await commitAndPushReports(cfg, '[teamai] Register member: alice', ['members/']);
+
+    expect(fs.readFileSync(leftover, 'utf-8')).toContain('username: stale');
+    expect(fs.existsSync(path.join(wt, 'members', 'stale.yaml'))).toBe(false);
+    expect(fs.readFileSync(path.join(wt, 'members', 'alice.yaml'), 'utf-8')).toContain('username: alice');
+
+    const originGit = simpleGit(origin);
+    const reportsTree = await originGit.raw(['ls-tree', '-r', '--name-only', 'teamai-reports']);
+    expect(reportsTree).toContain('members/alice.yaml');
+    expect(reportsTree).not.toContain('members/stale.yaml');
+  });
+
+  it('still allows an empty-repo skeleton push to the default branch, separate from members', async () => {
+    const origin = path.join(tmp, 'empty.git');
+    await simpleGit().init(['--bare', '--initial-branch=main', origin]);
+
+    const clone = path.join(tmp, 'team-repo');
+    fs.mkdirSync(clone, { recursive: true });
+    const git = simpleGit(clone);
+    await git.init(['--initial-branch=main']);
+    await configureGit(clone);
+    await git.addRemote('origin', origin);
+
+    fs.writeFileSync(path.join(clone, 'teamai.yaml'), 'team: acme\n');
+    for (const dir of ['skills', 'rules', 'docs', 'env', 'members']) {
+      fs.mkdirSync(path.join(clone, dir), { recursive: true });
+      fs.writeFileSync(path.join(clone, dir, '.gitkeep'), '');
+    }
+    await pushRepoDirectly(clone, '[teamai] Initialize team repo skeleton', [
+      'teamai.yaml',
+      'skills/.gitkeep',
+      'rules/.gitkeep',
+      'docs/.gitkeep',
+      'env/.gitkeep',
+      'members/.gitkeep',
+    ]);
+
+    const cfg = gitConfig(clone, origin);
+    const wt = await ensureReportsWorktree(cfg);
+    fs.mkdirSync(path.join(wt, 'members'), { recursive: true });
+    fs.writeFileSync(path.join(wt, 'members', 'alice.yaml'), 'username: alice\n');
+    const pushed = await commitAndPushReports(cfg, '[teamai] Register member: alice', ['members/']);
+    expect(pushed).toBe(true);
+
+    const originGit = simpleGit(origin);
+    const mainTree = await originGit.raw(['ls-tree', '-r', '--name-only', 'main']);
+    expect(mainTree).toContain('teamai.yaml');
+    expect(mainTree).toContain('skills/.gitkeep');
+    expect(mainTree).not.toContain('members/alice.yaml');
+
+    const reportsTree = await originGit.raw(['ls-tree', '-r', '--name-only', 'teamai-reports']);
+    expect(reportsTree).toContain('members/alice.yaml');
+  });
+
+  it('refuses to create a reports worktree on a non-clone path inside a business repo', async () => {
+    const business = path.join(tmp, 'business');
+    fs.mkdirSync(business, { recursive: true });
+    const git = simpleGit(business);
+    await git.init(['--initial-branch=main']);
+    await configureGit(business);
+    fs.writeFileSync(path.join(business, 'app.js'), 'console.log(1)\n');
+    await git.add('.');
+    await git.commit('init');
+
+    const nested = path.join(business, '.teamai', 'team-repo');
+    fs.mkdirSync(nested, { recursive: true });
+    const cfg = gitConfig(nested, 'https://example.com/team.git');
+
+    await expect(ensureReportsWorktree(cfg)).rejects.toThrow(/not a dedicated team-repo clone root/);
+    const logBefore = await git.log();
+    expect(fs.existsSync(path.join(path.dirname(nested), REPORTS_WORKTREE_DIRNAME))).toBe(false);
+    const logAfter = await git.log();
+    expect(logAfter.total).toBe(logBefore.total);
+  });
+});

--- a/src/__tests__/git-kind-reports.test.ts
+++ b/src/__tests__/git-kind-reports.test.ts
@@ -207,4 +207,33 @@ describe('git-kind reports branch', () => {
     const logAfter = await git.log();
     expect(logAfter.total).toBe(logBefore.total);
   });
+
+  it('rebuilds a dangling sibling reports worktree after the clone is removed and re-cloned', async () => {
+    const { origin, clone } = await seedBareOrigin();
+    const cfg = gitConfig(clone, origin);
+
+    const wt = await ensureReportsWorktree(cfg);
+    fs.mkdirSync(path.join(wt, 'members'), { recursive: true });
+    fs.writeFileSync(path.join(wt, 'members', 'alice.yaml'), 'username: alice\n');
+    expect(await commitAndPushReports(cfg, '[teamai] Register member: alice', ['members/'])).toBe(true);
+
+    fs.rmSync(clone, { recursive: true, force: true });
+    await simpleGit().clone(origin, clone);
+    await configureGit(clone);
+
+    // The sibling husk is still on disk; isGitRepo would return true, but the
+    // gitdir under the old clone is gone. ensureReportsWorktree must recreate.
+    expect(fs.existsSync(wt)).toBe(true);
+    const rebuilt = await ensureReportsWorktree(cfg);
+    expect(rebuilt).toBe(wt);
+
+    fs.mkdirSync(path.join(wt, 'members'), { recursive: true });
+    fs.writeFileSync(path.join(wt, 'members', 'bob.yaml'), 'username: bob\n');
+    expect(await commitAndPushReports(cfg, '[teamai] Register member: bob', ['members/'])).toBe(true);
+
+    const originGit = simpleGit(origin);
+    const reportsTree = await originGit.raw(['ls-tree', '-r', '--name-only', 'teamai-reports']);
+    expect(reportsTree).toContain('members/alice.yaml');
+    expect(reportsTree).toContain('members/bob.yaml');
+  });
 });

--- a/src/__tests__/hook-handlers.test.ts
+++ b/src/__tests__/hook-handlers.test.ts
@@ -91,6 +91,15 @@ vi.mock('../votes.js', () => ({
   syncVotesToTeam: mockSyncVotesToTeam,
 }));
 
+const reportsBranchMocks = vi.hoisted(() => ({
+  ensureReportsWorktree: vi.fn().mockResolvedValue('/tmp/reports-wt'),
+  commitAndPushReports: vi.fn().mockResolvedValue(true),
+}));
+vi.mock('../utils/reports-branch.js', () => ({
+  ensureReportsWorktree: (...args: unknown[]) => reportsBranchMocks.ensureReportsWorktree(...args),
+  commitAndPushReports: (...args: unknown[]) => reportsBranchMocks.commitAndPushReports(...args),
+}));
+
 const mockSeedProjectAgentRoot = vi.fn().mockResolvedValue(undefined);
 vi.mock('../project-agent-root.js', () => ({
   seedProjectAgentRoot: mockSeedProjectAgentRoot,

--- a/src/__tests__/maintenance-paths.test.ts
+++ b/src/__tests__/maintenance-paths.test.ts
@@ -50,14 +50,15 @@ describe('resolveMaintenancePaths', () => {
     expect(refreshReportsWorktree).toHaveBeenCalledWith(config, { pushIfCreated: false });
   });
 
-  it('keeps knowledge and votes together for standalone team repos', async () => {
+  it('reads git-kind votes from the sibling reports worktree', async () => {
     const config = makeConfig('git');
 
     await expect(resolveMaintenancePaths(config)).resolves.toEqual({
       repoPath: '/home/alice/.teamai/team-repo',
-      votesDir: '/home/alice/.teamai/team-repo/votes',
+      votesDir: path.join('/home/alice/.teamai', REPORTS_WORKTREE_DIRNAME, 'votes'),
       learningsDir: '/home/alice/.teamai/team-repo/learnings',
     });
-    expect(refreshReportsWorktree).not.toHaveBeenCalled();
+    expect(refreshReportsWorktree).toHaveBeenCalledOnce();
+    expect(refreshReportsWorktree).toHaveBeenCalledWith(config, { pushIfCreated: false });
   });
 });

--- a/src/__tests__/members.test.ts
+++ b/src/__tests__/members.test.ts
@@ -12,6 +12,16 @@ vi.mock('../config.js', () => ({
 
 vi.mock('../utils/git.js', () => ({
   pullRepo: vi.fn().mockResolvedValue('Already up to date.'),
+  isDedicatedRepoRoot: vi.fn().mockResolvedValue(true),
+}));
+
+const reportsMocks = vi.hoisted(() => ({
+  ensureReportsWorktree: vi.fn(),
+  refreshReportsWorktree: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../utils/reports-branch.js', () => ({
+  ensureReportsWorktree: (...args: unknown[]) => reportsMocks.ensureReportsWorktree(...args),
+  refreshReportsWorktree: (...args: unknown[]) => reportsMocks.refreshReportsWorktree(...args),
 }));
 
 vi.mock('../utils/logger.js', () => ({
@@ -136,11 +146,23 @@ describe('getMemberConfig', () => {
 
 describe('listMembers', () => {
   let tmpDir: string;
+  let cloneDir: string;
+  let reportsDir: string;
   let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  async function writeReportsMember(filename: string, data: string | Record<string, unknown>): Promise<void> {
+    const body = typeof data === 'string' ? data : YAML.stringify(data);
+    await fse.writeFile(path.join(reportsDir, 'members', filename), body);
+  }
 
   beforeEach(async () => {
     tmpDir = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-test-'));
-    await fse.ensureDir(path.join(tmpDir, 'members'));
+    cloneDir = path.join(tmpDir, 'team-repo');
+    reportsDir = path.join(tmpDir, 'reports-wt');
+    await fse.ensureDir(path.join(cloneDir, 'members'));
+    await fse.ensureDir(path.join(reportsDir, 'members'));
+    reportsMocks.ensureReportsWorktree.mockReset().mockResolvedValue(reportsDir);
+    reportsMocks.refreshReportsWorktree.mockReset().mockResolvedValue(undefined);
     consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.mocked(log.info).mockClear();
     vi.mocked(log.warn).mockClear();
@@ -152,33 +174,36 @@ describe('listMembers', () => {
   });
 
   it('should show "No team members registered" when members dir is empty', async () => {
-    mockRequireInit(tmpDir);
+    mockRequireInit(cloneDir);
+    await fse.writeFile(
+      path.join(cloneDir, 'members', 'stale.yaml'),
+      YAML.stringify({
+        username: 'stale',
+        displayName: 'Leftover on clone',
+        registeredAt: '2025-01-01T00:00:00.000Z',
+      }),
+    );
 
     await listMembers({});
 
     expect(log.info).toHaveBeenCalledWith('No team members registered');
     expect(consoleSpy).not.toHaveBeenCalled();
+    expect(reportsMocks.ensureReportsWorktree).toHaveBeenCalled();
   });
 
   it('should display members without role tags', async () => {
-    await fse.writeFile(
-      path.join(tmpDir, 'members', 'alice.yaml'),
-      YAML.stringify({
-        username: 'alice',
-        displayName: 'Alice Chen',
-        registeredAt: '2025-01-01T00:00:00.000Z',
-      }),
-    );
-    await fse.writeFile(
-      path.join(tmpDir, 'members', 'bob.yaml'),
-      YAML.stringify({
-        username: 'bob',
-        displayName: 'Bob Li',
-        registeredAt: '2025-01-01T00:00:00.000Z',
-      }),
-    );
+    await writeReportsMember('alice.yaml', {
+      username: 'alice',
+      displayName: 'Alice Chen',
+      registeredAt: '2025-01-01T00:00:00.000Z',
+    });
+    await writeReportsMember('bob.yaml', {
+      username: 'bob',
+      displayName: 'Bob Li',
+      registeredAt: '2025-01-01T00:00:00.000Z',
+    });
 
-    mockRequireInit(tmpDir, 'alice');
+    mockRequireInit(cloneDir, 'alice');
 
     await listMembers({});
 
@@ -192,24 +217,18 @@ describe('listMembers', () => {
   });
 
   it('should mark only the current user with (you)', async () => {
-    await fse.writeFile(
-      path.join(tmpDir, 'members', 'alice.yaml'),
-      YAML.stringify({
-        username: 'alice',
-        displayName: 'Alice',
-        registeredAt: '2025-01-01T00:00:00.000Z',
-      }),
-    );
-    await fse.writeFile(
-      path.join(tmpDir, 'members', 'bob.yaml'),
-      YAML.stringify({
-        username: 'bob',
-        displayName: 'Bob',
-        registeredAt: '2025-01-01T00:00:00.000Z',
-      }),
-    );
+    await writeReportsMember('alice.yaml', {
+      username: 'alice',
+      displayName: 'Alice',
+      registeredAt: '2025-01-01T00:00:00.000Z',
+    });
+    await writeReportsMember('bob.yaml', {
+      username: 'bob',
+      displayName: 'Bob',
+      registeredAt: '2025-01-01T00:00:00.000Z',
+    });
 
-    mockRequireInit(tmpDir, 'bob');
+    mockRequireInit(cloneDir, 'bob');
 
     await listMembers({});
 
@@ -221,15 +240,12 @@ describe('listMembers', () => {
   });
 
   it('should omit display name separator when displayName is empty', async () => {
-    await fse.writeFile(
-      path.join(tmpDir, 'members', 'nodisplay.yaml'),
-      YAML.stringify({
-        username: 'nodisplay',
-        registeredAt: '2025-01-01T00:00:00.000Z',
-      }),
-    );
+    await writeReportsMember('nodisplay.yaml', {
+      username: 'nodisplay',
+      registeredAt: '2025-01-01T00:00:00.000Z',
+    });
 
-    mockRequireInit(tmpDir, 'other');
+    mockRequireInit(cloneDir, 'other');
 
     await listMembers({});
 
@@ -239,16 +255,13 @@ describe('listMembers', () => {
   });
 
   it('should show registeredAt in verbose mode', async () => {
-    await fse.writeFile(
-      path.join(tmpDir, 'members', 'alice.yaml'),
-      YAML.stringify({
-        username: 'alice',
-        displayName: 'Alice',
-        registeredAt: '2025-06-15T10:30:00.000Z',
-      }),
-    );
+    await writeReportsMember('alice.yaml', {
+      username: 'alice',
+      displayName: 'Alice',
+      registeredAt: '2025-06-15T10:30:00.000Z',
+    });
 
-    mockRequireInit(tmpDir, 'alice');
+    mockRequireInit(cloneDir, 'alice');
 
     await listMembers({ verbose: true });
 
@@ -257,16 +270,13 @@ describe('listMembers', () => {
   });
 
   it('should not show registeredAt in non-verbose mode', async () => {
-    await fse.writeFile(
-      path.join(tmpDir, 'members', 'alice.yaml'),
-      YAML.stringify({
-        username: 'alice',
-        displayName: 'Alice',
-        registeredAt: '2025-06-15T10:30:00.000Z',
-      }),
-    );
+    await writeReportsMember('alice.yaml', {
+      username: 'alice',
+      displayName: 'Alice',
+      registeredAt: '2025-06-15T10:30:00.000Z',
+    });
 
-    mockRequireInit(tmpDir, 'alice');
+    mockRequireInit(cloneDir, 'alice');
 
     await listMembers({});
 
@@ -275,12 +285,9 @@ describe('listMembers', () => {
   });
 
   it('should warn on invalid member YAML files', async () => {
-    await fse.writeFile(
-      path.join(tmpDir, 'members', 'broken.yaml'),
-      '{{broken yaml [[[',
-    );
+    await writeReportsMember('broken.yaml', '{{broken yaml [[[');
 
-    mockRequireInit(tmpDir, 'other');
+    mockRequireInit(cloneDir, 'other');
 
     await listMembers({});
 
@@ -288,23 +295,46 @@ describe('listMembers', () => {
   });
 
   it('should handle legacy YAML with extra role field gracefully', async () => {
-    await fse.writeFile(
-      path.join(tmpDir, 'members', 'legacy.yaml'),
-      YAML.stringify({
-        username: 'legacy',
-        displayName: 'Legacy User',
-        registeredAt: '2025-01-01T00:00:00.000Z',
-        role: 'readonly',
-      }),
-    );
+    await writeReportsMember('legacy.yaml', {
+      username: 'legacy',
+      displayName: 'Legacy User',
+      registeredAt: '2025-01-01T00:00:00.000Z',
+      role: 'readonly',
+    });
 
-    mockRequireInit(tmpDir, 'other');
+    mockRequireInit(cloneDir, 'other');
 
     await listMembers({});
 
     const allOutput = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
     expect(allOutput).not.toContain('[readonly]');
     expect(allOutput).toContain('legacy');
+  });
+
+  it('does not list leftover members YAML on the default-branch clone', async () => {
+    await writeReportsMember('alice.yaml', {
+      username: 'alice',
+      displayName: 'Alice Chen',
+      registeredAt: '2025-01-01T00:00:00.000Z',
+    });
+    await fse.writeFile(
+      path.join(cloneDir, 'members', 'stale.yaml'),
+      YAML.stringify({
+        username: 'stale',
+        displayName: 'Leftover on clone',
+        registeredAt: '2025-01-01T00:00:00.000Z',
+      }),
+    );
+
+    mockRequireInit(cloneDir, 'alice');
+
+    await listMembers({});
+
+    const allOutput = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
+    expect(allOutput).toContain('alice');
+    expect(allOutput).toContain('Team members (1)');
+    expect(allOutput).not.toContain('stale');
+    expect(allOutput).not.toContain('Leftover on clone');
   });
 });
 

--- a/src/__tests__/pull-scope-isolation.test.ts
+++ b/src/__tests__/pull-scope-isolation.test.ts
@@ -274,6 +274,15 @@ describe('pull scope isolation (issue #73)', () => {
     expect(log.info).not.toHaveBeenCalledWith(SKIP_MSG);
     expect(pullSources).toHaveBeenCalledTimes(1);
     expect(vi.mocked(pullSources).mock.calls[0][0]).toMatchObject({ scope: 'user' });
+    expect(reportUsageToTeam).toHaveBeenCalledWith(
+      userRepoPath,
+      'userscope',
+      expect.objectContaining({
+        selfConfig: expect.objectContaining({
+          repo: expect.objectContaining({ localPath: userRepoPath }),
+        }),
+      }),
+    );
   });
 
   it('user mode self-repo: reportUsageToTeam receives selfConfig so business repo is never reset', async () => {

--- a/src/__tests__/reports-branch-readonly.test.ts
+++ b/src/__tests__/reports-branch-readonly.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
     commit: vi.fn(),
     push: vi.fn(),
     status: vi.fn(),
+    revparse: vi.fn(),
   },
   isGitRepo: vi.fn(),
 }));
@@ -110,6 +111,7 @@ describe('commitAndPushReports', () => {
     mocks.worktreeGit.add.mockResolvedValue(undefined);
     mocks.worktreeGit.commit.mockResolvedValue(undefined);
     mocks.worktreeGit.push.mockResolvedValue(undefined);
+    mocks.worktreeGit.revparse.mockResolvedValue('true');
     mocks.worktreeGit.status.mockResolvedValue({ staged: ['members/alice.yaml'] });
     vi.mocked(acquireLock).mockResolvedValue(true);
     vi.mocked(releaseLock).mockResolvedValue(undefined);

--- a/src/__tests__/reports-branch-readonly.test.ts
+++ b/src/__tests__/reports-branch-readonly.test.ts
@@ -24,6 +24,7 @@ vi.mock('../utils/git.js', () => ({
   isGitRepo: mocks.isGitRepo,
   getDefaultBranch: vi.fn(),
   hasCommits: vi.fn(),
+  isDedicatedRepoRoot: vi.fn().mockResolvedValue(true),
   commitSkippingHooks: (git: { commit: (...args: unknown[]) => unknown }, message: string) =>
     git.commit(message, { '--no-verify': null }),
 }));

--- a/src/__tests__/self-mode-no-business-reset.test.ts
+++ b/src/__tests__/self-mode-no-business-reset.test.ts
@@ -1,6 +1,7 @@
 /**
  * E2E (real git, NO mocks): proves reportUsageToTeam never wipes a self-mode
- * business repo working tree, and still resets a genuine git-mode cache clone.
+ * business repo working tree, and git-kind reports land on the sibling
+ * teamai-reports checkout instead of resetting the knowledge clone.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
@@ -71,29 +72,60 @@ describe('E2E self-mode: business repo working tree is never reset', () => {
     expect(content).toContain('MY UNCOMMITTED WORK');
   });
 
-  it('git mode: resets cache garbage but preserves an uncommitted teamai.yaml edit', async () => {
-    // A dedicated cache clone: repoPath IS the git top level.
-    // Use 'main' as default branch so resetToCleanMaster's fallback checkout matches.
+  it('git mode: writes stats to sibling teamai-reports and does not reset the clone', async () => {
+    const origin = path.join(tmp, 'origin.git');
+    await simpleGit().init(['--bare', '--initial-branch=main', origin]);
+
     const cacheRoot = path.join(tmp, 'cache');
     await makeRepo(cacheRoot, 'main');
     const git = simpleGit(cacheRoot);
-
     fs.writeFileSync(path.join(cacheRoot, 'teamai.yaml'), 'team: original\n');
     await git.add('teamai.yaml');
     await git.commit('add team config');
+    await git.addRemote('origin', origin);
+    await git.push(['-u', 'origin', 'main']);
 
-    // Simulate both disposable cache garbage and a pending source add.
     fs.writeFileSync(path.join(cacheRoot, 'app.js'), 'garbage\n');
     fs.writeFileSync(
       path.join(cacheRoot, 'teamai.yaml'),
       'team: original\nsources:\n  - name: beta-source\n    repo: https://source.test/root/beta-source.git\n',
     );
+    fs.mkdirSync(path.join(cacheRoot, 'members'), { recursive: true });
+    fs.writeFileSync(path.join(cacheRoot, 'members', 'stale.yaml'), 'username: stale\n');
 
-    await reportUsageToTeam(cacheRoot, 'me', { skipTruncate: true });
+    const ts = new Date().toISOString();
+    const eventsDir = path.join(process.env.HOME!, '.teamai', 'dashboard');
+    fs.mkdirSync(eventsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(eventsDir, 'events.jsonl'),
+      `${JSON.stringify({ type: 'session_start', timestamp: ts, sessionId: 's1', tool: 'claude', cwd: '/p' })}\n` +
+      `${JSON.stringify({ type: 'stop', timestamp: ts, sessionId: 's1', tool: 'claude', interventions: { interrupt: 1, toolReject: 0 } })}\n`,
+    );
 
-    expect(fs.readFileSync(path.join(cacheRoot, 'app.js'), 'utf-8')).toBe('console.log(1)\n');
+    const cfg: LocalConfig = {
+      repo: { localPath: cacheRoot, remote: origin, kind: 'git' },
+      username: 'me',
+      scope: 'user',
+      additionalRoles: [],
+    } as unknown as LocalConfig;
+
+    await reportUsageToTeam(cacheRoot, 'me', { skipTruncate: true, selfConfig: cfg });
+
+    // Knowledge clone is not reset — uncommitted clone edits survive.
+    expect(fs.readFileSync(path.join(cacheRoot, 'app.js'), 'utf-8')).toBe('garbage\n');
     expect(fs.readFileSync(path.join(cacheRoot, 'teamai.yaml'), 'utf-8'))
       .toContain('name: beta-source');
+    expect(fs.readFileSync(path.join(cacheRoot, 'members', 'stale.yaml'), 'utf-8'))
+      .toContain('username: stale');
+    expect(fs.existsSync(path.join(cacheRoot, 'stats', 'me.yaml'))).toBe(false);
+
+    const reportsWt = path.join(tmp, 'reports-wt');
+    expect(fs.existsSync(path.join(reportsWt, 'stats', 'me.yaml'))).toBe(true);
+    const originReports = simpleGit(origin);
+    const reportsTree = await originReports.raw(['ls-tree', '-r', '--name-only', 'teamai-reports']);
+    expect(reportsTree).toContain('stats/me.yaml');
+    const mainTree = await originReports.raw(['ls-tree', '-r', '--name-only', 'main']);
+    expect(mainTree).not.toContain('stats/me.yaml');
   });
 
   it('project scope (git kind): business repo is NOT reset when team-repo dir lacks its own .git', async () => {

--- a/src/__tests__/single-repo-mode.test.ts
+++ b/src/__tests__/single-repo-mode.test.ts
@@ -4,6 +4,7 @@ import {
   getReportsDir,
   getKnowledgeDir,
   isSelfMode,
+  usesReportsBranch,
   REPORTS_WORKTREE_DIRNAME,
   LocalConfigSchema,
   TeamaiConfigSchema,
@@ -33,6 +34,13 @@ describe('single-repo mode path helpers', () => {
     expect(isSelfMode(makeConfig('http'))).toBe(false);
   });
 
+  it('usesReportsBranch is true for every non-HTTP kind, including omitted kind', () => {
+    expect(usesReportsBranch(makeConfig('self'))).toBe(true);
+    expect(usesReportsBranch(makeConfig('git'))).toBe(true);
+    expect(usesReportsBranch(makeConfig('http'))).toBe(false);
+    expect(usesReportsBranch({ repo: {} })).toBe(true);
+  });
+
   it('getKnowledgeDir returns localPath in every mode', () => {
     expect(getKnowledgeDir(makeConfig('self'))).toBe('/repo/.teamai');
     expect(getKnowledgeDir(makeConfig('git', '/home/alice/.teamai/team-repo'))).toBe(
@@ -40,13 +48,13 @@ describe('single-repo mode path helpers', () => {
     );
   });
 
-  it('getReportsDir points at the reports worktree only in self mode', () => {
+  it('getReportsDir points at the reports worktree for self and git, clone/localPath for http', () => {
     expect(getReportsDir(makeConfig('self'))).toBe(
       path.join('/repo/.teamai', REPORTS_WORKTREE_DIRNAME),
     );
-    // Non-self modes keep reports alongside knowledge (localPath) — unchanged behavior.
+    // Independent git clone: sibling of the clone, not nested inside it.
     expect(getReportsDir(makeConfig('git', '/home/alice/.teamai/team-repo'))).toBe(
-      '/home/alice/.teamai/team-repo',
+      path.join('/home/alice/.teamai', REPORTS_WORKTREE_DIRNAME),
     );
     expect(getReportsDir(makeConfig('http', '/home/alice/.teamai/team-repo'))).toBe(
       '/home/alice/.teamai/team-repo',

--- a/src/__tests__/team-push-interventions.test.ts
+++ b/src/__tests__/team-push-interventions.test.ts
@@ -3,16 +3,25 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import YAML from 'yaml';
+import type { LocalConfig } from '../types.js';
 
-// Stub out all real git I/O so we exercise reportUsageToTeam's reporting logic
+// Stub out git I/O so we exercise reportUsageToTeam's reporting logic
 // (delta → stats yaml → reported snapshot) without a real repo/remote.
 const pushRepoDirectly = vi.fn().mockResolvedValue(undefined);
+const reportsMocks = vi.hoisted(() => ({
+  commitAndPushReports: vi.fn().mockResolvedValue(true),
+  ensureReportsWorktree: vi.fn(),
+}));
 vi.mock('../utils/git.js', () => ({
   createGit: vi.fn(() => ({})),
   pushRepoDirectly: (...args: unknown[]) => pushRepoDirectly(...args),
   pullRepo: vi.fn().mockResolvedValue(undefined),
   resetToCleanMaster: vi.fn().mockResolvedValue(undefined),
   isDedicatedRepoRoot: vi.fn().mockResolvedValue(true),
+}));
+vi.mock('../utils/reports-branch.js', () => ({
+  ensureReportsWorktree: (...args: unknown[]) => reportsMocks.ensureReportsWorktree(...args),
+  commitAndPushReports: (...args: unknown[]) => reportsMocks.commitAndPushReports(...args),
 }));
 vi.mock('../utils/logger.js', () => ({
   log: { info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
@@ -33,6 +42,19 @@ let tmpDir: string;
 let repoDir: string;
 let originalHome: string;
 
+function gitConfig(): LocalConfig {
+  return {
+    repo: { localPath: repoDir, remote: 'https://example.com/team.git', kind: 'git' },
+    username: 'me',
+    scope: 'user',
+    additionalRoles: [],
+  };
+}
+
+function reportsStatsPath(): string {
+  return path.join(tmpDir, 'reports-wt', 'stats', 'me.yaml');
+}
+
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-tp-iv-'));
   originalHome = process.env.HOME ?? '';
@@ -40,6 +62,12 @@ beforeEach(() => {
   repoDir = path.join(tmpDir, 'repo');
   fs.mkdirSync(repoDir, { recursive: true });
   pushRepoDirectly.mockClear();
+  reportsMocks.commitAndPushReports.mockClear().mockResolvedValue(true);
+  reportsMocks.ensureReportsWorktree.mockReset().mockImplementation(async (cfg: LocalConfig) => {
+    const dir = path.join(path.dirname(cfg.repo.localPath), 'reports-wt');
+    fs.mkdirSync(dir, { recursive: true });
+    return dir;
+  });
 });
 
 afterEach(() => {
@@ -61,18 +89,18 @@ describe('reportUsageToTeam — intervention reporting', () => {
       { type: 'stop', timestamp: ts, sessionId: 's1', tool: 'claude', interventions: { interrupt: 2, toolReject: 1 } },
     ]);
 
-    await reportUsageToTeam(repoDir, 'me');
+    await reportUsageToTeam(repoDir, 'me', { selfConfig: gitConfig() });
 
-    // stats yaml carries the merged intervention totals
-    const statsPath = path.join(repoDir, 'stats', 'me.yaml');
+    // stats yaml carries the merged intervention totals on the reports worktree
+    const statsPath = reportsStatsPath();
     expect(fs.existsSync(statsPath)).toBe(true);
     const stats = YAML.parse(fs.readFileSync(statsPath, 'utf-8'));
     expect(stats.interventions).toEqual({ sessions: 1, interrupt: 2, toolReject: 1, correction: 0 });
     expect(stats.daily[ts.slice(0, 10)]).toMatchObject({ sessionsEnded: 1, sessionsSucceeded: 0 });
 
-    // push was attempted with the stats file staged
-    expect(pushRepoDirectly).toHaveBeenCalledTimes(1);
-    expect(pushRepoDirectly.mock.calls[0][2]).toContain('stats/me.yaml');
+    expect(pushRepoDirectly).not.toHaveBeenCalled();
+    expect(reportsMocks.commitAndPushReports).toHaveBeenCalledTimes(1);
+    expect(reportsMocks.commitAndPushReports.mock.calls[0][2]).toContain('stats/me.yaml');
 
     // reported snapshot persisted so a second run reports nothing new
     const reportedPath = path.join(tmpDir, '.teamai', 'dashboard', 'reported-interventions.json');
@@ -82,16 +110,18 @@ describe('reportUsageToTeam — intervention reporting', () => {
     const dailyPath = path.join(tmpDir, '.teamai', 'dashboard', 'reported-daily-sessions.json');
     expect(JSON.parse(fs.readFileSync(dailyPath, 'utf-8')).s1.date).toBe(ts.slice(0, 10));
 
-    pushRepoDirectly.mockClear();
-    await reportUsageToTeam(repoDir, 'me');
+    reportsMocks.commitAndPushReports.mockClear();
+    await reportUsageToTeam(repoDir, 'me', { selfConfig: gitConfig() });
     // Nothing new (no usage, no intervention delta, no votes) → no push
+    expect(reportsMocks.commitAndPushReports).not.toHaveBeenCalled();
     expect(pushRepoDirectly).not.toHaveBeenCalled();
   });
 
   it('does nothing when there are no events, interventions, or votes', async () => {
-    await reportUsageToTeam(repoDir, 'me');
+    await reportUsageToTeam(repoDir, 'me', { selfConfig: gitConfig() });
+    expect(reportsMocks.commitAndPushReports).not.toHaveBeenCalled();
     expect(pushRepoDirectly).not.toHaveBeenCalled();
-    expect(fs.existsSync(path.join(repoDir, 'stats', 'me.yaml'))).toBe(false);
+    expect(fs.existsSync(reportsStatsPath())).toBe(false);
   });
 });
 
@@ -108,9 +138,9 @@ describe('reportUsageToTeam — preserve fields across partial reports (Issue #4
         tokens: { input: 10, output: 5, cacheRead: 0, cacheCreation: 0 },
       },
     ]);
-    await reportUsageToTeam(repoDir, 'me');
+    await reportUsageToTeam(repoDir, 'me', { selfConfig: gitConfig() });
 
-    const statsPath = path.join(repoDir, 'stats', 'me.yaml');
+    const statsPath = reportsStatsPath();
     let stats = YAML.parse(fs.readFileSync(statsPath, 'utf-8'));
     expect(stats.interventions).toEqual({ sessions: 1, interrupt: 2, toolReject: 1, correction: 0 });
     expect(stats.prompts).toBe(1);
@@ -127,15 +157,16 @@ describe('reportUsageToTeam — preserve fields across partial reports (Issue #4
         tokens: { input: 50, output: 20, cacheRead: 0, cacheCreation: 0 },
       },
     ]);
-    pushRepoDirectly.mockClear();
-    await reportUsageToTeam(repoDir, 'me');
+    reportsMocks.commitAndPushReports.mockClear();
+    await reportUsageToTeam(repoDir, 'me', { selfConfig: gitConfig() });
 
     stats = YAML.parse(fs.readFileSync(statsPath, 'utf-8'));
     // Must still have interventions after a tokens-only report
     expect(stats.interventions).toEqual({ sessions: 1, interrupt: 2, toolReject: 1, correction: 0 });
     expect(stats.prompts).toBe(2);
     expect(stats.tokens).toEqual({ input: 50, output: 20, cacheRead: 0, cacheCreation: 0 });
-    expect(pushRepoDirectly).toHaveBeenCalledTimes(1);
+    expect(reportsMocks.commitAndPushReports).toHaveBeenCalledTimes(1);
+    expect(pushRepoDirectly).not.toHaveBeenCalled();
   });
 
   it('keeps prompts/tokens when a follow-up report is intervention-only', async () => {
@@ -149,9 +180,9 @@ describe('reportUsageToTeam — preserve fields across partial reports (Issue #4
         tokens: { input: 10, output: 5, cacheRead: 0, cacheCreation: 0 },
       },
     ]);
-    await reportUsageToTeam(repoDir, 'me');
+    await reportUsageToTeam(repoDir, 'me', { selfConfig: gitConfig() });
 
-    const statsPath = path.join(repoDir, 'stats', 'me.yaml');
+    const statsPath = reportsStatsPath();
     let stats = YAML.parse(fs.readFileSync(statsPath, 'utf-8'));
     expect(stats.prompts).toBe(1);
     expect(stats.tokens).toEqual({ input: 10, output: 5, cacheRead: 0, cacheCreation: 0 });
@@ -166,14 +197,15 @@ describe('reportUsageToTeam — preserve fields across partial reports (Issue #4
         tokens: { input: 10, output: 5, cacheRead: 0, cacheCreation: 0 },
       },
     ]);
-    pushRepoDirectly.mockClear();
-    await reportUsageToTeam(repoDir, 'me');
+    reportsMocks.commitAndPushReports.mockClear();
+    await reportUsageToTeam(repoDir, 'me', { selfConfig: gitConfig() });
 
     stats = YAML.parse(fs.readFileSync(statsPath, 'utf-8'));
     expect(stats.interventions).toEqual({ sessions: 1, interrupt: 1, toolReject: 0, correction: 0 });
     // Must still have prompts/tokens after an intervention-only report
     expect(stats.prompts).toBe(1);
     expect(stats.tokens).toEqual({ input: 10, output: 5, cacheRead: 0, cacheCreation: 0 });
-    expect(pushRepoDirectly).toHaveBeenCalledTimes(1);
+    expect(reportsMocks.commitAndPushReports).toHaveBeenCalledTimes(1);
+    expect(pushRepoDirectly).not.toHaveBeenCalled();
   });
 });

--- a/src/contribute.ts
+++ b/src/contribute.ts
@@ -54,7 +54,8 @@ async function rebuildIndexAfterContribute(localConfig: LocalConfig): Promise<vo
   const docsRepoDir = path.join(repoPath, 'docs');
   const rulesRepoDir = path.join(repoPath, 'rules');
   const skillsRepoDir = path.join(repoPath, 'skills');
-  const votesDir = path.join(repoPath, 'votes');
+  const { getReportsDir } = await import('./types.js');
+  const votesDir = path.join(getReportsDir(localConfig), 'votes');
 
   // user scope mirrors learnings/ into ~/.teamai/learnings/ (legacy behavior,
   // same as pull.ts); project scope indexes the repo's learnings/ directly.

--- a/src/digest.ts
+++ b/src/digest.ts
@@ -410,11 +410,12 @@ export async function generateDigest(options: GlobalOptions): Promise<void> {
     const localConfig = projectConfig ?? (await requireInit()).localConfig;
     const repoPath = localConfig.repo.localPath;
 
-    // In self mode, knowledge (learnings, skill git-log) lives under localPath on
-    // main, but report data (stats, sessions) lives on the teamai-reports orphan
-    // branch — read those from the reports worktree, refreshed from origin.
+    // Knowledge (learnings, skill git-log) lives under localPath on the default
+    // branch; report data (stats, sessions) lives on the teamai-reports orphan
+    // branch for non-HTTP repos — read those from the reports worktree.
     let reportsRoot = repoPath;
-    if (localConfig.repo.kind === 'self') {
+    const { usesReportsBranch } = await import('./types.js');
+    if (usesReportsBranch(localConfig)) {
       const { ensureReportsWorktree, refreshReportsWorktree } = await import('./utils/reports-branch.js');
       await refreshReportsWorktree(localConfig);
       reportsRoot = await ensureReportsWorktree(localConfig);

--- a/src/hook-handlers.ts
+++ b/src/hook-handlers.ts
@@ -310,9 +310,10 @@ const votesSyncHandler: HookHandler = {
       if (verifiedDocIds.length > 0) {
         await incrementUpvoted(votePath, verifiedDocIds);
       }
-      if (localConfig.repo.kind === 'self') {
-        // Self mode: votes are report data → the teamai-reports orphan branch,
-        // written through an isolated worktree (never the active tree).
+      const { usesReportsBranch } = await import('./types.js');
+      if (usesReportsBranch(localConfig)) {
+        // Votes are report data → the teamai-reports orphan branch, written
+        // through an isolated worktree (never the default branch / active tree).
         try {
           const { ensureReportsWorktree, commitAndPushReports } = await import('./utils/reports-branch.js');
           const wt = await ensureReportsWorktree(localConfig);

--- a/src/init.ts
+++ b/src/init.ts
@@ -1233,6 +1233,7 @@ export async function init(options: GlobalOptions & {
   // Remote teamai.yaml.scope (if present) is ignored — local install location
   // is decided only by --scope / default (issue #250).
   const teamConfig = await loadTeamConfig(localPath);
+  const createdSkeleton = !teamConfig;
   if (!teamConfig) {
     log.warn('teamai.yaml not found in repo. Creating default config...');
     const defaultConfig = YAML.stringify({
@@ -1248,7 +1249,8 @@ export async function init(options: GlobalOptions & {
     });
     await writeFile(path.join(localPath, 'teamai.yaml'), defaultConfig);
 
-    // Create standard directories
+    // Knowledge-tree skeleton on the default branch so an empty remote has a
+    // committable HEAD. Member YAML files go to teamai-reports, not here.
     for (const dir of ['members', 'skills', 'rules', 'docs', 'env']) {
       await ensureDir(path.join(localPath, dir));
       const gitkeep = path.join(localPath, dir, '.gitkeep');
@@ -1270,41 +1272,72 @@ export async function init(options: GlobalOptions & {
     process.exit(1);
   }
 
-  // Step 5: Create or update member file. Membership is the union of every
-  // project this user has init'd (append + dedupe), so re-running init in another
-  // project directory adds that project to the roster rather than being a no-op.
-  const memberPath = path.join(localPath, 'members', `${username}.yaml`);
-  const isNewMember = !await pathExists(memberPath);
-  const existingMember = await getMemberConfig(localPath, username);
-  const { config: memberConfig, changed: memberChanged } = mergeMemberConfig(existingMember, {
+  const reportsConfig: LocalConfig = {
+    repo: { localPath, remote: repoInfo.httpsUrl },
     username,
-    projects: resolvedProjects,
-  });
-  if (memberChanged) {
-    await writeFile(memberPath, YAML.stringify(memberConfig));
-    log.success(isNewMember
-      ? `Registered as team member: ${username}`
-      : `Updated member roster: ${username}${memberConfig.projects ? ` (projects: ${memberConfig.projects.join(', ')})` : ''}`);
+    scope,
+    projectRoot,
+    additionalRoles: [],
+  };
 
-    if (!options.dryRun) {
-      try {
-        await pushRepoDirectly(localPath, isNewMember
+  // Empty-repo exception: a one-time skeleton push of teamai.yaml + gitkeeps may
+  // still land on the default branch so the knowledge tree exists. Member files
+  // after that go to teamai-reports.
+  if (createdSkeleton && !options.dryRun) {
+    try {
+      await pushRepoDirectly(localPath, '[teamai] Initialize team repo skeleton', [
+        'teamai.yaml',
+        'skills/.gitkeep',
+        'rules/.gitkeep',
+        'docs/.gitkeep',
+        'env/.gitkeep',
+        'members/.gitkeep',
+      ]);
+    } catch (e) {
+      log.warn(`Push failed (you can push manually later): ${(e as Error).message}`);
+    }
+  }
+
+  // Step 5: member roster on the teamai-reports orphan branch (never the
+  // default branch). Leftover members/ on the clone is ignored.
+  let isNewMember = true;
+  if (!options.dryRun) {
+    try {
+      const { ensureReportsWorktree, commitAndPushReports } = await import('./utils/reports-branch.js');
+      const wt = await ensureReportsWorktree(reportsConfig);
+      const memberDir = path.join(wt, 'members');
+      await ensureDir(memberDir);
+      const memberPath = path.join(memberDir, `${username}.yaml`);
+      isNewMember = !await pathExists(memberPath);
+      const existingMember = await getMemberConfig(wt, username);
+      const { config: memberConfig, changed: memberChanged } = mergeMemberConfig(existingMember, {
+        username,
+        projects: resolvedProjects,
+      });
+      if (memberChanged) {
+        await writeFile(memberPath, YAML.stringify(memberConfig));
+        log.success(isNewMember
+          ? `Registered as team member: ${username}`
+          : `Updated member roster: ${username}${memberConfig.projects ? ` (projects: ${memberConfig.projects.join(', ')})` : ''}`);
+        const pushed = await commitAndPushReports(reportsConfig, isNewMember
           ? `[teamai] Register member: ${username}`
-          : `[teamai] Update member roster: ${username}`, [
-          'members/',
-          'teamai.yaml',
-          'skills/.gitkeep',
-          'rules/.gitkeep',
-          'docs/.gitkeep',
-          'env/.gitkeep',
-        ]);
-        log.success('Member registration pushed to team repo');
-      } catch (e) {
-        log.warn(`Push failed (you can push manually later): ${(e as Error).message}`);
+          : `[teamai] Update member roster: ${username}`, ['members/']);
+        if (pushed) {
+          log.success(isNewMember
+            ? 'Member registered on the teamai-reports branch'
+            : 'Member roster updated on the teamai-reports branch');
+        } else {
+          log.warn('Member registration could not be pushed (no write access?). You are still set up locally.');
+        }
+      } else {
+        log.info(`Member ${username} already registered`);
+        isNewMember = false;
       }
+    } catch (e) {
+      log.warn(`Member registration skipped (non-blocking): ${(e as Error).message}`);
     }
   } else {
-    log.info(`Member ${username} already registered`);
+    log.info(`[dry-run] Would register member ${username} on the teamai-reports branch`);
   }
 
   // Step 5.5: Configure default MR reviewers (only for fresh setup with no reviewers yet).

--- a/src/maintenance/paths.ts
+++ b/src/maintenance/paths.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 
 import type { LocalConfig } from '../types.js';
-import { getKnowledgeDir, getReportsDir, isSelfMode } from '../types.js';
+import { getKnowledgeDir, getReportsDir, usesReportsBranch } from '../types.js';
 
 export interface MaintenancePaths {
   repoPath: string;
@@ -12,8 +12,8 @@ export interface MaintenancePaths {
 /**
  * Resolve the knowledge and report roots used by recall maintenance commands.
  *
- * In self mode, knowledge remains on the business repository's main branch,
- * while votes live in the teamai-reports worktree. Other repository kinds keep
+ * Knowledge remains on the default branch (or self-mode `.teamai/` on main).
+ * Votes live in the teamai-reports worktree for every non-HTTP repo. HTTP keeps
  * both data sets under localConfig.repo.localPath. Maintenance is a report
  * reader, so a cold start may create its local cache but never publishes a new
  * reports branch as a side effect.
@@ -21,7 +21,7 @@ export interface MaintenancePaths {
 export async function resolveMaintenancePaths(
   localConfig: LocalConfig,
 ): Promise<MaintenancePaths> {
-  if (isSelfMode(localConfig)) {
+  if (usesReportsBranch(localConfig)) {
     const { refreshReportsWorktree } = await import('../utils/reports-branch.js');
     await refreshReportsWorktree(localConfig, { pushIfCreated: false });
   }

--- a/src/members.ts
+++ b/src/members.ts
@@ -65,10 +65,12 @@ export async function listMembers(options: GlobalOptions): Promise<void> {
   const projectConfig = await detectProjectConfig();
   const localConfig = projectConfig ?? (await requireInit()).localConfig;
 
-  // Members live on the teamai-reports orphan branch in self mode; read them from
-  // the reports worktree (refreshed from origin) instead of the team repo clone.
+  // Members live on the teamai-reports orphan branch for non-HTTP repos; read
+  // them from the reports worktree (refreshed from origin). Leftover members/
+  // on the default-branch clone is ignored. HTTP keeps the clone/API path.
   let repoPath: string;
-  if (localConfig.repo.kind === 'self') {
+  const { usesReportsBranch } = await import('./types.js');
+  if (usesReportsBranch(localConfig)) {
     const { ensureReportsWorktree, refreshReportsWorktree } = await import('./utils/reports-branch.js');
     await refreshReportsWorktree(localConfig);
     repoPath = await ensureReportsWorktree(localConfig);

--- a/src/projects-cmd.ts
+++ b/src/projects-cmd.ts
@@ -130,25 +130,27 @@ export async function projectsMembers(
 ): Promise<void> {
   const { localConfig } = await autoDetectInit();
 
-  // Members live on the teamai-reports orphan branch in self mode; read them from
-  // the refreshed reports worktree. Otherwise read the team repo clone.
-  let repoPath: string;
-  if (localConfig.repo.kind === 'self') {
+  // Members live on the teamai-reports orphan branch for non-HTTP repos; the
+  // projects manifest is knowledge on the default branch. Split the two roots
+  // so leftover clone members/ is ignored and projects.yaml is still found.
+  const knowledgePath = localConfig.repo.localPath;
+  let membersRoot = knowledgePath;
+  const { usesReportsBranch } = await import('./types.js');
+  if (usesReportsBranch(localConfig)) {
     const { ensureReportsWorktree, refreshReportsWorktree } = await import('./utils/reports-branch.js');
     await refreshReportsWorktree(localConfig);
-    repoPath = await ensureReportsWorktree(localConfig);
+    membersRoot = await ensureReportsWorktree(localConfig);
   } else {
-    repoPath = localConfig.repo.localPath;
-    await pullRepo(repoPath).catch(() => { /* offline — read local copy */ });
+    await pullRepo(knowledgePath).catch(() => { /* offline — read local copy */ });
   }
 
-  const manifest = await loadProjectsManifest(repoPath);
+  const manifest = await loadProjectsManifest(knowledgePath);
   if (manifest && !listProjectIds(manifest).includes(projectId)) {
     log.warn(`Project "${projectId}" is not defined in manifest/projects.yaml.`);
     // Continue anyway — the roster may still record historical membership.
   }
 
-  const membersDir = path.join(repoPath, 'members');
+  const membersDir = path.join(membersRoot, 'members');
   const files = (await listFiles(membersDir)).filter((f) => f.endsWith('.yaml') || f.endsWith('.yml'));
 
   const members: string[] = [];

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -28,6 +28,7 @@ import {
   isAgentDisabled,
   scopedToolPaths,
   SYNC_LOCK_FILENAME,
+  usesReportsBranch,
 } from './types.js';
 import type { CultureFrontmatter } from './types.js';
 import { loadRolesManifest, resolveRoleResourceNamespaces, type ResourceNamespaces } from './roles.js';
@@ -828,18 +829,19 @@ async function pullForScope(
       const docsRepoDir = path.join(localConfig.repo.localPath, 'docs');
       const rulesRepoDir = path.join(localConfig.repo.localPath, 'rules');
       const skillsRepoDir = path.join(localConfig.repo.localPath, 'skills');
-      // votes/ lives on the teamai-reports orphan branch in self mode (gitignored
-      // under localPath), so vote-weighted recall must read it from the reports
-      // worktree — otherwise ranking is silently disabled. Best-effort: fall back
-      // to localPath/votes (empty) if the worktree can't be resolved.
-      let votesDir = path.join(localConfig.repo.localPath, 'votes');
-      if (localConfig.repo.kind === 'self') {
+      // votes/ lives on the teamai-reports orphan branch for non-HTTP repos, so
+      // vote-weighted recall must read it from the reports worktree. Do not fall
+      // back to leftover default-branch clone votes after the switch.
+      let votesDir: string | undefined;
+      if (usesReportsBranch(localConfig)) {
         try {
           const { ensureReportsWorktree } = await import('./utils/reports-branch.js');
           votesDir = path.join(await ensureReportsWorktree(localConfig), 'votes');
         } catch (e) {
-          log.debug(`[self] reports worktree for votes unavailable: ${(e as Error).message}`);
+          log.debug(`reports worktree for votes unavailable: ${(e as Error).message}`);
         }
+      } else {
+        votesDir = path.join(localConfig.repo.localPath, 'votes');
       }
 
       // user scope: sync learnings to ~/.teamai/learnings/ (legacy behavior)
@@ -894,7 +896,7 @@ async function pullForScope(
       const effectiveCodebaseDir = await pathExists(repoCodebaseDir) ? repoCodebaseDir : undefined;
 
       if (hasAnySource || effectiveCodebaseDir) {
-        const votesExist = await pathExists(votesDir);
+        const votesExist = votesDir ? await pathExists(votesDir) : false;
         const teamaiHome = getDataHome(localConfig);
         const indexPath = path.join(teamaiHome, 'search-index.json');
         const { buildIndex } = await import('./utils/search-index.js');
@@ -1059,23 +1061,24 @@ async function pullForScope(
       const YAML = (await import('yaml')).default;
       const { listFiles, readFileSafe } = await import('./utils/fs.js');
       const { getRecommendations, displayRecommendations } = await import('./skill-recommend.js');
-      // stats/ lives on the teamai-reports orphan branch in self mode (gitignored
-      // under localPath), so recommendations must read it from the reports worktree
-      // — otherwise they never appear. Best-effort fallback to localPath/stats.
-      let statsDir = path.join(localConfig.repo.localPath, 'stats');
-      if (localConfig.repo.kind === 'self') {
+      // stats/ lives on the teamai-reports orphan branch for non-HTTP repos.
+      // Do not fall back to leftover default-branch clone stats after the switch.
+      let statsDir: string | undefined;
+      if (usesReportsBranch(localConfig)) {
         try {
           const { ensureReportsWorktree } = await import('./utils/reports-branch.js');
           statsDir = path.join(await ensureReportsWorktree(localConfig), 'stats');
         } catch (e) {
-          log.debug(`[self] reports worktree for stats unavailable: ${(e as Error).message}`);
+          log.debug(`reports worktree for stats unavailable: ${(e as Error).message}`);
         }
+      } else {
+        statsDir = path.join(localConfig.repo.localPath, 'stats');
       }
-      const files = await listFiles(statsDir);
+      const files = statsDir ? await listFiles(statsDir) : [];
       const teamStats = [];
       for (const file of files) {
         if (!file.endsWith('.yaml')) continue;
-        const content = await readFileSafe(path.join(statsDir, file));
+        const content = await readFileSafe(path.join(statsDir!, file));
         if (!content) continue;
         try {
           const parsed = YAML.parse(content);
@@ -1556,8 +1559,8 @@ export async function pull(options: GlobalOptions): Promise<void> {
           opts: {
             skipTruncate: true,
             projectRoot: reconcileProject.projectRoot,
-            // Self mode routes stats/votes to the teamai-reports orphan branch.
-            ...(reconcileProject.repo.kind === 'self' ? { selfConfig: reconcileProject } : {}),
+            // Non-HTTP repos route stats/votes to the teamai-reports orphan branch.
+            selfConfig: reconcileProject,
           },
         });
       }
@@ -1568,9 +1571,9 @@ export async function pull(options: GlobalOptions): Promise<void> {
           opts: {
             skipTruncate: true,
             excludeProjectRoots: projectConfig?.projectRoot ? [projectConfig.projectRoot] : [],
-            // Self mode routes stats/votes to the teamai-reports orphan branch —
-            // never reset/pull the business repo working tree.
-            ...(reconcileUser.repo.kind === 'self' ? { selfConfig: reconcileUser } : {}),
+            // Non-HTTP repos route stats/votes to the teamai-reports orphan branch —
+            // never reset/pull the default branch (or, in self mode, the business tree).
+            selfConfig: reconcileUser,
           },
         });
       }

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -295,9 +295,11 @@ async function loadOrBuildScopeIndex(
   // condition triggers rebuild when the file is missing entirely.
   const needsRebuild = !index || isLegacyIndex(index);
   if (needsRebuild && (effectiveLearningsDir || await pathExists(path.join(localConfig.repo.localPath, 'docs')) || await pathExists(path.join(localConfig.repo.localPath, 'rules')) || await pathExists(path.join(localConfig.repo.localPath, 'skills')))) {
-    // Votes live on the teamai-reports orphan branch in self mode; getReportsDir
-    // points at the worktree. If it isn't materialized yet, votesExist is false
-    // and vote-weighted ranking is simply skipped (graceful degradation).
+    // Votes live on the teamai-reports orphan branch for non-HTTP repos;
+    // getReportsDir points at the worktree (sibling of the clone in git-kind).
+    // If it isn't materialized yet, votesExist is false and vote-weighted
+    // ranking is simply skipped (graceful degradation — leftover default-branch
+    // votes/ are not used).
     const { getReportsDir } = await import('./types.js');
     const votesDir = path.join(getReportsDir(localConfig), 'votes');
     const votesExist = await pathExists(votesDir);

--- a/src/save-session.ts
+++ b/src/save-session.ts
@@ -27,7 +27,7 @@ import {
 } from './session-collector.js';
 import { log, spinner } from './utils/logger.js';
 import { withTimeout } from './utils/async.js';
-import { getSessionLogsDir } from './types.js';
+import { getSessionLogsDir, usesReportsBranch } from './types.js';
 import type { GlobalOptions, LocalConfig } from './types.js';
 
 export interface SaveSessionOptions extends GlobalOptions {
@@ -132,10 +132,10 @@ export async function saveSession(options: SaveSessionOptions): Promise<void> {
     return;
   }
 
-  // Single-repo mode: session summaries are report data → the teamai-reports
-  // orphan branch, written through an isolated worktree so main / the user's
-  // active tree is never touched.
-  if (localConfig.repo.kind === 'self') {
+  // Non-HTTP repos: session summaries are report data → the teamai-reports
+  // orphan branch, written through an isolated worktree so the default branch
+  // (and in self mode, the user's active tree) is never touched.
+  if (usesReportsBranch(localConfig)) {
     const spin = spinner('Pushing session summary to team...').start();
     try {
       const { ensureReportsWorktree, commitAndPushReports } = await import('./utils/reports-branch.js');

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -51,9 +51,11 @@ async function loadReportedStats(): Promise<UserStats | null> {
   try {
     const config = await detectProjectConfig() ?? await loadLocalConfig();
     if (!config) return null;
-    // Self mode: stats live on the teamai-reports orphan branch worktree.
+    // Non-HTTP: stats live on the teamai-reports orphan branch worktree.
+    // Leftover stats/ on the default-branch clone is ignored.
     let statsRoot = config.repo.localPath;
-    if (config.repo.kind === 'self') {
+    const { usesReportsBranch } = await import('./types.js');
+    if (usesReportsBranch(config)) {
       const { ensureReportsWorktree } = await import('./utils/reports-branch.js');
       statsRoot = await ensureReportsWorktree(config);
     }

--- a/src/team-push.ts
+++ b/src/team-push.ts
@@ -15,7 +15,7 @@ import { withTimeout } from './utils/async.js';
 import { writeFile, readFileSafe, ensureDir, pathExists, readJson, writeJson } from './utils/fs.js';
 import { log } from './utils/logger.js';
 import type { UserStats, UserInterventionStats, SessionMetrics, TokenUsage, DashboardEvent, LocalConfig } from './types.js';
-import { getUserVotesDir, emptyTokenUsage, addTokenUsage } from './types.js';
+import { getUserVotesDir, emptyTokenUsage, addTokenUsage, usesReportsBranch } from './types.js';
 import { getUserHome } from './utils/home.js';
 import {
   aggregateDailySessions,
@@ -345,18 +345,16 @@ export async function reportUsageToTeam(
   username: string,
   options?: { skipTruncate?: boolean; projectRoot?: string; excludeProjectRoots?: string[]; selfConfig?: LocalConfig },
 ): Promise<void> {
-  // Single-repo mode: stats + votes are report data → the teamai-reports orphan
+  // Non-HTTP repos: stats + votes are report data → the teamai-reports orphan
   // branch (isolated worktree). We must NOT resetToCleanMaster / pullRepo /
-  // pushRepoDirectly on the business repo root — that would touch the user's
-  // active working tree. The dedicated writer handles the worktree + rebase race.
-  const selfConfig = options?.selfConfig;
-  const selfMode = selfConfig?.repo.kind === 'self';
+  // pushRepoDirectly on the default branch (or, in self mode, the business
+  // working tree). The dedicated writer handles the worktree + rebase race.
+  const reportsConfig = options?.selfConfig;
+  const useReportsBranch = !!reportsConfig && usesReportsBranch(reportsConfig);
 
-  // git-mode auto-report reset/pull/commit/pushes the SHARED team clone. Its
-  // caller (pull()) holds the partition sync-lock across this scope's whole
-  // clone-consuming lifecycle, so we must NOT acquire it here — the lock is
-  // non-reentrant and re-acquiring in the same process would fail. (self mode
-  // writes the reports orphan-branch worktree, coordinated by its own reports-lock.)
+  // Reports-branch writes use the reports-lock, not the partition sync-lock
+  // (non-reentrant; pull() already holds it). The else-branch clone reset is
+  // only for callers that did not pass a config.
 
   try {
     const events = await readUsageEvents();
@@ -394,12 +392,13 @@ export async function reportUsageToTeam(
     const hasPromptTokens = hasPromptTokenDelta(promptTokenDelta);
     const hasDaily = hasDailyDelta(dailyDelta);
 
-    // Resolve where report data is written. In self mode this is the reports
-    // orphan-branch worktree; in git mode it is the team repo clone.
+    // Resolve where report data is written. Non-HTTP repos use the reports
+    // orphan-branch worktree; HTTP / callers without a config still write the
+    // dedicated clone (legacy path used by unit tests of merge logic).
     let writeRoot = repoPath;
-    if (selfMode && selfConfig) {
+    if (useReportsBranch && reportsConfig) {
       const { ensureReportsWorktree } = await import('./utils/reports-branch.js');
-      writeRoot = await ensureReportsWorktree(selfConfig);
+      writeRoot = await ensureReportsWorktree(reportsConfig);
     } else {
       // The team repo is a disposable cache clone here — safe to discard local state
       // and reset to the default branch before pulling (same pattern as push.ts).
@@ -504,10 +503,10 @@ export async function reportUsageToTeam(
     // Guard the push with a 5s timeout. withTimeout clears its timer once the
     // push settles, so a fast success does not leave a 5s timer pinning the
     // event loop (and hanging `teamai pull`) after the work is done.
-    if (selfMode && selfConfig) {
+    if (useReportsBranch && reportsConfig) {
       const { commitAndPushReports } = await import('./utils/reports-branch.js');
       await withTimeout(
-        commitAndPushReports(selfConfig, commitMsg, filesToPush),
+        commitAndPushReports(reportsConfig, commitMsg, filesToPush),
         5000,
         'Auto-report timeout (5s)',
       );

--- a/src/types.ts
+++ b/src/types.ts
@@ -342,6 +342,8 @@ export const LocalConfigSchema = z.object({
      *           Knowledge lives on main under <businessRepoRoot>/.teamai/;
      *           reports (members/sessions/votes/stats) live on the
      *           `teamai-reports` orphan branch. localPath = <businessRepoRoot>/.teamai.
+     * Independent git clones (`kind: 'git'` or omitted) use the same reports
+     * branch; the worktree sits beside the clone, not inside it.
      */
     kind: z.enum(['git', 'http', 'self']).optional(),
     /** Base URL of the HTTP team repo (only when kind === 'http'). */
@@ -1418,9 +1420,19 @@ export function isSelfMode(localConfig: { repo: { kind?: string } }): boolean {
   return localConfig.repo.kind === 'self';
 }
 
-/** Orphan branch that carries reports (members/sessions/votes/stats) in single-repo mode. */
+/**
+ * True when report dirs (`members/` `sessions/` `votes/` `stats/`) live on the
+ * `teamai-reports` orphan branch instead of the default branch. HTTP backends
+ * keep their API write path; every other kind (self, git, and legacy configs
+ * that omit `kind`) uses the reports branch.
+ */
+export function usesReportsBranch(localConfig: { repo: { kind?: string } }): boolean {
+  return localConfig.repo.kind !== 'http';
+}
+
+/** Orphan branch that carries reports (members/sessions/votes/stats) for non-HTTP repos. */
 export const REPORTS_BRANCH = 'teamai-reports';
-/** Worktree directory (under .teamai) that checks out the reports orphan branch. */
+/** Worktree directory name that checks out the reports orphan branch. */
 export const REPORTS_WORKTREE_DIRNAME = 'reports-wt';
 /** Worktree directory (under .teamai) used to stage knowledge PRs off the active tree. */
 export const KNOWLEDGE_WORKTREE_DIRNAME = 'knowledge-wt';
@@ -1475,17 +1487,21 @@ export function getDataHome(localConfig: LocalConfig): string {
 
 /**
  * Directory holding reports data (members/sessions/votes/stats).
- * - git/http: same as knowledge (localPath) — reports live alongside knowledge.
- * - self:     <localPath>/reports-wt — a git worktree checked out on the
- *             `teamai-reports` orphan branch, so reports never land on main.
+ * - http: same as knowledge (localPath) — HTTP does not use the git reports branch.
+ * - self: <localPath>/reports-wt — nested under the knowledge dir (`.teamai/`).
+ * - git (and legacy configs with no kind): sibling of the clone
+ *   (`<dirname(localPath)>/reports-wt`) so clone `reset --hard` cannot nest-destroy it.
  * Callers must ensure the worktree exists first (see ensureReportsWorktree)
- * when the returned path is the self-mode worktree.
+ * when the returned path is a reports-branch worktree.
  */
 export function getReportsDir(localConfig: LocalConfig): string {
+  if (!usesReportsBranch(localConfig)) {
+    return localConfig.repo.localPath;
+  }
   if (isSelfMode(localConfig)) {
     return path.join(localConfig.repo.localPath, REPORTS_WORKTREE_DIRNAME);
   }
-  return localConfig.repo.localPath;
+  return path.join(path.dirname(localConfig.repo.localPath), REPORTS_WORKTREE_DIRNAME);
 }
 
 /**

--- a/src/utils/reports-branch.ts
+++ b/src/utils/reports-branch.ts
@@ -1,15 +1,19 @@
 /**
- * Single-repo mode: manage the `teamai-reports` orphan branch via an isolated
- * git worktree under <business-repo>/.teamai/reports-wt.
+ * Manage the `teamai-reports` orphan branch via an isolated git worktree.
+ *
+ * Used for every non-HTTP team repo (`kind !== 'http'`):
+ *  - self: worktree under <business-repo>/.teamai/reports-wt
+ *  - git / legacy: sibling of the clone (`<dirname(localPath)>/reports-wt`) so
+ *    clone `reset --hard` cannot nest-destroy it
  *
  * Why an orphan branch + dedicated worktree?
- *  - In single-repo mode the business repo IS the team repo. High-frequency,
- *    noisy report data (members/sessions/votes/stats) must NOT pollute main.
+ *  - High-frequency report data (members/sessions/votes/stats) must NOT pollute
+ *    the default branch, so members can use the team repo with branch protection.
  *    The orphan branch has an independent history, so main stays clean.
- *  - Report writes involve `git reset --hard` / `rebase --hard`. Running those
- *    on the user's active working tree would destroy their uncommitted business
- *    code. A separate worktree confines every destructive git op to the orphan
- *    branch checkout — the active tree is never touched.
+ *  - Report writes involve `git reset --hard` / rebase. Running those on the
+ *    user's active working tree (self) or nesting the worktree inside the
+ *    knowledge clone (git) would destroy uncommitted work. A separate worktree
+ *    confines every destructive git op to the orphan-branch checkout.
  *
  * Concurrency: the branch is shared by the whole team, but each member only ever
  * writes their own `<user>.yaml`, so files never collide. Pushes race at the git
@@ -17,7 +21,7 @@
  */
 import path from 'node:path';
 import fse from 'fs-extra';
-import { createGit, isGitRepo, getDefaultBranch, hasCommits, commitSkippingHooks } from './git.js';
+import { createGit, isGitRepo, getDefaultBranch, hasCommits, commitSkippingHooks, isDedicatedRepoRoot } from './git.js';
 import { acquireLock, releaseLock } from '../update.js';
 import { ensureDir, writeFile, pathExists } from './fs.js';
 import { log } from './logger.js';
@@ -27,6 +31,8 @@ import {
   REPORTS_LOCK_FILENAME,
   KNOWLEDGE_WORKTREE_DIRNAME,
   getReportsDir,
+  isSelfMode,
+  usesReportsBranch,
   type LocalConfig,
 } from '../types.js';
 
@@ -50,9 +56,26 @@ function businessRoot(localConfig: LocalConfig): string {
   return localConfig.repo.businessRepoRoot ?? path.dirname(localConfig.repo.localPath);
 }
 
-/** Path to the reports worktree directory (<repo>/.teamai/reports-wt). */
+/**
+ * Git repository that owns the reports worktree.
+ * - self: the business repo (knowledge lives in `.teamai/` inside it)
+ * - git: the dedicated team clone (`localPath` itself)
+ */
+function reportsGitRoot(localConfig: LocalConfig): string {
+  if (isSelfMode(localConfig)) {
+    return businessRoot(localConfig);
+  }
+  return localConfig.repo.localPath;
+}
+
+/** Path to the reports worktree directory (see getReportsDir). */
 function reportsWorktreePath(localConfig: LocalConfig): string {
-  return path.join(localConfig.repo.localPath, REPORTS_WORKTREE_DIRNAME);
+  return getReportsDir(localConfig);
+}
+
+/** Lock file sitting beside the reports worktree (never inside the clone). */
+function reportsLockPath(localConfig: LocalConfig): string {
+  return path.join(path.dirname(getReportsDir(localConfig)), REPORTS_LOCK_FILENAME);
 }
 
 /** Whether the remote already has the reports branch. */
@@ -67,8 +90,9 @@ async function remoteBranchExists(repoRoot: string): Promise<boolean> {
 }
 
 /**
- * Ensure a git worktree checked out on the `teamai-reports` orphan branch exists
- * at <repo>/.teamai/reports-wt. Idempotent. Returns the worktree absolute path.
+ * Ensure a git worktree checked out on the `teamai-reports` orphan branch exists.
+ * Self: <knowledgeDir>/reports-wt. Independent git: sibling of the clone.
+ * Idempotent. Returns the worktree absolute path.
  *
  * Cold-start cases handled:
  *  - worktree already present  → return it (optionally refreshed by caller).
@@ -88,8 +112,18 @@ export async function ensureReportsWorktree(
   localConfig: LocalConfig,
   options: EnsureReportsWorktreeOptions = {},
 ): Promise<string> {
+  if (!usesReportsBranch(localConfig)) {
+    return getReportsDir(localConfig);
+  }
+
   const wt = reportsWorktreePath(localConfig);
-  const repoRoot = businessRoot(localConfig);
+  const repoRoot = reportsGitRoot(localConfig);
+
+  if (!isSelfMode(localConfig) && !(await isDedicatedRepoRoot(repoRoot))) {
+    throw new Error(
+      `Refusing to create a reports worktree: ${repoRoot} is not a dedicated team-repo clone root`,
+    );
+  }
 
   // Already a valid worktree — nothing to do.
   if (await isGitRepo(wt)) {
@@ -216,7 +250,7 @@ export async function commitAndPushReports(
   message: string,
   files: string[],
 ): Promise<boolean> {
-  const lockPath = path.join(localConfig.repo.localPath, REPORTS_LOCK_FILENAME);
+  const lockPath = reportsLockPath(localConfig);
   const locked = await acquireLock(lockPath);
   if (!locked) {
     log.debug('[reports] another reports write is in progress; skipping');
@@ -291,12 +325,11 @@ export async function refreshReportsWorktree(
 }
 
 /**
- * Ensure the reports directory exists and return it. For self mode this creates
- * the worktree first; for other modes it just returns localPath (reports live
- * alongside knowledge).
+ * Ensure the reports directory exists and return it. For non-HTTP repos this
+ * creates the reports worktree first; HTTP keeps reports alongside knowledge.
  */
 export async function ensureReportsDir(localConfig: LocalConfig): Promise<string> {
-  if (localConfig.repo.kind === 'self') {
+  if (usesReportsBranch(localConfig)) {
     return ensureReportsWorktree(localConfig);
   }
   return getReportsDir(localConfig);

--- a/src/utils/reports-branch.ts
+++ b/src/utils/reports-branch.ts
@@ -125,9 +125,18 @@ export async function ensureReportsWorktree(
     );
   }
 
-  // Already a valid worktree — nothing to do.
+  // Already a valid worktree — nothing to do. `isGitRepo` only checks that a
+  // `.git` file/dir exists; after a sibling clone is deleted and re-cloned the
+  // worktree gitdir (`<clone>/.git/worktrees/reports-wt`) is gone and git ops
+  // fail with "not a git repository". Probe a real git command and fall through
+  // to remove+recreate when the link is stale.
   if (await isGitRepo(wt)) {
-    return wt;
+    try {
+      await createGit(wt).revparse(['--is-inside-work-tree']);
+      return wt;
+    } catch {
+      // stale/dangling worktree link (clone was re-cloned/pruned) — recreate below.
+    }
   }
 
   // Path exists but is not a git worktree (stale/partial) — clear it so we can recreate.

--- a/src/viz.ts
+++ b/src/viz.ts
@@ -152,7 +152,8 @@ export async function resolveVizRoot(opts: VizOptions): Promise<VizPaths> {
   const config = await detectProjectConfig() ?? await loadLocalConfig();
 
   if (config?.repo?.localPath) {
-    if (config.repo.kind === 'self') {
+    const { usesReportsBranch } = await import('./types.js');
+    if (usesReportsBranch(config)) {
       const { ensureReportsWorktree } = await import('./utils/reports-branch.js');
       await ensureReportsWorktree(config);
     }


### PR DESCRIPTION
## Summary

Independent git clones currently write `members/` `sessions/` `votes/` `stats/` onto the default branch via `pushRepoDirectly`, so every member needs write access on `main`. This reuses the existing `teamai-reports` orphan-branch worktree writer that single-repo mode already uses.

- Git-kind reports checkout is a **sibling of the clone** (`<dirname(localPath)>/reports-wt`), so clone `reset --hard` cannot nest-destroy it.
- `kind: self` keeps today's nested `<knowledgeDir>/reports-wt`.
- `kind: http` is unchanged (no git reports branch).
- Empty-repo `init` may still push `teamai.yaml` + gitkeeps to the default branch so the knowledge tree exists; member YAML goes to `teamai-reports`.
- Leftover report files already on `main` are not copied, not deleted, and not used as the source of truth after the switch.
- No new CLI command. Learnings stay on the default branch (#485 is separate).

Closes #484

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an existing issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing behavior to change)
- [ ] Documentation only
- [ ] Refactor / internal cleanup

## Test Plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` focused suites — 117 tests passed, including:
  - `src/__tests__/git-kind-reports.test.ts` (real git: write to `origin/teamai-reports`, leftover clone `members/` ignored, empty-repo skeleton on default branch, dedicated-root guard)
  - `src/__tests__/self-mode-no-business-reset.test.ts` (git-kind no longer `reset --hard`s the clone)
  - `src/__tests__/members.test.ts` (`listMembers` reads reports worktree; leftover clone YAML is not listed)
  - `src/__tests__/team-push-interventions.test.ts` (git-kind auto-report uses `commitAndPushReports`, not `pushRepoDirectly`)
- [x] `npm run build` then built CLI (`dist/index.js`) against a local bare remote whose `update` hook rejects default-branch pushes:
  1. `teamai init https://git.example.test/acme/team.git --scope user --force` — English success; `Member registered on the teamai-reports branch`
  2. `teamai session save --push --force --session-id s1 --scope user` — `Pushed: sessions/alice/2026-09.md`
  3. `teamai pull` — auto-report wrote `stats/alice.yaml`
  - `git ls-tree origin/teamai-reports` contained `members/alice.yaml`, `sessions/alice/2026-09.md`, `stats/alice.yaml`
  - default-branch tree still only had `teamai.yaml` + knowledge gitkeeps (no new report files)
  - reports worktree was a sibling of the clone (`~/.teamai/reports-wt`); clone had no `members/` `stats/` `sessions/`
- [x] EN/ZH `docs/usage-guide.md` updated so independent git clones also write reports to `teamai-reports` (learnings still on the default branch)

## Related Issues

Closes #484

## Notes for Reviewers

- Writers switched: `init` member registration, `session save --push`, pull auto-report, Stop-hook votes.
- Readers switched: `members`, `digest`, `stats`, `viz`, `pull` votes/stats index, `recall`, `maintenance/paths`, `projects members` (manifest still from knowledge clone).
- `reportUsageToTeam` still has a no-config fallback that `pushRepoDirectly`s the clone; production `pull` now always passes `selfConfig` for non-HTTP repos.
- Follow-ups: #485 (`learnings/` → `teamai-learnings`) and #486 (permission-matrix docs).