### PR TITLE
docs: list Projects first in bilingual README distribution tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file. See [standa
 ### 📝 Documentation
 
 - Align the public usage guides, drop internal-only details, and cover the missing commands and configuration ([#442](https://github.com/Tencent/teamai-cli/pull/442)).
+- Document `teamai projects` in the bilingual READMEs as the lead distribution control, including learnings isolation ([#490](https://github.com/Tencent/teamai-cli/pull/490), for [#487](https://github.com/Tencent/teamai-cli/issues/487)).
 
 ## [0.23.0](https://github.com/Tencent/teamai-cli/compare/v0.22.0...v0.23.0) (2026-09-08)
 

--- a/README.md
+++ b/README.md
@@ -103,9 +103,12 @@ Team-wide settings an admin configures once and delivers to every member on `tea
 
 | Capability | Command | What it does |
 |------------|---------|--------------|
+| **Projects** | `teamai projects` | Bind a working directory to one or more logical projects so it syncs that project's skills, knowledge, and isolated learnings. Orthogonal to roles. |
 | **Roles** | `teamai roles` | Define role → namespace mappings so each member syncs only the skills for their role. |
 | **Tags** | `teamai tags` | Tag skills / rules so members subscribe to just the tags they need. |
 | **Sources** | `teamai source` | Subscribe to additional skill repos — other teams' public repos, or shared/public repos within your own org; subscribed skills sync automatically on pull. |
+
+Learnings isolation: `learnings/` at the repo root is shared with everyone; `learnings/<project-id>/` is project-private. See the [usage guide](docs/usage-guide.md#multi-project-project-as-a-dimension-orthogonal-to-role).
 
 ## Team Execution
 
@@ -250,6 +253,7 @@ Insight into how the team actually uses its AI tools, and a starting point for t
 | `teamai codebase --lint` | Knowledge graph health check |
 | `teamai ci extract-mr --url <url>` | CI: extract knowledge from MR, post comments, write after merge |
 | `teamai members` | List team members |
+| `teamai projects` | Bind a working directory to one or more logical projects |
 | `teamai roles` | Manage team roles and namespaces |
 | `teamai tags` | Manage tag-based skill/rule filtering |
 | `teamai skill exclude add/remove/list` | Manage skills excluded from local sync ([usage guide](docs/usage-guide.md#excluding-skills-you-dont-need)) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -103,9 +103,12 @@ teamai init https://github.com/yourorg/yourrepo --scope user
 
 | 能力 | 命令 | 作用 |
 |------|------|------|
+| **项目（Projects）** | `teamai projects` | 将工作目录绑定到一个或多个逻辑项目，使其同步该项目的 skills、knowledge 以及隔离的 learnings。与角色正交。 |
 | **角色（Roles）** | `teamai roles` | 定义「角色 → 命名空间」映射，让每位成员只同步与自身角色匹配的 skills。 |
 | **标签（Tags）** | `teamai tags` | 给 skills / rules 打标签，成员只订阅自己需要的标签。 |
 | **订阅源（Sources）** | `teamai source` | 订阅额外的 skill 仓库——其他团队的公开仓库，或本团队内的公共/共享仓库；已订阅的 skills 会在 pull 时自动同步。 |
+
+learnings 隔离：仓库 `learnings/` 根目录对所有人共享；`learnings/<project-id>/` 为项目私有。详见[使用指南](docs/usage-guide.zh-CN.md#多项目project-作为与-role-正交的维度)。
 
 ## Team Execution
 
@@ -250,6 +253,7 @@ teamai recall maintenance --update-quality       # 为过时 skills / docs 生�
 | `teamai codebase --lint` | 知识图谱健康检查 |
 | `teamai ci extract-mr --url <url>` | CI：从 MR 提取知识、发评论、合并后写入 |
 | `teamai members` | 查看团队成员 |
+| `teamai projects` | 将工作目录绑定到一个或多个逻辑项目 |
 | `teamai roles` | 管理团队角色和命名空间 |
 | `teamai tags` | 管理基于标签的 skill/rule 过滤 |
 | `teamai skill exclude add/remove/list` | 管理不参与本地同步的 skills（[使用指南](docs/usage-guide.zh-CN.md#排除个人不需要的-skill)） |


### PR DESCRIPTION
## Summary

Fill the README gap in #487: bilingual READMEs never mentioned `projects` even though `docs/usage-guide.md` already documents multi-project.

- Put **Projects** first in the Distribution Controls / 分发策略 tables (ahead of Roles / Tags / Sources), using `teamai projects`.
- Put `teamai projects` before `teamai roles` / `teamai tags` in both Commands tables.
- Add a short learnings-isolation note: `learnings/` root is shared with everyone; `learnings/<project-id>/` is project-private; link the matching usage-guide heading in each language.
- Keep EN / ZH in sync. No CLI behavior changes.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing behavior to change)
- [x] Documentation only
- [ ] Refactor / internal cleanup

## Test Plan

- [x] `README.md` Distribution Controls table lists **Projects** first, command `teamai projects`, with the issue wording: bind a working directory to one or more logical projects so it syncs that project's skills, knowledge, and isolated learnings; orthogonal to roles
- [x] `README.zh-CN.md` 分发策略 table uses the same row order and the same facts
- [x] Both Commands tables include `teamai projects` before `teamai roles` / `teamai tags`
- [x] Both READMEs include the isolation note (`learnings/` shared, `learnings/<project-id>/` project-private) and link `docs/usage-guide.md` / `docs/usage-guide.zh-CN.md`
- [x] Usage-guide heading anchors already exist (`#multi-project-project-as-a-dimension-orthogonal-to-role` / `#多项目project-作为与-role-正交的维度`); no usage-guide edit
- [x] `git diff upstream/main --name-only` is `CHANGELOG.md`, `README.md`, `README.zh-CN.md`
- [x] `git log upstream/main..HEAD` is only this docs commit
- [x] `git diff --check` clean

## Related Issues

Closes #487

## Notes for Reviewers

This PR covers only the README docs gap from #487. The issue's community dogfood checklist (no-manifest regression, agent/provider/scope matrix) is out of scope.