### PR TITLE
fix(deep-enrich): retry missing AI docs after temporary failures

### DIFF
--- a/src/__tests__/codebase-deep-enrich.test.ts
+++ b/src/__tests__/codebase-deep-enrich.test.ts
@@ -15,6 +15,7 @@ vi.mock('../utils/ai-client.js', () => ({
   }),
 }));
 
+import { callClaude, callClaudeParallel } from '../utils/ai-client.js';
 import { codebaseCmd } from '../codebase-cmd.js';
 
 const temporaryDirectories: string[] = [];
@@ -82,15 +83,22 @@ describe('codebase deep-enrich', () => {
 
     await codebaseCmd({ deepEnrich: true, project: 'faketest', output: root, json: true });
 
-    expect(process.exitCode).toBeUndefined();
+    expect(process.exitCode).toBe(1);
     const report = JSON.parse(String(log.mock.calls.at(-1)?.[0]));
-    expect(report).toMatchObject({ project: 'faketest', complete: true });
+    expect(report).toMatchObject({
+      project: 'faketest',
+      complete: false,
+      missingComponents: ['Auth'],
+      missingArchitecture: true,
+    });
 
     const docsDir = path.join(root, 'teamwiki', 'evidence', 'code', 'faketest', 'docs');
     expect(fs.existsSync(path.join(docsDir, 'graph-g1-relations.md'))).toBe(true);
     expect(fs.existsSync(path.join(docsDir, 'graph-g2-dataflow.md'))).toBe(true);
     expect(fs.existsSync(path.join(docsDir, 'graph-g3-interfaces.md'))).toBe(true);
     expect(fs.readFileSync(path.join(docsDir, 'graph-g1-relations.md'), 'utf8').length).toBeGreaterThan(0);
+    expect(fs.existsSync(path.join(docsDir, 'Auth.md'))).toBe(false);
+    expect(fs.existsSync(path.join(docsDir, 'architecture.md'))).toBe(false);
   });
 
   it('does not report success when the evidence dir has no components', async () => {
@@ -118,6 +126,96 @@ describe('codebase deep-enrich', () => {
       dryRun: true,
     });
     expect(fs.existsSync(path.join(root, 'teamwiki', 'evidence', 'code', 'faketest', 'docs'))).toBe(false);
+  });
+
+  it('retries missing AI docs after recovery without wiping graph docs', async () => {
+    const root = createEnrichFixture();
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const docsDir = path.join(root, 'teamwiki', 'evidence', 'code', 'faketest', 'docs');
+
+    await codebaseCmd({ deepEnrich: true, project: 'faketest', output: root, json: true });
+    expect(process.exitCode).toBe(1);
+    const first = JSON.parse(String(log.mock.calls.at(-1)?.[0]));
+    expect(first).toMatchObject({ complete: false, missingComponents: ['Auth'], missingArchitecture: true });
+    expect(fs.existsSync(path.join(docsDir, 'Auth.md'))).toBe(false);
+    expect(fs.existsSync(path.join(docsDir, 'architecture.md'))).toBe(false);
+    const graphBefore = fs.readFileSync(path.join(docsDir, 'graph-g1-relations.md'), 'utf8');
+
+    process.exitCode = undefined;
+    vi.mocked(callClaude).mockResolvedValue('# Architecture\n\nAuth sits at the edge.\n');
+    vi.mocked(callClaudeParallel).mockImplementation(async (tasks) => (
+      tasks.map(() => '# Auth\n\nAuthenticates users.\n')
+    ));
+
+    await codebaseCmd({ deepEnrich: true, project: 'faketest', output: root, json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const recovered = JSON.parse(String(log.mock.calls.at(-1)?.[0]));
+    expect(recovered).toMatchObject({ complete: true, missingComponents: [], missingArchitecture: false });
+    expect(fs.readFileSync(path.join(docsDir, 'Auth.md'), 'utf8')).toContain('Authenticates users');
+    expect(fs.readFileSync(path.join(docsDir, 'architecture.md'), 'utf8')).toContain('Auth sits at the edge');
+    expect(fs.readFileSync(path.join(docsDir, 'graph-g1-relations.md'), 'utf8')).toBe(graphBefore);
+
+    process.exitCode = undefined;
+    vi.mocked(callClaude).mockRejectedValue(new Error('mock: AI unavailable'));
+    vi.mocked(callClaudeParallel).mockRejectedValue(new Error('mock: AI batch unavailable'));
+    await codebaseCmd({ deepEnrich: true, project: 'faketest', output: root, json: true });
+    expect(process.exitCode).toBeUndefined();
+    expect(JSON.parse(String(log.mock.calls.at(-1)?.[0]))).toMatchObject({ complete: true });
+    expect(fs.readFileSync(path.join(docsDir, 'Auth.md'), 'utf8')).toContain('Authenticates users');
+    expect(fs.readFileSync(path.join(docsDir, 'architecture.md'), 'utf8')).toContain('Auth sits at the edge');
+  });
+
+  it('preserves a completed component doc when architecture generation still fails', async () => {
+    const root = createEnrichFixture();
+    const docsDir = path.join(root, 'teamwiki', 'evidence', 'code', 'faketest', 'docs');
+    fs.mkdirSync(docsDir, { recursive: true });
+    fs.writeFileSync(path.join(docsDir, 'Auth.md'), '# Auth\n\nKeep me.\n');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await codebaseCmd({ deepEnrich: true, project: 'faketest', output: root, json: true });
+
+    expect(process.exitCode).toBe(1);
+    expect(JSON.parse(String(log.mock.calls.at(-1)?.[0]))).toMatchObject({
+      complete: false,
+      missingComponents: [],
+      missingArchitecture: true,
+    });
+    expect(fs.readFileSync(path.join(docsDir, 'Auth.md'), 'utf8')).toBe('# Auth\n\nKeep me.\n');
+    expect(fs.existsSync(path.join(docsDir, 'graph-g1-relations.md'))).toBe(true);
+  });
+
+  it('still reports remaining missing AI work when a later retry also fails', async () => {
+    const root = createEnrichFixture();
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const docsDir = path.join(root, 'teamwiki', 'evidence', 'code', 'faketest', 'docs');
+
+    await codebaseCmd({ deepEnrich: true, project: 'faketest', output: root, json: true });
+    expect(JSON.parse(String(log.mock.calls.at(-1)?.[0])).complete).toBe(false);
+    const graphBefore = fs.readFileSync(path.join(docsDir, 'graph-g1-relations.md'), 'utf8');
+
+    process.exitCode = undefined;
+    await codebaseCmd({ deepEnrich: true, project: 'faketest', output: root, json: true });
+
+    expect(process.exitCode).toBe(1);
+    const second = JSON.parse(String(log.mock.calls.at(-1)?.[0]));
+    expect(second).toMatchObject({
+      complete: false,
+      missingComponents: ['Auth'],
+      missingArchitecture: true,
+    });
+    expect(fs.existsSync(path.join(docsDir, 'Auth.md'))).toBe(false);
+    expect(fs.existsSync(path.join(docsDir, 'architecture.md'))).toBe(false);
+    expect(fs.readFileSync(path.join(docsDir, 'graph-g1-relations.md'), 'utf8')).toBe(graphBefore);
+
+    process.exitCode = undefined;
+    await codebaseCmd({ deepEnrich: true, project: 'faketest', output: root });
+    const text = log.mock.calls.flat().map(String).join('\n');
+    expect(text).toContain('Deep enrichment incomplete');
+    expect(text).toContain('missing component docs: Auth');
+    expect(text).toContain('missing architecture.md');
+    expect(text).not.toMatch(/Deep enrichment complete: project=faketest/);
+    expect(process.exitCode).toBe(1);
   });
 
   it('rejects a project slug that escapes the evidence directory', async () => {

--- a/src/__tests__/codebase-deep-enrich.test.ts
+++ b/src/__tests__/codebase-deep-enrich.test.ts
@@ -218,6 +218,84 @@ describe('codebase deep-enrich', () => {
     expect(process.exitCode).toBe(1);
   });
 
+  it('regenerates component and architecture docs when the extract manifest is newer', async () => {
+    const root = createEnrichFixture();
+    const evidence = path.join(root, 'teamwiki', 'evidence', 'code', 'faketest');
+    const docsDir = path.join(evidence, 'docs');
+    fs.mkdirSync(path.join(evidence, '_review'), { recursive: true });
+    fs.mkdirSync(docsDir, { recursive: true });
+    const manifest = JSON.parse(fs.readFileSync(path.join(evidence, '_manifest.json'), 'utf8')) as {
+      generatedAt: string;
+      components: Array<{ responsibilities: string[] }>;
+    };
+    manifest.generatedAt = '2026-09-11T00:00:00Z';
+    manifest.components[0].responsibilities = ['NEW OAuth flow'];
+    fs.writeFileSync(path.join(evidence, '_manifest.json'), JSON.stringify(manifest, null, 2));
+    fs.writeFileSync(path.join(evidence, '_review', 'progress.json'), JSON.stringify({
+      project: 'faketest',
+      phase: 'done',
+      componentsDone: ['Auth'],
+      componentsPending: [],
+      startedAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    }));
+    fs.writeFileSync(path.join(docsDir, 'Auth.md'), '# OLD password flow');
+    fs.writeFileSync(path.join(docsDir, 'architecture.md'), '# OLD architecture');
+    fs.writeFileSync(path.join(docsDir, 'graph-g1-relations.md'), '# graph placeholder\n');
+    fs.writeFileSync(path.join(docsDir, 'graph-g5-scenarios.md'), '# OLD G5');
+
+    vi.mocked(callClaude).mockResolvedValue('# NEW architecture\n');
+    vi.mocked(callClaudeParallel).mockImplementation(async (tasks) => (
+      tasks.map(() => '# NEW Auth\n')
+    ));
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await codebaseCmd({ deepEnrich: true, project: 'faketest', output: root, json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(JSON.parse(String(log.mock.calls.at(-1)?.[0]))).toMatchObject({ complete: true });
+    expect(fs.readFileSync(path.join(docsDir, 'Auth.md'), 'utf8')).toContain('NEW Auth');
+    expect(fs.readFileSync(path.join(docsDir, 'Auth.md'), 'utf8')).not.toContain('OLD password flow');
+    expect(fs.readFileSync(path.join(docsDir, 'architecture.md'), 'utf8')).toContain('NEW architecture');
+    expect(fs.existsSync(path.join(docsDir, 'graph-g1-relations.md'))).toBe(true);
+    expect(fs.existsSync(path.join(docsDir, 'graph-g5-scenarios.md'))).toBe(false);
+  });
+
+  it('does not report complete with stale AI docs after a newer extract when AI still fails', async () => {
+    const root = createEnrichFixture();
+    const evidence = path.join(root, 'teamwiki', 'evidence', 'code', 'faketest');
+    const docsDir = path.join(evidence, 'docs');
+    fs.mkdirSync(path.join(evidence, '_review'), { recursive: true });
+    fs.mkdirSync(docsDir, { recursive: true });
+    const manifest = JSON.parse(fs.readFileSync(path.join(evidence, '_manifest.json'), 'utf8')) as {
+      generatedAt: string;
+    };
+    manifest.generatedAt = '2026-09-11T00:00:00Z';
+    fs.writeFileSync(path.join(evidence, '_manifest.json'), JSON.stringify(manifest, null, 2));
+    fs.writeFileSync(path.join(evidence, '_review', 'progress.json'), JSON.stringify({
+      project: 'faketest',
+      phase: 'done',
+      componentsDone: ['Auth'],
+      componentsPending: [],
+      startedAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    }));
+    fs.writeFileSync(path.join(docsDir, 'Auth.md'), '# OLD password flow');
+    fs.writeFileSync(path.join(docsDir, 'architecture.md'), '# OLD architecture');
+
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    await codebaseCmd({ deepEnrich: true, project: 'faketest', output: root, json: true });
+
+    expect(process.exitCode).toBe(1);
+    expect(JSON.parse(String(log.mock.calls.at(-1)?.[0]))).toMatchObject({
+      complete: false,
+      missingComponents: ['Auth'],
+      missingArchitecture: true,
+    });
+    expect(fs.existsSync(path.join(docsDir, 'Auth.md'))).toBe(false);
+    expect(fs.existsSync(path.join(docsDir, 'architecture.md'))).toBe(false);
+  });
+
   it('rejects a project slug that escapes the evidence directory', async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-deep-enrich-escape-'));
     temporaryDirectories.push(root);

--- a/src/codebase-cmd.ts
+++ b/src/codebase-cmd.ts
@@ -138,12 +138,26 @@ export async function codebaseCmd(opts: CodebaseCmdOptions): Promise<void> {
             return;
         }
         const { deepEnrich } = await import('./deep-enrich.js');
-        await deepEnrich({ project, evidenceDir, wikiRoot: teamwikiDir });
+        const result = await deepEnrich({ project, evidenceDir, wikiRoot: teamwikiDir });
         if (opts.json) {
-            console.log(JSON.stringify({ project, evidenceDir, complete: true }, null, 2));
-        } else {
+            console.log(JSON.stringify({
+                project,
+                evidenceDir,
+                complete: result.complete,
+                missingComponents: result.missingComponents,
+                missingArchitecture: result.missingArchitecture,
+            }, null, 2));
+        } else if (result.complete) {
             console.log(`Deep enrichment complete: project=${project}`);
+        } else {
+            const parts: string[] = [];
+            if (result.missingComponents.length > 0) {
+                parts.push(`missing component docs: ${result.missingComponents.join(', ')}`);
+            }
+            if (result.missingArchitecture) parts.push('missing architecture.md');
+            console.log(`Deep enrichment incomplete: project=${project}, ${parts.join(', ')}`);
         }
+        if (!result.complete) process.exitCode = 1;
         return;
     }
 

--- a/src/deep-enrich.ts
+++ b/src/deep-enrich.ts
@@ -13,6 +13,14 @@ export interface DeepEnrichOptions {
   maxModules?: number;  // 限制 AI 处理的最大组件数（费用控制）
 }
 
+/** Public-command status: full completion vs remaining AI docs. */
+export interface DeepEnrichResult {
+  project: string;
+  complete: boolean;
+  missingComponents: string[];
+  missingArchitecture: boolean;
+}
+
 interface ProgressState {
   project: string;
   phase: 'pending' | 'components' | 'architecture' | 'graph' | 'ai-graph' | 'index-enhance' | 'done';
@@ -627,6 +635,11 @@ async function runPhaseAiGraph(
   await writeFile(path.join(docsDir, 'graph-g6-multihop.md'), g6, 'utf-8');
   log.debug(`deep-enrich[${project}]: G6 multi-hop analysis written`);
 
+  const g5Path = path.join(docsDir, 'graph-g5-scenarios.md');
+  if (await pathExists(g5Path)) {
+    return { g5Generated: true, g6Generated: g6HasEdges };
+  }
+
   // G5: AI 生成场景序列图（需要足够的模块数据）
   let g5Generated = false;
   if (ctx.moduleDocs.size < 2) {
@@ -728,6 +741,34 @@ async function runPhaseIndexEnhance(
   log.debug(`deep-enrich[${project}]: Index incremental update complete`);
 }
 
+function architectureDocPath(docsDir: string): string {
+  return path.join(docsDir, 'architecture.md');
+}
+
+async function existingComponentSlugs(docsDir: string, slugs: string[]): Promise<string[]> {
+  const found: string[] = [];
+  for (const slug of slugs) {
+    try {
+      assertSafeResourceName(slug);
+    } catch {
+      continue;
+    }
+    if (await pathExists(path.join(docsDir, `${slug}.md`))) found.push(slug);
+  }
+  return found;
+}
+
+async function collectMissingAiDocs(
+  docsDir: string,
+  slugs: string[],
+): Promise<{ missingComponents: string[]; missingArchitecture: boolean }> {
+  const existing = new Set(await existingComponentSlugs(docsDir, slugs));
+  return {
+    missingComponents: slugs.filter((slug) => !existing.has(slug)),
+    missingArchitecture: !(await pathExists(architectureDocPath(docsDir))),
+  };
+}
+
 // ─── 主函数 ─────────────────────────────────────────────────
 
 /**
@@ -740,11 +781,13 @@ async function runPhaseIndexEnhance(
  * - Phase 4: AI 图谱文档（G5 场景序列图 + G6 多跳路径）
  * - Phase 5: 索引增强（graph/README.md 路由分发表）
  *
- * 支持断点续传：通过 _review/progress.json 记录已完成组件。
+ * Resume is based on files on disk: missing component/architecture docs are
+ * retried even when progress.json says `done` (deterministic graph files keep
+ * `docs/` nonempty). Completed AI docs are not overwritten.
  *
  * @param opts DeepEnrichOptions
  */
-export async function deepEnrich(opts: DeepEnrichOptions): Promise<void> {
+export async function deepEnrich(opts: DeepEnrichOptions): Promise<DeepEnrichResult> {
   const { project, evidenceDir } = opts;
   const docsDir = path.join(evidenceDir, 'docs');
 
@@ -756,7 +799,7 @@ export async function deepEnrich(opts: DeepEnrichOptions): Promise<void> {
 
   if (components.length === 0) {
     log.warn(`deep-enrich[${project}]: No components in _manifest.json, aborting`);
-    return;
+    return { project, complete: false, missingComponents: [], missingArchitecture: true };
   }
 
   if (opts.maxModules && components.length > opts.maxModules) {
@@ -765,69 +808,55 @@ export async function deepEnrich(opts: DeepEnrichOptions): Promise<void> {
     ctx.manifest = { ...ctx.manifest, components };
   }
 
-  // 2. 初始化 progress（断点续传）
   const allSlugs = components.map(c => c.slug);
   const progress = await loadProgress(evidenceDir, project, allSlugs);
 
-  // 2b. Stale progress guard: reset when progress is outdated relative to the manifest.
-  // This happens when import writes a fresh _manifest.json but an old progress.json
-  // (from a prior run) survives on the git branch that deep-enrich executes against.
-  if (progress.phase === 'done') {
-    const manifestTime = ctx.manifest.generatedAt;
-    const progressStale = manifestTime && progress.startedAt < manifestTime;
-    let docsEmpty = true;
-    if (await pathExists(docsDir)) {
-      const entries = await readdir(docsDir).catch(() => [] as string[]);
-      docsEmpty = entries.filter(e => e.endsWith('.md')).length === 0;
-    }
-    if (docsEmpty || progressStale) {
-      log.info(`deep-enrich[${project}]: stale progress detected (phase=done, docs_empty=${docsEmpty}, progress_stale=${Boolean(progressStale)}), resetting`);
-      progress.phase = 'pending';
-      progress.componentsDone = [];
-      progress.componentsPending = [...allSlugs];
-      progress.startedAt = new Date().toISOString();
-      await saveProgress(evidenceDir, progress);
-    }
-  }
+  // Disk is the source of truth for resume. A prior AI skip still writes
+  // deterministic graph markdown, so `phase: done` + nonempty docs/ must not
+  // skip missing component/architecture files.
+  const existing = await existingComponentSlugs(docsDir, allSlugs);
+  progress.componentsDone = existing;
+  progress.componentsPending = allSlugs.filter((slug) => !existing.includes(slug));
 
-  // 3. Phase 1: 组件设计文档
-  if (progress.phase === 'pending' || progress.phase === 'components') {
+  if (progress.componentsPending.length > 0) {
     progress.phase = 'components';
     await saveProgress(evidenceDir, progress);
     await runPhaseComponents(opts, ctx, progress, docsDir);
   }
 
-  // 4. Phase 2: 架构总览
-  if (progress.phase === 'components' || progress.phase === 'architecture') {
+  if (!(await pathExists(architectureDocPath(docsDir)))) {
     progress.phase = 'architecture';
     await saveProgress(evidenceDir, progress);
     await runPhaseArchitecture(opts, ctx, docsDir);
   }
 
-  // 5. Phase 3: 确定性图谱文档
-  if (progress.phase === 'architecture' || progress.phase === 'graph') {
-    progress.phase = 'graph';
-    await saveProgress(evidenceDir, progress);
-    await runPhaseGraph(opts, ctx, docsDir);
-  }
-
-  // 6. Phase 4: AI 图谱（G5 场景序列图 + G6 多跳路径）
-  let graphFlags = { g5Generated: false, g6Generated: true };
-  if (progress.phase === 'graph' || progress.phase === 'ai-graph') {
-    progress.phase = 'ai-graph';
-    await saveProgress(evidenceDir, progress);
-    graphFlags = await runPhaseAiGraph(opts, ctx, docsDir);
-  }
-
-  // 7. Phase 5: 索引增强（graph/README.md 路由表）
-  if (progress.phase === 'ai-graph' || progress.phase === 'index-enhance') {
-    progress.phase = 'index-enhance';
-    await saveProgress(evidenceDir, progress);
-    await runPhaseIndexEnhance(opts, ctx, docsDir, graphFlags);
-  }
-
-  // 8. 完成
-  progress.phase = 'done';
+  progress.phase = 'graph';
   await saveProgress(evidenceDir, progress);
-  log.success(`deep-enrich[${project}]: Deep knowledge generation complete`);
+  await runPhaseGraph(opts, ctx, docsDir);
+
+  progress.phase = 'ai-graph';
+  await saveProgress(evidenceDir, progress);
+  const graphFlags = await runPhaseAiGraph(opts, ctx, docsDir);
+
+  progress.phase = 'index-enhance';
+  await saveProgress(evidenceDir, progress);
+  await runPhaseIndexEnhance(opts, ctx, docsDir, graphFlags);
+
+  const missing = await collectMissingAiDocs(docsDir, allSlugs);
+  const complete = missing.missingComponents.length === 0 && !missing.missingArchitecture;
+  progress.componentsDone = allSlugs.filter((slug) => !missing.missingComponents.includes(slug));
+  progress.componentsPending = missing.missingComponents;
+  progress.phase = complete ? 'done' : (missing.missingComponents.length > 0 ? 'components' : 'architecture');
+  await saveProgress(evidenceDir, progress);
+
+  if (complete) {
+    log.success(`deep-enrich[${project}]: Deep knowledge generation complete`);
+  } else {
+    const missingComps = missing.missingComponents.join(', ') || '(none)';
+    log.warn(
+      `deep-enrich[${project}]: incomplete — missing component docs: ${missingComps}, architecture: ${missing.missingArchitecture}`,
+    );
+  }
+
+  return { project, complete, ...missing };
 }

--- a/src/deep-enrich.ts
+++ b/src/deep-enrich.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, readdir, mkdir } from 'node:fs/promises';
+import { readFile, writeFile, readdir, mkdir, unlink } from 'node:fs/promises';
 import path from 'node:path';
 import { pathExists } from './utils/fs.js';
 import { callClaude, callClaudeParallel } from './utils/ai-client.js';
@@ -769,6 +769,28 @@ async function collectMissingAiDocs(
   };
 }
 
+async function removeIfExists(filePath: string): Promise<void> {
+  try {
+    await unlink(filePath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
+}
+
+/** Drop AI docs that belong to a previous extract so file-based resume retries them. */
+async function invalidateStaleAiDocs(docsDir: string, slugs: string[]): Promise<void> {
+  for (const slug of slugs) {
+    try {
+      assertSafeResourceName(slug);
+    } catch {
+      continue;
+    }
+    await removeIfExists(path.join(docsDir, `${slug}.md`));
+  }
+  await removeIfExists(architectureDocPath(docsDir));
+  await removeIfExists(path.join(docsDir, 'graph-g5-scenarios.md'));
+}
+
 // ─── 主函数 ─────────────────────────────────────────────────
 
 /**
@@ -783,7 +805,8 @@ async function collectMissingAiDocs(
  *
  * Resume is based on files on disk: missing component/architecture docs are
  * retried even when progress.json says `done` (deterministic graph files keep
- * `docs/` nonempty). Completed AI docs are not overwritten.
+ * `docs/` nonempty). Completed AI docs are kept for the same extract, but a
+ * newer `_manifest.json` generatedAt invalidates component/architecture/G5 docs.
  *
  * @param opts DeepEnrichOptions
  */
@@ -810,6 +833,21 @@ export async function deepEnrich(opts: DeepEnrichOptions): Promise<DeepEnrichRes
 
   const allSlugs = components.map(c => c.slug);
   const progress = await loadProgress(evidenceDir, project, allSlugs);
+
+  // A newer extract rewrites _manifest.json without clearing docs/. File-based
+  // resume would otherwise keep old component/architecture/G5 docs forever.
+  const manifestTime = ctx.manifest.generatedAt;
+  if (manifestTime && progress.startedAt < manifestTime) {
+    log.info(
+      `deep-enrich[${project}]: stale progress detected (manifest newer than progress.startedAt), invalidating AI docs`,
+    );
+    await invalidateStaleAiDocs(docsDir, allSlugs);
+    progress.phase = 'pending';
+    progress.componentsDone = [];
+    progress.componentsPending = [...allSlugs];
+    progress.startedAt = new Date().toISOString();
+    await saveProgress(evidenceDir, progress);
+  }
 
   // Disk is the source of truth for resume. A prior AI skip still writes
   // deterministic graph markdown, so `phase: done` + nonempty docs/ must not


### PR DESCRIPTION
## Summary

A temporary AI failure during deep enrichment left component and architecture documents missing, but the engine still saved `phase: \"done\"`. The next run skipped the missing AI work because deterministic graph markdown kept `docs/` nonempty, and the public command still reported `complete: true`.

Resume now treats files on disk as the source of truth: missing `docs/<slug>.md` and `docs/architecture.md` are retried, completed AI docs and G1/G2/G3 graph files are preserved, and `teamai codebase --deep-enrich` reports incomplete work in English instead of claiming full completion.

Fixes #488.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an existing issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing behavior to change)
- [ ] Documentation only
- [ ] Refactor / internal cleanup

## Test Plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/__tests__/codebase-deep-enrich.test.ts src/__tests__/deep-enrich-graph-preserve.test.ts` — 10/10 passed (AI client mocked; no live LLM)
- [x] Fail then recover: first `codebaseCmd --deep-enrich` with rejecting AI writes graph docs, omits `Auth.md` / `architecture.md`, JSON `complete: false`; second call with recovered mocks writes those AI docs and keeps G1 unchanged
- [x] Fail again: a later rejecting retry still reports `complete: false` / `Deep enrichment incomplete` with missing component and architecture docs listed
- [x] Completed `Auth.md` is preserved when architecture generation still fails
- [x] Did not spawn a live enrich on the built CLI (AI hang up to 600s)

## Related Issues

Fixes #488. Related to #480 / #360 (does not close #360).

## Notes for Reviewers

- Public entry is still `teamai codebase --deep-enrich --project <slug> --output <repo>`.
- Hidden `teamai deep-enrich` is unchanged.
- Incomplete runs set `process.exitCode = 1` and print `Deep enrichment incomplete`.
- Graph generation remains deterministic and may rewrite G1/G2/G3 with the same content; existing component/architecture files are not overwritten.