### PR TITLE
fix: count namespaced skills and nested docs correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Insight into how the team actually uses its AI tools, and a starting point for t
 | `teamai pull` | Pull team resources and inject into local AI tools |
 | `teamai push` | Push local resources to a branch and open a Merge Request |
 | `teamai packages [install] [target]` | Install declared npm packages and Claude plugins; with a target, also update `teamai.yaml`. Bare `teamai packages` installs everything; `teamai packages install <target>` adds one |
-| `teamai status` | Show local vs team repo diff |
+| `teamai status` | Show local vs team repo diff and resource counts, including namespaced skills and nested docs |
 | `teamai contribute` | Share session experience to team repo |
 | `teamai recall <query>` | Search the team knowledge base (BM25 + graph-boost) |
 | `teamai recall enable/disable/status` | Toggle or check recall state |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -237,7 +237,7 @@ teamai recall maintenance --update-quality       # 为过时 skills / docs 生�
 | `teamai pull` | 拉取团队资源并注入到本地 AI 工具 |
 | `teamai push` | 推送本地资源到分支并创建合并请求 |
 | `teamai packages [install] [target]` | 安装团队 npm 包和 Claude 插件。裸 `teamai packages` 安装全部；`teamai packages install <target>` 添加单个并更新声明 |
-| `teamai status` | 显示本地与团队仓库的差异 |
+| `teamai status` | 显示本地与团队仓库的差异及资源数量，包含 namespace 下的技能和子目录中的文档 |
 | `teamai contribute` | 将 session 经验分享到团队仓库 |
 | `teamai recall <query>` | 搜索团队知识库（BM25 + 图谱增强） |
 | `teamai recall enable/disable/status` | 开关或查看 recall 状态 |

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -551,6 +551,17 @@ teamai status        # Current scope, last sync time, resource stats
 teamai status --all  # List every project data partition under ~/.teamai/projects
 ```
 
+Under `Team resources`, `skills` counts the team repo entries shown by
+`teamai list skills --source repo`: both flat skills (`skills/<name>/SKILL.md`)
+and skills inside namespaces (`skills/<namespace>/<name>/SKILL.md`). Namespace
+directories and modules bundled inside a skill are not counted separately. For
+example, six skills under `skills/ai/` plus `skills/officecli/` count as seven.
+
+`docs` counts files recursively under `docs/`, excluding hidden files and hidden
+directories. Documents stored only in subdirectories are also discovered and
+synced by `pull`. Learnings are not included in this resource summary; they are
+shared at the root or selected by active projects, not by roles.
+
 `--all` enumerates every project's machine-data partition and flags each as
 **active** (project still on disk), **ORPHAN** (project moved/deleted — its
 partition is safe to `rm -rf`), or **unknown** (no `anchor` file, so it cannot be

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -536,6 +536,15 @@ teamai status        # 当前 scope、同步时间、资源统计
 teamai status --all  # 列出 ~/.teamai/projects 下所有项目数据分区
 ```
 
+`Team resources` 中的 `skills` 数量与 `teamai list skills --source repo` 的团队仓库列表一致，
+包含平铺技能（`skills/<name>/SKILL.md`）和 namespace 下的技能
+（`skills/<namespace>/<name>/SKILL.md`）。namespace 目录及技能包内部的子模块不单独计数。
+例如，`skills/ai/` 下有 6 个技能，另有 `skills/officecli/`，总数为 7。
+
+`docs` 递归统计 `docs/` 下的文件，排除隐藏文件和隐藏目录。全部放在子目录里的文档也会被
+`pull` 发现并同步。此资源摘要不包含经验数量；经验在根目录全团队共享，或按启用的项目选择，
+不按角色划分。
+
 `--all` 会枚举每个项目的机器数据分区，并标注为 **active**（项目仍在磁盘上）、
 **ORPHAN**（项目已移动/删除——该分区可安全 `rm -rf`）或 **unknown**（无 `anchor`
 文件，无法确认是否孤儿——绝不建议删除）。ORPHAN 判定只依据 anchor，因此绝不会凭猜测

--- a/src/__tests__/docs.test.ts
+++ b/src/__tests__/docs.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import os from 'node:os';
+import fse from 'fs-extra';
+import { DocsHandler } from '../resources/docs.js';
+import { LocalConfigSchema, TeamaiConfigSchema, type LocalConfig, type TeamaiConfig } from '../types.js';
+
+describe('DocsHandler nested documents', () => {
+  const handler = new DocsHandler();
+  let tmpDir: string;
+  let docsDir: string;
+  let localConfig: LocalConfig;
+  let teamConfig: TeamaiConfig;
+
+  beforeEach(async () => {
+    tmpDir = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-docs-'));
+    vi.stubEnv('HOME', tmpDir);
+    docsDir = path.join(tmpDir, 'repo', 'docs');
+    localConfig = LocalConfigSchema.parse({
+      repo: { localPath: path.join(tmpDir, 'repo'), remote: 'local/docs-test' },
+      username: 'test', scope: 'user',
+    });
+    teamConfig = TeamaiConfigSchema.parse({ team: 'test', repo: 'local/docs-test', provider: 'git' });
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await fse.remove(tmpDir);
+  });
+
+  it('discovers and syncs documents when all visible files are nested', async () => {
+    const visible = ['ai/setup.md', 'ai/reference/api.pdf'];
+    const hidden = ['.gitkeep', 'ai/.draft.md', 'ai/.private/note.md'];
+    for (const docPath of [...visible, ...hidden]) {
+      await fse.outputFile(path.join(docsDir, docPath), `Content: ${docPath}\n`);
+    }
+    const items = await handler.scanTeamForPull(teamConfig, localConfig);
+    expect(items).toHaveLength(1);
+    expect(await handler.countDocFiles(docsDir)).toBe(2);
+
+    await handler.pullItem(items[0], teamConfig, localConfig);
+
+    for (const docPath of visible) {
+      expect(await fse.readFile(path.join(tmpDir, '.teamai', 'docs', docPath), 'utf8')).toBe(`Content: ${docPath}\n`);
+    }
+    for (const docPath of hidden) {
+      expect(await fse.pathExists(path.join(tmpDir, '.teamai', 'docs', docPath))).toBe(false);
+    }
+  });
+
+  it('does not offer a docs bundle for missing, empty, or hidden-only trees', async () => {
+    expect(await handler.countDocFiles(docsDir)).toBe(0);
+    expect(await handler.scanTeamForPull(teamConfig, localConfig)).toEqual([]);
+
+    await fse.ensureDir(path.join(docsDir, 'empty'));
+    await fse.outputFile(path.join(docsDir, 'ai', '.gitkeep'), '');
+    await fse.outputFile(path.join(docsDir, '.private', 'note.md'), 'Hidden\n');
+    expect(await handler.countDocFiles(docsDir)).toBe(0);
+    expect(await handler.scanTeamForPull(teamConfig, localConfig)).toEqual([]);
+  });
+});

--- a/src/__tests__/status-list.test.ts
+++ b/src/__tests__/status-list.test.ts
@@ -163,4 +163,34 @@ describe('teamai list / status resource coverage', () => {
     const out = lines.join('\n');
     expect(out).toMatch(/rules:\s*1/);
   });
+
+  it('status counts nested docs and excludes hidden files at every depth', async () => {
+    for (const docPath of ['guide.md', 'ai/setup.md', 'ai/reference/api.pdf', '.gitkeep', 'ai/.draft.md', '.private/note.md']) {
+      await fse.outputFile(path.join(repoPath, 'docs', docPath), 'Documentation\n');
+    }
+
+    await status({});
+
+    expect(lines).toContain('  docs: 3');
+  });
+
+  it.each([
+    { layout: 'flat', skillPaths: ['review', 'officecli'] },
+    { layout: 'namespaced', skillPaths: ['ai/review', 'ai/planning', 'ops/review', 'ops/deploy'] },
+    {
+      layout: 'mixed with nested modules inside a skill',
+      skillPaths: ['ai/log-reader', 'ai/asset-import', 'ai/asset-replacement', 'ai/project-analysis', 'ai/unity-skills', 'ai/skills-setup', 'officecli'],
+      nestedModules: ['ai/unity-skills/skills/scene', 'ai/unity-skills/skills/camera'],
+    },
+    { layout: 'empty', skillPaths: [] },
+  ])('status counts skills in a $layout repo instead of top-level directories', async ({ skillPaths, nestedModules = [] }) => {
+    for (const skillPath of [...skillPaths, ...nestedModules]) {
+      await fse.outputFile(path.join(repoPath, 'skills', skillPath, 'SKILL.md'), '# Skill\n');
+    }
+    await fse.ensureDir(path.join(repoPath, 'skills', 'empty-namespace'));
+
+    await status({});
+
+    expect(lines).toContain(`  skills: ${skillPaths.length}`);
+  });
 });

--- a/src/resources/docs.ts
+++ b/src/resources/docs.ts
@@ -3,7 +3,7 @@ import fse from 'fs-extra';
 import { ResourceHandler } from './base.js';
 import type { ResourceItem, TeamaiConfig, LocalConfig } from '../types.js';
 import { resolveBaseDir } from '../types.js';
-import { pathExists, expandHome, listFiles } from '../utils/fs.js';
+import { expandHome, listFilesRecursive } from '../utils/fs.js';
 import { log } from '../utils/logger.js';
 
 export class DocsHandler extends ResourceHandler {
@@ -16,12 +16,8 @@ export class DocsHandler extends ResourceHandler {
 
   async scanTeamForPull(_teamConfig: TeamaiConfig, localConfig: LocalConfig): Promise<ResourceItem[]> {
     const docsDir = path.join(localConfig.repo.localPath, 'docs');
-    if (!await pathExists(docsDir)) return [];
-
-    // Check if there are actual doc files (ignore .gitkeep and other dot files)
-    const files = await listFiles(docsDir);
-    const realFiles = files.filter(f => !f.startsWith('.'));
-    if (realFiles.length === 0) return [];
+    // Nested documents are synced as part of the same bundle.
+    if (await this.countDocFiles(docsDir) === 0) return [];
 
     return [{
       name: 'docs',
@@ -32,8 +28,8 @@ export class DocsHandler extends ResourceHandler {
   }
 
   async countDocFiles(sourcePath: string): Promise<number> {
-    const files = await listFiles(sourcePath);
-    return files.filter(f => !f.startsWith('.')).length;
+    const files = await listFilesRecursive(sourcePath);
+    return files.filter(f => f.split('/').every(segment => !segment.startsWith('.'))).length;
   }
 
   async pushItem(_item: ResourceItem, _teamConfig: TeamaiConfig, _localConfig: LocalConfig): Promise<void> {

--- a/src/status.ts
+++ b/src/status.ts
@@ -5,8 +5,9 @@ import { getRepoStatus } from './utils/git.js';
 import { assertSafeResourceName } from './utils/path-safety.js';
 import { log } from './utils/logger.js';
 import { getAllHandlers } from './resources/index.js';
-import { listDirs, listFiles, listFilesRecursive, pathExists, readFileSafe } from './utils/fs.js';
+import { listDirs, listFilesRecursive, pathExists, readFileSafe } from './utils/fs.js';
 import { SkillsHandler } from './resources/skills.js';
+import { DocsHandler } from './resources/docs.js';
 import { detectInstalledAgents, type ResolvedAgent } from './known-agents.js';
 import {
   buildClassifyContext,
@@ -81,15 +82,13 @@ export async function status(options: GlobalOptions): Promise<void> {
   const repoPath = localConfig.repo.localPath;
   const counts: Record<string, number> = {};
 
-  const skillsDirs = await listDirs(path.join(repoPath, 'skills'));
-  counts.skills = skillsDirs.length;
+  // Match `list skills --source repo`: count skills, not namespace directories.
+  counts.skills = (await new SkillsHandler().scanTeamForPull(teamConfig, localConfig)).length;
 
   const rulesFiles = (await listFilesRecursive(path.join(repoPath, 'rules'))).filter(f => f.endsWith('.md'));
   counts.rules = rulesFiles.length;
 
-  const docsExists = await pathExists(path.join(repoPath, 'docs'));
-  const docFiles = docsExists ? (await listFiles(path.join(repoPath, 'docs'))).filter(f => !f.startsWith('.')) : [];
-  counts.docs = docFiles.length;
+  counts.docs = await new DocsHandler().countDocFiles(path.join(repoPath, 'docs'));
 
   const envYamlPath = path.join(repoPath, 'env', 'env.yaml');
   let envCount = 0;


### PR DESCRIPTION
## Summary

`teamai status` counted top-level skill directories, so six skills inside `skills/ai/` plus one flat skill were reported as 2 instead of 7. Reuse the repository skill scanner so status matches `teamai list skills --source repo` and does not count modules bundled inside a skill separately.

Count visible documents recursively and reuse that count when discovering the docs bundle. This also fixes `pull` skipping documentation when all files live in subdirectories. Update the English and Chinese documentation and add regression coverage.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Plan

- [x] `npm run build` passed.
- [x] TypeScript checking passed: `node ../../node_modules/typescript/bin/tsc --noEmit`.
- [x] 123 targeted Vitest tests passed across 10 suites:
  - `status-list`, `docs`, `skills`, `roles`, `learnings-namespace`, `learnings-mirror`
  - `pull-exclude`, `pull-scope-isolation`, `status-agent-flag`, `agent-skills`
- [x] Added regression tests for flat/namespaced/mixed skills, nested skill modules, empty namespaces, nested-only docs discovery and copying, hidden files, and missing/empty docs trees.
- [x] Ran the built CLI's `status`, `list skills --source repo`, and `list docs --source repo` against all 12 isolated local configurations below.

| Provider configuration | Claude | Codex | CodeBuddy | OpenCode |
| --- | --- | --- | --- | --- |
| git | PASS | PASS | PASS | PASS |
| gitlab | PASS | PASS | PASS | PASS |
| github | PASS | PASS | PASS | PASS |

Every CLI configuration reported 7 skills, listed the same 7 repo skills, counted 2 visible nested document files, and discovered the docs bundle. Hidden files and nested skill modules were excluded from the corresponding counts. The built CLI also changed the reproduced real-config skill count from 2 to 7.

## Notes for Reviewers

Validation ran on Windows with test temporary directories inside the worktree. The provider matrix exercises local CLI scanning with each provider configuration; it does not exercise hosted-provider network operations. The full repository test suite has not been run locally.

Team resource counts retain their existing repository scope. Built-in agents/hooks and role/project learning behavior are unchanged.
