### PR TITLE
test: prove Distilly provenance frontmatter survives source deploy

### DIFF
--- a/src/__tests__/distilly-roundtrip.test.ts
+++ b/src/__tests__/distilly-roundtrip.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { copyDir, readFileSafe } from '../utils/fs.js';
+import { ensureSkillFrontmatter } from '../resources/skills.js';
+import { splitFrontmatter } from '../utils/frontmatter.js';
+
+// Exercises the exact two operations pullSingleSource() runs on a deployed
+// skill (source.ts: `copyDir(skill.sourcePath, targetDir)` followed by the
+// same frontmatter validation push runs via ensureSkillFrontmatter), against
+// a SKILL.md carrying Distilly-style provenance metadata in frontmatter.
+describe('Distilly export -> TeamAI source deploy round trip', () => {
+  it('preserves custom provenance/version frontmatter fields byte-for-byte', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'distilly-rt-'));
+    const sourceSkillDir = path.join(tmp, 'source', 'skills', 'hello-distilly');
+    const targetSkillDir = path.join(tmp, 'deployed', '.claude', 'skills', 'hello-distilly');
+    await fs.mkdir(sourceSkillDir, { recursive: true });
+
+    const skillMd = `---
+name: hello-distilly
+description: Example skill exported from a Distilly profile.
+distilly_source: profiles/onboarding-guide.md
+distilly_version: 1.4.0
+distilly_profile_id: 9f2c1a7e
+provenance: https://github.com/titanwings/distilly/commit/abc1234
+---
+
+# Hello Distilly
+
+This skill body is unrelated to the frontmatter under test.
+`;
+    await fs.writeFile(path.join(sourceSkillDir, 'SKILL.md'), skillMd, 'utf-8');
+
+    // Step 1: the exact deploy call pullSingleSource() makes.
+    await copyDir(sourceSkillDir, targetSkillDir);
+
+    // Step 2: the exact validation call the push path makes on skills.
+    const mutated = await ensureSkillFrontmatter(targetSkillDir, 'hello-distilly');
+    expect(mutated).toBe(false); // already has name+description -> untouched
+
+    const deployedRaw = await readFileSafe(path.join(targetSkillDir, 'SKILL.md'));
+    expect(deployedRaw).toBe(skillMd); // byte-for-byte identical, not just field-equal
+
+    const { data } = splitFrontmatter(deployedRaw!);
+    expect(data['distilly_source']).toBe('profiles/onboarding-guide.md');
+    expect(data['distilly_version']).toBe('1.4.0');
+    expect(data['distilly_profile_id']).toBe('9f2c1a7e');
+    expect(data['provenance']).toBe('https://github.com/titanwings/distilly/commit/abc1234');
+  });
+});


### PR DESCRIPTION
## Summary

PoC for the Distilly integration (see the Distilly collaboration issue): a Distilly-exported skill carries version/provenance metadata as extra YAML frontmatter keys, and this test proves TeamAI's existing deploy path preserves them byte-for-byte. No CLI behavior change — test only.

Example source repo: https://github.com/Gugilla-Aakash/distilly-teamai-example (`teamai.yaml` with `publicSkills: [hello-distilly]` + `skills/hello-distilly/SKILL.md`).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing behavior to change)
- [ ] Documentation only
- [ ] Refactor / internal cleanup

Test-only PoC: none of the above apply, no production code touched.

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` passes (217 files, 2979 tests, incl. the new one)
- [x] Added/updated tests for the change (`src/__tests__/distilly-roundtrip.test.ts`)

Real-CLI end-to-end verification with the built CLI (`npm run build` OK), provider `github`, agent `claude`, isolated throwaway team repo (private, since deleted from daily use):

- `teamai init Gugilla-Aakash/distilly-poc-team --scope project --agent claude` → success
- `teamai source add https://github.com/Gugilla-Aakash/distilly-teamai-example --name distilly-demo` → cloned, no warnings (source `teamai.yaml`+`publicSkills` recognized)
- `teamai source browse distilly-demo` → lists `hello-distilly` with description
- `teamai pull --force` → `[source:distilly-demo] Synced 1 skills (1 new, 0 updated)`
- `diff` source vs deployed `SKILL.md` → IDENTICAL; all four keys (`distilly_source`, `distilly_version`, `distilly_profile_id`, `provenance`) present

## Related Issues

Distilly collaboration issue (Distilly export → TeamAI source distribution PoC). Happy to link the number if a maintainer drops it in.

## Notes for Reviewers

- The test replays the exact two operations `pullSingleSource` runs (`copyDir` in `src/source.ts` + `ensureSkillFrontmatter` in `src/resources/skills.ts`, the same validation the team-repo `push` path uses), so it covers both distribution and push/pull round-trip halves without touching production code.
- Proposed frontmatter convention (`distilly_*` + `provenance`) is open for discussion with @titanwings; if agreed, a follow-up can document it. No schema change needed since `types.ts` carries no skill-version field by design.