### PR TITLE
fix(ai-client): resolve the AI CLI on Windows with where + cross-spawn

### DIFF
--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -1176,6 +1176,8 @@ teamai import --from-repo https://github.com/org/repo --incremental
 teamai import --from-repo https://github.com/org/repo --skip-enrich
 ```
 
+AI-backed steps (`--deep-enrich`, knowledge enrichment) shell out to an AI coding CLI already installed on the machine instead of calling a model API directly. teamai probes `claude` → `claude-internal` → `codex` → `codex-internal` → `codebuddy` → `workbuddy` → `openclaw` and uses the first one it finds. On macOS and Linux the probe runs through a login shell, so a CLI installed under `~/.nvm/` is found too. On Windows it uses the native `where`, which returns the npm shim (`%APPDATA%\npm\claude.cmd`) that Windows can actually launch — a Git Bash or WSL `bash` only reports MSYS paths such as `/c/Users/...`, which Windows cannot start.
+
 For GitLab behind an API gateway, set `GITLAB_URL` and `GITLAB_API_PREFIX=api/gitlab` before running `teamai import --from-org https://gitlab.example.com/myorg`. Organization listing uses the configured prefix on every page; an unset or blank prefix defaults to `api/v4`.
 
 The graph stores components, interfaces, configs, and cross-repo dependencies. `teamai recall` uses the graph for BM25 + graph-boosted ranking.

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -1145,6 +1145,8 @@ teamai import --from-repo https://github.com/org/repo --incremental
 teamai import --from-repo https://github.com/org/repo --skip-enrich
 ```
 
+需要 AI 的步骤（`--deep-enrich`、知识增强）复用本机已安装的 AI 编码 CLI，而不是直接调用模型 API。teamai 按 `claude` → `claude-internal` → `codex` → `codex-internal` → `codebuddy` → `workbuddy` → `openclaw` 的顺序探测，取第一个可用者。macOS / Linux 上探测经由 login shell，因此装在 `~/.nvm/` 下的 CLI 也能找到；Windows 上改用原生命令 `where`，拿到的是 Windows 真正能启动的 npm shim（`%APPDATA%\npm\claude.cmd`）——Git Bash 或 WSL 的 `bash` 只会返回 `/c/Users/...` 这类 MSYS 路径，Windows 无法启动。
+
 对于 API 网关后的 GitLab，先设置 `GITLAB_URL` 和 `GITLAB_API_PREFIX=api/gitlab`，再运行 `teamai import --from-org https://gitlab.example.com/myorg`。组织仓库列表的每一页请求都会使用配置的前缀；未设置或为空时默认使用 `api/v4`。
 
 图谱存储组件、接口、配置和跨仓库依赖关系。`teamai recall` 利用图谱进行 BM25 + graph-boost 增强排名。

--- a/src/__tests__/ai-client.test.ts
+++ b/src/__tests__/ai-client.test.ts
@@ -2,15 +2,23 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { ChildProcess } from 'node:child_process';
 import type { EventEmitter } from 'node:events';
 
-// ─── Mock child_process ────────────────────────────────────────────────────
+// ─── Mock child_process / cross-spawn ──────────────────────────────────────
 // vi.mock 会被 hoist 到文件顶部，factory 中不能引用外部 const/let 变量
 // 改用 vi.fn() 内联，通过 vi.mocked(spawn) 在测试中动态设置行为
 
+// callClaude 经 cross-spawn 启动 CLI：Windows 上 CLI 多为 npm 生成的 `.cmd` shim，
+// Node 原生 spawn 无权直接执行（EINVAL），必须由 cross-spawn 经 cmd.exe 转义启动。
+vi.mock('cross-spawn', () => ({
+  default: vi.fn(),
+}));
+
 vi.mock('node:child_process', () => ({
-  spawn: vi.fn(),
-  // detectClaudeCli 通过 execFileSync('bash', ['-lc', 'command -v <cmd>']) 获取绝对路径，
+  // detectClaudeCli 探测绝对路径：POSIX 走 bash -lc，Windows 走 where。
   // 测试环境中返回伪路径，配合 existsSync mock 让探测成功并选中第一个候选 'claude'。
-  execFileSync: vi.fn(() => '/usr/local/bin/claude\n'),
+  // Windows 分支只接受可执行后缀（.exe/.cmd/.bat），因此伪路径需要按平台给出。
+  execFileSync: vi.fn(() =>
+    process.platform === 'win32' ? 'C:\\npm\\claude.cmd\n' : '/usr/local/bin/claude\n'
+  ),
 }));
 
 // mock existsSync，使探测到的伪路径被视为存在
@@ -18,8 +26,14 @@ vi.mock('node:fs', () => ({
   existsSync: vi.fn(() => true),
 }));
 
-import { spawn } from 'node:child_process';
-import { callClaude, callClaudeParallel } from '../utils/ai-client.js';
+import spawn from 'cross-spawn';
+import { execFileSync } from 'node:child_process';
+import {
+  callClaude,
+  callClaudeParallel,
+  pickWindowsCommand,
+  resolveCliPath,
+} from '../utils/ai-client.js';
 
 // ─── Helpers ───────────────────────────────────────────────────────────────
 
@@ -188,5 +202,113 @@ describe('callClaudeParallel', () => {
 
     // 最大并发不超过 2
     expect(maxRunning).toBeLessThanOrEqual(2);
+  });
+});
+
+// ─── pickWindowsCommand ────────────────────────────────────────────────────
+// `where` 的输出解析是纯函数，因此在所有平台上都能回归（Windows 上的真实探测
+// 由这些用例固定契约，不需要 Windows runner）。
+
+describe('pickWindowsCommand', () => {
+  it('npm 的 shim 三件套：跳过无扩展名的 POSIX shim，选中 .cmd', () => {
+    // `where claude` 的真实输出顺序：无扩展名的 shim 排在最前
+    const output = [
+      'C:\\Users\\me\\AppData\\Roaming\\npm\\claude',
+      'C:\\Users\\me\\AppData\\Roaming\\npm\\claude.cmd',
+      '',
+    ].join('\r\n');
+
+    expect(pickWindowsCommand(output)).toBe('C:\\Users\\me\\AppData\\Roaming\\npm\\claude.cmd');
+  });
+
+  it('原生安装的 .exe 优先于同名 .cmd（PATHEXT 优先级）', () => {
+    const output = [
+      'C:\\tools\\claude.cmd',
+      'C:\\Program Files\\Claude\\claude.exe',
+    ].join('\r\n');
+
+    expect(pickWindowsCommand(output)).toBe('C:\\Program Files\\Claude\\claude.exe');
+  });
+
+  it('.bat 与 .exe 并存时选中 .exe', () => {
+    const output = ['C:\\tools\\claude.bat', 'C:\\tools\\claude.exe'].join('\n');
+
+    expect(pickWindowsCommand(output)).toBe('C:\\tools\\claude.exe');
+  });
+
+  it('忽略前后空白并把扩展名匹配视为大小写不敏感', () => {
+    expect(pickWindowsCommand('  C:\\npm\\CLAUDE.CMD  \r\n')).toBe('C:\\npm\\CLAUDE.CMD');
+  });
+
+  it('只有无扩展名的 shim 时返回 null（CreateProcess 无法启动它）', () => {
+    expect(pickWindowsCommand('C:\\npm\\claude\r\n')).toBeNull();
+  });
+
+  it('where 未找到任何匹配时返回 null', () => {
+    expect(pickWindowsCommand('')).toBeNull();
+    expect(pickWindowsCommand('\r\n \r\n')).toBeNull();
+  });
+});
+
+// ─── resolveCliPath ────────────────────────────────────────────────────────
+// platform 参数可注入，使 Windows 分支在 ubuntu / macos 的 CI 上也有覆盖。
+
+/** execFileSync 是重载函数，vi.mocked 推不出返回值类型，这里取一个够用的视图。 */
+const execFileSyncMock = vi.mocked(execFileSync) as unknown as {
+  mock: { calls: unknown[][] };
+  mockReturnValueOnce: (value: unknown) => void;
+  mockImplementationOnce: (impl: () => never) => void;
+};
+
+describe('resolveCliPath', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('win32：走 where，返回 where 输出里可启动的那条路径', () => {
+    execFileSyncMock.mockReturnValueOnce('C:\\npm\\claude\r\nC:\\npm\\claude.cmd\r\n');
+
+    expect(resolveCliPath('claude', 'win32')).toBe('C:\\npm\\claude.cmd');
+    expect(execFileSyncMock.mock.calls[0][0]).toBe('where');
+    expect(execFileSyncMock.mock.calls[0][1]).toEqual(['claude']);
+  });
+
+  it('win32：只调用 where，不碰 bash / zsh / which', () => {
+    execFileSyncMock.mockReturnValueOnce('C:\\npm\\claude.cmd\r\n');
+
+    resolveCliPath('claude', 'win32');
+
+    expect(execFileSyncMock.mock.calls.map((call) => call[0])).toEqual(['where']);
+  });
+
+  it('win32：where 未命中（退出码非 0）时返回 null', () => {
+    execFileSyncMock.mockImplementationOnce(() => {
+      throw new Error('Command failed: where claude');
+    });
+
+    expect(resolveCliPath('claude', 'win32')).toBeNull();
+  });
+
+  it('win32：where 只给出无扩展名的 shim 时返回 null，避免 spawn EINVAL', () => {
+    execFileSyncMock.mockReturnValueOnce('C:\\npm\\claude\r\n');
+
+    expect(resolveCliPath('claude', 'win32')).toBeNull();
+  });
+
+  it('posix：优先使用 bash login shell 的结果', () => {
+    execFileSyncMock.mockReturnValueOnce('/usr/local/bin/claude\n');
+
+    expect(resolveCliPath('claude', 'linux')).toBe('/usr/local/bin/claude');
+    expect(execFileSyncMock.mock.calls[0][0]).toBe('bash');
+  });
+
+  it('posix：bash 抛错时回退到 zsh', () => {
+    execFileSyncMock.mockImplementationOnce(() => {
+      throw new Error('spawn bash ENOENT');
+    });
+    execFileSyncMock.mockReturnValueOnce('/opt/homebrew/bin/claude\n');
+
+    expect(resolveCliPath('claude', 'darwin')).toBe('/opt/homebrew/bin/claude');
+    expect(execFileSyncMock.mock.calls.map((call) => call[0])).toEqual(['bash', 'zsh']);
   });
 });

--- a/src/utils/ai-client.ts
+++ b/src/utils/ai-client.ts
@@ -1,4 +1,5 @@
-import { spawn, execFileSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
+import spawn from 'cross-spawn';
 import { existsSync } from 'node:fs';
 import { log } from './logger.js';
 
@@ -9,6 +10,14 @@ const ALLOWED_CLI_CANDIDATES = [
 
 /** CLI 探测超时（毫秒），防止 execFileSync 挂死。 */
 const CLI_DETECT_TIMEOUT_MS = 5_000;
+
+/**
+ * 可按扩展名直接启动的 Windows 可执行后缀，按 PATHEXT 优先级排列。
+ *
+ * `npm install -g` 在 Windows 上同时生成三个 shim：无扩展名的 POSIX 脚本、
+ * `<cmd>.cmd`、`<cmd>.ps1`。无扩展名的那个 CreateProcess 无法启动。
+ */
+const WIN_EXEC_EXTENSIONS = ['.exe', '.cmd', '.bat'] as const;
 
 /**
  * 默认 AI 调用超时时间（毫秒）。
@@ -28,16 +37,133 @@ interface CliInfo {
 }
 
 /**
+ * 从 `where <cmd>` 的输出中挑出可启动的那一条。
+ *
+ * `where` 会列出所有匹配项，且顺序上无扩展名的 POSIX shim 往往排在前面
+ * （例如 `C:\npm\claude` 先于 `C:\npm\claude.cmd`）。无扩展名的文件
+ * CreateProcess 无法启动，因此这里只接受可执行后缀。
+ *
+ * @param whereOutput  `where <cmd>` 的原始 stdout
+ * @returns            首个可启动路径；没有可执行后缀时返回 null
+ */
+export function pickWindowsCommand(whereOutput: string): string | null {
+  const lines = whereOutput
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  for (const ext of WIN_EXEC_EXTENSIONS) {
+    const hit = lines.find((line) => line.toLowerCase().endsWith(ext));
+    if (hit !== undefined) return hit;
+  }
+  return null;
+}
+
+/**
+ * 用 Windows 原生命令 `where` 解析候选 CLI，返回真正的 Windows 路径。
+ *
+ * `where` 是 `which` 的 Windows 原生等价物，返回 `C:\...\claude.cmd` 这类
+ * Windows API 能识别的路径。
+ *
+ * @param cmd  候选命令名
+ * @returns    存在且可启动的绝对路径；未安装时返回 null
+ */
+function whereOnWindows(cmd: string): string | null {
+  try {
+    const out = execFileSync('where', [cmd], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      shell: false,
+      timeout: CLI_DETECT_TIMEOUT_MS,
+    });
+    const p = pickWindowsCommand(out);
+    return p !== null && existsSync(p) ? p : null;
+  } catch {
+    // where 未找到时退出码非 0（stderr 为 "INFO: Could not find files..."），走这里
+    return null;
+  }
+}
+
+/**
+ * POSIX 侧的策略链，依次尝试各 shell 环境，返回第一个解析成功且真实存在的路径：
+ *   1. `bash -lc command -v <cmd>` —— login shell，覆盖 ~/.nvm/ 等路径
+ *   2. `zsh -lc command -v <cmd>`  —— macOS 默认 shell fallback
+ *   3. `which <cmd>` —— 最终 fallback，使用 process.env.PATH 直接查找
+ *
+ * @param cmd  候选命令名
+ * @returns    存在的绝对路径；三种策略都失败时返回 null
+ */
+function whichOnPosix(cmd: string): string | null {
+  // 策略 1：bash login shell（shell: false 是 execFileSync 默认行为，此处显式标注）
+  try {
+    const p = execFileSync('bash', ['-lc', `command -v ${cmd}`], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      shell: false,
+      timeout: CLI_DETECT_TIMEOUT_MS,
+    }).trim();
+    if (p && existsSync(p)) return p;
+  } catch {
+    // 继续尝试下一策略
+  }
+
+  // 策略 2：zsh login shell（macOS 默认 shell / bash 不可用时）
+  try {
+    const p = execFileSync('zsh', ['-lc', `command -v ${cmd}`], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      shell: false,
+      timeout: CLI_DETECT_TIMEOUT_MS,
+    }).trim();
+    if (p && existsSync(p)) return p;
+  } catch {
+    // 继续尝试下一策略
+  }
+
+  // 策略 3：which 命令（使用 process.env.PATH，覆盖 fish / CI 容器等环境）
+  try {
+    const p = execFileSync('which', [cmd], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      shell: false,
+      timeout: CLI_DETECT_TIMEOUT_MS,
+    }).trim();
+    if (p && existsSync(p)) return p;
+  } catch {
+    // 三种策略都不可用
+  }
+
+  return null;
+}
+
+/**
+ * 把候选 CLI 命令名解析为存在的绝对路径。
+ *
+ * Windows 上必须走 `where`：`bash` / `which` 在 Windows 上来自 Git Bash 或 WSL，
+ * 返回的是 MSYS 风格路径（如 `/c/Users/me/AppData/Roaming/npm/claude`），
+ * Node 对这类路径 `existsSync` 恒为 false，spawn 也无法启动，所以 POSIX 策略在
+ * Windows 上永远不可能成功（WSL 的 bash 更会返回完全不可用的 Linux 路径）。
+ *
+ * `platform` 之所以可注入，是因为仓库 CI 只跑 ubuntu / macos：写死 process.platform
+ * 的话 Windows 分支将没有任何测试覆盖（这正是该缺陷长期未被发现的原因）。
+ *
+ * @param cmd       候选命令名
+ * @param platform  目标平台，默认当前进程平台
+ * @returns         存在的绝对路径；该平台上不可用时返回 null
+ */
+export function resolveCliPath(
+  cmd: string,
+  platform: NodeJS.Platform = process.platform,
+): string | null {
+  return platform === 'win32' ? whereOnWindows(cmd) : whichOnPosix(cmd);
+}
+
+/**
  * 按优先级探测可用的 AI CLI，返回命令名与绝对路径。
  *
  * 各 CLI 非交互调用语法不同：
  *   - claude / claude-internal / codebuddy / workbuddy / openclaw：`<cli> -p <prompt>`
  *   - codex / codex-internal：`<cli> exec <prompt>`
- *
- * 依次通过以下方式获取绝对路径，确保覆盖各类 shell 环境：
- *   1. `bash -lc command -v <cmd>` —— login shell，覆盖 ~/.nvm/ 等路径
- *   2. `zsh -lc command -v <cmd>`  —— macOS 默认 shell fallback
- *   3. `which <cmd>` —— 最终 fallback，使用 process.env.PATH 直接查找
  *
  * 探测顺序：`claude` → `claude-internal` → `codex` → `codex-internal` → `codebuddy` → `workbuddy` → `openclaw`。
  * 结果缓存，进程生命周期内只探测一次。
@@ -46,47 +172,9 @@ interface CliInfo {
  * @throws  所有候选均不可用时抛出 Error
  */
 function detectClaudeCli(): CliInfo {
-  const candidates = ALLOWED_CLI_CANDIDATES;
-
-  for (const cmd of candidates) {
-    // 策略 1：bash login shell（shell: false 是 execFileSync 默认行为，此处显式标注）
-    try {
-      const p = execFileSync('bash', ['-lc', `command -v ${cmd}`], {
-        encoding: 'utf8',
-        stdio: ['ignore', 'pipe', 'ignore'],
-        shell: false,
-        timeout: CLI_DETECT_TIMEOUT_MS,
-      }).trim();
-      if (p && existsSync(p)) return { cmd, absPath: p };
-    } catch {
-      // 继续尝试下一策略
-    }
-
-    // 策略 2：zsh login shell（macOS 默认 shell / bash 不可用时）
-    try {
-      const p = execFileSync('zsh', ['-lc', `command -v ${cmd}`], {
-        encoding: 'utf8',
-        stdio: ['ignore', 'pipe', 'ignore'],
-        shell: false,
-        timeout: CLI_DETECT_TIMEOUT_MS,
-      }).trim();
-      if (p && existsSync(p)) return { cmd, absPath: p };
-    } catch {
-      // 继续尝试下一策略
-    }
-
-    // 策略 3：which 命令（使用 process.env.PATH，覆盖 fish / CI 容器等环境）
-    try {
-      const p = execFileSync('which', [cmd], {
-        encoding: 'utf8',
-        stdio: ['ignore', 'pipe', 'ignore'],
-        shell: false,
-        timeout: CLI_DETECT_TIMEOUT_MS,
-      }).trim();
-      if (p && existsSync(p)) return { cmd, absPath: p };
-    } catch {
-      // 此候选不可用，尝试下一个
-    }
+  for (const cmd of ALLOWED_CLI_CANDIDATES) {
+    const absPath = resolveCliPath(cmd);
+    if (absPath !== null) return { cmd, absPath };
   }
 
   throw new Error(
@@ -94,6 +182,7 @@ function detectClaudeCli(): CliInfo {
     'claude / claude-internal / codex / codex-internal / codebuddy / workbuddy / openclaw'
   );
 }
+
 
 /**
  * 根据 CLI 类型构建非交互参数数组。
@@ -128,6 +217,8 @@ export function getAICliName(): string {
  * 通过子进程直接调用 AI CLI（claude/codex 等），返回 stdout 文本。
  *
  * 按 CLI 类型自动选择 -p 或 exec 子命令，直接 spawn 绝对路径，不走 bash -lc，彻底消除 shell 拼接。
+ * spawn 使用 cross-spawn：Windows 上 CLI 多为 npm 生成的 `.cmd` shim，Node 原生
+ * spawn 无权直接执行 `.cmd`（报 EINVAL），cross-spawn 会正确地经 cmd.exe 启动并转义参数。
  * CLI 探测优先级：`claude` → `claude-internal` → `codex` → `codex-internal` → `codebuddy` → `workbuddy` → `openclaw`，
  * 结果缓存，进程内只探测一次。
  *
@@ -155,8 +246,8 @@ export async function callClaude(
     log.debug(`[ai-client] calling ${_cliInfo.cmd}, timeout=${Math.round(timeoutMs / 1000)}s, prompt=${prompt.slice(0, 60).replace(/\n/g, ' ')}...`);
     const child = spawn(_cliInfo.absPath, buildCliArgs(_cliInfo.cmd, prompt), { stdio: ['ignore', 'pipe', 'pipe'] });
 
-    child.stdout.on('data', (chunk: Buffer) => chunks.push(chunk));
-    child.stderr.on('data', (chunk: Buffer) => errChunks.push(chunk));
+    child.stdout?.on('data', (chunk: Buffer) => chunks.push(chunk));
+    child.stderr?.on('data', (chunk: Buffer) => errChunks.push(chunk));
 
     // 超时控制
     const timer = setTimeout(() => {

--- a/src/utils/ai-client.ts
+++ b/src/utils/ai-client.ts
@@ -178,8 +178,8 @@ function detectClaudeCli(): CliInfo {
   }
 
   throw new Error(
-    'AI CLI 不可用：请安装以下任意一个 CLI 工具：' +
-    'claude / claude-internal / codex / codex-internal / codebuddy / workbuddy / openclaw'
+    'AI CLI unavailable: install one of claude / claude-internal / codex / ' +
+    'codex-internal / codebuddy / workbuddy / openclaw'
   );
 }
 


### PR DESCRIPTION
## Problem

Every AI-backed command (`teamai import --from-claude`, `import --from-repo` enrichment, `codebase --deep-enrich`, `enrichWithAI`) fails on Windows even when `claude` / `codex` / `codebuddy` is installed and on `PATH`.

`detectClaudeCli()` resolved each candidate through `bash -lc 'command -v <cmd>'`, `zsh -lc …` or `which`, then gated the result on `existsSync()`:

```
$ bash -lc 'command -v claude'
/c/Users/me/AppData/Roaming/npm/claude

$ node -e "console.log(require('fs').existsSync('/c/Users/me/AppData/Roaming/npm/claude'))"
false
```

On Windows those programs come from Git Bash or WSL and print MSYS paths. Node resolves `/c/...` against the current drive (`C:\c\...`), so `existsSync()` is always false, all three fallbacks fail for every candidate, and detection throws regardless of what is installed. WSL's `bash.exe` — which the Windows `PATH` can also reach before Git Bash — is worse: it returns Linux paths that are meaningless to Windows.

A second, independent failure waits behind the first. Even with a correct path, Node's `spawn` cannot start the `.cmd` shim that `npm install -g` produces on Windows:

```
spawnSync('C:\\Users\\me\\AppData\\Roaming\\npm\\claude.cmd', ['-p','hi'])
→ error: EINVAL
```

## Why it went unnoticed

- CI runs `ubuntu-latest` and `macos-latest` only (`.github/workflows/ci.yml`). There is no Windows job, and the `e2e` job is skipped for fork PRs.
- The failure is **silent**, not fatal: `classifyWithAI()` catches it and falls back to the conservative strategy, which marks every entry `isPersonal` and drops it. On Windows, import simply produces nothing.
- The existing unit test mocks `existsSync` to always return `true`, which is precisely the call that fails on Windows.

## Changes

- **Detection**: on Windows resolve candidates with the native `where` — the `which` equivalent — which returns `C:\Users\me\AppData\Roaming\npm\claude.cmd`. POSIX behaviour is unchanged.
- `pickWindowsCommand()` accepts only `.exe` / `.cmd` / `.bat`. `where` also lists npm's extensionless POSIX shim, usually *first*, and `CreateProcess` cannot start that one.
- **Spawn**: `callClaude()` uses `cross-spawn` (already a dependency of this package; `src/utils/exec.ts` already uses it). On POSIX it is a pass-through to `child_process.spawn`; on Windows it starts the `.cmd` through `cmd.exe` and escapes each argument, so the prompt is still never spliced into a shell string.
- The POSIX strategies are hoisted verbatim into `whichOnPosix()` and the platform dispatch moved into `resolveCliPath(cmd, platform)`. Most of the diff in `ai-client.ts` is re-indentation from that hoist — `git diff -w` shows it.
- `platform` is injectable (defaults to `process.platform`) so the Windows branch is covered by the existing ubuntu/macos CI instead of only by a Windows machine. That missing coverage is the reason this bug survived.

## Test Plan

| # | Step | Result |
|---|---|---|
| 1 | `npx tsc --noEmit` | clean |
| 2 | `npm run build` | clean |
| 3 | `npx vitest run src/__tests__/ai-client.test.ts` | 17 passed (5 pre-existing + 12 new) |
| 4 | `npx vitest run` for the eight suites that reference `ai-client` (`ai-client`, `codebase`, `codebase-deep-enrich`, `deep-enrich-graph-preserve`, `iwiki-dual`, `iwiki-review-apply`, `maintenance-promote`, `tclaude-tcodex`) | 7 passed, 1 failed — `maintenance-promote` fails at `expect(targetPath).toContain('skills/candidate.md')` (line 137) because the received value is a Windows `\` path. It only `vi.mock`s `ai-client` (line 13) and never exercises it, and it fails identically on `main` |
| 5 | Real end-to-end on Windows 11 / Node 22 with an npm-style shim trio (`claude`, `claude.cmd`, `claude.ps1`) on `PATH` | before → after below |
| 6 | `npx vitest run --reporter=json` on Windows, `main` vs this branch, compared per test | identical failing set; this branch adds 12 passing tests |

New unit tests run on every platform: `pickWindowsCommand` (shim trio order, `.exe` over `.cmd`, case-insensitivity, extensionless-only → `null`, empty `where` output → `null`) and `resolveCliPath` for `win32` (only `where` is invoked; `where` failing → `null`) and for `linux` / `darwin` (bash → zsh fallback).

### Step 5 — real CLI, before

```
$ teamai import --from-claude --all --output ./out
✖ AI classification partially failed, using conservative strategy for all entries: AggregateError: 3 AI task(s) failed
ℹ all entries processed, no further interaction needed.
```

No `~/.teamai/import-session.json` is written: 0 of 3 entries survive, silently.

### Step 5 — real CLI, after

```
$ teamai import --from-claude --all --output ./out
```

No AI error, and `~/.teamai/import-session.json` holds 3 items, all `accepted`.

`import-session.json` is the observable I used because the step after it requires a GitHub-shaped team repo, which I cannot provision locally — the same reason CI skips the `e2e` job for fork PRs. Detection latency on Windows also drops from ~18 s per call (7 candidates × 3 strategies, each waiting out the 5 s probe timeout) to ~0.3 s.

### Step 6 detail

Compared per test, not in aggregate: `main` and this branch fail **the same** assertions (114 across 41 files), and none of them is `ai-client.test.ts`. The only delta is the 12 new tests, all passing.

I am reporting this because it is the convention here (#462 did the same), but the Windows suite is not a clean signal in either state — every one of those 41 files asserts a POSIX separator (`.agents/skills/...`) or uses a Linux-only directory name, which is exactly why CI stays green on ubuntu/macos. Raw totals do drift between runs on this machine (timeout-sensitive tests), which is why the comparison is per test rather than by count.

## Also in this PR (separate commit, easy to drop)

`fix(ai-client): use English for the missing-AI-CLI error`. AGENTS.md requires CLI user-facing output to be English; that thrown message is on this exact failure path and was Chinese. Say the word and I will split it into its own PR.

## Not in this PR

Three other call sites resolve executables the same POSIX-only way and are still broken on Windows — I kept this PR to the AI client so it stays reviewable:

- `src/providers/github/gh-cli.ts`: `getGhPath()` runs `execSync('which gh')` and hands the MSYS path straight to `spawnSync`, which fails with `ENOENT` (verified on Windows).
- `src/providers/cnb/cnb-cli.ts`: `execSync('which cnb')`.
- `src/providers/tgit/gf-cli.ts`: `execSync('test -x …')`, which runs through `cmd.exe` on Windows and is not a valid command there.

Happy to follow up on those, or fold them in here if you would rather land the Windows path handling in one go.

## Labels

bug, windows
