### PR TITLE
test(hooks): pin golden hook fixtures to LF so the byte anchor holds on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Keep this file itself LF so the rules below stay stable on Windows too.
+/.gitattributes text eol=lf
+
+# Hook output fixtures are compared byte-for-byte by
+# src/__tests__/hooks-golden.test.ts ("兼容锚点", issue #19 §8): the injected
+# settings must stay identical to the captured baseline so that an existing
+# installation sees a zero-diff reconcile after a CLI upgrade.
+#
+# Git for Windows defaults to core.autocrlf=true, which rewrites these files to
+# CRLF on checkout, so on Windows the comparison failed for every tool while CI
+# (ubuntu/macos) stayed green. Pin them to LF so the anchor holds everywhere.
+src/__tests__/fixtures/hooks/*.json text eol=lf


### PR DESCRIPTION
## Summary

`src/__tests__/hooks-golden.test.ts` is the "兼容锚点" byte-equality anchor from issue #19 §8: it asserts that `injectHooks()` output is byte-identical to `fixtures/hooks/<tool>.json`, so a machine that already has hooks installed sees a zero-diff reconcile after a CLI upgrade. On Windows **all five of its cases fail**, because this repository has no `.gitattributes` and Git for Windows defaults to `core.autocrlf=true`.

This PR adds a two-rule `.gitattributes` pinning those five fixtures to LF.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing behavior to change)
- [ ] Documentation only
- [ ] Refactor / internal cleanup

## Problem

```
$ git config core.autocrlf
true

$ git check-attr -a src/__tests__/fixtures/hooks/claude.json
                       # ← no attributes at all before this PR
```

`readFile(..., 'utf-8')` does not normalise newlines, and the assertion is a plain
string compare:

```ts
const got  = await fse.readFile(p, 'utf-8');                              // injector output, LF
const want = await fse.readFile(path.join(fixturesDir, `${tool}.json`), 'utf-8');
expect(got).toBe(want);
```

The blobs are stored as LF, so `core.autocrlf=true` rewrites every LF to CRLF on
checkout and `want` can never equal `got`. The counts line up exactly — the number
of LF bytes in each committed blob equals the number of CR bytes that landed on disk:

| fixture | LF in blob | CR on disk (before) |
|---|---|---|
| `claude-internal.json` | 72 | 72 |
| `claude.json` | 72 | 72 |
| `codebuddy.json` | 78 | 78 |
| `cursor.json` | 39 | 39 |
| `workbuddy.json` | 78 | 78 |

This is not environment-specific: it is the behaviour of **default Git for Windows**, so it affects every Windows contributor, and it fails the moment they run the suite.

## Why it went unnoticed

`.github/workflows/ci.yml` runs the matrix `os: [ubuntu-latest, macos-latest]`. There is no Windows job, and `core.autocrlf` defaults to `false` on both of those platforms, so CI never saw CRLF in these files.

## Changes

```
/.gitattributes                     text eol=lf
src/__tests__/fixtures/hooks/*.json text eol=lf
```

The second rule covers exactly those five files, and `grep -rn "fixtures/hooks"` finds
exactly one reader in the repository — `hooks-golden.test.ts` — so nothing else can
be affected.

The first rule is for the file itself. Without it Git keeps warning that it will
rewrite `.gitattributes` to CRLF on the next touch, which would be a poor look for a
PR about line endings; git tolerates CRLF in `.gitattributes`, but the file may as
well be stable.

## Test Plan

Windows 11, Node 22, Git for Windows with `core.autocrlf=true`. "Before" is this
repo with the `.gitattributes` line removed and the fixtures re-checked out
(`git checkout -- src/__tests__/fixtures/hooks/`), which is what a fresh clone on a
default Windows machine produces.

| # | Step | Before | After |
|---|---|---|---|
| 1 | `git check-attr text eol -- .../hooks/claude.json` | *(no attributes)* | `text: set`, `eol: lf` |
| 2 | CR bytes across the five fixtures | `72 72 78 39 78` | `0 0 0 0 0` |
| 3 | `npx vitest run src/__tests__/hooks-golden.test.ts` | `Test Files 1 failed (1)` — 5 failed | `Test Files 1 passed (1)` — 5 passed |
| 4 | full suite, compared **per test** against the pre-fix tree | 5 `hooks-golden` cases failing | 0 `hooks-golden` cases failing, **no new failures** |

### Step 3

```
# before
 FAIL  src/__tests__/hooks-golden.test.ts > hooks golden — built-in output is
       byte-identical to the captured baseline > claude output matches golden fixture
 FAIL  ... claude-internal / codebuddy / cursor / workbuddy   (5 total)
 Test Files  1 failed (1)

# after
 ✓ src/__tests__/hooks-golden.test.ts (5 tests) 37ms
 Test Files  1 passed (1)
```

### Step 4 detail

I compared the two runs **per test** (`file::fullName`), not by totals, because this
suite drifts on Windows between runs — two consecutive full runs of the *same* tree
reported 107 and 73 failing tests, all of them HOME-scoped files (`scope.test.ts`,
`remove.test.ts`, `pull-*.test.ts`, `rules.test.ts`) racing on shared state. Two
independent full runs with the change in place both report **0** `hooks-golden`
failures, and the second shows **no test anywhere that changed from passing to
failing**.

The same root cause applies to the rest of the Windows suite failing on
`path.join`-built POSIX expectations, but that is a different problem and I am not
touching it here.

## Related Issues

None open. This is the CI/platform gap behind issue #19 §8 rather than a reported
bug — no issue was filed because the anchor is described as working, and on
ubuntu/macos it is.

## Notes for Reviewers

- Two lines, one file, no source changes. `eol=lf` is what Git for Windows itself
  recommends for fixtures used in byte comparisons.
- Deliberately not `* text=auto`: that would re-normalise the whole working tree and
  would show up in other people's branches. This stays scoped to the five files that
  actually need it.
- If you would rather not carry a `.gitattributes`, the alternative is to normalise
  inside the test (`want.replace(/\r\n/g, '\n')`). That is a weaker fix: it hides the
  platform difference instead of removing it, and any future fixture added to that
  directory would silently need the same treatment. I went with `.gitattributes` for
  that reason — happy to switch if you prefer.
- Unrelated to #496, which is a different failure on the same platform.
