### PR TITLE
fix(skills): skip hermes pull when home not installed

### DIFF
--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -1138,6 +1138,79 @@ describe('SkillsHandler.pullItem honors disabledAgents', () => {
   });
 });
 
+describe('SkillsHandler.pullItem skips hermes when not installed', () => {
+  let tmpDir: string;
+  let homeDir: string;
+  let handler: SkillsHandler;
+  let teamConfig: TeamaiConfig;
+  let localConfig: LocalConfig;
+  let sourcePath: string;
+
+  beforeEach(async () => {
+    tmpDir = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-skills-pull-hermes-'));
+    homeDir = path.join(tmpDir, 'home');
+    const repoPath = path.join(tmpDir, 'team-repo');
+
+    sourcePath = path.join(repoPath, 'skills', 'team-skill');
+    await fse.ensureDir(sourcePath);
+    await fse.writeFile(path.join(sourcePath, 'SKILL.md'), '---\nname: team-skill\ndescription: X\n---\n');
+
+    vi.stubEnv('HOME', homeDir);
+    handler = new SkillsHandler();
+
+    teamConfig = {
+      team: 'test',
+      description: '',
+      repo: 'https://git.woa.com/test/repo.git',
+      provider: 'tgit' as const,
+      reviewers: [],
+      sharing: { skills: {}, rules: { enforced: [] }, docs: { localDir: '' }, env: { injectShellProfile: true } },
+      toolPaths: {
+        hermes: { skills: '.hermes/skills' },
+      },
+    };
+
+    localConfig = {
+      repo: { localPath: repoPath, remote: 'https://git.woa.com/test/repo.git' },
+      username: 'testuser',
+      updatePolicy: 'auto',
+      additionalRoles: [],
+      scope: 'user',
+      disabledAgents: [],
+    };
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await fse.remove(tmpDir);
+  });
+
+  const item = () => ({
+    name: 'team-skill',
+    type: 'skills' as const,
+    sourcePath,
+    relativePath: 'skills/team-skill',
+  });
+
+  it('does not create a hermes home that was never installed', async () => {
+    vi.stubEnv('HERMES_HOME', path.join(homeDir, '.hermes'));
+
+    await handler.pullItem(item(), teamConfig, localConfig);
+
+    expect(await fse.pathExists(path.join(homeDir, '.hermes'))).toBe(false);
+  });
+
+  it('syncs normally when the hermes home exists', async () => {
+    const hermesHome = path.join(homeDir, '.hermes');
+    await fse.ensureDir(hermesHome);
+    vi.stubEnv('HERMES_HOME', hermesHome);
+
+    await handler.pullItem(item(), teamConfig, localConfig);
+
+    expect(await fse.pathExists(path.join(hermesHome, 'skills', 'team-skill', 'SKILL.md'))).toBe(true);
+  });
+});
+
 describe('SkillsHandler.pullItem Codex shared skills', () => {
   let tmpDir: string;
 

--- a/src/resources/skills.ts
+++ b/src/resources/skills.ts
@@ -481,6 +481,13 @@ export class SkillsHandler extends ResourceHandler {
         }
         dest = path.join(wsDir, 'skills', item.name);
       } else if (tool === 'hermes') {
+        // Like every other tool, skip when not installed: getHermesHome()
+        // always resolves (HERMES_HOME or ~/.hermes), so without this check
+        // every pull creates a hermes home the user never asked for.
+        if (!await pathExists(getHermesHome())) {
+          log.debug(`Skipping skill sync for ${tool}: tool not installed`);
+          continue;
+        }
         dest = path.join(getHermesHome(), 'skills', item.name);
       } else {
         if (!await ResourceHandler.isToolInstalled(toolPath.skills, baseDir)) {


### PR DESCRIPTION
pullItem synced hermes unconditionally: getHermesHome() always resolves (HERMES_HOME or ~/.hermes), so every pull created a hermes home the user never asked for. All other tools are gated on installed-checks; hermes was the exception.

Change: gate the hermes branch on home existence, same skip semantics as other tools.

Proof: two unit tests (absent home stays absent; present home syncs normally). tsc clean, skills+hermes suites green (75 passed).