### PR TITLE
fix(update): resolve npm and install prefix from the running CLI for self-update

### DIFF
--- a/src/__tests__/update.test.ts
+++ b/src/__tests__/update.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock, type MockInstance } from 'vitest';
 
 // ─── Mocks ──────────────────────────────────────────────
 
@@ -51,6 +51,10 @@ vi.mock('../types.js', () => ({
   getUpdateLockPath: () => '/tmp/test-update-lock',
 }));
 
+vi.mock('../builtin-hooks.js', () => ({
+  resolveTeamaiEntryScript: vi.fn(),
+}));
+
 let readlineAnswer = 'n';
 vi.mock('../utils/prompt.js', () => ({
   askQuestion: vi.fn((_prompt: string, defaultValue?: string) => {
@@ -67,6 +71,8 @@ vi.mock('../utils/prompt.js', () => ({
 // ─── Imports (after mocks) ──────────────────────────────
 
 import fse from 'fs-extra';
+import fs from 'node:fs';
+import path from 'node:path';
 import { loadState, saveState, loadLocalConfig, loadTeamConfig } from '../config.js';
 import { log } from '../utils/logger.js';
 
@@ -79,7 +85,10 @@ import {
   checkForUpdate,
   doUpdate,
   update,
+  resolveNpmCommand,
+  prefixFromEntryPath,
 } from '../update.js';
+import { resolveTeamaiEntryScript } from '../builtin-hooks.js';
 
 // ─── Typed mock references ──────────────────────────────
 
@@ -233,7 +242,7 @@ describe('checkForUpdate', () => {
 
     expect(mockedExecSync).toHaveBeenCalledTimes(1);
     expect(mockedExecSync).toHaveBeenCalledWith(
-      'npm',
+      expect.any(String),
       expect.arrayContaining(['view', 'version']),
       expect.any(Object),
     );
@@ -309,7 +318,7 @@ describe('doUpdate', () => {
 
     expect(mockedExecSync).toHaveBeenCalledTimes(3);
     expect(mockedExecSync).toHaveBeenCalledWith(
-      'npm',
+      expect.any(String),
       expect.arrayContaining(['install', '-g']),
       expect.any(Object),
     );
@@ -404,7 +413,7 @@ describe('doUpdate', () => {
     // Only the version-check exec ran; no npm install
     expect(mockedExecSync).toHaveBeenCalledTimes(1);
     expect(mockedExecSync).not.toHaveBeenCalledWith(
-      'npm',
+      expect.any(String),
       expect.arrayContaining(['install']),
       expect.anything(),
     );
@@ -435,7 +444,7 @@ describe('doUpdate', () => {
     await doUpdate();
 
     expect(mockedExecSync).toHaveBeenCalledWith(
-      'npm',
+      expect.any(String),
       expect.arrayContaining(['install', '-g']),
       expect.any(Object),
     );
@@ -548,7 +557,7 @@ describe('checkForUpdate with corrupted state', () => {
     const result = await checkForUpdate();
 
     expect(mockedExecSync).toHaveBeenCalledWith(
-      'npm',
+      expect.any(String),
       expect.arrayContaining(['view', 'version']),
       expect.any(Object),
     );
@@ -597,7 +606,31 @@ describe('update', () => {
 // ─── Hook refresh after update tests ────────────────────
 
 describe('hook refresh after update', () => {
-  it('should spawn "teamai hooks inject --silent" after successful update', async () => {
+  const mockedEntry = resolveTeamaiEntryScript as Mock;
+
+  it('should run the resolved entry with the current Node binary', async () => {
+    // A .js entry cannot be spawned directly on Windows (no shebang/PATHEXT
+    // resolution) — the running Node must be the executable.
+    mockedEntry.mockReturnValue('/teamai/dist/index.js');
+    mockedExecSync
+      .mockResolvedValueOnce({ stdout: '99.0.0\n', stderr: '' }) // npm view
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })          // npm install
+      .mockResolvedValueOnce({ stdout: '', stderr: '' });         // hooks inject
+
+    await doUpdate();
+
+    expect(mockedExecSync).toHaveBeenCalledWith(
+      process.execPath,
+      ['/teamai/dist/index.js', 'hooks', 'inject', '--silent'],
+      expect.objectContaining({ timeout: 15_000 }),
+    );
+    expect(mockedLog.success).toHaveBeenCalledWith(
+      expect.stringContaining('Refreshed hooks'),
+    );
+  });
+
+  it('should fall back to teamai from PATH when the entry cannot be resolved', async () => {
+    mockedEntry.mockReturnValue(null);
     mockedExecSync
       .mockResolvedValueOnce({ stdout: '99.0.0\n', stderr: '' }) // npm view
       .mockResolvedValueOnce({ stdout: '', stderr: '' })          // npm install
@@ -728,5 +761,103 @@ describe('releaseLock', () => {
     await releaseLock('/tmp/never-acquired-by-us');
 
     expect(mockedFse.remove).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Self-update resolvers (npm CLI + install prefix) ────
+
+/** Temporarily replace process.execPath (read by resolveNpmCommand). */
+function stubExecPath(value: string): () => void {
+  const original = process.execPath;
+  Object.defineProperty(process, 'execPath', { value, configurable: true });
+  return () => Object.defineProperty(process, 'execPath', { value: original, configurable: true });
+}
+
+describe('resolveNpmCommand', () => {
+  let restoreExecPath: () => void;
+  let existsSpy: MockInstance<typeof fs.existsSync>;
+
+  beforeEach(() => {
+    existsSpy = vi.spyOn(fs, 'existsSync');
+  });
+  afterEach(() => {
+    restoreExecPath();
+    existsSpy.mockRestore();
+  });
+
+  it('resolves npm-cli.js flat next to node (bundled-runtime layout)', () => {
+    restoreExecPath = stubExecPath(path.join('/runtime', 'node'));
+    const npmCli = path.join('/runtime', 'node_modules', 'npm', 'bin', 'npm-cli.js');
+    existsSpy.mockImplementation((p) => p === npmCli);
+
+    expect(resolveNpmCommand()).toEqual({ cmd: path.join('/runtime', 'node'), args: [npmCli] });
+  });
+
+  it('resolves npm one level up from bin (canonical POSIX prefix layout)', () => {
+    // Official tarball / Homebrew / nvm: <prefix>/bin/node + <prefix>/lib/node_modules/npm.
+    restoreExecPath = stubExecPath(path.join('/usr', 'local', 'bin', 'node'));
+    const npmCli = path.join('/usr', 'local', 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js');
+    // Candidate paths contain a literal '..' (path.join does not normalize) —
+    // compare resolved forms, like the real filesystem would.
+    existsSpy.mockImplementation((p) => path.resolve(String(p)) === path.resolve(npmCli));
+
+    expect(resolveNpmCommand()).toEqual({ cmd: path.join('/usr', 'local', 'bin', 'node'), args: [npmCli] });
+  });
+
+  it('falls back to npm from PATH when no co-located npm-cli.js exists', () => {
+    restoreExecPath = stubExecPath(path.join('/runtime', 'node'));
+    existsSpy.mockReturnValue(false);
+
+    expect(resolveNpmCommand()).toEqual({ cmd: 'npm', args: [] });
+  });
+});
+
+describe('prefixFromEntryPath', () => {
+  let existsSpy: MockInstance<typeof fs.existsSync>;
+
+  beforeEach(() => {
+    existsSpy = vi.spyOn(fs, 'existsSync');
+  });
+  afterEach(() => {
+    existsSpy.mockRestore();
+  });
+
+  it('strips the POSIX lib/ nesting and hands npm the prefix it expects', () => {
+    const entry = path.join('/usr', 'local', 'lib', 'node_modules', 'teamai-cli', 'dist', 'index.js');
+    existsSpy.mockReturnValue(true);
+
+    expect(prefixFromEntryPath(entry, true)).toBe(path.join('/usr', 'local'));
+    // The sanity check must look under <prefix>/lib/node_modules/<pkg>.
+    expect(existsSpy).toHaveBeenCalledWith(
+      path.join('/usr', 'local', 'lib', 'node_modules', 'teamai-cli'),
+    );
+  });
+
+  it('returns the slice before node_modules on Windows layouts', () => {
+    const entry = path.join('C:', 'tools', 'node_modules', 'teamai-cli', 'dist', 'index.js');
+    existsSpy.mockReturnValue(true);
+
+    expect(prefixFromEntryPath(entry, false)).toBe(path.join('C:', 'tools'));
+    expect(existsSpy).toHaveBeenCalledWith(path.join('C:', 'tools', 'node_modules', 'teamai-cli'));
+  });
+
+  it('keeps non-lib roots on POSIX (project-local installs)', () => {
+    const entry = path.join('/home', 'u', 'proj', 'node_modules', 'teamai-cli', 'dist', 'index.js');
+    existsSpy.mockReturnValue(true);
+
+    expect(prefixFromEntryPath(entry, true)).toBe(path.join('/home', 'u', 'proj'));
+  });
+
+  it('returns null for paths outside an npm-managed layout', () => {
+    existsSpy.mockReturnValue(true);
+
+    expect(prefixFromEntryPath('/home/u/dev/teamai-cli/dist/index.js', true)).toBeNull();
+  });
+
+  it('returns null when the package dir is not under the derived prefix', () => {
+    const entry = path.join('/usr', 'local', 'lib', 'node_modules', 'teamai-cli', 'dist', 'index.js');
+    existsSpy.mockReturnValue(false);
+
+    expect(prefixFromEntryPath(entry, true)).toBeNull();
   });
 });

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,10 +1,13 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import fse from 'fs-extra';
 import { loadState, saveState, loadLocalConfig, loadTeamConfig } from './config.js';
 import { resolveEffectiveUpdatePolicy } from './update-policy.js';
+import { resolveTeamaiEntryScript } from './builtin-hooks.js';
 import { log } from './utils/logger.js';
 import { expandHome, ensureDir } from './utils/fs.js';
 import { getUpdateLockPath } from './types.js';
@@ -46,6 +49,65 @@ export function resolveRegistryForPackage(pkgName: string): string {
 }
 
 /**
+ * Resolve the npm CLI belonging to the running Node. Bundled runtimes
+ * (WorkBuddy/CodeBuddy) ship npm inside their install dir, and their hook
+ * subprocesses have no npm on PATH, so prefer the co-located npm-cli.js and
+ * fall back to `npm` from PATH. All standard layouts are probed regardless
+ * of platform — a layout mismatch must not silently disable self-update in
+ * exactly the PATH-less contexts this resolver exists for.
+ */
+export function resolveNpmCommand(): { cmd: string; args: string[] } {
+  const nodeDir = path.dirname(process.execPath);
+  const candidates = [
+    // Bundled runtimes: npm installed flat next to node.exe.
+    path.join(nodeDir, 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+    // POSIX layout rooted at the node dir itself.
+    path.join(nodeDir, 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+    // Canonical POSIX install (official tarball, Homebrew, nvm): node lives in
+    // <prefix>/bin with npm at <prefix>/lib/node_modules — one level up.
+    path.join(nodeDir, '..', 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+  ];
+  for (const c of candidates) {
+    if (fs.existsSync(c)) return { cmd: process.execPath, args: [c] };
+  }
+  log.debug('No npm-cli.js found next to the running Node; falling back to npm from PATH');
+  return { cmd: 'npm', args: [] };
+}
+
+/**
+ * Derive the npm install prefix from an entry-script path: the slice before
+ * `<prefix>/[lib/]node_modules/<pkg>`, sanity-checked so only genuine
+ * npm-managed layouts yield a prefix. `posix` selects the layout — POSIX npm
+ * global installs nest one level deeper (<prefix>/lib/node_modules) and npm
+ * re-adds the lib/ component itself, so the prefix it expects is the slice
+ * above it. Exported for testing — split out from resolveInstallPrefix.
+ */
+export function prefixFromEntryPath(entry: string, posix: boolean): string | null {
+  const marker = `${path.sep}node_modules${path.sep}`;
+  const idx = entry.lastIndexOf(marker);
+  if (idx <= 0) return null;
+  const root = entry.slice(0, idx);
+  const prefix = posix && path.basename(root) === 'lib' ? path.dirname(root) : root;
+  // Sanity-check the slice: only trust it when the running package actually
+  // sits in the npm-managed layout under the prefix we would hand back.
+  const nmDir = posix ? path.join('lib', 'node_modules') : 'node_modules';
+  return fs.existsSync(path.join(prefix, nmDir, getCurrentPackageName()))
+    ? prefix
+    : null;
+}
+
+/**
+ * Resolve the install prefix the running CLI lives in
+ * (<prefix>/node_modules/<pkg>/...) so a self-update reinstalls into the
+ * same location. Returns null when the entry cannot be attributed to an
+ * npm-managed install (e.g. a linked checkout) — callers then keep the
+ * default global install behavior.
+ */
+function resolveInstallPrefix(): string | null {
+  return prefixFromEntryPath(fileURLToPath(import.meta.url), process.platform !== 'win32');
+}
+
+/**
  * Fetch the latest version from the npm registry
  * Returns null on any error (timeout, network, etc.)
  *
@@ -61,9 +123,10 @@ export async function fetchLatestVersion(
     // Async execFile so the hook dispatcher's event loop is not blocked while
     // the registry is queried — a synchronous execSync here would freeze all
     // sibling Stop handlers for up to `timeout` ms.
+    const npm = resolveNpmCommand();
     const { stdout } = await execFileAsync(
-      'npm',
-      ['view', pkgName, 'version', `--registry=${resolvedRegistry}`],
+      npm.cmd,
+      [...npm.args, 'view', pkgName, 'version', `--registry=${resolvedRegistry}`],
       { timeout, encoding: 'utf-8' },
     );
     const version = stdout.trim();
@@ -421,16 +484,30 @@ export async function doUpdate(): Promise<void> {
   try {
     const pkgName = getCurrentPackageName();
     const registry = resolveRegistryForPackage(pkgName);
+    const npm = resolveNpmCommand();
+    const prefix = resolveInstallPrefix();
     await execFileAsync(
-      'npm',
-      ['install', '-g', pkgName, `--registry=${registry}`],
+      npm.cmd,
+      [
+        ...npm.args,
+        'install', '-g', pkgName,
+        ...(prefix ? [`--prefix=${prefix}`] : []),
+        `--registry=${registry}`,
+      ],
       { timeout: INSTALL_TIMEOUT },
     );
     log.success(`Updated teamai to v${result.latest}`);
 
-    // Refresh hooks using new version's code (spawn new process so updated code is loaded)
+    // Refresh hooks using new version's code (spawn new process so updated code is loaded).
+    // PATH-less subprocesses (bundled runtimes) may not have `teamai` on PATH:
+    // resolve the running CLI's entry and run it with the current Node binary —
+    // spawning the .js directly only works behind a shebang + PATH on POSIX.
     try {
-      await execFileAsync('teamai', ['hooks', 'inject', '--silent'], {
+      const entry = resolveTeamaiEntryScript();
+      const refresh = entry
+        ? { cmd: process.execPath, args: [entry, 'hooks', 'inject', '--silent'] }
+        : { cmd: 'teamai', args: ['hooks', 'inject', '--silent'] };
+      await execFileAsync(refresh.cmd, refresh.args, {
         timeout: 15_000,
       });
       log.success('Refreshed hooks with new version');


### PR DESCRIPTION
## Summary

Self-update shells out to a bare `'npm'` and relies on npm's default global prefix. Both guesses break in exactly the environments teamai is embedded in: bundled runtimes (WorkBuddy/CodeBuddy) execute teamai from hook subprocesses with **no npm on PATH**, and npm-installed-elsewhere layouts (custom `--prefix`) would be updated into the wrong location.

This PR resolves both from the running CLI instead of the environment:

- `resolveNpmCommand()`: prefer the `npm-cli.js` co-located with `process.execPath` (both `<nodeDir>/node_modules/npm` and `<nodeDir>/lib/node_modules/npm` layouts are probed on every platform - a layout mismatch must not silently disable self-update), fall back to `npm` from PATH.
- `resolveInstallPrefix()`: derive the install prefix from this module's own path via the `<prefix>/node_modules/<pkg>` marker, sanity-checked so linked checkouts keep the default global behavior. On POSIX the slice above `lib/` is used (npm re-adds the `lib/` component itself; handing it `<prefix>/lib` would install into `<prefix>/lib/lib/node_modules`). Windows layout is unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `src/__tests__/update.test.ts` updated: `'npm'` expectations become `expect.any(String)` so the suite is environment-independent; 41/41 pass on Windows and macOS
- [x] Verified in production: WorkBuddy hook subprocess (PATH-less, bundled Node 22 + npm layout) now self-updates the correct install

## Notes for Reviewers

- Shelling out to `npm-cli.js` rather than npm's programmatic API is deliberate - the internal install API is unsupported/unstable.
- The update path only runs on explicit `teamai update` / the auto-update flow, never at CLI startup, so the extra `existsSync` probes cost nothing on hot paths.