### PR TITLE
fix(hooks): inject hooks for WorkBuddy on Windows via its bundled PortableGit sh

### DIFF
--- a/src/__tests__/hooks-shell-check.test.ts
+++ b/src/__tests__/hooks-shell-check.test.ts
@@ -29,6 +29,13 @@ import { hasShell, _resetShellCache } from '../builtin-hooks.js';
 import { injectHooksToAllTools } from '../hooks.js';
 import { log } from '../utils/logger.js';
 
+// Isolate getUserHome() so ensureTeamaiWrapper / bundled-shell detection read
+// a per-test home directory instead of the real one.
+const homeState = vi.hoisted(() => ({ home: '' }));
+vi.mock('../utils/home.js', () => ({
+  getUserHome: () => homeState.home,
+}));
+
 describe('hasShell()', () => {
   beforeEach(() => {
     _resetShellCache();
@@ -66,6 +73,7 @@ describe('injectHooksToAllTools — no-shell skip', () => {
   beforeEach(async () => {
     _resetShellCache();
     tmp = await fse.mkdtemp(path.join(os.tmpdir(), 'hooks-shell-'));
+    homeState.home = tmp;
     vi.mocked(log.warn).mockClear();
   });
 
@@ -82,7 +90,7 @@ describe('injectHooksToAllTools — no-shell skip', () => {
     await injectHooksToAllTools({ codebuddy: { settings: settingsPath } }, tmp);
 
     expect(vi.mocked(log.warn)).toHaveBeenCalledWith(
-      expect.stringContaining('Skipping hook injection for CodeBuddy/WorkBuddy'),
+      expect.stringContaining('Skipping hook injection for codebuddy'),
     );
     const settingsExists = await fse.pathExists(path.join(tmp, settingsPath));
     expect(settingsExists).toBe(false);
@@ -98,5 +106,46 @@ describe('injectHooksToAllTools — no-shell skip', () => {
 
     const settingsExists = await fse.pathExists(path.join(tmp, settingsPath));
     expect(settingsExists).toBe(true);
+  });
+});
+
+describe('injectHooksToAllTools — workbuddy bundled PortableGit sh (win32)', () => {
+  let tmp: string;
+  let platformSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    _resetShellCache();
+    tmp = await fse.mkdtemp(path.join(os.tmpdir(), 'wb-sh-'));
+    homeState.home = tmp;
+    platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    vi.mocked(log.warn).mockClear();
+  });
+
+  afterEach(async () => {
+    platformSpy.mockRestore();
+    await fse.remove(tmp);
+  });
+
+  it('injects workbuddy hooks via the bundled PortableGit sh without /bin/sh', async () => {
+    shellExists = false;
+    const shBin = path.join(tmp, '.workbuddy', 'binaries', 'PortableGit', 'versions', '1.2.0', 'usr', 'bin', 'sh.exe');
+    await fse.ensureFile(shBin);
+
+    await injectHooksToAllTools({ workbuddy: { settings: '.workbuddy/settings.json' } }, tmp);
+
+    expect(vi.mocked(log.warn)).not.toHaveBeenCalled();
+    expect(await fse.pathExists(path.join(tmp, '.workbuddy', 'settings.json'))).toBe(true);
+  });
+
+  it('skips workbuddy when the bundled sh is missing', async () => {
+    shellExists = false;
+    await fse.ensureDir(path.join(tmp, '.workbuddy'));
+
+    await injectHooksToAllTools({ workbuddy: { settings: '.workbuddy/settings.json' } }, tmp);
+
+    expect(vi.mocked(log.warn)).toHaveBeenCalledWith(
+      expect.stringContaining('Skipping hook injection for workbuddy'),
+    );
+    expect(await fse.pathExists(path.join(tmp, '.workbuddy', 'settings.json'))).toBe(false);
   });
 });

--- a/src/builtin-hooks.ts
+++ b/src/builtin-hooks.ts
@@ -4,6 +4,8 @@ import { fileURLToPath } from 'node:url';
 import { TEAMAI_HOOK_DESCRIPTION_PREFIX } from './types.js';
 import type { HookDef } from './types.js';
 import { getUserHome } from './utils/home.js';
+import { log } from './utils/logger.js';
+import { bundledShellFor, resetBundledRuntimeCache, resolveCodebuddyNode, resolveWorkbuddyNode } from './bundled-runtime.js';
 
 // ─── Built-in (A) operational hooks as data ─────────────────
 //
@@ -27,7 +29,6 @@ import { getUserHome } from './utils/home.js';
 //  the golden fixture output is stable across machines.
 //  Other tools keep the plain `bash -lc "teamai ..."` form.
 
-const WORKBUDDY_BUNDLED_NODE_DIR = '.workbuddy/bundled/node/versions';
 const TEAMAI_BIN_DIR = '.teamai/bin';
 const WRAPPER_NAME = 'teamai';
 
@@ -56,73 +57,10 @@ export function hasShell(): boolean {
   return _hasShellCache;
 }
 
-/** Reset the cached hasShell result. Test-only. */
+/** Reset the cached shell results. Test-only. */
 export function _resetShellCache(): void {
   _hasShellCache = undefined;
-}
-
-/**
- * Compare two semver-like version strings numerically (segment by segment).
- * Returns negative if a < b, 0 if equal, positive if a > b.
- */
-function compareSemver(a: string, b: string): number {
-  const aParts = a.split('.').map(s => parseInt(s, 10) || 0);
-  const bParts = b.split('.').map(s => parseInt(s, 10) || 0);
-  const len = Math.max(aParts.length, bParts.length);
-  for (let i = 0; i < len; i++) {
-    const diff = (aParts[i] ?? 0) - (bParts[i] ?? 0);
-    if (diff !== 0) return diff;
-  }
-  return 0;
-}
-
-/**
- * Pick the latest version string from an array using numeric semver comparison.
- */
-function pickLatestVersion(versions: string[]): string | undefined {
-  if (versions.length === 0) return undefined;
-  return versions.reduce((best, v) => compareSemver(v, best) > 0 ? v : best, versions[0]);
-}
-
-/**
- * Find WorkBuddy's bundled Node binary. WorkBuddy ships its own Node under
- * ~/.workbuddy/bundled/node/versions/<ver>/bin/node. Pick the latest version
- * using numeric semver comparison (avoids '9.0.0' > '10.11.0' lexicographic error).
- */
-function resolveWorkbuddyNode(): string | null {
-  const home = getUserHome();
-  const versionsDir = path.join(home, WORKBUDDY_BUNDLED_NODE_DIR);
-  try {
-    const versions = fs.readdirSync(versionsDir).filter(d => !d.startsWith('.'));
-    const latest = pickLatestVersion(versions);
-    if (!latest) return null;
-    const nodeBin = path.join(versionsDir, latest, 'bin', 'node');
-    if (fs.existsSync(nodeBin)) return nodeBin;
-  } catch { /* not installed */ }
-  return null;
-}
-
-/**
- * Find CodeBuddy's bundled Node binary. CodeBuddy ships its own Node under
- * ~/.codebuddy-server-<variant>/bin/stable-<version>/node (prefix may vary).
- */
-function resolveCodebuddyNode(): string | null {
-  const home = getUserHome();
-  try {
-    const entries = fs.readdirSync(home);
-    for (const entry of entries) {
-      if (!entry.startsWith('.codebuddy-server')) continue;
-      try {
-        const binDir = path.join(home, entry, 'bin');
-        const stableDirs = fs.readdirSync(binDir).filter(d => d.startsWith('stable-'));
-        for (const stable of stableDirs) {
-          const nodeBin = path.join(binDir, stable, 'node');
-          if (fs.existsSync(nodeBin)) return nodeBin;
-        }
-      } catch { /* skip unreadable dirs */ }
-    }
-  } catch { /* home not readable */ }
-  return null;
+  resetBundledRuntimeCache();
 }
 
 /**
@@ -174,14 +112,41 @@ export function ensureTeamaiWrapper(): string | null {
 }
 
 /**
- * If /bin/sh is available, write the teamai wrapper and return true.
- * Returns false when /bin/sh is absent — callers should skip
- * shell-dependent tool injection and warn the user.
+ * Per-tool variant of hasShell(). A tool that bundles its own shell (see
+ * bundled-runtime.ts) can execute hook commands even where /bin/sh is
+ * absent; everything else keeps the conservative /bin/sh check. POSIX
+ * always uses /bin/sh.
  */
-export function ensureWrapperIfShellAvailable(): boolean {
-  if (!hasShell()) return false;
-  ensureTeamaiWrapper();
-  return true;
+function hasShellFor(tool: string): boolean {
+  if (bundledShellFor(tool)) return true;
+  return hasShell();
+}
+
+/**
+ * Gate shell-dependent tools on an executable shell: create the PATH wrapper
+ * when any of them has one, warn about the rest, and return the tools that
+ * must be skipped (their hook commands could never execute). Non-dependent
+ * tools are never included.
+ */
+export function skipToolsWithoutShell(tools: string[]): Set<string> {
+  const skipped = new Set<string>();
+  let withShell = false;
+  for (const tool of tools) {
+    if (!SHELL_DEPENDENT_TOOLS.has(tool)) continue;
+    if (hasShellFor(tool)) {
+      withShell = true;
+    } else {
+      skipped.add(tool);
+    }
+  }
+  if (withShell) ensureTeamaiWrapper();
+  if (skipped.size > 0) {
+    log.warn(
+      `Skipping hook injection for ${[...skipped].join(', ')}: no shell is available in this environment to execute hooks. ` +
+      'Other tools (Claude Code, Cursor) are not affected.',
+    );
+  }
+  return skipped;
 }
 
 /** Generate the hook-dispatch command for a given event, tool, and optional matcher. */

--- a/src/bundled-runtime.ts
+++ b/src/bundled-runtime.ts
@@ -1,0 +1,136 @@
+// Bundled-runtime resolution: where GUI tools (WorkBuddy, CodeBuddy) ship
+// their own Node and shell, and which of them bundle a shell their hook
+// commands can execute with. All layout knowledge for these runtimes lives
+// here so hook injection can stay tool-agnostic.
+import fs from 'node:fs';
+import path from 'node:path';
+import { getUserHome } from './utils/home.js';
+
+const WORKBUDDY_BUNDLED_NODE_DIR = '.workbuddy/bundled/node/versions';
+const WORKBUDDY_PORTABLE_GIT_DIR = '.workbuddy/binaries/PortableGit/versions';
+
+let _wbShellCache: string | null | undefined;
+
+/** Reset cached bundled-runtime lookups. Test-only. */
+export function resetBundledRuntimeCache(): void {
+  _wbShellCache = undefined;
+}
+
+/**
+ * Compare two semver-like version strings numerically (segment by segment).
+ * Returns negative if a < b, 0 if equal, positive if a > b.
+ * Local copy rather than update.ts's compareVersions: this module sits on the
+ * hook-injection fast path and must not drag in update's import graph.
+ */
+function compareSemver(a: string, b: string): number {
+  const aParts = a.split('.').map(s => parseInt(s, 10) || 0);
+  const bParts = b.split('.').map(s => parseInt(s, 10) || 0);
+  const len = Math.max(aParts.length, bParts.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (aParts[i] ?? 0) - (bParts[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+/**
+ * Pick the latest version string from an array using numeric semver comparison
+ * (avoids '9.0.0' > '10.11.0' lexicographic error).
+ */
+function pickLatestVersion(versions: string[]): string | undefined {
+  if (versions.length === 0) return undefined;
+  return versions.reduce((best, v) => compareSemver(v, best) > 0 ? v : best, versions[0]);
+}
+
+/**
+ * Resolve <home>/<relDir>/<latest-version> — the newest versioned runtime
+ * directory under a bundled-runtime root, or null when absent.
+ */
+function latestVersionDir(relDir: string): string | null {
+  const versionsDir = path.join(getUserHome(), relDir);
+  try {
+    const versions = fs.readdirSync(versionsDir).filter(d => !d.startsWith('.'));
+    const latest = pickLatestVersion(versions);
+    return latest ? path.join(versionsDir, latest) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Find WorkBuddy's bundled Node binary. WorkBuddy ships its own Node under
+ * ~/.workbuddy/bundled/node/versions/<ver>/bin/node. Pick the latest version
+ * using numeric semver comparison.
+ */
+export function resolveWorkbuddyNode(): string | null {
+  const dir = latestVersionDir(WORKBUDDY_BUNDLED_NODE_DIR);
+  const nodeBin = dir && path.join(dir, 'bin', 'node');
+  return nodeBin && fs.existsSync(nodeBin) ? nodeBin : null;
+}
+
+/**
+ * Find CodeBuddy's bundled Node binary. CodeBuddy ships its own Node under
+ * ~/.codebuddy-server-<variant>/bin/stable-<version>/node (prefix may vary).
+ */
+export function resolveCodebuddyNode(): string | null {
+  const home = getUserHome();
+  try {
+    const entries = fs.readdirSync(home);
+    for (const entry of entries) {
+      if (!entry.startsWith('.codebuddy-server')) continue;
+      try {
+        const binDir = path.join(home, entry, 'bin');
+        const stableDirs = fs.readdirSync(binDir).filter(d => d.startsWith('stable-'));
+        for (const stable of stableDirs) {
+          const nodeBin = path.join(binDir, stable, 'node');
+          if (fs.existsSync(nodeBin)) return nodeBin;
+        }
+      } catch { /* skip unreadable dirs */ }
+    }
+  } catch { /* home not readable */ }
+  return null;
+}
+
+/**
+ * Find the sh binary inside WorkBuddy's bundled PortableGit runtime
+ * (~/.workbuddy/binaries/PortableGit/versions/<ver>/, either bin/sh.exe or
+ * usr/bin/sh.exe). Windows builds of WorkBuddy ship this MSYS shell, so hook
+ * commands are executable there even though /bin/sh does not exist. Memoized
+ * — the bundled runtime cannot change mid-process. Returns null when not
+ * found.
+ */
+function resolveWorkbuddyShell(): string | null {
+  if (_wbShellCache === undefined) {
+    _wbShellCache = null;
+    if (process.platform === 'win32') {
+      const dir = latestVersionDir(WORKBUDDY_PORTABLE_GIT_DIR);
+      if (dir) {
+        for (const rel of ['bin', path.join('usr', 'bin')]) {
+          const shBin = path.join(dir, rel, 'sh.exe');
+          if (fs.existsSync(shBin)) {
+            _wbShellCache = shBin;
+            break;
+          }
+        }
+      }
+    }
+  }
+  return _wbShellCache;
+}
+
+/**
+ * Tools that bundle a shell their hook commands can execute with, per tool id.
+ * A tool without an entry falls back to the conservative /bin/sh gate.
+ */
+const BUNDLED_SHELLS: Record<string, () => string | null> = {
+  workbuddy: resolveWorkbuddyShell,
+};
+
+/**
+ * Return the bundled shell for a tool, or null when the tool does not bundle
+ * one (the caller should then fall back to the /bin/sh check).
+ */
+export function bundledShellFor(tool: string): string | null {
+  const resolver = BUNDLED_SHELLS[tool];
+  return resolver ? resolver() : null;
+}

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -5,7 +5,7 @@ import { log } from './utils/logger.js';
 import { TEAMAI_HOOK_DESCRIPTION_PREFIX, TEAMAI_CUSTOM_HOOK_PREFIX, TEAMAI_AGENT_HOOK_PREFIX, resolveHookScope, resolveLegacyProjectHookScope } from './types.js';
 import type { HookDef, TeamaiConfig, LocalConfig } from './types.js';
 import { isSelfMode } from './types.js';
-import { builtinHookDefs, applyBuiltinOverride, ensureWrapperIfShellAvailable, SHELL_DEPENDENT_TOOLS } from './builtin-hooks.js';
+import { builtinHookDefs, applyBuiltinOverride, skipToolsWithoutShell } from './builtin-hooks.js';
 import type { BuiltinHookOverride } from './builtin-hooks.js';
 import { resolveTeamHooks } from './resources/hooks.js';
 import { getUserHome } from './utils/home.js';
@@ -987,20 +987,12 @@ async function reconcileOpencodePlugin(baseDir: string, removeAll = false, insta
  */
 export async function injectHooksToAllTools(toolPaths: Record<string, { settings?: string }>, baseDir?: string, filterAgents?: string[]): Promise<void> {
   const resolvedBaseDir = baseDir ?? getUserHome();
-  const tools = Object.keys(toolPaths).filter(t => !filterAgents || filterAgents.includes(t));
-  let shellAvailable = true;
-  if (tools.some(t => SHELL_DEPENDENT_TOOLS.has(t))) {
-    shellAvailable = ensureWrapperIfShellAvailable();
-    if (!shellAvailable) {
-      log.warn(
-        'Skipping hook injection for CodeBuddy/WorkBuddy: /bin/sh is not available in this environment. ' +
-        'Hooks require a shell to execute. Other tools (Claude Code, Cursor) are not affected.',
-      );
-    }
-  }
+  const skipped = skipToolsWithoutShell(
+    Object.keys(toolPaths).filter(t => !filterAgents || filterAgents.includes(t)),
+  );
   for (const [tool, paths] of Object.entries(toolPaths)) {
     if (filterAgents && !filterAgents.includes(tool)) continue;
-    if (!shellAvailable && SHELL_DEPENDENT_TOOLS.has(tool)) continue;
+    if (skipped.has(tool)) continue;
     if (paths.settings) {
       const toolRoot = path.join(resolvedBaseDir, paths.settings.split('/')[0]);
       if (!await pathExists(toolRoot)) continue;
@@ -1053,20 +1045,17 @@ export async function reconcileHooksToAllTools(
   manifestPath: string,
   opts: { removeAll?: boolean; builtinOverride?: BuiltinHookOverride; filterAgents?: string[]; settingsOnly?: boolean; installedBaseDir?: string; teamHookProjectRoot?: string } = {},
 ): Promise<void> {
-  const activeTools = Object.keys(toolPaths).filter(t => !opts.filterAgents || opts.filterAgents.includes(t));
-  let shellAvailable = true;
-  if (activeTools.some(t => SHELL_DEPENDENT_TOOLS.has(t))) {
-    shellAvailable = ensureWrapperIfShellAvailable();
-    if (!shellAvailable) {
-      log.warn(
-        'Skipping hook injection for CodeBuddy/WorkBuddy: /bin/sh is not available in this environment. ' +
-        'Hooks require a shell to execute. Other tools (Claude Code, Cursor) are not affected.',
+  // Removal is JSON editing and needs no shell, so the gate only applies to
+  // injection passes — otherwise tools without a shell could never clean up
+  // their injected entries.
+  const skipped = opts.removeAll
+    ? new Set<string>()
+    : skipToolsWithoutShell(
+        Object.keys(toolPaths).filter(t => !opts.filterAgents || opts.filterAgents.includes(t)),
       );
-    }
-  }
   for (const [tool, paths] of Object.entries(toolPaths)) {
     if (opts.filterAgents && !opts.filterAgents.includes(tool)) continue;
-    if (!shellAvailable && SHELL_DEPENDENT_TOOLS.has(tool)) continue;
+    if (skipped.has(tool)) continue;
     // Hermes uses config.yaml (YAML) + a script dir + allowlist instead of a
     // JSON settings file, so it bypasses the settings-based reconcile path.
     // Install when the .hermes home exists; removeAll clears the teamai hook.


### PR DESCRIPTION
## Summary

On Windows, hook reconcile gates every shell-dependent tool on `/bin/sh`. `/bin/sh` does not exist on Windows, so **WorkBuddy hook injection is silently skipped** - even though WorkBuddy executes hook commands with its own bundled MSYS bash (PortableGit), which ships with the app. The gate checks for the wrong shell.

This PR fixes the gate, not the command bytes: hook command generation is untouched, so the `hooks-golden` byte anchor (#497) holds as-is.

- New `src/bundled-runtime.ts`: all bundled-runtime layout knowledge in one module - the existing `resolveWorkbuddyNode`/`resolveCodebuddyNode` resolvers move here, plus a memoized `resolveWorkbuddyShell()` that finds `sh.exe` under `~/.workbuddy/binaries/PortableGit/versions/<ver>/` (`bin/` or `usr/bin/`). POSIX memoizes `null` and the `/bin/sh` gate stays authoritative there.
- `hasShellFor(tool)` (builtin-hooks.ts): a tool that bundles an executable shell passes the gate without `/bin/sh`; everything else keeps the conservative check.
- `skipToolsWithoutShell(...)`: tools with no executable shell are skipped with a single warn instead of failing later; consumed by both injection entry points. The removal path is exempt (hooks must be removable even shellless).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `src/__tests__/hooks-shell-check.test.ts` extended: Windows with/without PortableGit, POSIX behavior, and the `ensureTeamaiWrapper` interplay
- [x] `npx vitest run` on macOS: full suite green; Windows: no new failures vs. pre-existing platform failures
- [x] Verified in a 20-member Windows-only WorkBuddy fleet: hooks inject and fire on session start; `teamai update`-style PATH-less subprocesses work

## Notes for Reviewers

- Related: #497 (Windows golden fixtures), #166 (WorkBuddy hook timeout).
- Follow-up idea (not in this PR): the per-tool facts (command style, timeout, bundled shell, wrapper path) are currently spread across four tool-id sets in `builtin-hooks.ts`; a single capability table would make the next tool a data entry instead of a 4-site edit. `BUNDLED_SHELLS` in bundled-runtime.ts is already that seam.