### PR TITLE
fix(agents): honor enabledAgents scoping in hooks inject and resource sync

### DIFF
--- a/src/__tests__/hooks-cmd.test.ts
+++ b/src/__tests__/hooks-cmd.test.ts
@@ -12,6 +12,7 @@ vi.mock('../hooks.js', async () => {
     return {
         getHookStatus: vi.fn(),
         reconcileHooksToAllTools: vi.fn(),
+        reconcileTeamHooksForConfig: vi.fn(),
         sweepLegacyProjectHooks: vi.fn(),
         hasInstalledCodexTrustGatedTool: vi.fn(),
         // Keep the real reminder text so assertions verify the actual wording.
@@ -21,7 +22,6 @@ vi.mock('../hooks.js', async () => {
 
 vi.mock('../resources/hooks.js', () => ({
     parseTeamHooks: vi.fn(),
-    resolveTeamHooks: vi.fn(),
 }));
 
 vi.mock('../utils/logger.js', () => ({
@@ -37,8 +37,8 @@ vi.mock('../utils/logger.js', () => ({
 // ── Imports (after mocks) ────────────────────────────────
 
 import { autoDetectInit } from '../config.js';
-import { getHookStatus, reconcileHooksToAllTools, sweepLegacyProjectHooks, hasInstalledCodexTrustGatedTool } from '../hooks.js';
-import { parseTeamHooks, resolveTeamHooks } from '../resources/hooks.js';
+import { getHookStatus, reconcileHooksToAllTools, reconcileTeamHooksForConfig, sweepLegacyProjectHooks, hasInstalledCodexTrustGatedTool } from '../hooks.js';
+import { parseTeamHooks } from '../resources/hooks.js';
 import { log } from '../utils/logger.js';
 import { hooksInject, hooksRemove, hooksList } from '../hooks-cmd.js';
 
@@ -46,9 +46,9 @@ const mockedAutoDetectInit = autoDetectInit as Mock;
 const mockedGetHookStatus = getHookStatus as Mock;
 const mockedSweep = sweepLegacyProjectHooks as Mock;
 const mockedReconcile = reconcileHooksToAllTools as Mock;
+const mockedReconcileForConfig = reconcileTeamHooksForConfig as Mock;
 const mockedHasCodexTrustGated = hasInstalledCodexTrustGatedTool as Mock;
 const mockedParseTeamHooks = parseTeamHooks as Mock;
-const mockedResolveTeamHooks = resolveTeamHooks as Mock;
 const mockedLog = log as unknown as { info: Mock; success: Mock; warn: Mock; error: Mock; debug: Mock };
 
 const mockLocalConfig = {
@@ -83,9 +83,9 @@ beforeEach(() => {
     mockedAutoDetectInit.mockResolvedValue({ localConfig: mockLocalConfig, teamConfig: mockTeamConfig });
     mockedGetHookStatus.mockResolvedValue('missing');
     mockedReconcile.mockResolvedValue(undefined);
+    mockedReconcileForConfig.mockResolvedValue(undefined);
     mockedHasCodexTrustGated.mockResolvedValue(false);
     mockedParseTeamHooks.mockResolvedValue(TEAM_DEFS);
-    mockedResolveTeamHooks.mockResolvedValue({ defs: TEAM_DEFS, builtin: undefined });
 });
 
 describe('hooksInject', () => {
@@ -93,21 +93,22 @@ describe('hooksInject', () => {
         await hooksInject({});
 
         expect(mockedAutoDetectInit).toHaveBeenCalled();
-        expect(mockedResolveTeamHooks).toHaveBeenCalledWith(mockTeamConfig, '/tmp/repo', expect.objectContaining({ auto: false }));
-        expect(mockedReconcile).toHaveBeenCalledTimes(1);
-        expect(mockedReconcile).toHaveBeenCalledWith(
-            mockTeamConfig.toolPaths,
-            expect.any(String),
-            TEAM_DEFS,
-            expect.stringContaining('managed-hooks.json'),
-            { builtinOverride: undefined },
+        // Injection routes through reconcileTeamHooksForConfig so it applies
+        // the same enabledAgents whitelist minus disabledAgents scoping as
+        // pull and init (the per-tool reconciliation itself is covered by the
+        // hooks-reconcile tests).
+        expect(mockedReconcileForConfig).toHaveBeenCalledTimes(1);
+        expect(mockedReconcileForConfig).toHaveBeenCalledWith(
+            mockTeamConfig,
+            mockLocalConfig,
+            expect.objectContaining({ auto: false }),
         );
         expect(mockedLog.success).toHaveBeenCalledWith(expect.stringContaining('Hooks injected'));
     });
 
     it('suppresses success message with --silent', async () => {
         await hooksInject({ silent: true });
-        expect(mockedReconcile).toHaveBeenCalled();
+        expect(mockedReconcileForConfig).toHaveBeenCalled();
         expect(mockedLog.success).not.toHaveBeenCalled();
     });
 
@@ -139,38 +140,22 @@ describe('hooksInject', () => {
         await expect(hooksInject({})).rejects.toThrow('not initialized');
     });
 
-    it('injects into HOME and sweeps the legacy <projectRoot> copy (#264/#370)', async () => {
-        const restoreHome = mockHome('/home/testuser');
+    it('delegates reconciliation to the shared per-config choke point (project scope)', async () => {
         mockedAutoDetectInit.mockResolvedValue({
             localConfig: { ...mockLocalConfig, scope: 'project', projectRoot: '/path/to/project' },
             teamConfig: mockTeamConfig,
         });
-        try {
-            await hooksInject({});
-        } finally {
-            restoreHome();
-        }
+        await hooksInject({});
 
-        // #264: project scope injects the single copy into HOME (covers all cwds;
-        // dispatch identifies the project via stdin.cwd). #370: it also sweeps any
-        // legacy <projectRoot> copy an older CLI wrote, so only HOME's copy fires.
-        // The sweep is delegated to the shared sweepLegacyProjectHooks so this
-        // command, init/pull and hooks remove all clean up identically; what that
-        // helper does on disk is covered in hooks-reconcile-scope.test.ts.
-        expect(mockedReconcile).toHaveBeenCalledTimes(1);
-        expect(mockedReconcile).toHaveBeenCalledWith(
-            mockTeamConfig.toolPaths, '/home/testuser', TEAM_DEFS, expect.any(String), {
-                builtinOverride: undefined,
-                teamHookProjectRoot: '/path/to/project',
-                installedBaseDir: '/path/to/project',
-            },
-        );
-        const injectManifest = mockedReconcile.mock.calls[0][3] as string;
-        expect(injectManifest).toContain('/home/testuser');
-        expect(injectManifest).not.toContain('/path/to/project');
-        expect(mockedSweep).toHaveBeenCalledWith(
-            mockTeamConfig.toolPaths,
+        // #264/#370: HOME targeting and the legacy <projectRoot> sweep are owned
+        // by the shared reconcileTeamHooksForConfig choke point (identical to
+        // init/pull); their on-disk behavior is covered in
+        // hooks-reconcile-scope.test.ts.
+        expect(mockedReconcileForConfig).toHaveBeenCalledTimes(1);
+        expect(mockedReconcileForConfig).toHaveBeenCalledWith(
+            mockTeamConfig,
             expect.objectContaining({ scope: 'project', projectRoot: '/path/to/project' }),
+            expect.objectContaining({ auto: false }),
         );
     });
 });

--- a/src/hooks-cmd.ts
+++ b/src/hooks-cmd.ts
@@ -1,11 +1,11 @@
 import path from 'node:path';
 import { autoDetectInit } from './config.js';
-import { reconcileHooksToAllTools, sweepLegacyProjectHooks, getHookStatus, hasInstalledCodexTrustGatedTool, codexTrustReminder, type HookStatus } from './hooks.js';
+import { reconcileHooksToAllTools, reconcileTeamHooksForConfig, sweepLegacyProjectHooks, getHookStatus, hasInstalledCodexTrustGatedTool, codexTrustReminder, type HookStatus } from './hooks.js';
 import { builtinHookDefs } from './builtin-hooks.js';
-import { parseTeamHooks, resolveTeamHooks } from './resources/hooks.js';
+import { parseTeamHooks } from './resources/hooks.js';
 import { log } from './utils/logger.js';
 import type { GlobalOptions } from './types.js';
-import { resolveHookScope, isSelfMode } from './types.js';
+import { resolveHookScope } from './types.js';
 import { getUserHome } from './utils/home.js';
 
 type HookListStatus = HookStatus | 'not configured';
@@ -52,26 +52,15 @@ export async function hooksInject(options: GlobalOptions): Promise<void> {
     const { localConfig, teamConfig } = await autoDetectInit();
 
     // Explicit user action → not gated by sharing.hooks.autoApply (auto: false).
-    const { defs: teamDefs, builtin } = await resolveTeamHooks(teamConfig, localConfig.repo.localPath, {
+    const { baseDir } = resolveHookScope(localConfig);
+    await reconcileTeamHooksForConfig(teamConfig, localConfig, {
         auto: false,
         silent: options.silent,
     });
     let codexTrustGated = false;
-    const { baseDir, manifestPath } = resolveHookScope(localConfig);
-    await reconcileHooksToAllTools(teamConfig.toolPaths, baseDir, teamDefs, manifestPath, {
-        builtinOverride: builtin,
-        teamHookProjectRoot: localConfig.scope === 'project' && !isSelfMode(localConfig)
-            ? localConfig.projectRoot
-            : undefined,
-        installedBaseDir: localConfig.scope === 'project' ? (localConfig.projectRoot ?? baseDir) : undefined,
-    });
     if (await hasInstalledCodexTrustGatedTool(teamConfig.toolPaths, baseDir)) {
         codexTrustGated = true;
     }
-
-    // Sweep any legacy <projectRoot> copy a pre-#370 CLI left behind, so the
-    // HOME copy this command just wrote is the only one that fires (#264/#370).
-    await sweepLegacyProjectHooks(teamConfig.toolPaths, localConfig);
 
     if (!options.silent) {
         log.success('Hooks injected into all AI tool settings');

--- a/src/resources/agents.ts
+++ b/src/resources/agents.ts
@@ -5,7 +5,7 @@ import { ResourceHandler } from './base.js';
 import type { ResourceItem, ResourceItemStatus, TeamaiConfig, LocalConfig } from '../types.js';
 import { listFiles, pathExists, copyFile, ensureDir, remove, fileContentEqual, getFileMtime, writeFile, readFileSafe } from '../utils/fs.js';
 import { log } from '../utils/logger.js';
-import { resolveBaseDir, isAgentDisabled, isSelfMode, scopedToolPaths } from '../types.js';
+import { resolveBaseDir, isAgentExcluded, isSelfMode, scopedToolPaths } from '../types.js';
 import { BUILTIN_AGENT_NAMES } from '../builtin-agents.js';
 import {
   parseAgentYaml,
@@ -154,7 +154,7 @@ export class AgentsHandler extends ResourceHandler {
         // Compare like with like: native files against a native rendering of
         // the canonical YAML. Unchanged/untargeted copies must not join a merge.
         for (const [tool, filePath] of toolFiles) {
-          if (!isKnownTool(tool) || isAgentDisabled(localConfig, tool)
+          if (!isKnownTool(tool) || isAgentExcluded(localConfig, tool)
             || (canonicalSpec.targets && !canonicalSpec.targets.includes(tool))) {
             toolFiles.delete(tool);
             continue;
@@ -383,7 +383,7 @@ export class AgentsHandler extends ResourceHandler {
         log.debug(`Skipping agent sync for ${tool}: tool not installed`);
         continue;
       }
-      if (isAgentDisabled(localConfig, tool)) continue;
+      if (isAgentExcluded(localConfig, tool)) continue;
 
       const destDir = path.join(baseDir, toolPath.agents);
       try {
@@ -458,7 +458,7 @@ export class AgentsHandler extends ResourceHandler {
         log.debug(`Skipping legacy agent sync for ${tool}: tool not installed`);
         continue;
       }
-      if (isAgentDisabled(localConfig, tool)) continue;
+      if (isAgentExcluded(localConfig, tool)) continue;
 
       const destDir = path.join(baseDir, toolPath.agents);
       try {

--- a/src/resources/rules.ts
+++ b/src/resources/rules.ts
@@ -3,7 +3,7 @@ import { ResourceHandler } from './base.js';
 import type { ResourceItem, ResourceItemStatus, TeamaiConfig, LocalConfig } from '../types.js';
 import { listFilesRecursive, pathExists, copyFile, ensureDir, remove, fileContentEqual, getFileMtime, listDirs, readFileSafe, writeFile } from '../utils/fs.js';
 import { log } from '../utils/logger.js';
-import { TEAMAI_RULES_START, TEAMAI_RULES_END, resolveBaseDir, isAgentDisabled, scopedToolPaths } from '../types.js';
+import { TEAMAI_RULES_START, TEAMAI_RULES_END, resolveBaseDir, isAgentExcluded, scopedToolPaths } from '../types.js';
 import { EXCLUDED_RULE_NAMES } from '../builtin-rules.js';
 import { teamRuleToCursorMdc, mergeCursorBodyIntoTeamMd, cursorMdcBodyEqualsTeamMd } from './cursor-mdc.js';
 import {
@@ -166,7 +166,7 @@ export class RulesHandler extends ResourceHandler {
   async pullItem(item: ResourceItem, teamConfig: TeamaiConfig, localConfig: LocalConfig): Promise<void> {
     const baseDir = resolveBaseDir(localConfig);
     for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
-      if (isAgentDisabled(localConfig, tool)) continue;
+      if (isAgentExcluded(localConfig, tool)) continue;
       if (!toolPath.rules) continue;
 
       // Skip tools that are not installed
@@ -252,7 +252,7 @@ export class RulesHandler extends ResourceHandler {
     // Hermes: inline all team rules into a teamai-managed block in SOUL.md
     // (user-level standing instructions). Only when Hermes is actually
     // installed — never create ~/.hermes for users who don't use it.
-    if (!isAgentDisabled(localConfig, 'hermes')) {
+    if (!isAgentExcluded(localConfig, 'hermes')) {
       const { getHermesHome } = await import('../hermes-home.js');
       if (await pathExists(getHermesHome())) {
         const bodies: string[] = [];
@@ -366,7 +366,7 @@ export class RulesHandler extends ResourceHandler {
     localConfig: LocalConfig,
     present: boolean,
   ): Promise<void> {
-    if (isAgentDisabled(localConfig, 'opencode')) return;
+    if (isAgentExcluded(localConfig, 'opencode')) return;
     const scoped = scopedToolPaths(teamConfig, localConfig);
     const paths = scoped['opencode'];
     if (!paths?.rules) return;

--- a/src/resources/skills.ts
+++ b/src/resources/skills.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import YAML from 'yaml';
 import { ResourceHandler } from './base.js';
 import type { ResourceItem, ResourceItemStatus, TeamaiConfig, LocalConfig } from '../types.js';
-import { resolveBaseDir, getPushignorePath, isAgentDisabled, scopedToolPaths } from '../types.js';
+import { resolveBaseDir, getPushignorePath, isAgentExcluded, scopedToolPaths } from '../types.js';
 import { listDirs, pathExists, copyDir, remove, dirContentEqual, dirTeamSubsetEqual, getDirLatestMtime, readFileSafe, writeFile } from '../utils/fs.js';
 import { log } from '../utils/logger.js';
 import { BUILTIN_SKILL_NAMES } from '../builtin-skills.js';
@@ -469,7 +469,7 @@ export class SkillsHandler extends ResourceHandler {
     const baseDir = resolveBaseDir(localConfig);
 
     for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
-      if (isAgentDisabled(localConfig, tool)) continue;
+      if (isAgentExcluded(localConfig, tool)) continue;
       if (!toolPath.skills) continue;
 
       let dest: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1378,6 +1378,20 @@ export function isAgentDisabled(localConfig: { disabledAgents?: string[] }, tool
 }
 
 /**
+ * True when `tool` should be skipped during resource sync: explicitly
+ * disabled via disabledAgents, or outside the enabledAgents whitelist when
+ * the team scoped its opt-in with `--agent` (undefined whitelist = all
+ * installed tools).
+ */
+export function isAgentExcluded(
+  localConfig: { disabledAgents?: string[]; enabledAgents?: string[] },
+  tool: string,
+): boolean {
+  if (isAgentDisabled(localConfig, tool)) return true;
+  return localConfig.enabledAgents ? !localConfig.enabledAgents.includes(tool) : false;
+}
+
+/**
  * Return `teamConfig.toolPaths` with per-scope path overrides applied.
  *
  * Almost every tool keeps its user-scope and project-scope resources at the same


### PR DESCRIPTION
## Summary

`init --agent` scopes a team's opt-in to specific tools, but two paths still ignore it and deploy into every configured tool directory:

1. **`hooks inject`** reconciled every configured tool directly (resolve team hooks, then `reconcileHooksToAllTools`), re-seeding injections for tools the team never opted into - e.g. unconditional writes into tools outside the whitelist. This PR routes it through `reconcileTeamHooksForConfig`, the same choke point `init`, `pull` and the bootstrap already use, so all four entry points share one scoping implementation (whitelist minus `disabledAgents`).
2. **Per-tool resource handlers** (skills / rules / agents) only checked `isAgentDisabled`, so skills were still copied into e.g. `~/.hermes/skills` on a machine whose team scoped `--agent workbuddy`. This PR adds `isAgentExcluded` (explicitly disabled **or** outside the `enabledAgents` whitelist when one exists; undefined whitelist = all installed tools, preserving backward compatibility) and migrates the deploy loops in `resources/agents.ts`, `resources/rules.ts`, `resources/skills.ts` plus the agents status-diff site to it.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `src/__tests__/hooks-cmd.test.ts` updated: the hooksInject tests now assert the `reconcileTeamHooksForConfig` delegation (the mock previously pinned the old two-stage plumbing); codex-trust and silent-mode assertions unchanged
- [x] `npx vitest run` on macOS: full suite green; Windows: no new failures vs. pre-existing platform failures
- [x] Verified in a 20-member fleet pinned to `--agent workbuddy`: no hermes/opencode directory creation on pull or `hooks inject`

## Notes for Reviewers

- Deliberately a reuse fix: the hooks half just migrates the one remaining caller to the existing choke point; only the resources half is new logic.
- Follow-up worth discussing: ~10 more sites (deployBuiltinAgents/Rules/Skills, CLAUDE.md-class injects in pull.ts) still check `isAgentDisabled` only, and `scopedToolPaths()` would be the natural single choke point to fold exclusion into so future handlers cannot forget it. Left out to keep this PR's diff reviewable.