### PR TITLE
feat(pull): opt-out usage reporting (teamai.yaml usageReport: false)

### DIFF
--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -1402,6 +1402,16 @@ Auto-update runs in the Stop hook and is controlled by two tiers:
 
 The user-level `updatePolicy` always takes priority over the team-level `autoUpdate`.
 
+### Usage reporting
+
+By default, `teamai pull` commits session/usage stats into the team repo.
+Teams that pull from a read-only remote (or simply don't want stat commits)
+can turn this off in `teamai.yaml`:
+
+```yaml
+usageReport: false
+```
+
 ### CI Integration
 
 `teamai ci extract-mr` plugs into your CI pipeline, automatically extracting knowledge from every MR/PR:

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -1371,6 +1371,15 @@ teamai remove mcp <name>
 
 用户级 `updatePolicy` 始终优先于团队级 `autoUpdate`。
 
+### 使用统计上报
+
+默认情况下，`teamai pull` 会把会话/使用统计提交进团队仓。从只读远端拉取（或
+不想要统计提交）的团队可在 `teamai.yaml` 中关闭：
+
+```yaml
+usageReport: false
+```
+
 ### CI 集成
 
 `teamai ci extract-mr` 接入 CI 流水线，从每个 MR/PR 自动提取知识：

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -127,6 +127,11 @@ async function refreshTeamRepo(
   return { label: result, version, reportingOnly: false };
 }
 
+/** teamai.yaml `usageReport: false` — per-repo opt-out of stat commits. */
+async function usageReportDisabled(repoPath: string): Promise<boolean> {
+  return (await loadTeamConfig(repoPath))?.usageReport === false;
+}
+
 export async function buildRolePullContext(localConfig: LocalConfig): Promise<RolePullContext | null> {
   const activeProjects = localConfig.projects ?? [];
   const hasRole = !!localConfig.primaryRole;
@@ -1549,7 +1554,11 @@ export async function pull(options: GlobalOptions): Promise<void> {
       const { reportUsageToTeam } = await import('./team-push.js');
       const { truncateUsageAfterReport, readUsageEvents } = await import('./usage-tracker.js');
       const targets: Array<{ repoPath: string; username: string; opts: { skipTruncate: true; projectRoot?: string; excludeProjectRoots?: string[]; selfConfig?: LocalConfig } }> = [];
-      if (reconcileProject && reconcileProject.repo.kind !== 'http') {
+      // Per-target opt-out (teamai.yaml `usageReport: false`): a repo that
+      // disables stat commits is dropped from the targets — e.g. teams
+      // pulling from a read-only remote never accumulate unpushable commits.
+      if (reconcileProject && reconcileProject.repo.kind !== 'http'
+        && !await usageReportDisabled(reconcileProject.repo.localPath)) {
         targets.push({
           repoPath: reconcileProject.repo.localPath,
           username: reconcileProject.username,
@@ -1561,7 +1570,8 @@ export async function pull(options: GlobalOptions): Promise<void> {
           },
         });
       }
-      if (reconcileUser && reconcileUser.repo.kind !== 'http') {
+      if (reconcileUser && reconcileUser.repo.kind !== 'http'
+        && !await usageReportDisabled(reconcileUser.repo.localPath)) {
         targets.push({
           repoPath: reconcileUser.repo.localPath,
           username: reconcileUser.username,
@@ -1583,6 +1593,8 @@ export async function pull(options: GlobalOptions): Promise<void> {
           log.error(`Auto-report to ${t.repoPath} skipped: ${(e as Error).message}`);
         }
       }
+      // Truncate only what was reported — an opted-out repo keeps its local
+      // event log (the dashboard still reads it).
       if (eventCount > 0 && targets.length > 0) {
         await truncateUsageAfterReport(eventCount);
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -241,6 +241,10 @@ export const TeamaiConfigSchema = z.object({
    * can override via `updatePolicy` in local config. Undefined = team has no
    * opinion (preserves legacy behavior). */
   autoUpdate: z.boolean().optional(),
+  /** Report session/usage stats back into the team repo on pull. Off = the
+   * team repo never receives stat commits (e.g. read-only pull setups).
+   * Default: on. */
+  usageReport: z.boolean().optional(),
   // MCP paths are only set for tools whose config location has been verified.
   // Tools left without `mcp` are skipped by MCP sync rather than guessed at, so a
   // wrong guess can never create a junk config file on a user's machine.


### PR DESCRIPTION
## Summary

`teamai pull` auto-commits session/usage stats into the team repo with no way to opt out: `reportUsageToTeam` only skips `http`-kind targets, so a team pulling from a **read-only remote** (e.g. a reverse proxy fronting the Git host with read-only deploy tokens) still attempts the report on every pull - recurring warn/error churn per session, and stat commits accumulating locally on the shared clone.

This PR adds a per-repo opt-out knob:

```yaml
usageReport: false
```

A repo with the knob is dropped from the report targets entirely, so it never receives stat commits and never triggers the push-failure path. Events stay in the local dashboard log (`~/.teamai/usage.jsonl`) - truncation only happens when at least one target was reported, so local dashboards keep working. Documented in docs/usage-guide (en + zh-CN).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` on macOS: full suite green; Windows: no new failures vs. pre-existing platform failures
- [x] Verified in a 20-member fleet on a read-only proxy remote: zero stat commits since rollout (previously several per day per machine)

## Notes for Reviewers

- The knob is named after the subsystem it gates: `reportUsageToTeam` handles sessions, intervention deltas, prompt/token deltas and daily stats as one "usage report" family, all derived from the same dashboard event stream - so the knob intentionally cuts all of them.
- Alternative shape considered: a push-failure quiesce latch inside `reportUsageToTeam` (dry-run probe, or "failed N times -> skip with one warn") would also help read-only setups with zero config. Happy to add that as a follow-up; the knob still carries the plain "we don't want stat commits" privacy opt-out.