### PR TITLE
fix(hooks): hide console windows for detached hook child processes

### DIFF
--- a/src/hook-dispatch-cli.ts
+++ b/src/hook-dispatch-cli.ts
@@ -92,6 +92,7 @@ function spawnBackground(
     }
     const child = spawn(process.execPath, args, {
       detached: true,
+      windowsHide: true,
       stdio: ['pipe', 'ignore', 'ignore'],
       ...(cwd ? { cwd } : {}),
     });

--- a/src/local-agent.ts
+++ b/src/local-agent.ts
@@ -871,7 +871,7 @@ async function maybeReconcilePlugins(context: LocalAgentContext): Promise<void> 
     const { spawn } = await import('node:child_process');
     if (!process.argv[1]) { log.debug('[local-agent] plugin reconcile: no CLI entrypoint (argv[1]), skipping'); return; }
     const child = spawn(process.execPath, [process.argv[1], 'source', 'reconcile-plugins'],
-      { detached: true, stdio: 'ignore', env: { ...process.env, TEAMAI_PLUGIN_LOCAL_AGENT_ID: localAgentId } });
+      { detached: true, windowsHide: true, stdio: 'ignore', env: { ...process.env, TEAMAI_PLUGIN_LOCAL_AGENT_ID: localAgentId } });
     child.unref();
   } catch (e) { log.debug(`[local-agent] plugin reconcile spawn skipped: ${(e as Error).message}`); }
 }


### PR DESCRIPTION
## Summary

`detached: true` without `windowsHide: true` gives the child process its own console window on Windows. Every hook dispatch from a GUI host therefore flashed a transient console window: WorkBuddy fires `hook-dispatch` on session start, the parent spawns the background-only child (which re-runs npm-registry checks), and a "npm" console window pops up and vanishes on the user's desktop.

This sets `windowsHide: true` on both detached spawn sites:

- `src/hook-dispatch-cli.ts` - the background-only dispatch child (`--bg-only`)
- `src/local-agent.ts` - the plugin reconcile worker

Zero behavior change otherwise: same stdio configuration, same unref, same error swallowing.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` on macOS: full suite green; Windows: no new failures vs. pre-existing platform failures
- [x] Verified in a 20-member Windows-only WorkBuddy fleet: session-start hook chains no longer flash any console window

## Notes for Reviewers

- Same class as the existing `windowsHide` on the `cmd /c` plugin exec in `local-agent.ts` - this covers the remaining detached sites (2/2; a tree-wide search finds no other `detached:` spawn).
- Follow-up idea: a shared `spawnDetached()` helper in `src/utils/` would make hidden-launch a property of the infrastructure instead of a per-site option to remember; happy to do that if preferred.