### PR TITLE
fix(ci): pick an explicit release-notes base on the same lineage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Release notes need every stable tag to pick their comparison base.
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -81,8 +84,66 @@ jobs:
       - name: Publish
         run: npm publish --access public --tag "${{ steps.disttag.outputs.dist_tag }}"
 
+      - name: Resolve release notes base
+        id: notesbase
+        env:
+          IS_PRERELEASE: ${{ steps.disttag.outputs.is_prerelease }}
+        run: |
+          # GitHub picks the base as the newest tag reachable from the tagged
+          # commit. Release commits are created detached and never land on a
+          # branch, so no release tag is an ancestor of the next one and the
+          # base walks back to whichever old release happened to be merged.
+          # Pick it explicitly instead.
+          #
+          # A prerelease compares against the tag right before it, keeping its
+          # notes incremental; a stable release compares against the previous
+          # stable tag. Either way, skip tags whose own parent is not in this
+          # release's history: those were cut from an unrelated lineage (an
+          # internal mirror sync), so their merge-base sits months back and
+          # would drag hundreds of unrelated PRs into the notes.
+          git config --add versionsort.suffix -beta
+          git config --add versionsort.suffix -rc
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            CANDIDATES=$(git tag -l 'v*' --sort=-v:refname)
+          else
+            CANDIDATES=$(git tag -l 'v*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$')
+          fi
+          PREV=""
+          PAST_CURRENT=""
+          for TAG in $CANDIDATES; do
+            if [ "$TAG" = "$GITHUB_REF_NAME" ]; then
+              PAST_CURRENT=1
+              continue
+            fi
+            [ -n "$PAST_CURRENT" ] || continue
+            if git merge-base --is-ancestor "$TAG^{commit}^1" "$GITHUB_REF_NAME^{commit}" 2>/dev/null; then
+              PREV="$TAG"
+              break
+            fi
+            echo "Skipping $TAG: cut from an unrelated lineage."
+          done
+          if [ -n "$PREV" ]; then
+            echo "Release notes base: $PREV"
+            echo "prev_tag=$PREV" >> "$GITHUB_OUTPUT"
+          else
+            echo "No usable earlier tag; letting GitHub pick the base."
+          fi
+
+      - name: Generate release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PREV_TAG: ${{ steps.notesbase.outputs.prev_tag }}
+        run: |
+          ARGS=(-f tag_name="$GITHUB_REF_NAME")
+          if [ -n "$PREV_TAG" ]; then
+            ARGS+=(-f previous_tag_name="$PREV_TAG")
+          fi
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+            "${ARGS[@]}" -q .body > "${RUNNER_TEMP}/release-notes.md"
+          cat "${RUNNER_TEMP}/release-notes.md"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          generate_release_notes: true
+          body_path: ${{ runner.temp }}/release-notes.md
           prerelease: ${{ steps.disttag.outputs.is_prerelease == 'true' }}


### PR DESCRIPTION
## Problem

Every recent GitHub Release compares against a long-superseded version:

| Release | Generated base | Notes |
|---|---|---|
| `v0.24.0-beta.7` | `v0.22.0` | starts at PR #380 |
| `v0.24.0-beta.6` / `.5` / `.1` | `v0.22.0` | same |
| `v0.23.1` (stable) | `v0.17.4` | 234 lines, starts at PR #207 |
| `v0.23.0` (stable) | `v0.17.4` | same |

Two causes, both rooted in how tags relate to `main`'s history:

1. `generate_release_notes: true` makes GitHub pick the base itself, and it picks the **newest tag reachable from the tagged commit**. Release commits are created in a detached worktree and never land on a branch, so no release tag is an ancestor of the next one. The walk back lands on `v0.22.0`, the last release whose commit reached `main` (via the #396 merge).
2. `v0.23.0` and `v0.23.1` were cut from an internal mirror sync commit, not from `main`. Their merge-base with `main` is the `v0.17.4` commit (2026-07-20), so any range involving them spans three months of unrelated PRs. Passing `previous_tag_name=v0.23.1` for beta.7 makes things *worse*, not better — verified below.

## Fix

Resolve the base explicitly and hand it to the `releases/generate-notes` API instead of letting the action guess:

- **Prerelease** → the tag immediately before it, so beta notes stay incremental.
- **Stable** → the previous stable tag.
- **Both** skip any candidate whose own parent commit is absent from this release's history. That is precisely the mirror-sync signature, so an off-lineage tag can no longer poison the range.

`fetch-depth: 0` is needed so the checkout sees every tag. `versionsort.suffix` entries make `git tag --sort=-v:refname` order `v0.24.0-beta.7` before `v0.24.0`.

When no usable predecessor exists (the oldest tag), `previous_tag_name` is omitted and GitHub falls back to its own choice.

## Test Plan

All items were executed against the real repository, not simulated.

**1. Base resolution, exercised with the exact script from the workflow against the real tag list** (candidates restricted to tags present on the GitHub remote, matching what a CI checkout sees):

```
PASS  v0.24.0-beta.7     (prerelease=true ) -> v0.24.0-beta.6     skipped:[]
PASS  v0.24.0-beta.6     (prerelease=true ) -> v0.24.0-beta.5     skipped:[]
PASS  v0.24.0-beta.1     (prerelease=true ) -> v0.23.0-beta.8     skipped:[v0.23.1 v0.23.0]
PASS  v0.22.0            (prerelease=false) -> v0.21.0            skipped:[]
PASS  v0.19.0            (prerelease=false) -> v0.18.0            skipped:[]
PASS  v0.3.13            (prerelease=false) -> (none)             skipped:[]
PASS  v0.24.0            (prerelease=false) -> v0.22.0            skipped:[v0.23.1 v0.23.0]
all cases passed
```

The last case uses a throwaway local tag at beta.7's commit (deleted afterwards, never pushed) to cover the next stable release: it correctly skips both off-lineage 0.23.x stables.

**2. Real `generate-notes` API output for the resolved base** (`v0.24.0-beta.7` vs `v0.24.0-beta.6`) — 11 lines, exactly the 5 PRs merged between the two betas:

```
## What's Changed
* test(hooks): pin golden hook fixtures to LF ... #497
* feat(pull): opt-out usage reporting ... #505
* fix(hooks): inject hooks for WorkBuddy on Windows ... #503
* fix(agents): honor enabledAgents scoping ... #504
* fix(hooks): hide console windows for detached hook child processes ... #506
**Full Changelog**: https://github.com/Tencent/teamai-cli/compare/v0.24.0-beta.6...v0.24.0-beta.7
```

For comparison, the same tag with base `v0.22.0` (current behavior) yields ~130 PRs, and with base `v0.23.1` yields 234 lines starting at PR #207.

**3. Workflow integrity**: YAML parses, step order is `Publish` → `Resolve release notes base` → `Generate release notes` → `Create GitHub Release`, and the notes file is written under `$RUNNER_TEMP` so it can never reach the published package.

**4. Repo checks**: `npm ci --ignore-scripts`, `npx tsc --noEmit`, `npm run build` all pass. `npx vitest run` passes on this base commit (217 files / 3006 tests, run during the 0.24.0-beta.7 release). No runtime source is touched.

## Notes

This only makes the notes correct given the current tag topology. The 0.23.x stables remain off-lineage, so the next stable release will compare against `v0.22.0` until a stable tag is once again cut from `main`. Already-published notes are left untouched.

Made with [Cursor](https://cursor.com)