### PR TITLE
fix(codebase): always write the evidence manifest so deep-enrich can run

### DIFF
--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -1196,7 +1196,9 @@ The graph stores components, interfaces, configs, and cross-repo dependencies. `
 Dependency edges are extracted by two parallel tracks: a WASM tree-sitter **AST track** (TypeScript/JavaScript, Python, Go) that resolves imports, calls, and TS `implements` clauses to precise file-to-file edges (`code-ast`), and a regex **heuristic track** (all languages, `code-heuristic`) that also covers languages the AST track does not. AST results win on overlap. The AST parser needs no native toolchain; on load failure, extraction falls back to heuristics and records an `AST_UNAVAILABLE` gap. Set `TEAMAI_SKIP_AST=1` to force heuristic-only extraction.
 
 ```bash
-# Extract code facts and the graph from a local repo (writes <repo>/teamwiki/)
+# Extract code facts and the graph from a local repo (writes <repo>/teamwiki/).
+# The evidence manifest that --deep-enrich reads is always written, even when
+# AI enrichment is skipped or yields nothing.
 teamai codebase --extract /path/to/repo --project my-service
 
 # Incremental refresh: reuse the original repository path and project slug

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -1164,6 +1164,7 @@ teamai import --from-repo https://github.com/org/repo --skip-enrich
 
 ```bash
 # 从本地仓库提取代码事实与图谱（写入 <repo>/teamwiki/）
+# --deep-enrich 读取的 evidence manifest 一定会写出，即使 AI 增强被跳过或无产出
 teamai codebase --extract /path/to/repo --project my-service
 
 # 增量刷新：复用首次提取的仓库路径和项目名

--- a/src/__tests__/extract-fallback-manifest.test.ts
+++ b/src/__tests__/extract-fallback-manifest.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// The fallback manifest itself needs no AI at all, but `deep-enrich` does call
+// out to the CLI. Make those calls fail instantly so the integration cases
+// assert on the manifest plumbing instead of waiting on real 600s timeouts.
+vi.mock('../utils/ai-client.js', () => ({
+  getAICliName: () => 'mock-cli',
+  callClaude: vi.fn(async () => {
+    throw new Error('mock: AI unavailable');
+  }),
+  callClaudeParallel: vi.fn(async () => {
+    throw new Error('mock: AI batch unavailable');
+  }),
+}));
+
+import { buildFallbackManifest } from '../enrich-with-ai.js';
+import { codebaseCmd } from '../codebase-cmd.js';
+import { extractCodebase } from '../codebase-extract.js';
+import type { CodeFact } from '../wiki-engine/adapters/index.js';
+
+const temporaryDirectories: string[] = [];
+
+function fact(partial: Partial<CodeFact> & Pick<CodeFact, 'kind' | 'file'>): CodeFact {
+  return {
+    name: 'Widget',
+    lineStart: 1,
+    detail: '',
+    confidence: 'EXTRACTED',
+    ...partial,
+  };
+}
+
+/** A one-file repo: a single component fact, so no module reaches the 5-fact threshold. */
+function createSmallRepo(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-extract-fallback-'));
+  temporaryDirectories.push(root);
+  fs.mkdirSync(path.join(root, 'src'), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, 'src', 'widget.ts'),
+    'export class Widget {\n  render() { return "hi"; }\n}\n',
+  );
+  return root;
+}
+
+function manifestPathFor(root: string, project: string): string {
+  return path.join(root, 'teamwiki', 'evidence', 'code', project, '_manifest.json');
+}
+
+/** Silence the CLI and return a joined view of everything it printed. */
+function captureOutput() {
+  const calls: string[] = [];
+  const record = (...args: unknown[]) => {
+    calls.push(args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '));
+  };
+  vi.spyOn(console, 'log').mockImplementation(record);
+  vi.spyOn(console, 'warn').mockImplementation(record);
+  vi.spyOn(console, 'error').mockImplementation(record);
+  return () => calls.join('\n');
+}
+
+afterEach(() => {
+  process.exitCode = undefined;
+  vi.restoreAllMocks();
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('buildFallbackManifest', () => {
+  it('derives one component per module that has a component fact', () => {
+    const manifest = buildFallbackManifest('proj', [
+      fact({ kind: 'component', file: 'src/widget.ts', name: 'Widget' }),
+      fact({ kind: 'component', file: 'src/button.ts', name: 'Button' }),
+      fact({ kind: 'component', file: 'lib/util.ts', name: 'Util' }),
+    ]);
+
+    expect(manifest.schemaVersion).toBe('team-wiki.codebase-output-manifest.v2');
+    expect(manifest.project).toBe('proj');
+    expect(manifest.edges).toEqual([]);
+    expect(manifest.components.map((c) => c.slug)).toEqual(['src', 'lib']);
+  });
+
+  it('deduplicates modules that appear in several component facts', () => {
+    const manifest = buildFallbackManifest('proj', [
+      fact({ kind: 'component', file: 'src/a.ts' }),
+      fact({ kind: 'component', file: 'src/b.ts' }),
+      fact({ kind: 'component', file: 'src/c.ts' }),
+    ]);
+
+    expect(manifest.components.map((c) => c.slug)).toEqual(['src']);
+  });
+
+  it('maps a file with no directory to the _root module', () => {
+    const manifest = buildFallbackManifest('proj', [fact({ kind: 'component', file: 'index.ts' })]);
+
+    expect(manifest.components.map((c) => c.slug)).toEqual(['_root']);
+  });
+
+  it('ignores facts that are not components', () => {
+    const manifest = buildFallbackManifest('proj', [
+      fact({ kind: 'interface', file: 'src/api.ts' }),
+      fact({ kind: 'relation', file: 'src/widget.ts' }),
+      fact({ kind: 'config', file: 'src/config.ts' }),
+    ]);
+
+    expect(manifest.components).toEqual([]);
+  });
+
+  it('produces schema-conformant components', () => {
+    const [component] = buildFallbackManifest('proj', [
+      fact({ kind: 'component', file: 'src/widget.ts' }),
+    ]).components;
+
+    expect(component).toEqual({
+      slug: 'src',
+      docPath: 'evidence/code/proj/src.md',
+      title: 'src',
+      category: 'unknown',
+      confidence: 'EXTRACTED',
+    });
+  });
+
+  it('stamps a parseable generatedAt', () => {
+    const { generatedAt } = buildFallbackManifest('proj', []);
+
+    expect(Number.isNaN(Date.parse(generatedAt))).toBe(false);
+  });
+});
+
+describe('extract gives deep-enrich something to work with', () => {
+  it('writes a minimal _manifest.json when no module reaches the 5-fact threshold', async () => {
+    const root = createSmallRepo();
+    captureOutput();
+
+    await codebaseCmd({ extract: root, project: 'widget', output: root, json: true });
+
+    const manifestPath = manifestPathFor(root, 'widget');
+    expect(fs.existsSync(manifestPath)).toBe(true);
+
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as {
+      components: Array<{ slug: string }>;
+    };
+    expect(manifest.components.map((c) => c.slug)).toEqual(['src']);
+  });
+
+  it('also writes it when enrichment is skipped (import --skip-enrich)', async () => {
+    const root = createSmallRepo();
+    captureOutput();
+
+    await extractCodebase({ path: root, project: 'widget', skipEnrich: true, json: true });
+
+    expect(fs.existsSync(manifestPathFor(root, 'widget'))).toBe(true);
+  });
+
+  it('no longer aborts deep-enrich with "No components"', async () => {
+    const root = createSmallRepo();
+    const output = captureOutput();
+
+    await codebaseCmd({ extract: root, project: 'widget', output: root, json: true });
+    await codebaseCmd({ deepEnrich: true, project: 'widget', output: root, json: true });
+
+    expect(output()).not.toContain('No components');
+  });
+
+  it('does not invent a manifest when there is nothing to describe', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-extract-empty-'));
+    temporaryDirectories.push(root);
+    fs.mkdirSync(path.join(root, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'src', 'notes.ts'), '// nothing but a comment\n');
+    captureOutput();
+
+    await codebaseCmd({ extract: root, project: 'emptyproj', output: root, json: true });
+
+    expect(fs.existsSync(manifestPathFor(root, 'emptyproj'))).toBe(false);
+  });
+});

--- a/src/codebase-extract.ts
+++ b/src/codebase-extract.ts
@@ -712,6 +712,7 @@ export async function extractCodebase(opts: ExtractCodebaseOptions): Promise<voi
 
   // AI enrichment (optional, non-blocking; skipped with --skip-enrich)
   let aiDomains: DomainGroup[] = [];
+  let manifestWritten = false;
   if (opts.skipEnrich) {
     if (!opts.json) console.log(chalk.dim('  [AI enrich: skipped (--skip-enrich)]'));
   } else try {
@@ -728,6 +729,7 @@ export async function extractCodebase(opts: ExtractCodebaseOptions): Promise<voi
     const enrichResult = await enrichWithAI({ project, facts, interfaceInventory, modules });
     if (enrichResult) {
       await writeManifest(enrichResult.manifest, evidenceDir);
+      manifestWritten = true;
       aiDomains = enrichResult.domains;
       // Persist AI-inferred domain classification for rebuildWikiIndex
       const domainMeta = {
@@ -745,6 +747,29 @@ export async function extractCodebase(opts: ExtractCodebaseOptions): Promise<voi
   } catch (e) {
     if (!opts.json) {
       console.log(chalk.dim(`  [AI enrich skipped: ${(e as Error).message}]`));
+    }
+  }
+
+  // `deep-enrich` reads `_manifest.json` and aborts when it holds no components.
+  // AI enrichment writes nothing whenever no module reaches the five-fact
+  // threshold, the AI call fails, or `--skip-enrich` was given — so on a small
+  // repo `--extract` reported success while leaving `deep-enrich` with nothing
+  // to work on, and the two commands never formed a closed loop. Fall back to
+  // the component facts the extract already has so a successful extract always
+  // leaves a usable manifest behind.
+  if (!manifestWritten) {
+    const { buildFallbackManifest, writeManifest } = await import('./enrich-with-ai.js');
+    const fallback = buildFallbackManifest(project, facts);
+    if (fallback.components.length > 0) {
+      await writeManifest(fallback, evidenceDir);
+      if (!opts.json) {
+        const n = fallback.components.length;
+        console.log(chalk.dim(
+          `  [AI enrich: no AI manifest; wrote a minimal _manifest.json covering ${n} module${n === 1 ? '' : 's'}]`,
+        ));
+      }
+    } else if (!opts.json) {
+      console.log(chalk.dim('  [AI enrich: no AI manifest and no component facts found; deep-enrich will have nothing to do]'));
     }
   }
 

--- a/src/enrich-with-ai.ts
+++ b/src/enrich-with-ai.ts
@@ -296,3 +296,46 @@ export async function writeManifest(manifest: CodebaseOutputManifestV2, outputDi
   await writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf-8');
   return manifestPath;
 }
+
+/**
+ * Build a minimal manifest from the component facts an extract already holds.
+ *
+ * `enrichWithAI` returns `null` — and therefore nothing is written — whenever no
+ * top-level module reaches the five-fact threshold, the AI call fails, or
+ * enrichment is skipped. `deep-enrich` then aborts with "No components in
+ * _manifest.json", so `--extract` and `deep-enrich` were not a closed loop.
+ *
+ * The component facts are enough to describe which modules exist, which is all
+ * `deep-enrich` needs to proceed. Slugs are module names (the first path segment
+ * of a fact's file), matching the `components[]` a successful `enrichWithAI`
+ * run produces. `docPath` follows the same convention and is only descriptive:
+ * `deep-enrich` derives the document location from the slug itself.
+ */
+export function buildFallbackManifest(project: string, facts: CodeFact[]): CodebaseOutputManifestV2 {
+  const slugs: string[] = [];
+  const seen = new Set<string>();
+  for (const fact of facts) {
+    if (fact.kind !== 'component') continue;
+    const parts = fact.file.split('/');
+    const moduleName = parts.length > 1 ? parts[0] : '_root';
+    if (seen.has(moduleName)) continue;
+    seen.add(moduleName);
+    slugs.push(moduleName);
+  }
+
+  const components: ManifestComponentV2[] = slugs.map((slug) => ({
+    slug,
+    docPath: `evidence/code/${project}/${slug}.md`,
+    title: slug,
+    category: 'unknown',
+    confidence: 'EXTRACTED' as const,
+  }));
+
+  return {
+    schemaVersion: 'team-wiki.codebase-output-manifest.v2',
+    project,
+    generatedAt: new Date().toISOString(),
+    components,
+    edges: [],
+  };
+}


### PR DESCRIPTION
## Summary

`codebase --extract` only wrote the evidence manifest when AI enrichment returned a result, which needs at least one top-level module with five or more facts. On a smaller repo the extract reported success but left no `_manifest.json` behind, so `teamai deep-enrich --project <p>` aborted immediately with `No components in _manifest.json` — also exiting 0. This PR makes a successful extract always leave a usable manifest, derived from the component facts it already holds.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing behavior to change)
- [ ] Documentation only
- [ ] Refactor / internal cleanup

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` passes
- [x] Added/updated tests for the change

| # | Step | Result |
|---|---|---|
| 1 | `npx tsc --noEmit` | clean |
| 2 | `npm run build` | clean |
| 3 | `npx vitest run src/__tests__/extract-fallback-manifest.test.ts` | 10 passed (7 pure + 3 integration) |
| 4 | `npx vitest run --config vitest.e2e.config.ts src/__tests__/e2e/codebase-extract-cli.test.ts` | 5 passed, including "extracts a tiny local repo into teamwiki graph output" |
| 5 | Real end-to-end on a repo holding a single `src/widget.ts` | before → after below |
| 6 | Full suite, `--reporter=json`, compared **per test** against the same tree without the fix | zero regressions |

### Step 3 detail — the integration tests were falsified before being kept

Reverting only the call site in `codebase-extract.ts` (leaving the new function in place) makes all 3 integration tests fail — `expected false to be true` for the manifest check, and the captured output still contains `No components` — while the 7 pure `buildFallbackManifest` cases stay green. The tests fail for the reason they were written for.

### Step 5 — real CLI, before

```
$ teamai codebase --extract . --project widget --output .
  Facts: 1 (component:1)                    ← reports a component

$ find . -name _manifest.json
(no output)                                  ← but none is written

$ teamai deep-enrich --project widget --wiki-root ./teamwiki
  ⚠ No components in _manifest.json, aborting
exit=0                                       ← silent success

$ teamai codebase --lint --output .
  ✓ no issues                                ← the asymmetry is invisible to lint
```

### Step 5 — real CLI, after

```
$ teamai codebase --extract . --project widget --output .
  Facts: 1 (component:1)
  [AI enrich: no AI manifest; wrote a minimal _manifest.json covering 1 module]

$ cat teamwiki/evidence/code/widget/_manifest.json
  components: [{ "slug": "src", "title": "src", "category": "unknown",
                 "confidence": "EXTRACTED",
                 "docPath": "evidence/code/widget/src.md" }]

$ teamai deep-enrich --project widget --wiki-root ./teamwiki
  → runs phases 1–5 and writes 5 deterministic docs under
    teamwiki/evidence/code/widget/docs/   ← did not exist before
```

Two further paths are covered by the same fix and were checked by hand: a module with ≥5 facts where the AI call fails, and `codebase --deep-enrich`, which the same `componentCount === 0` check used to block.

### Step 6 detail

Compared per test, not by totals. Against the same tree without the fix this branch adds **no** failing assertion. The totals do differ by ~30 between runs on this machine, but that is run-to-run flake in the suites that race on shared `HOME` state (`scope`, `remove`, `pull-*`, `rules`) — a property of the Windows suite, not of this change. One `push-team-config` case also flipped red in a single run and did not reproduce in two later full runs or in 3/3 isolated runs.

## Related Issues

Fixes #508

## Notes for Reviewers

- The AI-success path is untouched: `buildFallbackManifest` runs only when `manifestWritten === false`, i.e. `enrichWithAI` returned `null` or threw, or `--skip-enrich` was passed. The fallback is called **after** the existing `try/catch`, so the throwing path is covered too.
- Slugs are module names (the first path segment of a fact's file), which is the same convention a successful `enrichWithAI` run produces, so `deep-enrich` needs no change. `docPath` is descriptive only — `deep-enrich` derives the document location from the slug — so the fallback keeps the existing format rather than introducing a second convention.
- When there are no component facts at all, no manifest is written and the CLI says so, rather than writing an empty manifest that would make `deep-enrich` fail on the next line.
- `--skip-enrich` is an `import` option, not a `codebase` one, so that branch is covered by the integration test rather than by the CLI.
- Docs are updated in both languages, as AGENTS.md requires.
