### PR TITLE
fix(pull): honour enabledAgents at the remaining resource write sites

### DIFF
--- a/src/__tests__/enabled-agents-scoping.test.ts
+++ b/src/__tests__/enabled-agents-scoping.test.ts
@@ -1,0 +1,322 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import os from 'node:os';
+import fse from 'fs-extra';
+
+// Mock external dependencies (same shape as pull-skip-sync.test.ts).
+vi.mock('../config.js', () => ({
+  requireInit: vi.fn(),
+  loadState: vi.fn().mockResolvedValue({ lastPull: null, lastPullRev: null }),
+  saveState: vi.fn(),
+  loadLocalConfigForScope: vi.fn(),
+  loadTeamConfig: vi.fn(),
+  detectProjectConfig: vi.fn().mockResolvedValue(null),
+  loadStateForScope: vi.fn().mockResolvedValue({ lastPull: null, lastPullRev: null }),
+  saveStateForScope: vi.fn(),
+}));
+
+vi.mock('../utils/git.js', () => ({
+  pullRepo: vi.fn().mockResolvedValue('already up to date'),
+  getHeadRev: vi.fn().mockResolvedValue('abc1234'),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  log: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    dim: vi.fn(),
+  },
+  spinner: vi.fn(() => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    warn: vi.fn().mockReturnThis(),
+    info: vi.fn().mockReturnThis(),
+    stop: vi.fn().mockReturnThis(),
+  })),
+}));
+
+vi.mock('../roles.js', () => ({
+  loadRolesManifest: vi.fn().mockResolvedValue({
+    version: 1,
+    roles: [
+      {
+        id: 'hai',
+        name: 'HAI R&D',
+        description: 'HyperAI resources',
+        resources: { knowledge: ['common', 'hai'], skills: ['common', 'hai'], learnings: ['common', 'hai'] },
+      },
+    ],
+    defaults: { shareTarget: 'primary-role' },
+  }),
+  resolveRoleResourceNamespaces: vi.fn(({ manifest, primaryRole, additionalRoles }) => {
+    const allRoles = [primaryRole, ...additionalRoles].map((id: string) =>
+      manifest.roles.find((role: { id: string }) => role.id === id),
+    );
+    const dedupe = (values: string[]) => [...new Set(values)];
+    return {
+      knowledge: dedupe(allRoles.flatMap((role: { resources: { knowledge: string[] } }) => role.resources.knowledge)),
+      skills: dedupe(allRoles.flatMap((role: { resources: { skills: string[] } }) => role.resources.skills)),
+      learnings: dedupe(allRoles.flatMap((role: { resources: { learnings: string[] } }) => role.resources.learnings)),
+    };
+  }),
+}));
+
+// pull() takes a real ~/.teamai/.sync-lock; parallel vitest workers race on it.
+vi.mock('../update.js', () => ({
+  acquireLock: vi.fn().mockResolvedValue(true),
+  releaseLock: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { pull } from '../pull.js';
+import { loadLocalConfigForScope, loadTeamConfig, detectProjectConfig, loadStateForScope, saveStateForScope } from '../config.js';
+import { getHeadRev } from '../utils/git.js';
+import { log } from '../utils/logger.js';
+import { deployBuiltinSkills } from '../builtin-skills.js';
+import { deployBuiltinRules } from '../builtin-rules.js';
+import { deployBuiltinAgents } from '../builtin-agents.js';
+import type { TeamaiConfig, LocalConfig } from '../types.js';
+
+/**
+ * `init --agent` / `enabledAgents` scopes resource sync to an opt-in whitelist.
+ * These cases pin the sites that used to gate only on `disabledAgents`
+ * (`isAgentDisabled`), which let a pull keep writing into a tool that was
+ * installed on the machine but deliberately left out of the whitelist (#510).
+ *
+ * The observable throughout is the disk: with `enabledAgents: ['claude']` and
+ * both `~/.claude` and `~/.codebuddy` present, nothing may land under
+ * `~/.codebuddy` — not built-in skills/rules/agents, not CLAUDE.md injects, and
+ * not the target set that `pull` records for its skip-sync decision.
+ */
+const TOOL_PATHS = {
+  claude: {
+    skills: '.claude/skills',
+    rules: '.claude/rules',
+    agents: '.claude/agents',
+    claudemd: '.claude/CLAUDE.md',
+  },
+  codebuddy: {
+    skills: '.codebuddy/skills',
+    rules: '.codebuddy/rules',
+    agents: '.codebuddy/agents',
+    claudemd: '.codebuddy/CODEBUDDY.md',
+  },
+};
+
+function makeTeamConfig(): TeamaiConfig {
+  return {
+    team: 'test',
+    description: '',
+    repo: 'https://git.woa.com/test/repo.git',
+    provider: 'tgit' as const,
+    reviewers: [],
+    sharing: {
+      skills: {},
+      rules: { enforced: [] },
+      docs: { localDir: '' },
+      env: { injectShellProfile: true },
+    },
+    toolPaths: TOOL_PATHS,
+  };
+}
+
+describe('builtin deploy honours enabledAgents (whitelist)', () => {
+  let tmpDir: string;
+  let homeDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-whitelist-builtin-'));
+    homeDir = path.join(tmpDir, 'home');
+
+    // Both tools are installed; only claude is opted in.
+    for (const tool of ['.claude', '.codebuddy']) {
+      await fse.ensureDir(path.join(homeDir, tool, 'skills'));
+      await fse.ensureDir(path.join(homeDir, tool, 'rules'));
+      await fse.ensureDir(path.join(homeDir, tool, 'agents'));
+    }
+    vi.stubEnv('HOME', homeDir);
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await fse.remove(tmpDir);
+  });
+
+  function localConfig(): LocalConfig {
+    return {
+      repo: { localPath: path.join(tmpDir, 'repo'), remote: 'https://git.woa.com/test/repo.git' },
+      username: 'testuser',
+      updatePolicy: 'auto' as const,
+      additionalRoles: [],
+      scope: 'user' as const,
+      enabledAgents: ['claude'],
+    };
+  }
+
+  it('does not deploy built-in skills into an installed tool outside the whitelist', async () => {
+    const deployed = await deployBuiltinSkills(makeTeamConfig(), localConfig());
+
+    expect(deployed).toBeGreaterThan(0);
+    expect(await fse.pathExists(path.join(homeDir, '.claude/skills/team-wiki-codebase/SKILL.md'))).toBe(true);
+    expect(await fse.pathExists(path.join(homeDir, '.codebuddy/skills/team-wiki-codebase'))).toBe(false);
+    expect(await fse.pathExists(path.join(homeDir, '.codebuddy/skills/teamai-share-learnings'))).toBe(false);
+  });
+
+  it('does not deploy built-in rules into an installed tool outside the whitelist', async () => {
+    const deployed = await deployBuiltinRules(makeTeamConfig(), localConfig());
+
+    expect(deployed).toBeGreaterThan(0);
+    expect(await fse.pathExists(path.join(homeDir, '.claude/rules/teamai-recall.md'))).toBe(true);
+    expect(await fse.pathExists(path.join(homeDir, '.codebuddy/rules/teamai-recall.md'))).toBe(false);
+  });
+
+  it('does not deploy built-in agents into an installed tool outside the whitelist', async () => {
+    const deployed = await deployBuiltinAgents(makeTeamConfig(), localConfig());
+
+    expect(deployed).toBeGreaterThan(0);
+    expect(
+      await fse.pathExists(path.join(homeDir, '.claude/agents/teamai-recall.md')),
+    ).toBe(true);
+    expect(await fse.pathExists(path.join(homeDir, '.codebuddy/agents/teamai-recall.md'))).toBe(false);
+  });
+
+  it('still deploys everywhere when enabledAgents is not set', async () => {
+    const config = localConfig();
+    delete config.enabledAgents;
+
+    await deployBuiltinSkills(makeTeamConfig(), config);
+
+    // No whitelist means "every installed tool", i.e. the previous behaviour.
+    expect(await fse.pathExists(path.join(homeDir, '.claude/skills/team-wiki-codebase/SKILL.md'))).toBe(true);
+    expect(await fse.pathExists(path.join(homeDir, '.codebuddy/skills/team-wiki-codebase/SKILL.md'))).toBe(true);
+  });
+});
+
+describe('pull honours enabledAgents for the target set and skip-sync', () => {
+  let tmpDir: string;
+  let homeDir: string;
+  let repoPath: string;
+
+  beforeEach(async () => {
+    tmpDir = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-whitelist-pull-'));
+    homeDir = path.join(tmpDir, 'home');
+    repoPath = path.join(tmpDir, 'team-repo');
+
+    await fse.ensureDir(path.join(repoPath, 'rules'));
+    await fse.ensureDir(path.join(repoPath, 'skills', 'common', 'team-skill'));
+    await fse.writeFile(path.join(repoPath, 'skills', 'common', 'team-skill', 'SKILL.md'), '# Team Skill');
+    await fse.ensureDir(path.join(repoPath, 'skills', 'hai'));
+    await fse.ensureDir(path.join(repoPath, 'learnings', 'common'));
+    await fse.ensureDir(path.join(repoPath, 'learnings', 'hai'));
+    await fse.ensureDir(path.join(repoPath, 'manifest'));
+    await fse.writeFile(path.join(repoPath, 'manifest', 'roles.yaml'), 'version: 1\n');
+
+    // Both tools are installed on the machine; only claude is opted in initially.
+    for (const tool of ['.claude', '.codebuddy']) {
+      await fse.ensureDir(path.join(homeDir, tool, 'skills'));
+      await fse.ensureDir(path.join(homeDir, tool, 'rules'));
+      await fse.ensureDir(path.join(homeDir, tool, 'agents'));
+    }
+    vi.stubEnv('HOME', homeDir);
+
+    vi.mocked(loadTeamConfig).mockResolvedValue(makeTeamConfig());
+    vi.mocked(detectProjectConfig).mockResolvedValue(null);
+    vi.mocked(getHeadRev).mockResolvedValue('abc1234');
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+    await fse.remove(tmpDir);
+  });
+
+  function localConfig(enabled: string[]): LocalConfig {
+    return {
+      repo: { localPath: repoPath, remote: 'https://git.woa.com/test/repo.git' },
+      username: 'testuser',
+      updatePolicy: 'auto',
+      primaryRole: 'hai',
+      additionalRoles: [],
+      resourceProfileVersion: 1,
+      scope: 'user',
+      enabledAgents: enabled,
+    };
+  }
+
+  it('records only whitelisted tools as resource targets', async () => {
+    vi.mocked(loadLocalConfigForScope).mockResolvedValue(localConfig(['claude']));
+    vi.mocked(loadStateForScope).mockResolvedValue({
+      lastPull: null,
+      lastPullRev: null,
+      lastPush: null,
+      pushedRules: [],
+      pushedSkills: [],
+      pushedEnvVars: [],
+      pendingPushes: [],
+      lastUpdateCheck: null,
+      availableUpdate: null,
+    });
+
+    await pull({});
+
+    const saved = vi.mocked(saveStateForScope).mock.calls[0][0];
+    expect(saved.lastPullTargets).toEqual(['claude']);
+    expect(saved.lastPullTargets).not.toContain('codebuddy');
+
+    // And the un-whitelisted tool received nothing on this full sync.
+    expect(await fse.pathExists(path.join(homeDir, '.claude/skills/team-skill/SKILL.md'))).toBe(true);
+    expect(await fse.pathExists(path.join(homeDir, '.codebuddy/skills/team-skill'))).toBe(false);
+  });
+
+  it('syncs a newly whitelisted tool even when the repo HEAD is unchanged', async () => {
+    // The recorded state says "claude only" at this exact revision, then the
+    // team adds codebuddy to the whitelist without touching the repo.
+    vi.mocked(loadLocalConfigForScope).mockResolvedValue(localConfig(['claude', 'codebuddy']));
+    vi.mocked(loadStateForScope).mockResolvedValue({
+      lastPull: '2026-04-01',
+      lastPullRev: 'abc1234', // matches HEAD -> skip-sync fast-path candidate
+      lastPullTargets: ['claude'],
+      lastPush: null,
+      pushedRules: [],
+      pushedSkills: [],
+      pushedEnvVars: [],
+      pendingPushes: [],
+      lastUpdateCheck: null,
+      availableUpdate: null,
+    });
+
+    await pull({});
+
+    // The target set changed, so the fast-path must not fire...
+    expect(log.success).not.toHaveBeenCalledWith(expect.stringContaining('Already synced'));
+    // ...and the newly opted-in tool must actually receive the team skill.
+    expect(await fse.pathExists(path.join(homeDir, '.codebuddy/skills/team-skill/SKILL.md'))).toBe(true);
+    const saved = vi.mocked(saveStateForScope).mock.calls[0][0];
+    expect(saved.lastPullTargets).toEqual(['claude', 'codebuddy']);
+  });
+
+  it('still skips when the target set is unchanged', async () => {
+    vi.mocked(loadLocalConfigForScope).mockResolvedValue(localConfig(['claude']));
+    vi.mocked(loadStateForScope).mockResolvedValue({
+      lastPull: '2026-04-01',
+      lastPullRev: 'abc1234',
+      lastPullTargets: ['claude'],
+      lastPush: null,
+      pushedRules: [],
+      pushedSkills: [],
+      pushedEnvVars: [],
+      pendingPushes: [],
+      lastUpdateCheck: null,
+      availableUpdate: null,
+    });
+
+    await pull({});
+
+    expect(log.success).toHaveBeenCalledWith(expect.stringContaining('Already synced at abc1234, skipping'));
+    // The un-whitelisted tool is still not touched on the fast-path.
+    expect(await fse.pathExists(path.join(homeDir, '.codebuddy/skills/team-wiki-codebase'))).toBe(false);
+  });
+});

--- a/src/builtin-agents.ts
+++ b/src/builtin-agents.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { ensureDir, pathExists, readFileSafe, writeFile, remove, listFiles } from './utils/fs.js';
 import { log } from './utils/logger.js';
 import type { TeamaiConfig, LocalConfig } from './types.js';
-import { resolveBaseDir, isAgentDisabled, scopedToolPaths } from './types.js';
+import { resolveBaseDir, isAgentExcluded, scopedToolPaths } from './types.js';
 import { ResourceHandler } from './resources/base.js';
 import { getUserHome } from './utils/home.js';
 import { ALL_SUPPORTED_TOOLS, renderForTool, reverseFromClaude } from './resources/agent-format.js';
@@ -126,7 +126,7 @@ export async function deployBuiltinAgents(
       log.debug(`Skipping built-in agent deployment for ${tool}: tool not installed`);
       continue;
     }
-    if (localConfig && isAgentDisabled(localConfig, tool)) continue;
+    if (localConfig && isAgentExcluded(localConfig, tool)) continue;
     if (!(ALL_SUPPORTED_TOOLS as string[]).includes(tool)) {
       log.warn(
         `Skipping built-in agent deployment for ${tool}: unsupported agent format; ` +

--- a/src/builtin-rules.ts
+++ b/src/builtin-rules.ts
@@ -5,7 +5,7 @@ import { ResourceHandler } from './resources/base.js';
 import { ruleFileExtensionForTool, usesCursorMdcRules } from './resources/rule-format.js';
 import { teamRuleToCursorMdc } from './resources/cursor-mdc.js';
 import type { TeamaiConfig, LocalConfig } from './types.js';
-import { resolveBaseDir, isAgentDisabled, scopedToolPaths } from './types.js';
+import { resolveBaseDir, isAgentExcluded, scopedToolPaths } from './types.js';
 import fs from 'node:fs/promises';
 import { getUserHome } from './utils/home.js';
 
@@ -66,7 +66,7 @@ export async function deployBuiltinRules(
             log.debug(`Skipping built-in rules for ${tool}: tool not installed`);
             continue;
         }
-        if (localConfig && isAgentDisabled(localConfig, tool)) continue;
+        if (localConfig && isAgentExcluded(localConfig, tool)) continue;
 
         const rulesDir = path.join(baseDir, toolPath.rules);
         if (!await pathExists(rulesDir)) continue;

--- a/src/builtin-skills.ts
+++ b/src/builtin-skills.ts
@@ -5,7 +5,7 @@ import fse from 'fs-extra';
 import { pathExists } from './utils/fs.js';
 import { log } from './utils/logger.js';
 import type { TeamaiConfig, LocalConfig } from './types.js';
-import { resolveBaseDir, isAgentDisabled, scopedToolPaths } from './types.js';
+import { resolveBaseDir, isAgentExcluded, scopedToolPaths } from './types.js';
 import { ResourceHandler } from './resources/base.js';
 import { ensureSkillFrontmatter, resolveSkillDestination } from './resources/skills.js';
 import { getUserHome } from './utils/home.js';
@@ -68,6 +68,8 @@ async function copyBuiltinSkillDir(srcDir: string, destDir: string): Promise<voi
  * Silently skips if:
  * - Built-in skills directory doesn't exist (dev environment without build)
  * - A tool's skills directory is not configured
+ * - The tool is not installed, is disabled, or falls outside a set
+ *   `enabledAgents` whitelist (`isAgentExcluded`)
  */
 export async function deployBuiltinSkills(teamConfig: TeamaiConfig, localConfig?: LocalConfig, options?: { reportingOnly?: boolean; skipRecall?: boolean }): Promise<number> {
   // Reporting-only HTTP mode has no team repo to write to, so the team-repo-
@@ -115,7 +117,7 @@ export async function deployBuiltinSkills(teamConfig: TeamaiConfig, localConfig?
       log.debug(`Skipping built-in skill deployment for ${tool}: tool not installed`);
       continue;
     }
-    if (localConfig && isAgentDisabled(localConfig, tool)) continue;
+    if (localConfig && isAgentExcluded(localConfig, tool)) continue;
 
     for (const skillName of skillNames) {
       const srcDir = path.join(builtinDir, skillName);

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -25,7 +25,7 @@ import {
   resolveHookScope,
   getDataHome,
   isRecallEnabled,
-  isAgentDisabled,
+  isAgentExcluded,
   scopedToolPaths,
   SYNC_LOCK_FILENAME,
 } from './types.js';
@@ -338,7 +338,7 @@ export async function cleanupInactiveNamespaceSkills(
   const baseDir = resolveBaseDir(localConfig);
 
   for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
-    if (isAgentDisabled(localConfig, tool)) continue;
+    if (isAgentExcluded(localConfig, tool)) continue;
     if (!toolPath.skills) continue;
     if (!await ResourceHandler.isToolInstalled(toolPath.skills, baseDir)) continue;
     if (!await pathExists(path.join(baseDir, toolPath.skills))) continue;
@@ -451,7 +451,7 @@ async function getInstalledResourceTargets(
   const targets: string[] = [];
 
   for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
-    if (isAgentDisabled(localConfig, tool)) continue;
+    if (isAgentExcluded(localConfig, tool)) continue;
 
     const resourcePaths = [toolPath.skills, toolPath.rules, toolPath.agents]
       .filter((resourcePath): resourcePath is string => !!resourcePath);
@@ -735,7 +735,7 @@ async function pullForScope(
         const dir = toolPath[toolPathField];
         if (!dir) continue;
         if (!await ResourceHandler.isToolInstalled(dir, baseDir)) continue;
-        if (isAgentDisabled(localConfig, tool)) continue;
+        if (isAgentExcluded(localConfig, tool)) continue;
 
         // Rules carry a per-tool extension (`.mdc` for compatible tools), and those dirs
         // may still hold a `.md` copy from the layout that predates it, so a
@@ -779,7 +779,7 @@ async function pullForScope(
     const baseDir = resolveBaseDir(localConfig);
 
     for (const [tool, toolPath] of Object.entries(scopedToolPaths(freshConfig, localConfig))) {
-      if (isAgentDisabled(localConfig, tool)) continue;
+      if (isAgentExcluded(localConfig, tool)) continue;
       if (!toolPath.skills) continue;
       if (!await ResourceHandler.isToolInstalled(toolPath.skills, baseDir)) continue;
       const skillsDir = path.join(baseDir, toolPath.skills);
@@ -935,7 +935,7 @@ async function pullForScope(
           if (compiled) {
             const baseDir = resolveBaseDir(localConfig);
             for (const [tool, toolPath] of Object.entries(scopedToolPaths(freshConfig, localConfig))) {
-              if (isAgentDisabled(localConfig, tool)) continue;
+              if (isAgentExcluded(localConfig, tool)) continue;
               if (!toolPath.claudemd) continue;
               if (toolPath.rules && !await ResourceHandler.isToolInstalled(toolPath.rules, baseDir)) continue;
 
@@ -966,7 +966,7 @@ async function pullForScope(
         if (compiled) {
           const baseDir = resolveBaseDir(localConfig);
           for (const [tool, toolPath] of Object.entries(scopedToolPaths(freshConfig, localConfig))) {
-            if (isAgentDisabled(localConfig, tool)) continue;
+            if (isAgentExcluded(localConfig, tool)) continue;
             if (!toolPath.claudemd) continue;
             if (toolPath.rules && !await ResourceHandler.isToolInstalled(toolPath.rules, baseDir)) continue;
             const claudeMdPath = path.join(baseDir, toolPath.claudemd);
@@ -1214,7 +1214,7 @@ export async function injectRecallBlockIntoTools(
         const recallBlock = compileRecallRulesBlock();
         let injected = 0;
         for (const [tool, toolPath] of Object.entries(scopedToolPaths(config, localConfig))) {
-            if (isAgentDisabled(localConfig, tool)) continue;
+            if (isAgentExcluded(localConfig, tool)) continue;
             if (!toolPath.claudemd || !toolPath.agents) continue;
             if (!await ResourceHandler.isToolInstalled(toolPath.agents, baseDir)) continue;
 


### PR DESCRIPTION
## Summary

Follow-up to #504. `init --agent` / `enabledAgents` is honoured by `hooks inject` and by the skills/rules/agents **resource handlers**, but ten write paths still gated only on `disabledAgents` (`isAgentDisabled`). On a machine that already has another tool installed, they keep writing into it even though the team opted in to a single agent. This routes all of them through `isAgentExcluded`.

Sites changed:

| file | site |
| --- | --- |
| `src/builtin-skills.ts` | `deployBuiltinSkills` tool loop |
| `src/builtin-rules.ts` | `deployBuiltinRules` tool loop |
| `src/builtin-agents.ts` | `deployBuiltinAgents` tool loop |
| `src/pull.ts` | import + 7 guards: `cleanupInactiveNamespaceSkills`, `getInstalledResourceTargets`, the culture / shared-instructions CLAUDE.md injects, the two deploy-adjacent loops, `injectRecallBlockIntoTools` |

Deliberately **not** changed: `known-agents.ts:162` and `project-agent-root.ts:52`. Both already take their candidate set from `enabledAgents` first and use `isAgentDisabled` only to subtract explicitly disabled tools, so swapping the helper there is a semantic no-op. `isAgentDisabled` stays exported and is still used in both places plus inside `isAgentExcluded` itself.

`isToolInstalled` only prevents *creating* a missing tool root, so a check that asserts "no `~/.hermes` directory appeared" cannot see this leak — the writes land in a root that already exists. The skip-sync fast path (`pullForScope`) still calls `deployBuiltin*` + `injectRecallBlockIntoTools`, so the builtin leak also fires on a SessionStart pull where the team repo HEAD has not changed.

## Repro 1 — built-in resources land in an installed tool outside the whitelist

`enabledAgents: ['claude']`, `disabledAgents` empty, both `~/.claude` and `~/.codebuddy` exist.

| | before | after |
| --- | --- | --- |
| `~/.codebuddy/skills/team-wiki-codebase` | written | absent |
| `~/.codebuddy/skills/teamai-share-learnings` | written | absent |
| `~/.codebuddy/rules/teamai-recall.md` | written | absent |
| `~/.codebuddy/agents/teamai-recall.md` | written | absent |
| `~/.claude/skills/team-wiki-codebase/SKILL.md` | written | written (unchanged) |

Asserted on disk (real temp `HOME`, not mocks) by the four `builtin deploy honours enabledAgents` cases.

## Repro 2 — `lastPullTargets` treats unsynced tools as already synced

`enabledAgents: ['claude']`, both tools installed, `teamai pull`.

- before: `lastPullTargets` recorded `['claude', 'codebuddy']`; adding `codebuddy` to the whitelist without `init` (so `lastPullRev` is untouched) then printed `Already synced at <rev>, skipping`, and `.codebuddy/skills` never got the team skill.
- after: `lastPullTargets` is `['claude']`; a whitelist change makes the target set differ, so the fast path does not fire and the newly opted-in tool gets a full sync. When the target set is *unchanged* the fast path still skips — that behaviour is pinned by its own case so it cannot silently regress.

## Tests

`src/__tests__/enabled-agents-scoping.test.ts` (new, 7 cases, disk-level). Reverting only the four source files fails 5 of them:

```
x does not deploy built-in skills into an installed tool outside the whitelist
x does not deploy built-in rules into an installed tool outside the whitelist
x does not deploy built-in agents into an installed tool outside the whitelist
x records only whitelisted tools as resource targets
x syncs a newly whitelisted tool even when the repo HEAD is unchanged
```

The two negative controls — no whitelist ⇒ deploy everywhere, unchanged target set ⇒ still skip — pass before and after, so the suite is not just asserting the new behaviour everywhere.

## Verification

`npx tsc --noEmit` is clean.

A full-suite diff is **not** trustworthy on this Windows box: two consecutive runs of *identical* code differed by 15 failing cases, and under full-suite load ~105 unrelated cases fail with `Test timed out in 15000ms`. So instead I ran the 19 suites that touch the changed code paths (259 cases) five times — twice without the fix, three times with it:

| | new suite | the other 18 suites |
| --- | --- | --- |
| baseline, run 1 | 5 / 7 failed | 34 − 5 = 29 failed / 252 |
| baseline, run 2 | 5 / 7 failed | 49 − 5 = 44 failed / 252 |
| fix, runs 1–3 | 0 / 7 failed | 46 failed / 252 (identical in all three) |

Per-suite failure counts are identical between baseline run 2 and all three fix runs for 17 of the other 18 suites. The one suite that differs, `remove.test.ts` (6 → 8), fails only because a local sandbox guard refuses bulk deletes (`[safe-delete][SAFE_DELETE_BULK_CONFIRM_REQUIRED]`, 50/turn) — run on its own it is 27/27 green with this branch. The remaining spread (29 → 44 between the two baseline runs) is the same machine noise, with nothing attributable to this change.

Not covered: I did not run the real CLI end-to-end for the two repros; the evidence above is from the disk-level unit tests.

Fixes #510
