### PR TITLE
fix(providers): resolve and launch the gh/cnb CLIs portably

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### 🐛 Bug Fixes
 
+- The GitHub and CNB providers resolve their CLI to a launchable absolute path and start it through cross-spawn, so on Windows they no longer answer "installed" while every call fails silently ([#520](https://github.com/Tencent/teamai-cli/pull/520)).
 - `enabledAgents` now also gates CLI builtin deploy, CLAUDE.md-class injects, and last-pull skip-sync targets, so an already-installed tool outside the whitelist is not written to ([#510](https://github.com/Tencent/teamai-cli/issues/510)).
 - `teamai status` counts rule files in subdirectories recursively ([#437](https://github.com/Tencent/teamai-cli/pull/437)).
 - Codex Stop-phase contribution hints are deferred to the next prompt, so the host no longer rejects `additionalContext` ([#441](https://github.com/Tencent/teamai-cli/pull/441)).

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -303,6 +303,17 @@ reviewers:
   - bob
 ```
 
+## CLI 解析与启动（跨平台）
+
+GitHub 与 CNB 两个 provider 都把操作委托给平台自己的 CLI，因此二者共用同一套解析与启动逻辑（[`src/utils/cli-path.ts`](../src/utils/cli-path.ts)）：
+
+- **解析**：`resolveCliPath(cmd)` 在 Windows 上走原生 `where`，在 macOS / Linux 上依次尝试 `bash -lc` → `zsh -lc` → `which`，返回一个**存在且可启动**的绝对路径；找不到时返回 `null`。
+  - Windows 上不能用 `which`：它来自 Git Bash / WSL，返回 MSYS 风格路径（如 `/c/Program Files/GitHub CLI/gh`），Node 会把 `/c/...` 当成 `C:\c\...`，于是 `existsSync` 恒为 false、`spawn` 报 ENOENT。表现为 `isGhInstalled()` 回答"已安装"，而每次 `ghExec()` 都以 status 1 + **空 stderr** 静默失败。
+  - `where` 的输出里，npm 生成的不带扩展名的 shim 往往排在 `.cmd` 之前；`pickWindowsCommand()` 只接受 `.exe` / `.cmd` / `.bat`，因为无扩展名的文件 CreateProcess 无法启动。
+- **启动**：解析出的绝对路径交给 `cross-spawn` 启动。Node 原生 `spawn` 无法直接执行 `.cmd`（报 `EINVAL`）——`cnb` 由 npm 安装，在 Windows 上只有 `.cmd` / `.ps1`、没有 `.exe`，所以"能解析"和"能启动"必须同时成立；CLI 缺失时返回 127 并在 stderr 里说明原因，不再静默返回 status 1。
+
+TGit 的 `gf` CLI 是例外：它只支持 macOS / Linux，且其路径会作为参数传给 `bash -c`，因此保留原样。
+
 ## 新增 Provider
 
 Provider 是一个 TypeScript 接口（见 [`src/providers/types.ts`](../src/providers/types.ts)），新增带平台 API 能力的 GitLab / Bitbucket / Gitea provider 只需要：

--- a/src/__tests__/cli-path.test.ts
+++ b/src/__tests__/cli-path.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────
+// The resolver shells out (`where` on Windows, `bash -lc` / `which` elsewhere)
+// and then checks that the result exists. Both are mocked so the cases behave
+// identically on every runner — CI only runs ubuntu / macos, which is exactly
+// how this class of defect stays invisible.
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+  spawnSync: vi.fn(),
+}));
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+}));
+
+// Both wrappers launch through cross-spawn: a resolved `.cmd` shim (npm's only
+// Windows entry point for cnb) cannot be spawned directly. gh normally ships as
+// a native `gh.exe`, but `pickWindowsCommand` accepts `.cmd` as well, so the
+// launcher has to be able to run what the resolver may return.
+vi.mock('cross-spawn', () => ({
+  default: Object.assign(vi.fn(), { sync: vi.fn() }),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  log: { info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), dim: vi.fn() },
+  spinner: () => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    info: vi.fn().mockReturnThis(),
+    warn: vi.fn().mockReturnThis(),
+  }),
+}));
+
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import crossSpawn from 'cross-spawn';
+import { pickWindowsCommand, resolveCliPath } from '../utils/cli-path.js';
+import { ghExec, isGhInstalled } from '../providers/github/gh-cli.js';
+import { cnbExec, isCnbInstalled } from '../providers/cnb/cnb-cli.js';
+
+const mockedExecFileSync = execFileSync as Mock;
+const mockedExistsSync = existsSync as Mock;
+const mockedCrossSpawnSync = crossSpawn.sync as unknown as Mock;
+
+const GH_EXE = 'C:\\Program Files\\GitHub CLI\\gh.exe';
+const CNB_SHIM = 'C:\\Users\\me\\AppData\\Roaming\\npm\\cnb.cmd';
+
+/**
+ * Every CLI wrapper must launch the path `resolveCliPath` returns instead of the
+ * bare command name. On Windows `which <cmd>` prints an MSYS path
+ * (`/c/Program Files/GitHub CLI/gh`) which Node turns into
+ * `C:\c\Program Files\...` — spawn answers ENOENT, and a bare name is no better
+ * for npm-installed tools, whose only launchable entry is a `.cmd` shim.
+ */
+describe('resolveCliPath', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedExistsSync.mockReturnValue(true);
+  });
+
+  it('uses `where` on Windows and returns a launchable path', () => {
+    mockedExecFileSync.mockReturnValue(`${GH_EXE}\r\n`);
+    expect(resolveCliPath('gh', 'win32')).toBe(GH_EXE);
+    expect(mockedExecFileSync).toHaveBeenCalledWith('where', ['gh'], expect.anything());
+  });
+
+  it('rejects the MSYS path `which` prints on Windows', () => {
+    // The exact string the old `execSync('which gh')` handed to spawnSync.
+    expect(pickWindowsCommand('/c/Program Files/GitHub CLI/gh')).toBeNull();
+  });
+
+  it('prefers a real executable over the extension-less shim listed first', () => {
+    const out = 'C:\\npm\\gh\r\nC:\\npm\\gh.cmd\r\nC:\\npm\\gh.ps1\r\n';
+    expect(pickWindowsCommand(out)).toBe('C:\\npm\\gh.cmd');
+  });
+
+  it('falls through bash → zsh on POSIX', () => {
+    mockedExecFileSync
+      .mockImplementationOnce(() => { throw new Error('no bash'); })
+      .mockImplementationOnce(() => '/opt/homebrew/bin/gh\n');
+    expect(resolveCliPath('gh', 'darwin')).toBe('/opt/homebrew/bin/gh');
+  });
+
+  it('returns null when the tool is absent', () => {
+    mockedExecFileSync.mockImplementation(() => { throw new Error('not found'); });
+    expect(resolveCliPath('gh', 'win32')).toBeNull();
+    expect(resolveCliPath('gh', 'linux')).toBeNull();
+  });
+
+  it('returns null when the resolved path does not exist', () => {
+    mockedExecFileSync.mockReturnValue('/usr/local/bin/gh\n');
+    mockedExistsSync.mockReturnValue(false);
+    expect(resolveCliPath('gh', 'linux')).toBeNull();
+  });
+});
+
+describe('gh-cli launches the resolved executable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedExistsSync.mockReturnValue(true);
+    mockedCrossSpawnSync.mockReturnValue({ status: 0, stdout: 'gh version 2.0.0\n', stderr: '' });
+  });
+
+  it('starts the resolved path through cross-spawn', () => {
+    mockedExecFileSync.mockReturnValue(`${GH_EXE}\r\n`);
+    const r = ghExec(['--version']);
+    expect(mockedCrossSpawnSync).toHaveBeenCalledWith(GH_EXE, ['--version'], expect.anything());
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe('gh version 2.0.0');
+  });
+
+  it('forwards inheritStdio through cross-spawn', () => {
+    mockedExecFileSync.mockReturnValue(`${GH_EXE}\r\n`);
+    ghExec(['auth', 'status'], { inheritStdio: true });
+    expect(mockedCrossSpawnSync).toHaveBeenCalledWith(
+      GH_EXE, ['auth', 'status'], expect.objectContaining({ stdio: 'inherit' }),
+    );
+  });
+
+  it('reports gh as installed exactly when the resolver finds it', () => {
+    mockedExecFileSync.mockImplementation(() => { throw new Error('missing'); });
+    expect(isGhInstalled()).toBe(false);
+
+    mockedExecFileSync.mockReturnValue(`${GH_EXE}\r\n`);
+    expect(isGhInstalled()).toBe(true);
+  });
+});
+
+describe('cnb-cli launches the resolved executable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedExistsSync.mockReturnValue(true);
+    mockedCrossSpawnSync.mockReturnValue({ status: 0, stdout: '', stderr: '' });
+  });
+
+  it('starts the resolved .cmd shim through cross-spawn', () => {
+    mockedExecFileSync.mockReturnValue(`${CNB_SHIM}\r\n`);
+    cnbExec(['status']);
+    expect(mockedCrossSpawnSync).toHaveBeenCalledWith(CNB_SHIM, ['status'], expect.anything());
+  });
+
+  it('forwards inheritStdio through cross-spawn', () => {
+    mockedExecFileSync.mockReturnValue(`${CNB_SHIM}\r\n`);
+    cnbExec(['login'], { inheritStdio: true });
+    expect(mockedCrossSpawnSync).toHaveBeenCalledWith(
+      CNB_SHIM, ['login'], expect.objectContaining({ stdio: 'inherit' }),
+    );
+  });
+
+  it('returns 127 with an explicit message rather than a bare status 1', () => {
+    mockedExecFileSync.mockImplementation(() => { throw new Error('missing'); });
+    const r = cnbExec(['status']);
+    expect(r.status).toBe(127);
+    expect(r.stderr).toMatch(/not found on PATH/);
+    expect(mockedCrossSpawnSync).not.toHaveBeenCalled();
+  });
+
+  it('isCnbInstalled follows the resolver', () => {
+    mockedExecFileSync.mockImplementation(() => { throw new Error('missing'); });
+    expect(isCnbInstalled()).toBe(false);
+
+    mockedExecFileSync.mockReturnValue(`${CNB_SHIM}\r\n`);
+    expect(isCnbInstalled()).toBe(true);
+  });
+});

--- a/src/__tests__/cnb-login-host.test.ts
+++ b/src/__tests__/cnb-login-host.test.ts
@@ -1,11 +1,28 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-// cnbLogin spawns the real `cnb` binary; stub child_process so we can assert the
-// exact argv without touching the network.
-const spawnSync = vi.fn();
-vi.mock('node:child_process', () => ({
-  spawnSync: (...args: unknown[]) => spawnSync(...args),
-  execSync: vi.fn(),
+// cnbLogin launches the `cnb` CLI through the shared resolver + cross-spawn
+// (see providers/cnb/cnb-cli.ts). On Windows the npm-installed CLI is only a
+// `.cmd` shim, so a bare `spawnSync('cnb', ...)` — the call this file used to
+// stub — is precisely what cannot work there. Both layers are stubbed instead,
+// so the cases keep asserting the exact argv without touching the network.
+//
+// The stubs stay as plain outer consts rather than `vi.fn()` created inside the
+// factory: the cases call `vi.resetModules()` to re-evaluate CNB_HOST, which
+// re-runs each factory, and an instance created inside would no longer be the
+// one the assertions hold a reference to.
+const RESOLVED_CNB = '/opt/npm/bin/cnb';
+
+const crossSpawnSync = vi.fn();
+vi.mock('cross-spawn', () => ({
+  default: { sync: (...args: unknown[]) => crossSpawnSync(...args) },
+}));
+
+// Returning a path rather than the bare name is what makes the assertions prove
+// the exec went through the resolver: `expect(cmd).toBe('cnb')` would also pass
+// for a direct spawn of the command name, i.e. the bug.
+const resolveCliPathMock = vi.fn(() => RESOLVED_CNB);
+vi.mock('../utils/cli-path.js', () => ({
+  resolveCliPath: (...args: unknown[]) => resolveCliPathMock(...args),
 }));
 
 vi.mock('../utils/logger.js', () => ({
@@ -21,8 +38,10 @@ vi.mock('../utils/logger.js', () => ({
 
 describe('cnbLogin pins the platform host', () => {
   beforeEach(() => {
-    spawnSync.mockReset();
-    spawnSync.mockReturnValue({ status: 0, stdout: '', stderr: '' });
+    crossSpawnSync.mockReset();
+    crossSpawnSync.mockReturnValue({ status: 0, stdout: '', stderr: '' });
+    resolveCliPathMock.mockReset();
+    resolveCliPathMock.mockReturnValue(RESOLVED_CNB);
     delete process.env.TEAMAI_CNB_HOST;
     vi.resetModules();
   });
@@ -34,9 +53,9 @@ describe('cnbLogin pins the platform host', () => {
   it('passes --host cnb.cool so login ignores the current dir git remote', async () => {
     const { cnbLogin } = await import('../providers/cnb/cnb-cli.js');
     cnbLogin();
-    expect(spawnSync).toHaveBeenCalledTimes(1);
-    const [cmd, args] = spawnSync.mock.calls[0];
-    expect(cmd).toBe('cnb');
+    expect(crossSpawnSync).toHaveBeenCalledTimes(1);
+    const [cmd, args] = crossSpawnSync.mock.calls[0];
+    expect(cmd).toBe(RESOLVED_CNB);
     expect(args).toEqual(['login', '--host', 'cnb.cool']);
   });
 
@@ -44,7 +63,14 @@ describe('cnbLogin pins the platform host', () => {
     process.env.TEAMAI_CNB_HOST = 'cnb.internal.example.com';
     const { cnbLogin } = await import('../providers/cnb/cnb-cli.js');
     cnbLogin();
-    const [, args] = spawnSync.mock.calls[0];
+    const [, args] = crossSpawnSync.mock.calls[0];
     expect(args).toEqual(['login', '--host', 'cnb.internal.example.com']);
+  });
+
+  it('fails loudly when the cnb CLI is not on PATH', async () => {
+    resolveCliPathMock.mockReturnValue(null);
+    const { cnbLogin } = await import('../providers/cnb/cnb-cli.js');
+    expect(() => cnbLogin()).toThrow(/cnb login failed/);
+    expect(crossSpawnSync).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/cnb-login-host.test.ts
+++ b/src/__tests__/cnb-login-host.test.ts
@@ -12,7 +12,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // one the assertions hold a reference to.
 const RESOLVED_CNB = '/opt/npm/bin/cnb';
 
-const crossSpawnSync = vi.fn();
+const crossSpawnSync = vi.fn<(...args: unknown[]) => unknown>();
 vi.mock('cross-spawn', () => ({
   default: { sync: (...args: unknown[]) => crossSpawnSync(...args) },
 }));
@@ -20,7 +20,7 @@ vi.mock('cross-spawn', () => ({
 // Returning a path rather than the bare name is what makes the assertions prove
 // the exec went through the resolver: `expect(cmd).toBe('cnb')` would also pass
 // for a direct spawn of the command name, i.e. the bug.
-const resolveCliPathMock = vi.fn(() => RESOLVED_CNB);
+const resolveCliPathMock = vi.fn<(...args: unknown[]) => string | null>(() => RESOLVED_CNB);
 vi.mock('../utils/cli-path.js', () => ({
   resolveCliPath: (...args: unknown[]) => resolveCliPathMock(...args),
 }));

--- a/src/__tests__/e2e/providers-cli-path.test.ts
+++ b/src/__tests__/e2e/providers-cli-path.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { resolveCliPath } from '../../utils/cli-path.js';
+import { ghExec, isGhInstalled } from '../../providers/github/gh-cli.js';
+import { cnbExec, isCnbInstalled } from '../../providers/cnb/cnb-cli.js';
+
+/**
+ * Real-PATH integration test for the provider CLI wrappers — no `vi.mock`.
+ *
+ * The unit suite (`src/__tests__/cli-path.test.ts`) stubs the resolver, so it can
+ * prove the *logic* but never that a resolved path is actually launchable, and
+ * that gap is exactly where the bug lived: `isGhInstalled()` answered "installed"
+ * while every `ghExec()` returned status 1 with an empty stderr, because the
+ * resolved path was an MSYS path Node cannot spawn.
+ *
+ * These tests plant real executables in a temp dir, prepend it to PATH, and drive
+ * the real resolver + launcher. Both an extensionless POSIX shim and a `.cmd`
+ * shim are written, the way `npm install -g` does on Windows, so the picker has a
+ * wrong candidate to skip.
+ *
+ * Run with `npm run test:e2e`. This directory is excluded from the default
+ * `vitest run` (see `vitest.config.ts`), and `ci.yml` only runs the single e2e
+ * file it names explicitly — so this is not CI-gated. That is deliberate: the CI
+ * matrix has no Windows runner, and the `.cmd` branch can only be exercised on
+ * Windows. Run it there.
+ */
+const MARKER = 'teamai-fake-cli';
+
+let binDir: string;
+let originalPath: string | undefined;
+
+function sameDir(a: string, b: string): boolean {
+  const norm = (p: string) => path.resolve(p).replace(/[\\/]+$/, '');
+  return process.platform === 'win32'
+    ? norm(a).toLowerCase() === norm(b).toLowerCase()
+    : norm(a) === norm(b);
+}
+
+/** Write the two shims `npm install -g` drops on Windows, plus the POSIX one. */
+function writeShims(name: string): void {
+  const posix = path.join(binDir, name);
+  fs.writeFileSync(posix, `#!/bin/sh\necho "${MARKER} 1.2.3"\n`);
+  fs.chmodSync(posix, 0o755);
+  fs.writeFileSync(path.join(binDir, `${name}.cmd`), `@echo off\r\necho ${MARKER} 1.2.3\r\n`);
+}
+
+/**
+ * The planted shim is what the PATH scan finds on Windows and Linux. On macOS a
+ * machine-wide install can win instead — `bash -lc` goes through `path_helper`,
+ * which rebuilds PATH from `/etc/paths*` and drops the prepended dir — so assert
+ * the strict marker only when our own shim is the resolved one; otherwise assert
+ * the weaker but still regression-relevant "it launched and said something".
+ */
+function expectLaunched(
+  result: { stdout: string; stderr: string; status: number },
+  resolved: string | null,
+): void {
+  expect(result.status, `status=${result.status} stderr=${result.stderr}`).toBe(0);
+  if (resolved !== null && sameDir(path.dirname(resolved), binDir)) {
+    expect(result.stdout).toContain(MARKER);
+  } else {
+    expect(result.stdout.length, `resolved=${resolved}`).toBeGreaterThan(0);
+  }
+}
+
+beforeEach(() => {
+  binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-provider-cli-'));
+  originalPath = process.env.PATH;
+  process.env.PATH = `${binDir}${path.delimiter}${originalPath ?? ''}`;
+});
+
+afterEach(() => {
+  if (originalPath === undefined) delete process.env.PATH;
+  else process.env.PATH = originalPath;
+  fs.rmSync(binDir, { recursive: true, force: true });
+});
+
+describe('resolveCliPath against the real PATH', () => {
+  it('resolves a PATH-prepended executable to an absolute path that exists', () => {
+    // A name no machine-wide install can shadow, so the assertion is deterministic
+    // on every platform: the only candidate is the shim we just planted.
+    writeShims('teamai-probe-cli');
+    const resolved = resolveCliPath('teamai-probe-cli');
+    expect(resolved, 'planted shim was not found on PATH').not.toBeNull();
+    expect(sameDir(path.dirname(resolved!), binDir)).toBe(true);
+    // The original bug resolved to a path that failed this check, which is why
+    // detection said "installed" while the launcher got ENOENT.
+    expect(fs.existsSync(resolved!)).toBe(true);
+  });
+
+  it.skipIf(process.platform !== 'win32')(
+    "prefers the .cmd sibling over the extensionless npm shim, which CreateProcess cannot launch",
+    () => {
+      writeShims('teamai-probe-cli');
+      const resolved = resolveCliPath('teamai-probe-cli');
+      expect(resolved!.toLowerCase().endsWith('.cmd')).toBe(true);
+      expect(resolved!.toLowerCase().endsWith(`${path.sep}teamai-probe-cli.cmd`)).toBe(true);
+    },
+  );
+
+  it('returns null for a command that is not on PATH', () => {
+    expect(resolveCliPath('teamai-definitely-absent-cmd')).toBeNull();
+  });
+});
+
+describe('the gh and cnb wrappers launch what they resolve', () => {
+  it('ghExec does not fail silently', () => {
+    writeShims('gh');
+    expect(isGhInstalled()).toBe(true);
+    expectLaunched(ghExec(['--version']), resolveCliPath('gh'));
+  });
+
+  it('cnbExec does not fail silently', () => {
+    writeShims('cnb');
+    expect(isCnbInstalled()).toBe(true);
+    expectLaunched(cnbExec(['status']), resolveCliPath('cnb'));
+  });
+});

--- a/src/__tests__/github-provider.test.ts
+++ b/src/__tests__/github-provider.test.ts
@@ -3,8 +3,14 @@ import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vite
 // ─── Mocks ──────────────────────────────────────────────
 
 vi.mock('node:child_process', () => ({
-  execSync: vi.fn(),
   spawnSync: vi.fn(),
+}));
+
+// gh-cli resolves the CLI through utils/cli-path.js. Tests used to fake "gh not
+// installed" by making execSync('which gh') throw; the seam is now the resolver,
+// so drive that instead (default: not installed, see beforeEach blocks).
+vi.mock('../utils/cli-path.js', () => ({
+  resolveCliPath: vi.fn(),
 }));
 
 vi.mock('../utils/logger.js', () => ({
@@ -27,7 +33,7 @@ vi.mock('../utils/logger.js', () => ({
 
 // ─── Imports after mocks ────────────────────────────────
 
-import { execSync, spawnSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import { parseGitHubRepoInput } from '../providers/github/repo-url.js';
 import {
   ghPrCreate,
@@ -37,11 +43,12 @@ import {
   getGitHubToken,
   RepoNotFoundError,
 } from '../providers/github/gh-cli.js';
+import { resolveCliPath } from '../utils/cli-path.js';
 import { detectProvider, getProvider } from '../providers/registry.js';
 import { GitHubProvider } from '../providers/github/index.js';
 
-const mockedExecSync = execSync as Mock;
 const mockedSpawnSync = spawnSync as Mock;
+const mockedResolveCliPath = resolveCliPath as Mock;
 
 // ─── repo-url parsing ───────────────────────────────────
 
@@ -145,7 +152,7 @@ describe('ghIsAuthenticated', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockedExecSync.mockReset();
+    mockedResolveCliPath.mockReturnValue(null);
   });
 
   afterEach(() => {
@@ -160,9 +167,6 @@ describe('ghIsAuthenticated', () => {
   it('returns false when no gh, no token', () => {
     delete process.env.GITHUB_TOKEN;
     delete process.env.GH_TOKEN;
-    mockedExecSync.mockImplementation(() => {
-      throw new Error('command not found: gh');
-    });
     expect(ghIsAuthenticated()).toBe(false);
   });
 });
@@ -175,11 +179,8 @@ describe('ghRepoClone', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockedSpawnSync.mockReset();
-    mockedExecSync.mockReset();
-    // no gh CLI, no token by default
-    mockedExecSync.mockImplementation(() => {
-      throw new Error('not found');
-    });
+    mockedResolveCliPath.mockReturnValue(null);
+    // no gh CLI (resolver -> null), no token by default
     delete process.env.GITHUB_TOKEN;
     delete process.env.GH_TOKEN;
   });
@@ -225,7 +226,7 @@ describe('ghCreateRepo', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockedExecSync.mockReset();
+    mockedResolveCliPath.mockReturnValue(null);
     process.env.GITHUB_TOKEN = 'ghp_test';
   });
 
@@ -282,9 +283,6 @@ describe('ghCreateRepo', () => {
   it('throws when no token is available', async () => {
     delete process.env.GITHUB_TOKEN;
     delete process.env.GH_TOKEN;
-    mockedExecSync.mockImplementation(() => {
-      throw new Error('not found');
-    });
 
     await expect(ghCreateRepo('teamai', 'cli')).rejects.toThrow(/Cannot retrieve GitHub token/);
   });
@@ -298,11 +296,8 @@ describe('ghPrCreate via REST API', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockedExecSync.mockReset();
-    // no gh CLI → should use API
-    mockedExecSync.mockImplementation(() => {
-      throw new Error('not found');
-    });
+    mockedResolveCliPath.mockReturnValue(null);
+    // no gh CLI (resolver -> null) → should use API
     process.env.GITHUB_TOKEN = 'ghp_test';
   });
 

--- a/src/providers/cnb/cnb-cli.ts
+++ b/src/providers/cnb/cnb-cli.ts
@@ -1,14 +1,25 @@
 import { execSync, spawnSync } from 'node:child_process';
+import crossSpawn from 'cross-spawn';
 import { log, spinner } from '../../utils/logger.js';
+import { resolveCliPath } from '../../utils/cli-path.js';
 import type { RepoInfo } from '../types.js';
 
 /**
  * Thin wrapper around the CNB (cnb.cool) OpenAPI CLI — `@cnbcool/cnb-cli`.
  *
  * Mirrors the shape of tgit/gf-cli.ts: delegate auth + repo + PR operations to
- * the platform's own CLI. CNB's CLI is a plain binary (not a bash launcher), so
- * we invoke it via spawnSync with an args array — no shell, so repo paths /
- * branch names / titles cannot inject shell metacharacters.
+ * the platform's own CLI. Arguments are passed as an array and never through a
+ * shell string, so repo paths / branch names / titles cannot inject shell
+ * metacharacters. Two Windows details decide how we launch it:
+ *
+ *   - the package is `bin: { cnb: 'bin/cnb.js' }`, so npm only writes
+ *     `cnb.cmd` / `cnb.ps1` shims on Windows — there is no `cnb.exe`;
+ *   - a bare `cnb` therefore fails with ENOENT, and handing the resolved
+ *     `cnb.cmd` to `child_process.spawnSync` fails with EINVAL.
+ *
+ * `cross-spawn` handles both cases (same reason `utils/ai-client.ts` uses it),
+ * while `resolveCliPath` keeps "is it installed?" and "can we run it?" based on
+ * the same answer.
  *
  * Auth has two paths, matching how the GitHub provider treats GITHUB_TOKEN:
  *   - Interactive (dev laptop): `cnb login` (OAuth2 device flow) stores a token;
@@ -32,12 +43,23 @@ export function cnbExec(
   args: string[],
   options?: { inheritStdio?: boolean; cwd?: string },
 ): { stdout: string; stderr: string; status: number } {
-  log.debug(`cnb exec: cnb ${args.join(' ')}`);
+  // Resolve the executable first, then launch it through cross-spawn: on
+  // Windows the npm-installed CLI is only a `.cmd` shim, which neither a bare
+  // name (ENOENT) nor a direct child_process.spawnSync (EINVAL) can start. That
+  // used to come back as status 1 with an empty stderr, so cnbIsAuthenticated()
+  // reported "not logged in" for a perfectly installed CLI.
+  const cnbPath = resolveCliPath('cnb');
+  if (!cnbPath) {
+    log.debug('cnb CLI not found on PATH');
+    return { stdout: '', stderr: 'cnb CLI not found on PATH', status: 127 };
+  }
+
+  log.debug(`cnb exec: ${cnbPath} ${args.join(' ')}`);
   if (options?.inheritStdio) {
-    const r = spawnSync('cnb', args, { stdio: 'inherit', env: { ...process.env }, cwd: options.cwd });
+    const r = crossSpawn.sync(cnbPath, args, { stdio: 'inherit', env: { ...process.env }, cwd: options.cwd });
     return { stdout: '', stderr: '', status: r.status ?? 1 };
   }
-  const r = spawnSync('cnb', args, {
+  const r = crossSpawn.sync(cnbPath, args, {
     env: { ...process.env },
     encoding: 'utf-8',
     maxBuffer: 10 * 1024 * 1024,
@@ -69,12 +91,7 @@ export function assertCnbApiOk(out: string, action: string): void {
 // ─── Installation ────────────────────────────────────────
 
 export function isCnbInstalled(): boolean {
-  try {
-    execSync('which cnb', { stdio: ['pipe', 'pipe', 'pipe'] });
-    return true;
-  } catch {
-    return false;
-  }
+  return resolveCliPath('cnb') !== null;
 }
 
 /** Ensure the CNB CLI is available; install globally via npm if missing. */

--- a/src/providers/github/gh-cli.ts
+++ b/src/providers/github/gh-cli.ts
@@ -1,5 +1,7 @@
-import { execSync, spawnSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
+import crossSpawn from 'cross-spawn';
 import { log, spinner } from '../../utils/logger.js';
+import { resolveCliPath } from '../../utils/cli-path.js';
 
 // ─── Constants ───────────────────────────────────────────
 
@@ -14,18 +16,18 @@ function shellQuote(s: string): string {
 
 // ─── gh CLI detection ────────────────────────────────────
 
-/** Returns the full path to gh if available on PATH, else null. */
+/**
+ * Absolute path to the `gh` executable if available on PATH, else null.
+ *
+ * Not `which gh`: on Windows that lands on Git's `which`, which prints an MSYS
+ * path (`/c/Program Files/GitHub CLI/gh`) that Node resolves as
+ * `C:\c\Program Files\...` — `spawnSync` then fails with ENOENT, i.e.
+ * `isGhInstalled()` answered "installed" while every `ghExec()` returned
+ * status 1 with an empty stderr. `resolveCliPath` uses the native `where` on
+ * Windows and accepts only a launchable path (`.exe` / `.cmd` / `.bat`).
+ */
 function getGhPath(): string | null {
-  try {
-    const which = execSync('which gh', {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    const trimmed = which.trim();
-    return trimmed || null;
-  } catch {
-    return null;
-  }
+  return resolveCliPath('gh');
 }
 
 /** Check whether the gh CLI is installed and on PATH. */
@@ -36,6 +38,12 @@ export function isGhInstalled(): boolean {
 /**
  * Execute a gh CLI command.
  * Returns { stdout, stderr, status }.
+ *
+ * Launches through cross-spawn rather than the native `spawnSync`, for the same
+ * reason `callClaude` does: a `gh` that npm installed is a `.cmd` shim, and Node
+ * cannot execute `.cmd` directly (EINVAL). Resolving the path alone is not
+ * enough — `pickWindowsCommand` accepts `.cmd`, so the launcher has to be able
+ * to run what it resolves.
  */
 export function ghExec(
   args: string[],
@@ -51,7 +59,7 @@ export function ghExec(
   log.debug(`gh exec: ${ghPath} ${args.join(' ')}`);
 
   if (options?.inheritStdio) {
-    const result = spawnSync(ghPath, args, {
+    const result = crossSpawn.sync(ghPath, args, {
       stdio: 'inherit',
       env: { ...process.env, ...(options.env ?? {}) },
       cwd: options.cwd,
@@ -59,7 +67,7 @@ export function ghExec(
     return { stdout: '', stderr: '', status: result.status ?? 1 };
   }
 
-  const result = spawnSync(ghPath, args, {
+  const result = crossSpawn.sync(ghPath, args, {
     env: { ...process.env, ...(options?.env ?? {}) },
     encoding: 'utf-8',
     maxBuffer: 10 * 1024 * 1024,

--- a/src/utils/ai-client.ts
+++ b/src/utils/ai-client.ts
@@ -1,23 +1,18 @@
-import { execFileSync } from 'node:child_process';
 import spawn from 'cross-spawn';
-import { existsSync } from 'node:fs';
 import { log } from './logger.js';
+import { resolveCliPath } from './cli-path.js';
 
 /** 白名单：允许探测的 CLI 名称，防止意外执行任意命令。 */
 const ALLOWED_CLI_CANDIDATES = [
   'claude', 'claude-internal', 'tclaude', 'codex', 'codex-internal', 'tcodex', 'codebuddy', 'workbuddy', 'openclaw',
 ] as const;
 
-/** CLI 探测超时（毫秒），防止 execFileSync 挂死。 */
-const CLI_DETECT_TIMEOUT_MS = 5_000;
-
 /**
- * 可按扩展名直接启动的 Windows 可执行后缀，按 PATHEXT 优先级排列。
- *
- * `npm install -g` 在 Windows 上同时生成三个 shim：无扩展名的 POSIX 脚本、
- * `<cmd>.cmd`、`<cmd>.ps1`。无扩展名的那个 CreateProcess 无法启动。
+ * 命令探测（`resolveCliPath` / `pickWindowsCommand`）已抽到 `utils/cli-path.ts`，
+ * provider 的 CLI 包装层（gh / cnb）与本文件共用同一套解析逻辑。
+ * 这里保留再导出，既有 import 不受影响。
  */
-const WIN_EXEC_EXTENSIONS = ['.exe', '.cmd', '.bat'] as const;
+export { pickWindowsCommand, resolveCliPath } from './cli-path.js';
 
 /**
  * 默认 AI 调用超时时间（毫秒）。
@@ -36,127 +31,6 @@ interface CliInfo {
   absPath: string;
 }
 
-/**
- * 从 `where <cmd>` 的输出中挑出可启动的那一条。
- *
- * `where` 会列出所有匹配项，且顺序上无扩展名的 POSIX shim 往往排在前面
- * （例如 `C:\npm\claude` 先于 `C:\npm\claude.cmd`）。无扩展名的文件
- * CreateProcess 无法启动，因此这里只接受可执行后缀。
- *
- * @param whereOutput  `where <cmd>` 的原始 stdout
- * @returns            首个可启动路径；没有可执行后缀时返回 null
- */
-export function pickWindowsCommand(whereOutput: string): string | null {
-  const lines = whereOutput
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
-
-  for (const ext of WIN_EXEC_EXTENSIONS) {
-    const hit = lines.find((line) => line.toLowerCase().endsWith(ext));
-    if (hit !== undefined) return hit;
-  }
-  return null;
-}
-
-/**
- * 用 Windows 原生命令 `where` 解析候选 CLI，返回真正的 Windows 路径。
- *
- * `where` 是 `which` 的 Windows 原生等价物，返回 `C:\...\claude.cmd` 这类
- * Windows API 能识别的路径。
- *
- * @param cmd  候选命令名
- * @returns    存在且可启动的绝对路径；未安装时返回 null
- */
-function whereOnWindows(cmd: string): string | null {
-  try {
-    const out = execFileSync('where', [cmd], {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-      shell: false,
-      timeout: CLI_DETECT_TIMEOUT_MS,
-    });
-    const p = pickWindowsCommand(out);
-    return p !== null && existsSync(p) ? p : null;
-  } catch {
-    // where 未找到时退出码非 0（stderr 为 "INFO: Could not find files..."），走这里
-    return null;
-  }
-}
-
-/**
- * POSIX 侧的策略链，依次尝试各 shell 环境，返回第一个解析成功且真实存在的路径：
- *   1. `bash -lc command -v <cmd>` —— login shell，覆盖 ~/.nvm/ 等路径
- *   2. `zsh -lc command -v <cmd>`  —— macOS 默认 shell fallback
- *   3. `which <cmd>` —— 最终 fallback，使用 process.env.PATH 直接查找
- *
- * @param cmd  候选命令名
- * @returns    存在的绝对路径；三种策略都失败时返回 null
- */
-function whichOnPosix(cmd: string): string | null {
-  // 策略 1：bash login shell（shell: false 是 execFileSync 默认行为，此处显式标注）
-  try {
-    const p = execFileSync('bash', ['-lc', `command -v ${cmd}`], {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-      shell: false,
-      timeout: CLI_DETECT_TIMEOUT_MS,
-    }).trim();
-    if (p && existsSync(p)) return p;
-  } catch {
-    // 继续尝试下一策略
-  }
-
-  // 策略 2：zsh login shell（macOS 默认 shell / bash 不可用时）
-  try {
-    const p = execFileSync('zsh', ['-lc', `command -v ${cmd}`], {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-      shell: false,
-      timeout: CLI_DETECT_TIMEOUT_MS,
-    }).trim();
-    if (p && existsSync(p)) return p;
-  } catch {
-    // 继续尝试下一策略
-  }
-
-  // 策略 3：which 命令（使用 process.env.PATH，覆盖 fish / CI 容器等环境）
-  try {
-    const p = execFileSync('which', [cmd], {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-      shell: false,
-      timeout: CLI_DETECT_TIMEOUT_MS,
-    }).trim();
-    if (p && existsSync(p)) return p;
-  } catch {
-    // 三种策略都不可用
-  }
-
-  return null;
-}
-
-/**
- * 把候选 CLI 命令名解析为存在的绝对路径。
- *
- * Windows 上必须走 `where`：`bash` / `which` 在 Windows 上来自 Git Bash 或 WSL，
- * 返回的是 MSYS 风格路径（如 `/c/Users/me/AppData/Roaming/npm/claude`），
- * Node 对这类路径 `existsSync` 恒为 false，spawn 也无法启动，所以 POSIX 策略在
- * Windows 上永远不可能成功（WSL 的 bash 更会返回完全不可用的 Linux 路径）。
- *
- * `platform` 之所以可注入，是因为仓库 CI 只跑 ubuntu / macos：写死 process.platform
- * 的话 Windows 分支将没有任何测试覆盖（这正是该缺陷长期未被发现的原因）。
- *
- * @param cmd       候选命令名
- * @param platform  目标平台，默认当前进程平台
- * @returns         存在的绝对路径；该平台上不可用时返回 null
- */
-export function resolveCliPath(
-  cmd: string,
-  platform: NodeJS.Platform = process.platform,
-): string | null {
-  return platform === 'win32' ? whereOnWindows(cmd) : whichOnPosix(cmd);
-}
 
 /**
  * 按优先级探测可用的 AI CLI，返回命令名与绝对路径。

--- a/src/utils/cli-path.ts
+++ b/src/utils/cli-path.ts
@@ -1,0 +1,142 @@
+/**
+ * 跨平台命令探测：把一个 CLI 名称解析成"该平台上真正能被 Node 启动"的绝对路径。
+ *
+ * 从 `utils/ai-client.ts` 抽出——同一套坑（Windows 上 `which` 返回 MSYS 路径、
+ * npm shim 无扩展名项排第一）在 provider 的 CLI 包装层（`providers/github/gh-cli.ts`、
+ * `providers/cnb/cnb-cli.ts`）里重复出现，因此收敛到一处。
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+
+/** CLI 探测超时（毫秒），防止 execFileSync 挂死。 */
+export const CLI_DETECT_TIMEOUT_MS = 5_000;
+
+/**
+ * 可按扩展名直接启动的 Windows 可执行后缀，按 PATHEXT 优先级排列。
+ *
+ * `npm install -g` 在 Windows 上同时生成三个 shim：无扩展名的 POSIX 脚本、
+ * `<cmd>.cmd`、`<cmd>.ps1`。无扩展名的那个 CreateProcess 无法启动。
+ */
+export const WIN_EXEC_EXTENSIONS = ['.exe', '.cmd', '.bat'] as const;
+
+/**
+ * 从 `where <cmd>` 的输出中挑出可启动的那一条。
+ *
+ * `where` 会列出所有匹配项，且顺序上无扩展名的 POSIX shim 往往排在前面
+ * （例如 `C:\npm\claude` 先于 `C:\npm\claude.cmd`）。无扩展名的文件
+ * CreateProcess 无法启动，因此这里只接受可执行后缀。
+ *
+ * @param whereOutput  `where <cmd>` 的原始 stdout
+ * @returns            首个可启动路径；没有可执行后缀时返回 null
+ */
+export function pickWindowsCommand(whereOutput: string): string | null {
+  const lines = whereOutput
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  for (const ext of WIN_EXEC_EXTENSIONS) {
+    const hit = lines.find((line) => line.toLowerCase().endsWith(ext));
+    if (hit !== undefined) return hit;
+  }
+  return null;
+}
+
+/**
+ * 用 Windows 原生命令 `where` 解析候选 CLI，返回真正的 Windows 路径。
+ *
+ * `where` 是 `which` 的 Windows 原生等价物，返回 `C:\...\claude.cmd` 这类
+ * Windows API 能识别的路径。
+ *
+ * @param cmd  候选命令名
+ * @returns    存在且可启动的绝对路径；未安装时返回 null
+ */
+function whereOnWindows(cmd: string): string | null {
+  try {
+    const out = execFileSync('where', [cmd], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      shell: false,
+      timeout: CLI_DETECT_TIMEOUT_MS,
+    });
+    const p = pickWindowsCommand(out);
+    return p !== null && existsSync(p) ? p : null;
+  } catch {
+    // where 未找到时退出码非 0（stderr 为 "INFO: Could not find files..."），走这里
+    return null;
+  }
+}
+
+/**
+ * POSIX 侧的策略链，依次尝试各 shell 环境，返回第一个解析成功且真实存在的路径：
+ *   1. `bash -lc command -v <cmd>` —— login shell，覆盖 ~/.nvm/ 等路径
+ *   2. `zsh -lc command -v <cmd>`  —— macOS 默认 shell fallback
+ *   3. `which <cmd>` —— 最终 fallback，使用 process.env.PATH 直接查找
+ *
+ * @param cmd  候选命令名
+ * @returns    存在的绝对路径；三种策略都失败时返回 null
+ */
+function whichOnPosix(cmd: string): string | null {
+  // 策略 1：bash login shell（shell: false 是 execFileSync 默认行为，此处显式标注）
+  try {
+    const p = execFileSync('bash', ['-lc', `command -v ${cmd}`], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      shell: false,
+      timeout: CLI_DETECT_TIMEOUT_MS,
+    }).trim();
+    if (p && existsSync(p)) return p;
+  } catch {
+    // 继续尝试下一策略
+  }
+
+  // 策略 2：zsh login shell（macOS 默认 shell / bash 不可用时）
+  try {
+    const p = execFileSync('zsh', ['-lc', `command -v ${cmd}`], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      shell: false,
+      timeout: CLI_DETECT_TIMEOUT_MS,
+    }).trim();
+    if (p && existsSync(p)) return p;
+  } catch {
+    // 继续尝试下一策略
+  }
+
+  // 策略 3：which 命令（使用 process.env.PATH，覆盖 fish / CI 容器等环境）
+  try {
+    const p = execFileSync('which', [cmd], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      shell: false,
+      timeout: CLI_DETECT_TIMEOUT_MS,
+    }).trim();
+    if (p && existsSync(p)) return p;
+  } catch {
+    // 三种策略都不可用
+  }
+
+  return null;
+}
+
+/**
+ * 把候选 CLI 命令名解析为存在的绝对路径。
+ *
+ * Windows 上必须走 `where`：`bash` / `which` 在 Windows 上来自 Git Bash 或 WSL，
+ * 返回的是 MSYS 风格路径（如 `/c/Users/me/AppData/Roaming/npm/claude`），
+ * Node 对这类路径 `existsSync` 恒为 false，spawn 也无法启动，所以 POSIX 策略在
+ * Windows 上永远不可能成功（WSL 的 bash 更会返回完全不可用的 Linux 路径）。
+ *
+ * `platform` 之所以可注入，是因为仓库 CI 只跑 ubuntu / macos：写死 process.platform
+ * 的话 Windows 分支将没有任何测试覆盖（这正是该缺陷长期未被发现的原因）。
+ *
+ * @param cmd       候选命令名
+ * @param platform  目标平台，默认当前进程平台
+ * @returns         存在的绝对路径；该平台上不可用时返回 null
+ */
+export function resolveCliPath(
+  cmd: string,
+  platform: NodeJS.Platform = process.platform,
+): string | null {
+  return platform === 'win32' ? whereOnWindows(cmd) : whichOnPosix(cmd);
+}


### PR DESCRIPTION
## Summary

The GitHub and CNB provider wrappers locate their CLI in ways that cannot work on Windows — the same class as #496, but in `providers/` instead of `utils/ai-client.ts`. Both now share the resolver that #496 introduced, which was private to `ai-client.ts`.

| file | before | after |
| --- | --- | --- |
| `providers/github/gh-cli.ts` | `execSync('which gh')` → MSYS path → `spawnSync(path)` ENOENT | `resolveCliPath('gh')` → native `where` → `gh.exe` |
| `providers/cnb/cnb-cli.ts` | `spawnSync('cnb', …)` → ENOENT (no `cnb.exe`), and `.cmd` would be EINVAL | `resolveCliPath('cnb')` + `cross-spawn` → `.cmd` shim runs |
| `utils/cli-path.ts` (new) | `resolveCliPath` / `pickWindowsCommand` lived in `ai-client.ts` | shared; `ai-client.ts` re-exports, so its imports and tests are unchanged |
| `utils/ai-client.ts` | owned the resolver | imports + re-exports it |

Deliberately **not** touched: `providers/tgit/gf-cli.ts`. gf supports macOS/Linux only (it throws `Unsupported platform` for anything else) and its MSYS path is consumed by `bash -c`, so switching it to the Windows resolver would break it.

## Repro (real PATH, no mocks, Windows 11)

`gh` installed at `C:\Program Files\GitHub CLI\gh.exe`.

```
[before] old getGhPath() returned      : /c/Program Files/GitHub CLI/gh
[before] pickWindowsCommand(that)      : null
[before] spawnSync(that)               : status=null error=ENOENT
         => isGhInstalled() === true, every ghExec() status 1, stderr ""

[after]  resolveCliPath("gh")          : C:\Program Files\GitHub CLI\gh.exe
[after]  ghExec(["--version"])         : status=0
         stdout="gh version 2.93.0 (2026-05-27)\nhttps://github.com/cli/cli/releases/tag/v2.93.0"
```

For CNB, `@cnbcool/cnb-cli@1.15.20` is `bin: { cnb: 'bin/cnb.js' }` (checked against the registry), so on Windows `PATH` only ever holds `cnb.cmd` / `cnb.ps1` plus an extension-less sh script — no `cnb.exe`. Against a shim laid out exactly that way:

```
[shim] resolveCliPath("cnb") : ...\shimprobe-LbVVng\cnb.cmd
[shim] cnbExec(["status"])   : status=0 stdout="shim-ok"
       child_process.spawnSync(<that .cmd>, …)  -> EINVAL    (why cross-spawn)
       child_process.spawnSync('cnb', …)        -> ENOENT    (the old code)
```

Because the failure was ENOENT/EINVAL with an empty stderr, the user-visible symptom was misleading rather than loud: `isGhInstalled()` / `isCnbInstalled()` said "installed", `cnbIsAuthenticated()` said "not logged in", and `ghExec()` callers saw a bare `status 1` with nothing to print.

## Tests

`src/__tests__/cli-path.test.ts` (new, 12 cases): resolver behaviour with an injected platform (CI has no Windows runner, which is why this class of bug survives), plus the wiring — `ghExec` passes the resolved path to `spawnSync`, `cnbExec` starts the resolved `.cmd` through `cross-spawn` (including `stdio: 'inherit'`), a missing CLI returns 127 with a message, and `isGhInstalled` / `isCnbInstalled` follow the resolver.

`src/__tests__/github-provider.test.ts` used to fake "gh not installed" by making `execSync('which gh')` throw. That seam is gone, so those cases now drive `resolveCliPath` directly (default `null` in each `beforeEach`).

Falsification — reverting only the two call sites (resolver and `ai-client.ts` left in place):

```
cli-path.test.ts::gh-cli launches the resolved executable > passes the resolved path to spawnSync
cli-path.test.ts::gh-cli launches the resolved executable > reports gh as installed exactly when the resolver finds it
cli-path.test.ts::cnb-cli launches the resolved executable > starts the resolved .cmd shim through cross-spawn
cli-path.test.ts::cnb-cli launches the resolved executable > forwards inheritStdio through cross-spawn
cli-path.test.ts::cnb-cli launches the resolved executable > returns 127 with an explicit message rather than a bare status 1
cli-path.test.ts::cnb-cli launches the resolved executable > isCnbInstalled follows the resolver
```

6 of 12 red. The six resolver cases (which do not depend on the call sites) stay green, and the two negative controls — "returns null when the tool is absent", "returns null when the resolved path does not exist" — pass before and after.

## Verification

`npx tsc --noEmit` clean. The 18 suites that import any of the touched modules (271 cases) were run with the fix and with the two call sites reverted:

| | failed |
| --- | --- |
| call sites reverted | 7 |
| with this change | 1 |

The single remaining failure, `maintenance-promote.test.ts > executePromotion dry-run does not create files`, fails in both runs: it asserts a literal `skills/candidate.md` against a Windows `skills\candidate.md`. No regressions.

## Notes

- The `cnb` fix needed both halves: resolving the path is not enough, because a `.cmd` cannot be spawned directly. If you would rather not pull `cross-spawn` into the provider layer, say so and I will split that half out — the `gh` fix is independent and stands on its own.
- `gh` is a native `.exe` (verified `where gh`), so it needs no cross-spawn; only CNB's npm shim does.
