### PR TITLE
fix(agents): honor the enabledAgents whitelist outside the resource handlers

### DIFF
--- a/src/__tests__/agent-whitelist.test.ts
+++ b/src/__tests__/agent-whitelist.test.ts
@@ -1,0 +1,310 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import fse from 'fs-extra';
+
+// ─── Shared fixtures ───────────────────────────────────────
+
+const TEAM_CONFIG = {
+    toolPaths: {
+        claude: {
+            skills: '.claude/skills',
+            rules: '.claude/rules',
+            agents: '.claude/agents',
+            settings: '.claude/settings.json',
+            claudemd: '.claude/CLAUDE.md',
+        },
+        hermes: {
+            skills: '.hermes/skills',
+            rules: '.hermes/rules',
+            agents: '.hermes/agents',
+            claudemd: '.hermes/CLAUDE.md',
+        },
+        // cursor is in ALL_SUPPORTED_TOOLS (unlike hermes), so deployBuiltinAgents
+        // has no format gate to hide behind: it isolates the whitelist check alone.
+        cursor: {
+            skills: '.cursor/skills',
+            rules: '.cursor/rules',
+            agents: '.cursor/agents',
+        },
+    },
+} as any;
+
+/** localConfig with `claude` whitelisted; `hermes` installed but NOT opted in. */
+const WHITELIST_CONFIG = { enabledAgents: ['claude'], disabledAgents: [] } as any;
+
+function installBothTools(home: string): void {
+    for (const dir of [
+        '.claude/skills', '.claude/rules', '.claude/agents',
+        '.hermes/skills', '.hermes/rules', '.hermes/agents',
+        '.cursor/skills', '.cursor/rules', '.cursor/agents',
+    ]) {
+        fs.mkdirSync(path.join(home, dir), { recursive: true });
+    }
+}
+
+// ─── Part A/B: disk-level checks, no mocks ─────────────────
+
+describe('enabledAgents whitelist gates resource writes (issue #510)', () => {
+    let tmpDir: string;
+    let originalHome: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-agent-wl-'));
+        originalHome = process.env.HOME ?? '';
+        process.env.HOME = tmpDir;
+        installBothTools(tmpDir);
+    });
+
+    afterEach(() => {
+        process.env.HOME = originalHome;
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    describe('deployBuiltinSkills', () => {
+        it('deploys builtins into the whitelisted tool', async () => {
+            const { deployBuiltinSkills } = await import('../builtin-skills.js');
+            await deployBuiltinSkills(TEAM_CONFIG, WHITELIST_CONFIG);
+            expect(fs.existsSync(path.join(tmpDir, '.claude', 'skills', 'team-wiki-codebase'))).toBe(true);
+        });
+
+        it('must NOT write builtin skills into an installed tool outside the whitelist', async () => {
+            const { deployBuiltinSkills } = await import('../builtin-skills.js');
+            await deployBuiltinSkills(TEAM_CONFIG, WHITELIST_CONFIG);
+            expect(fs.readdirSync(path.join(tmpDir, '.hermes', 'skills'))).toEqual([]);
+        });
+    });
+
+    describe('deployBuiltinRules', () => {
+        it('deploys builtin rules into the whitelisted tool', async () => {
+            const { deployBuiltinRules } = await import('../builtin-rules.js');
+            await deployBuiltinRules(TEAM_CONFIG, WHITELIST_CONFIG);
+            expect(fs.existsSync(path.join(tmpDir, '.claude', 'rules', 'teamai-recall.md'))).toBe(true);
+        });
+
+        it('must NOT write builtin rules into an installed tool outside the whitelist', async () => {
+            const { deployBuiltinRules } = await import('../builtin-rules.js');
+            await deployBuiltinRules(TEAM_CONFIG, WHITELIST_CONFIG);
+            expect(fs.readdirSync(path.join(tmpDir, '.hermes', 'rules'))).toEqual([]);
+        });
+    });
+
+    describe('deployBuiltinAgents', () => {
+        it('deploys builtin agents into the whitelisted tool', async () => {
+            const { deployBuiltinAgents } = await import('../builtin-agents.js');
+            await deployBuiltinAgents(TEAM_CONFIG, WHITELIST_CONFIG);
+            const deployed = fs.readdirSync(path.join(tmpDir, '.claude', 'agents'));
+            expect(deployed.length).toBeGreaterThan(0);
+        });
+
+        it('must NOT write builtin agents into an installed tool outside the whitelist', async () => {
+            const { deployBuiltinAgents } = await import('../builtin-agents.js');
+            await deployBuiltinAgents(TEAM_CONFIG, WHITELIST_CONFIG);
+            expect(fs.readdirSync(path.join(tmpDir, '.cursor', 'agents'))).toEqual([]);
+        });
+    });
+
+    describe('injectRecallBlockIntoTools', () => {
+        it('injects the recall block into the whitelisted tool CLAUDE.md', async () => {
+            const { injectRecallBlockIntoTools } = await import('../pull.js');
+            const { TEAMAI_RECALL_RULES_START } = await import('../types.js');
+            await injectRecallBlockIntoTools(TEAM_CONFIG, { ...WHITELIST_CONFIG, recallEnabled: true } as any, 'test');
+            expect(fs.readFileSync(path.join(tmpDir, '.claude', 'CLAUDE.md'), 'utf-8')).toContain(TEAMAI_RECALL_RULES_START);
+        });
+
+        it('must NOT inject into an installed tool outside the whitelist', async () => {
+            const { injectRecallBlockIntoTools } = await import('../pull.js');
+            await injectRecallBlockIntoTools(TEAM_CONFIG, { ...WHITELIST_CONFIG, recallEnabled: true } as any, 'test');
+            expect(fs.existsSync(path.join(tmpDir, '.hermes', 'CLAUDE.md'))).toBe(false);
+        });
+    });
+});
+
+// ─── Part C: lastPullTargets via pull() (mocked externals) ──
+
+vi.mock('../config.js', () => ({
+    requireInit: vi.fn(),
+    loadState: vi.fn().mockResolvedValue({ lastPull: null, lastPullRev: null }),
+    saveState: vi.fn(),
+    loadLocalConfigForScope: vi.fn(),
+    loadTeamConfig: vi.fn(),
+    detectProjectConfig: vi.fn().mockResolvedValue(null),
+    loadStateForScope: vi.fn().mockResolvedValue({ lastPull: null, lastPullRev: null }),
+    saveStateForScope: vi.fn(),
+}));
+
+vi.mock('../utils/git.js', () => ({
+    pullRepo: vi.fn().mockResolvedValue('already up to date'),
+    getHeadRev: vi.fn().mockResolvedValue('abc1234'),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+    log: {
+        info: vi.fn(),
+        success: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+        dim: vi.fn(),
+    },
+    spinner: vi.fn(() => ({
+        start: vi.fn().mockReturnThis(),
+        succeed: vi.fn().mockReturnThis(),
+        fail: vi.fn().mockReturnThis(),
+        warn: vi.fn().mockReturnThis(),
+        info: vi.fn().mockReturnThis(),
+        stop: vi.fn().mockReturnThis(),
+    })),
+}));
+
+vi.mock('../roles.js', () => ({
+    loadRolesManifest: vi.fn().mockResolvedValue({
+        version: 1,
+        roles: [
+            {
+                id: 'hai',
+                name: 'HAI R&D',
+                description: 'HyperAI resources',
+                resources: { knowledge: ['common', 'hai'], skills: ['common', 'hai'], learnings: ['common', 'hai'] },
+            },
+        ],
+        defaults: { shareTarget: 'primary-role' },
+    }),
+    resolveRoleResourceNamespaces: vi.fn(({ manifest, primaryRole, additionalRoles }) => {
+        const allRoles = [primaryRole, ...additionalRoles].map((id: string) =>
+            manifest.roles.find((role: { id: string }) => role.id === id),
+        );
+        const dedupe = (values: string[]) => [...new Set(values)];
+        return {
+            knowledge: dedupe(allRoles.flatMap((role: { resources: { knowledge: string[] } }) => role.resources.knowledge)),
+            skills: dedupe(allRoles.flatMap((role: { resources: { skills: string[] } }) => role.resources.skills)),
+            learnings: dedupe(allRoles.flatMap((role: { resources: { learnings: string[] } }) => role.resources.learnings)),
+        };
+    }),
+}));
+
+vi.mock('../update.js', () => ({
+    acquireLock: vi.fn().mockResolvedValue(true),
+    releaseLock: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { pull } from '../pull.js';
+import { loadLocalConfigForScope, loadTeamConfig, detectProjectConfig, loadStateForScope, saveStateForScope } from '../config.js';
+import { getHeadRev } from '../utils/git.js';
+import { log } from '../utils/logger.js';
+import type { TeamaiConfig, LocalConfig } from '../types.js';
+
+describe('enabledAgents whitelist gates lastPullTargets (issue #510 repro 2)', () => {
+    let tmpDir: string;
+    let homeDir: string;
+    let repoPath: string;
+
+    beforeEach(async () => {
+        tmpDir = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-wl-targets-'));
+        homeDir = path.join(tmpDir, 'home');
+        repoPath = path.join(tmpDir, 'team-repo');
+
+        await fse.ensureDir(path.join(repoPath, 'rules'));
+        await fse.ensureDir(path.join(repoPath, 'skills', 'common'));
+        await fse.ensureDir(path.join(repoPath, 'skills', 'hai'));
+        await fse.ensureDir(path.join(repoPath, 'learnings', 'common'));
+        await fse.ensureDir(path.join(repoPath, 'learnings', 'hai'));
+        await fse.ensureDir(path.join(repoPath, 'manifest'));
+        await fse.writeFile(path.join(repoPath, 'manifest', 'roles.yaml'), 'version: 1\n');
+        installBothTools(homeDir);
+
+        vi.stubEnv('HOME', homeDir);
+
+        const teamConfig: TeamaiConfig = {
+            team: 'test',
+            description: '',
+            repo: 'https://git.woa.com/test/repo.git',
+            provider: 'tgit' as const,
+            reviewers: [],
+            sharing: {
+                skills: {},
+                rules: { enforced: [] },
+                docs: { localDir: '' },
+                env: { injectShellProfile: true },
+            },
+            toolPaths: TEAM_CONFIG.toolPaths,
+        };
+
+        const localConfig: LocalConfig = {
+            repo: { localPath: repoPath, remote: 'https://git.woa.com/test/repo.git' },
+            username: 'testuser',
+            updatePolicy: 'auto',
+            primaryRole: 'hai',
+            additionalRoles: [],
+            resourceProfileVersion: 1,
+            scope: 'user',
+            enabledAgents: ['claude'],
+        } as any;
+
+        vi.mocked(loadLocalConfigForScope).mockResolvedValue(localConfig);
+        vi.mocked(loadTeamConfig).mockResolvedValue(teamConfig);
+        vi.mocked(detectProjectConfig).mockResolvedValue(null);
+    });
+
+    afterEach(async () => {
+        vi.unstubAllEnvs();
+        vi.clearAllMocks();
+        await fse.remove(tmpDir);
+    });
+
+    it('records only whitelisted tools in lastPullTargets on first sync', async () => {
+        vi.mocked(getHeadRev).mockResolvedValue('abc1234');
+        vi.mocked(loadStateForScope).mockResolvedValue({
+            lastPull: null,
+            lastPullRev: null,
+            lastPush: null,
+            pushedRules: [],
+            pushedSkills: [],
+            pushedEnvVars: [],
+            pendingPushes: [],
+            lastUpdateCheck: null,
+            availableUpdate: null,
+        });
+
+        await pull({});
+
+        expect(saveStateForScope).toHaveBeenCalled();
+        expect(vi.mocked(saveStateForScope).mock.calls[0][0].lastPullTargets).toEqual(['claude']);
+    });
+
+    it('does not skip sync when a newly whitelisted installed tool joins with unchanged HEAD', async () => {
+        vi.mocked(getHeadRev).mockResolvedValue('abc1234');
+        vi.mocked(loadStateForScope).mockResolvedValue({
+            lastPull: '2026-04-01',
+            lastPullRev: 'abc1234',
+            lastPullTargets: ['claude'],
+            lastPush: null,
+            pushedRules: [],
+            pushedSkills: [],
+            pushedEnvVars: [],
+            pendingPushes: [],
+            lastUpdateCheck: null,
+            availableUpdate: null,
+        });
+        // User adds hermes to the whitelist without re-running init (rev cache not cleared).
+        vi.mocked(loadLocalConfigForScope).mockResolvedValue({
+            repo: { localPath: repoPath, remote: 'https://git.woa.com/test/repo.git' },
+            username: 'testuser',
+            updatePolicy: 'auto',
+            primaryRole: 'hai',
+            additionalRoles: [],
+            resourceProfileVersion: 1,
+            scope: 'user',
+            enabledAgents: ['claude', 'hermes'],
+        } as any);
+
+        await pull({});
+
+        expect(log.success).not.toHaveBeenCalledWith(
+            expect.stringContaining('Already synced'),
+        );
+        expect(saveStateForScope).toHaveBeenCalled();
+        expect(vi.mocked(saveStateForScope).mock.calls[0][0].lastPullTargets).toEqual(['claude', 'hermes']);
+    });
+});

--- a/src/builtin-agents.ts
+++ b/src/builtin-agents.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { ensureDir, pathExists, readFileSafe, writeFile, remove, listFiles } from './utils/fs.js';
 import { log } from './utils/logger.js';
 import type { TeamaiConfig, LocalConfig } from './types.js';
-import { resolveBaseDir, isAgentDisabled, scopedToolPaths } from './types.js';
+import { resolveBaseDir, isAgentExcluded, scopedToolPaths } from './types.js';
 import { ResourceHandler } from './resources/base.js';
 import { getUserHome } from './utils/home.js';
 import { ALL_SUPPORTED_TOOLS, renderForTool, reverseFromClaude } from './resources/agent-format.js';
@@ -126,7 +126,7 @@ export async function deployBuiltinAgents(
       log.debug(`Skipping built-in agent deployment for ${tool}: tool not installed`);
       continue;
     }
-    if (localConfig && isAgentDisabled(localConfig, tool)) continue;
+    if (localConfig && isAgentExcluded(localConfig, tool)) continue;
     if (!(ALL_SUPPORTED_TOOLS as string[]).includes(tool)) {
       log.warn(
         `Skipping built-in agent deployment for ${tool}: unsupported agent format; ` +

--- a/src/builtin-rules.ts
+++ b/src/builtin-rules.ts
@@ -5,7 +5,7 @@ import { ResourceHandler } from './resources/base.js';
 import { ruleFileExtensionForTool, usesCursorMdcRules } from './resources/rule-format.js';
 import { teamRuleToCursorMdc } from './resources/cursor-mdc.js';
 import type { TeamaiConfig, LocalConfig } from './types.js';
-import { resolveBaseDir, isAgentDisabled, scopedToolPaths } from './types.js';
+import { resolveBaseDir, isAgentExcluded, scopedToolPaths } from './types.js';
 import fs from 'node:fs/promises';
 import { getUserHome } from './utils/home.js';
 
@@ -66,7 +66,7 @@ export async function deployBuiltinRules(
             log.debug(`Skipping built-in rules for ${tool}: tool not installed`);
             continue;
         }
-        if (localConfig && isAgentDisabled(localConfig, tool)) continue;
+        if (localConfig && isAgentExcluded(localConfig, tool)) continue;
 
         const rulesDir = path.join(baseDir, toolPath.rules);
         if (!await pathExists(rulesDir)) continue;

--- a/src/builtin-skills.ts
+++ b/src/builtin-skills.ts
@@ -5,7 +5,7 @@ import fse from 'fs-extra';
 import { pathExists } from './utils/fs.js';
 import { log } from './utils/logger.js';
 import type { TeamaiConfig, LocalConfig } from './types.js';
-import { resolveBaseDir, isAgentDisabled, scopedToolPaths } from './types.js';
+import { resolveBaseDir, isAgentExcluded, scopedToolPaths } from './types.js';
 import { ResourceHandler } from './resources/base.js';
 import { ensureSkillFrontmatter, resolveSkillDestination } from './resources/skills.js';
 import { getUserHome } from './utils/home.js';
@@ -115,7 +115,7 @@ export async function deployBuiltinSkills(teamConfig: TeamaiConfig, localConfig?
       log.debug(`Skipping built-in skill deployment for ${tool}: tool not installed`);
       continue;
     }
-    if (localConfig && isAgentDisabled(localConfig, tool)) continue;
+    if (localConfig && isAgentExcluded(localConfig, tool)) continue;
 
     for (const skillName of skillNames) {
       const srcDir = path.join(builtinDir, skillName);

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -25,7 +25,7 @@ import {
   resolveHookScope,
   getDataHome,
   isRecallEnabled,
-  isAgentDisabled,
+  isAgentExcluded,
   scopedToolPaths,
   SYNC_LOCK_FILENAME,
 } from './types.js';
@@ -338,7 +338,7 @@ export async function cleanupInactiveNamespaceSkills(
   const baseDir = resolveBaseDir(localConfig);
 
   for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
-    if (isAgentDisabled(localConfig, tool)) continue;
+    if (isAgentExcluded(localConfig, tool)) continue;
     if (!toolPath.skills) continue;
     if (!await ResourceHandler.isToolInstalled(toolPath.skills, baseDir)) continue;
     if (!await pathExists(path.join(baseDir, toolPath.skills))) continue;
@@ -451,7 +451,7 @@ async function getInstalledResourceTargets(
   const targets: string[] = [];
 
   for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
-    if (isAgentDisabled(localConfig, tool)) continue;
+    if (isAgentExcluded(localConfig, tool)) continue;
 
     const resourcePaths = [toolPath.skills, toolPath.rules, toolPath.agents]
       .filter((resourcePath): resourcePath is string => !!resourcePath);
@@ -735,7 +735,7 @@ async function pullForScope(
         const dir = toolPath[toolPathField];
         if (!dir) continue;
         if (!await ResourceHandler.isToolInstalled(dir, baseDir)) continue;
-        if (isAgentDisabled(localConfig, tool)) continue;
+        if (isAgentExcluded(localConfig, tool)) continue;
 
         // Rules carry a per-tool extension (`.mdc` for compatible tools), and those dirs
         // may still hold a `.md` copy from the layout that predates it, so a
@@ -779,7 +779,7 @@ async function pullForScope(
     const baseDir = resolveBaseDir(localConfig);
 
     for (const [tool, toolPath] of Object.entries(scopedToolPaths(freshConfig, localConfig))) {
-      if (isAgentDisabled(localConfig, tool)) continue;
+      if (isAgentExcluded(localConfig, tool)) continue;
       if (!toolPath.skills) continue;
       if (!await ResourceHandler.isToolInstalled(toolPath.skills, baseDir)) continue;
       const skillsDir = path.join(baseDir, toolPath.skills);
@@ -935,7 +935,7 @@ async function pullForScope(
           if (compiled) {
             const baseDir = resolveBaseDir(localConfig);
             for (const [tool, toolPath] of Object.entries(scopedToolPaths(freshConfig, localConfig))) {
-              if (isAgentDisabled(localConfig, tool)) continue;
+              if (isAgentExcluded(localConfig, tool)) continue;
               if (!toolPath.claudemd) continue;
               if (toolPath.rules && !await ResourceHandler.isToolInstalled(toolPath.rules, baseDir)) continue;
 
@@ -966,7 +966,7 @@ async function pullForScope(
         if (compiled) {
           const baseDir = resolveBaseDir(localConfig);
           for (const [tool, toolPath] of Object.entries(scopedToolPaths(freshConfig, localConfig))) {
-            if (isAgentDisabled(localConfig, tool)) continue;
+            if (isAgentExcluded(localConfig, tool)) continue;
             if (!toolPath.claudemd) continue;
             if (toolPath.rules && !await ResourceHandler.isToolInstalled(toolPath.rules, baseDir)) continue;
             const claudeMdPath = path.join(baseDir, toolPath.claudemd);
@@ -1214,7 +1214,7 @@ export async function injectRecallBlockIntoTools(
         const recallBlock = compileRecallRulesBlock();
         let injected = 0;
         for (const [tool, toolPath] of Object.entries(scopedToolPaths(config, localConfig))) {
-            if (isAgentDisabled(localConfig, tool)) continue;
+            if (isAgentExcluded(localConfig, tool)) continue;
             if (!toolPath.claudemd || !toolPath.agents) continue;
             if (!await ResourceHandler.isToolInstalled(toolPath.agents, baseDir)) continue;
 


### PR DESCRIPTION
## Summary

Fixes #510. Every resource-write and target-set site that still gated on `isAgentDisabled` now goes through `isAgentExcluded`, so an installed tool outside `enabledAgents` no longer receives CLI builtin resources, CLAUDE.md injects, and is no longer recorded in `lastPullTargets`.

## Sites changed

| File | Site | Role |
| --- | --- | --- |
| `src/builtin-skills.ts` | `deployBuiltinSkills` loop | builtin skills leak (repro 1) |
| `src/builtin-rules.ts` | `deployBuiltinRules` loop | builtin rules leak (repro 1) |
| `src/builtin-agents.ts` | `deployBuiltinAgents` loop | builtin agents leak (repro 1) |
| `src/pull.ts` | culture CLAUDE.md inject (step 3.6) | claudemd inject leak (repro 1) |
| `src/pull.ts` | shared-instructions CLAUDE.md inject (step 3.7) | claudemd inject leak (repro 1) |
| `src/pull.ts` | `injectRecallBlockIntoTools` | claudemd inject leak (repro 1); also runs on the skip-sync fast path |
| `src/pull.ts` | `getInstalledResourceTargets` | feeds `lastPullTargets` (repro 2) |
| `src/pull.ts` | `cleanupInactiveNamespaceSkills` | cleanup consistency (lower severity) |
| `src/pull.ts` | tombstone cleanup loop | cleanup consistency (lower severity) |
| `src/pull.ts` | skills-not-in-desired-set cleanup loop | cleanup consistency (lower severity) |

`src/known-agents.ts` and `src/project-agent-root.ts` already perform the whitelist check (`known-agents.ts` seeds from `enabledAgents` and only filters `disabledAgents`; `project-agent-root.ts` checks both explicitly), so they are intentionally unchanged.

## Why per-site replacement instead of folding into `scopedToolPaths()`

#510 offers both options. `scopedToolPaths()` has ~50 call sites, and several of them legitimately enumerate *all* configured tools (logging, CLI plumbing, seeding) — folding an exclusion into it would silently change the meaning of the shared helper and touch far more surface than this fix needs. Per-site replacement keeps the diff to 14 lines and makes every gate explicit, matching the pattern #504 already established in the resource handlers.

## Repro 1 — builtin writes into an installed non-whitelisted tool (disk-level, no mocks)

`enabledAgents: ['claude']`, both `~/.claude` and `~/.hermes` pre-created, then call the deploy/inject functions directly. On current main, `~/.hermes` receives builtin skills, builtin rules, and the recall CLAUDE.md block. One subtlety: `deployBuiltinAgents` only escapes this leak for `hermes` because of its `ALL_SUPPORTED_TOOLS` format gate — a supported tool like `cursor` leaks agents too, which the new test exercises.

## Repro 2 — `lastPullTargets` counts non-whitelisted tools

`pull()` with `enabledAgents: ['claude']` and an installed `hermes` records `lastPullTargets: ['claude', 'hermes']` on current main. After this change it records `['claude']`. The skip-sync comparison in `pullForScope` then behaves as #510 expects: adding a previously installed tool to the whitelist with an unchanged HEAD no longer prints "Already synced" — it performs the missing sync for the new target.

Note for upgrades: installs that recorded over-broad target lists under the old behavior will see one extra full sync on their next `pull` (the recorded set no longer matches the computed set), after which the state self-corrects. This is harmless and one-time.

## Tests

New `src/__tests__/agent-whitelist.test.ts` (10 tests): disk-level checks for the three builtin deployers and the recall inject (no mocks), plus `pull()`-level checks for `lastPullTargets` using the same mock architecture as `pull-skip-sync.test.ts`.

**Before (current main): 6 of the 10 fail**, reproducing exactly the leaks listed in #510. **After: 10/10 pass.**

Targeted regression subset — 15 suites / 145 tests covering every touched module (`pull-*`, `builtin-*`, `claudemd-sync`, `culture`, `recall-rules`, `skip-uninstalled-tools`, `agent-skills`, `init`), run twice per side with per-case comparison:

- baseline: 135 passed / 10 failed (both runs identical)
- this branch: 141 passed / 4 failed (both runs identical)
- the only delta is the 6 new tests. The 4 `init.test.ts` failures ("empty repo fallback", "stale non-git directory") are identical on baseline and branch — pre-existing on main, unrelated to this change.

`tsc --noEmit` and `npm run build` both pass.

## What I did not verify

- The `E2E (GitHub provider, full surface)` job is skipped for fork PRs (no `TEAMAI_TEST_REPO_URL` secret), so no end-to-end run against a real provider.
- I did not run the real CLI against a live team repo; the disk-level tests exercise the changed functions directly.
