### PR TITLE
fix(codebase): write fallback evidence manifest so deep-enrich can start

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ teamai codebase --reconcile --output /path/to/repo # map product docs to code pa
 teamai codebase --lint --output /path/to/repo # check the locally extracted graph
 ```
 
+Extract writes `teamwiki/evidence/code/<project>/_manifest.json` even when AI enrichment is skipped or produces nothing, so `--deep-enrich` can start.
+
 The graph stores components, interfaces, configs, and cross-repo import edges. `teamai recall` uses it for graph-boosted re-ranking.
 When a recall hit comes from a codebase page, the result includes a `Sources:` line listing the relevant source file paths — giving agents a direct starting point for code changes instead of re-exploring the repo.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -199,6 +199,8 @@ teamai codebase --reconcile --output /path/to/repo # 将产品文档映射到代
 teamai codebase --lint --output /path/to/repo # 检查本地提取的图谱
 ```
 
+只要 extract 发现了组件，就会写入 `teamwiki/evidence/code/<project>/_manifest.json`（包括跳过 AI 增强或增强没有产出的情况），因此 `--deep-enrich` 可以接着跑。
+
 图谱存储组件、接口、配置和跨仓库依赖边。`teamai recall` 利用图谱进行增强排名。
 当召回命中 codebase 页面时，结果会附带一行 `Sources:`，列出相关源文件路径，供 agent 直接作为代码改动的入口，无需重新探索代码库。
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -1212,6 +1212,8 @@ teamai codebase --reconcile --output /path/to/repo
 teamai codebase --lint --output /path/to/repo
 ```
 
+When extract finds components, it writes `teamwiki/evidence/code/<project>/_manifest.json` even if AI enrichment is skipped or produces nothing, so `--deep-enrich` can start.
+
 ### Dashboard
 
 ```bash

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -1179,6 +1179,8 @@ teamai codebase --reconcile --output /path/to/repo
 teamai codebase --lint --output /path/to/repo
 ```
 
+只要 extract 发现了组件，就会写入 `teamwiki/evidence/code/<project>/_manifest.json`（包括跳过 AI 增强或增强没有产出的情况），因此 `--deep-enrich` 可以接着跑。
+
 ### Dashboard
 
 ```bash

--- a/src/__tests__/codebase-deep-enrich.test.ts
+++ b/src/__tests__/codebase-deep-enrich.test.ts
@@ -17,6 +17,7 @@ vi.mock('../utils/ai-client.js', () => ({
 
 import { callClaude, callClaudeParallel } from '../utils/ai-client.js';
 import { codebaseCmd } from '../codebase-cmd.js';
+import { runHiddenDeepEnrich } from '../deep-enrich.js';
 
 const temporaryDirectories: string[] = [];
 
@@ -110,7 +111,8 @@ describe('codebase deep-enrich', () => {
     await codebaseCmd({ deepEnrich: true, project: 'faketest', output: root, json: true });
 
     expect(process.exitCode).toBe(1);
-    expect(log.mock.calls.flat().join('\n')).toContain('No components in evidence');
+    expect(log.mock.calls.flat().join('\n')).toContain('No components in _manifest.json');
+    expect(log.mock.calls.flat().join('\n')).not.toContain('Run `teamai codebase --extract` first');
     expect(fs.existsSync(path.join(root, 'teamwiki', 'evidence', 'code', 'faketest', 'docs'))).toBe(false);
   });
 
@@ -294,6 +296,18 @@ describe('codebase deep-enrich', () => {
     });
     expect(fs.existsSync(path.join(docsDir, 'Auth.md'))).toBe(false);
     expect(fs.existsSync(path.join(docsDir, 'architecture.md'))).toBe(false);
+  });
+
+  it('hidden deep-enrich exits non-zero when _manifest.json has no components', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-hidden-deep-enrich-empty-'));
+    temporaryDirectories.push(root);
+    const wikiRoot = path.join(root, 'teamwiki');
+    fs.mkdirSync(path.join(wikiRoot, 'evidence', 'code', 'widget'), { recursive: true });
+
+    const result = await runHiddenDeepEnrich({ project: 'widget', wikiRoot });
+
+    expect(result.complete).toBe(false);
+    expect(process.exitCode).toBe(1);
   });
 
   it('rejects a project slug that escapes the evidence directory', async () => {

--- a/src/__tests__/codebase-extract-fallback.test.ts
+++ b/src/__tests__/codebase-extract-fallback.test.ts
@@ -1,0 +1,317 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// Mock the AI client so extract/deep-enrich cannot hang on a live CLI.
+vi.mock('../utils/ai-client.js', () => ({
+  getAICliName: () => 'mock-cli',
+  callClaude: vi.fn(async () => {
+    throw new Error('mock: AI unavailable');
+  }),
+  callClaudeParallel: vi.fn(async () => {
+    throw new Error('mock: AI batch unavailable');
+  }),
+}));
+
+import { callClaudeParallel } from '../utils/ai-client.js';
+import { extractCodebase } from '../codebase-extract.js';
+import { codebaseCmd } from '../codebase-cmd.js';
+import { runHiddenDeepEnrich } from '../deep-enrich.js';
+import {
+  buildFallbackManifest,
+  describeEvidenceManifest,
+  groupFactsByModule,
+} from '../enrich-with-ai.js';
+import type { CodeFact } from '../wiki-engine/code-knowledge/code-extractors.js';
+
+const temporaryDirectories: string[] = [];
+
+const WIDGET_SOURCE = 'export class Widget {\n  render() { return "hi"; }\n}\n';
+
+function createWidgetFixture(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-508-'));
+  temporaryDirectories.push(root);
+  fs.mkdirSync(path.join(root, 'src'));
+  fs.writeFileSync(path.join(root, 'src', 'widget.ts'), WIDGET_SOURCE);
+  return root;
+}
+
+function readEvidenceManifest(root: string, project: string): {
+  schemaVersion?: string;
+  components: Array<{ slug?: string; docPath?: string; category?: string; responsibilities?: string[] }>;
+} {
+  const manifestPath = path.join(root, 'teamwiki', 'evidence', 'code', project, '_manifest.json');
+  expect(fs.existsSync(manifestPath), `missing ${manifestPath}`).toBe(true);
+  return JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as {
+    schemaVersion?: string;
+    components: Array<{ slug?: string; docPath?: string; category?: string; responsibilities?: string[] }>;
+  };
+}
+
+afterEach(() => {
+  process.exitCode = undefined;
+  vi.restoreAllMocks();
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('extract writes a fallback evidence manifest (#508)', () => {
+  it('describes fallback and missing-manifest outcomes in English', () => {
+    expect(describeEvidenceManifest('fallback', 1)).toBe(
+      'Wrote fallback _manifest.json (1 component, no AI enrich)',
+    );
+    expect(describeEvidenceManifest('fallback', 2)).toBe(
+      'Wrote fallback _manifest.json (2 components, no AI enrich)',
+    );
+    expect(describeEvidenceManifest('none', 0)).toBe(
+      'AI enrich produced no manifest; deep-enrich will have no components',
+    );
+    expect(describeEvidenceManifest('ai', 3)).toBeUndefined();
+  });
+
+  it('builds fallback components from top-level modules, then component facts', () => {
+    const moduleFacts: CodeFact[] = [
+      {
+        kind: 'component',
+        name: 'Widget',
+        file: 'src/widget.ts',
+        lineStart: 1,
+        detail: 'export class Widget',
+        confidence: 'EXTRACTED',
+      },
+    ];
+    const fromModules = buildFallbackManifest({
+      project: 'widget',
+      facts: moduleFacts,
+      modules: groupFactsByModule(moduleFacts),
+    });
+    expect(fromModules?.components).toEqual([
+      expect.objectContaining({
+        slug: 'src',
+        docPath: 'evidence/code/widget/src.md',
+      }),
+    ]);
+
+    const rootFacts: CodeFact[] = [
+      {
+        kind: 'component',
+        name: 'Widget',
+        file: 'widget.ts',
+        lineStart: 1,
+        detail: 'export class Widget',
+        confidence: 'EXTRACTED',
+      },
+    ];
+    // Force the component-name path: empty modules, leftover component facts.
+    const fromNames = buildFallbackManifest({
+      project: 'widget',
+      facts: rootFacts,
+      modules: new Map(),
+    });
+    expect(fromNames?.components).toEqual([
+      expect.objectContaining({
+        slug: 'Widget',
+        docPath: 'evidence/code/widget/Widget.md',
+      }),
+    ]);
+
+    expect(buildFallbackManifest({ project: 'widget', facts: [], modules: new Map() })).toBeNull();
+  });
+
+  it('writes _manifest.json with components for the offline Widget fixture', async () => {
+    const root = createWidgetFixture();
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await extractCodebase({ path: root, project: 'widget', json: true });
+
+    const report = JSON.parse(String(log.mock.calls.at(-1)?.[0])) as {
+      facts: { byKind: Record<string, number> };
+      manifest: { written: boolean; source: string; components: number; note?: string };
+    };
+    expect(report.facts.byKind.component).toBeGreaterThanOrEqual(1);
+    expect(report.manifest.written).toBe(true);
+    expect(report.manifest.source).toBe('fallback');
+    expect(report.manifest.components).toBeGreaterThanOrEqual(1);
+    expect(report.manifest.note).toMatch(/Wrote fallback _manifest\.json/);
+    expect(report.manifest.note).toMatch(/no AI enrich/);
+
+    expect(fs.existsSync(path.join(root, 'teamwiki', 'source-manifest.json'))).toBe(true);
+
+    const manifest = readEvidenceManifest(root, 'widget');
+    expect(manifest.schemaVersion).toBe('team-wiki.codebase-output-manifest.v2');
+    expect(manifest.components.length).toBeGreaterThanOrEqual(1);
+    for (const component of manifest.components) {
+      expect(component.slug).toEqual(expect.any(String));
+      expect(component.slug?.length).toBeGreaterThan(0);
+      expect(component.docPath).toEqual(expect.any(String));
+      expect(component.docPath?.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('writes the same fallback when --skip-enrich is set', async () => {
+    const root = createWidgetFixture();
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await extractCodebase({ path: root, project: 'widget', json: true, skipEnrich: true });
+
+    const report = JSON.parse(String(log.mock.calls.at(-1)?.[0])) as {
+      manifest: { written: boolean; source: string; components: number; note?: string };
+    };
+    expect(report.manifest).toMatchObject({ written: true, source: 'fallback' });
+    expect(report.manifest.components).toBeGreaterThanOrEqual(1);
+    expect(report.manifest.note).toMatch(/Wrote fallback _manifest\.json/);
+
+    const manifest = readEvidenceManifest(root, 'widget');
+    expect(manifest.components.length).toBeGreaterThanOrEqual(1);
+    expect(manifest.components[0]?.slug).toBeTruthy();
+    expect(manifest.components[0]?.docPath).toBeTruthy();
+  });
+
+  it('writes a fallback when AI enrich is attempted and fails', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-508-ai-fail-'));
+    temporaryDirectories.push(root);
+    fs.mkdirSync(path.join(root, 'src'));
+    fs.writeFileSync(
+      path.join(root, 'src', 'app.ts'),
+      [
+        'export class Alpha { a() { return 1; } }',
+        'export class Beta { b() { return 2; } }',
+        'export class Gamma { c() { return 3; } }',
+        'export class Delta { d() { return 4; } }',
+        'export class Epsilon { e() { return 5; } }',
+        '',
+      ].join('\n'),
+    );
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await extractCodebase({ path: root, project: 'widget', json: true });
+
+    const report = JSON.parse(String(log.mock.calls.at(-1)?.[0])) as {
+      manifest: { written: boolean; source: string; components: number; note?: string };
+    };
+    expect(report.manifest.written).toBe(true);
+    expect(report.manifest.source).toBe('fallback');
+    expect(report.manifest.note).toMatch(/Wrote fallback _manifest\.json/);
+    expect(readEvidenceManifest(root, 'widget').components.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('prints English fallback text when not using --json', async () => {
+    const root = createWidgetFixture();
+    const lines: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      lines.push(args.map(String).join(' '));
+    });
+
+    await extractCodebase({ path: root, project: 'widget' });
+
+    const output = lines.join('\n');
+    expect(output).toMatch(/\[extract\] widget complete/);
+    expect(output).toMatch(/Wrote fallback _manifest\.json/);
+    expect(output).toMatch(/no AI enrich/);
+    expect(output).not.toMatch(/AI enrich produced no manifest; deep-enrich will have no components/);
+  });
+
+  it('does not abort deep-enrich for empty evidence after a successful extract', async () => {
+    const root = createWidgetFixture();
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await extractCodebase({ path: root, project: 'widget', json: true, skipEnrich: true });
+    process.exitCode = undefined;
+
+    await codebaseCmd({ deepEnrich: true, project: 'widget', output: root, json: true });
+
+    const output = vi.mocked(console.log).mock.calls.flat().map(String).join('\n');
+    expect(output).not.toMatch(/No components in evidence/);
+    expect(output).not.toMatch(/No components in _manifest\.json/);
+    expect(output).not.toMatch(/Run `teamai codebase --extract` first/);
+
+    const lastJson = [...vi.mocked(console.log).mock.calls]
+      .map(call => String(call[0]))
+      .reverse()
+      .find(text => text.trim().startsWith('{'));
+    expect(lastJson).toBeTruthy();
+    const report = JSON.parse(lastJson!) as { complete?: boolean; missingComponents?: string[] };
+    expect(report.complete).toBe(false);
+    expect(report.missingComponents?.length).toBeGreaterThan(0);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('hidden deep-enrich after extract does not abort for missing components', async () => {
+    const root = createWidgetFixture();
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await extractCodebase({ path: root, project: 'widget', json: true, skipEnrich: true });
+    process.exitCode = undefined;
+
+    const result = await runHiddenDeepEnrich({
+      project: 'widget',
+      wikiRoot: path.join(root, 'teamwiki'),
+    });
+
+    expect(result.complete).toBe(false);
+    expect(result.missingComponents.length).toBeGreaterThan(0);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('does not overwrite a successful AI enrich with the fallback', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-508-ai-ok-'));
+    temporaryDirectories.push(root);
+    fs.mkdirSync(path.join(root, 'src'));
+    fs.writeFileSync(
+      path.join(root, 'src', 'app.ts'),
+      [
+        'export class Alpha { a() { return 1; } }',
+        'export class Beta { b() { return 2; } }',
+        'export class Gamma { c() { return 3; } }',
+        'export class Delta { d() { return 4; } }',
+        'export class Epsilon { e() { return 5; } }',
+        '',
+      ].join('\n'),
+    );
+    vi.mocked(callClaudeParallel).mockImplementation(async (tasks) =>
+      tasks.map((task) =>
+        task.parse(
+          '{"domain":"widgets","responsibilities":["render"],"layer":"service","summary":"ui","description":"ui kit","keywords":["widget"]}',
+        ),
+      ),
+    );
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await extractCodebase({ path: root, project: 'widget', json: true });
+
+    const report = JSON.parse(String(log.mock.calls.at(-1)?.[0])) as {
+      manifest: { written: boolean; source: string; note?: string };
+    };
+    expect(report.manifest.written).toBe(true);
+    expect(report.manifest.source).toBe('ai');
+    expect(report.manifest.note).toBeUndefined();
+
+    const manifest = readEvidenceManifest(root, 'widget');
+    expect(manifest.components.length).toBeGreaterThanOrEqual(1);
+    expect(manifest.components[0]?.category).toBe('service');
+    expect(manifest.components[0]?.responsibilities).toEqual(['render']);
+  });
+
+  it('says so when extractable files yield no components to put in a manifest', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-508-none-'));
+    temporaryDirectories.push(root);
+    fs.mkdirSync(path.join(root, 'src'));
+    fs.writeFileSync(path.join(root, 'src', 'empty.ts'), '// no extractable symbols\n');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await extractCodebase({ path: root, project: 'empty', json: true, skipEnrich: true });
+
+    const report = JSON.parse(String(log.mock.calls.at(-1)?.[0])) as {
+      status?: string;
+      facts?: { total: number };
+      manifest?: { written: boolean; source: string; note?: string };
+    };
+    expect(report.status).not.toBe('no-files');
+    expect(report.facts?.total ?? 0).toBe(0);
+    expect(report.manifest).toMatchObject({ written: false, source: 'none' });
+    expect(report.manifest?.note).toBe('AI enrich produced no manifest; deep-enrich will have no components');
+    expect(fs.existsSync(path.join(root, 'teamwiki', 'evidence', 'code', 'empty', '_manifest.json'))).toBe(false);
+  });
+});

--- a/src/__tests__/e2e/codebase-extract-cli.test.ts
+++ b/src/__tests__/e2e/codebase-extract-cli.test.ts
@@ -193,6 +193,101 @@ describe('teamai codebase reconcile CLI (issue #360 slice 2)', () => {
   });
 });
 
+describe('teamai codebase extract CLI (issue #508)', () => {
+  it('writes fallback _manifest.json for a one-file Widget repo', async () => {
+    const fixture = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-508-cli-'));
+    try {
+      const srcDir = path.join(fixture, 'src');
+      fs.mkdirSync(srcDir);
+      fs.writeFileSync(
+        path.join(srcDir, 'widget.ts'),
+        'export class Widget {\n  render() { return "hi"; }\n}\n',
+      );
+
+      const result = await runCLI(
+        ['codebase', '--extract', fixture, '--project', 'widget'],
+        fixture,
+      );
+      expect(result.code, result.output).toBe(0);
+      expect(result.output).toMatch(/Wrote fallback _manifest\.json/);
+      expect(result.output).toMatch(/no AI enrich/);
+      expect(result.output).not.toMatch(/AI enrich produced no manifest; deep-enrich will have no components/);
+
+      const manifestPath = path.join(fixture, 'teamwiki', 'evidence', 'code', 'widget', '_manifest.json');
+      expect(fs.existsSync(manifestPath), result.output).toBe(true);
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as {
+        components?: Array<{ slug?: string; docPath?: string }>;
+      };
+      expect(manifest.components?.length).toBeGreaterThanOrEqual(1);
+      for (const component of manifest.components ?? []) {
+        expect(component.slug).toBeTruthy();
+        expect(component.docPath).toBeTruthy();
+      }
+    } finally {
+      fs.rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
+  it('writes fallback _manifest.json fields in --json extract output', async () => {
+    const fixture = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-508-json-'));
+    try {
+      const srcDir = path.join(fixture, 'src');
+      fs.mkdirSync(srcDir);
+      fs.writeFileSync(
+        path.join(srcDir, 'widget.ts'),
+        'export class Widget {\n  render() { return "hi"; }\n}\n',
+      );
+
+      const result = await runCLI(
+        ['codebase', '--extract', fixture, '--project', 'widget', '--json'],
+        fixture,
+      );
+      expect(result.code, result.output).toBe(0);
+      const report = JSON.parse(result.stdout) as {
+        manifest: { written: boolean; source: string; components: number; note?: string };
+      };
+      expect(report.manifest.written).toBe(true);
+      expect(report.manifest.source).toBe('fallback');
+      expect(report.manifest.components).toBeGreaterThanOrEqual(1);
+      expect(report.manifest.note).toMatch(/Wrote fallback _manifest\.json/);
+      expect(report.manifest.note).toMatch(/no AI enrich/);
+    } finally {
+      fs.rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
+  it('hidden deep-enrich exits non-zero when _manifest.json has no components', async () => {
+    const fixture = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-hidden-deep-enrich-508-'));
+    try {
+      const wikiRoot = path.join(fixture, 'teamwiki');
+      fs.mkdirSync(path.join(wikiRoot, 'evidence', 'code', 'widget'), { recursive: true });
+      const result = await runCLI(
+        ['deep-enrich', '--project', 'widget', '--wiki-root', wikiRoot],
+        fixture,
+      );
+      expect(result.code, result.output).toBe(1);
+    } finally {
+      fs.rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
+  it('public deep-enrich does not tell the user to extract first when evidence exists without components', async () => {
+    const fixture = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-public-deep-enrich-508-'));
+    try {
+      fs.mkdirSync(path.join(fixture, 'teamwiki', 'evidence', 'code', 'widget'), { recursive: true });
+      const result = await runCLI(
+        ['codebase', '--deep-enrich', '--project', 'widget', '--output', fixture],
+        fixture,
+      );
+      expect(result.code, result.output).toBe(1);
+      expect(result.output).toMatch(/No components in _manifest\.json/);
+      expect(result.output).not.toMatch(/Run `teamai codebase --extract` first/);
+    } finally {
+      fs.rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('teamai codebase deep-enrich CLI (issue #360 slice 3)', () => {
   it('lists --deep-enrich, documents it in the skill, and fails when teamwiki is missing', async () => {
     const help = await runCLI(['codebase', '--help']);

--- a/src/codebase-cmd.ts
+++ b/src/codebase-cmd.ts
@@ -125,7 +125,7 @@ export async function codebaseCmd(opts: CodebaseCmdOptions): Promise<void> {
             componentCount = 0;
         }
         if (componentCount === 0) {
-            console.log(`No components in evidence for project "${project}". Run \`teamai codebase --extract\` first.`);
+            console.log(`No components in _manifest.json for project "${project}".`);
             process.exitCode = 1;
             return;
         }

--- a/src/codebase-extract.ts
+++ b/src/codebase-extract.ts
@@ -64,6 +64,12 @@ interface ExtractResult {
   graph: { nodes: number; edges: number };
   incremental: boolean;
   outputDir: string;
+  manifest: {
+    written: boolean;
+    source: 'ai' | 'fallback' | 'none';
+    components: number;
+    note?: string;
+  };
 }
 
 interface KnowledgeGap {
@@ -710,43 +716,61 @@ export async function extractCodebase(opts: ExtractCodebaseOptions): Promise<voi
   // in import-repo.ts after all per-repo graphs are in place (avoids write races).
   await saveGraphIndex(wikiRoot, repoGraph);
 
-  // AI enrichment (optional, non-blocking; skipped with --skip-enrich)
+  // AI enrichment (optional, non-blocking; skipped with --skip-enrich).
+  // When enrich yields nothing, still write a deterministic _manifest.json so
+  // deep-enrich has components to work with (#508).
   let aiDomains: DomainGroup[] = [];
+  let manifestSource: 'ai' | 'fallback' | 'none' = 'none';
+  let manifestComponentCount = 0;
+  const {
+    enrichWithAI,
+    writeManifest,
+    buildFallbackManifest,
+    groupFactsByModule,
+    describeEvidenceManifest,
+  } = await import('./enrich-with-ai.js');
+  const modules = groupFactsByModule(facts);
+
   if (opts.skipEnrich) {
     if (!opts.json) console.log(chalk.dim('  [AI enrich: skipped (--skip-enrich)]'));
-  } else try {
-    const { enrichWithAI, writeManifest } = await import('./enrich-with-ai.js');
-    const modules = new Map<string, CodeFact[]>();
-    for (const fact of facts) {
-      if (fact.kind === 'relation') continue;
-      const mod = fact.file.split('/')[0] || '_root';
-      const existing = modules.get(mod) ?? [];
-      existing.push(fact);
-      modules.set(mod, existing);
-    }
-
-    const enrichResult = await enrichWithAI({ project, facts, interfaceInventory, modules });
-    if (enrichResult) {
-      await writeManifest(enrichResult.manifest, evidenceDir);
-      aiDomains = enrichResult.domains;
-      // Persist AI-inferred domain classification for rebuildWikiIndex
-      const domainMeta = {
-        domain: enrichResult.repoDomain || (enrichResult.domains[0]?.name ?? ''),
-        description: enrichResult.repoDescription || '',
-        keywords: enrichResult.repoKeywords || [],
-        components: enrichResult.domains[0]?.components ?? [],
-      };
-      await writeFile(path.join(evidenceDir, '_domains.json'), JSON.stringify(domainMeta, null, 2), 'utf-8');
+  } else {
+    try {
+      const enrichResult = await enrichWithAI({ project, facts, interfaceInventory, modules });
+      if (enrichResult) {
+        await writeManifest(enrichResult.manifest, evidenceDir);
+        manifestSource = 'ai';
+        manifestComponentCount = enrichResult.manifest.components.length;
+        aiDomains = enrichResult.domains;
+        // Persist AI-inferred domain classification for rebuildWikiIndex
+        const domainMeta = {
+          domain: enrichResult.repoDomain || (enrichResult.domains[0]?.name ?? ''),
+          description: enrichResult.repoDescription || '',
+          keywords: enrichResult.repoKeywords || [],
+          components: enrichResult.domains[0]?.components ?? [],
+        };
+        await writeFile(path.join(evidenceDir, '_domains.json'), JSON.stringify(domainMeta, null, 2), 'utf-8');
+        if (!opts.json) {
+          const domainLabel = domainMeta.domain || 'uncategorized';
+          console.log(`  AI enrich: ${enrichResult.manifest.components.length} modules, domain=${domainLabel}`);
+        }
+      }
+    } catch (e) {
       if (!opts.json) {
-        const domainLabel = domainMeta.domain || 'uncategorized';
-        console.log(`  AI enrich: ${enrichResult.manifest.components.length} modules, domain=${domainLabel}`);
+        console.log(chalk.dim(`  [AI enrich skipped: ${(e as Error).message}]`));
       }
     }
-  } catch (e) {
-    if (!opts.json) {
-      console.log(chalk.dim(`  [AI enrich skipped: ${(e as Error).message}]`));
+  }
+
+  if (manifestSource === 'none') {
+    const fallback = buildFallbackManifest({ project, facts, modules });
+    if (fallback && fallback.components.length > 0) {
+      await writeManifest(fallback, evidenceDir);
+      manifestSource = 'fallback';
+      manifestComponentCount = fallback.components.length;
     }
   }
+
+  const manifestNote = describeEvidenceManifest(manifestSource, manifestComponentCount);
 
   // 生成模块级摘要页（按顶层目录聚合）
   const moduleSummaries = buildModuleSummaries(facts, graph, project);
@@ -886,6 +910,12 @@ export async function extractCodebase(opts: ExtractCodebaseOptions): Promise<voi
     graph: { nodes: repoGraph.nodes.length, edges: repoGraph.edges.length },
     incremental: !!opts.incremental && !!changedFiles,
     outputDir: wikiRoot,
+    manifest: {
+      written: manifestSource !== 'none',
+      source: manifestSource,
+      components: manifestComponentCount,
+      ...(manifestNote ? { note: manifestNote } : {}),
+    },
   };
 
   if (opts.json) {
@@ -904,5 +934,8 @@ export async function extractCodebase(opts: ExtractCodebaseOptions): Promise<voi
       console.log(`  Call chains: ${callChains.length} chains (max depth ${Math.max(...callChains.map(c => c.depth))})`);
     }
     console.log(`  Output: ${wikiRoot}`);
+    if (manifestNote) {
+      console.log(`  ${manifestNote}`);
+    }
   }
 }

--- a/src/deep-enrich.ts
+++ b/src/deep-enrich.ts
@@ -794,6 +794,27 @@ async function invalidateStaleAiDocs(docsDir: string, slugs: string[]): Promise<
 // ─── 主函数 ─────────────────────────────────────────────────
 
 /**
+ * Hidden `teamai deep-enrich` CLI entry. Sets a failing exit code when
+ * enrichment cannot complete (empty `_manifest.json` or missing AI docs).
+ */
+export async function runHiddenDeepEnrich(opts: {
+  project: string;
+  wikiRoot?: string;
+  maxModules?: number;
+}): Promise<DeepEnrichResult> {
+  const wikiRoot = opts.wikiRoot ?? path.join(process.cwd(), '.teamai', 'team-repo', 'teamwiki');
+  const evidenceDir = path.join(wikiRoot, 'evidence', 'code', opts.project);
+  const result = await deepEnrich({
+    project: opts.project,
+    evidenceDir,
+    wikiRoot,
+    maxModules: opts.maxModules,
+  });
+  if (!result.complete) process.exitCode = 1;
+  return result;
+}
+
+/**
  * 对已导入仓库执行深度 AI 知识生成。
  *
  * 读取 evidenceDir 中已有的确定性提取结果，分阶段生成：

--- a/src/enrich-with-ai.ts
+++ b/src/enrich-with-ai.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { writeFile, mkdir } from 'node:fs/promises';
 import { callClaudeParallel, getAICliName } from './utils/ai-client.js';
 import { log } from './utils/logger.js';
+import { assertSafeResourceName } from './utils/path-safety.js';
 import type { CodeFact } from './wiki-engine/adapters/index.js';
 import type { InterfaceInventory } from './wiki-engine/interface-scanner.js';
 import type { CodebaseOutputManifestV2, ManifestComponentV2, ManifestEdgeV2, ManifestEdgeSource } from './wiki-engine/manifest-schema.js';
@@ -116,6 +117,84 @@ function resolveImportToModule(importerFile: string, importPath: string): string
   // Skip npm scoped packages (@scope/pkg) — not project modules
   if (first.startsWith('@')) return undefined;
   return first;
+}
+
+/** Group non-relation facts by top-level directory (same buckets as AI enrich). */
+export function groupFactsByModule(facts: CodeFact[]): Map<string, CodeFact[]> {
+  const modules = new Map<string, CodeFact[]>();
+  for (const fact of facts) {
+    if (fact.kind === 'relation') continue;
+    const mod = fact.file.split('/')[0] || '_root';
+    const existing = modules.get(mod) ?? [];
+    existing.push(fact);
+    modules.set(mod, existing);
+  }
+  return modules;
+}
+
+function isSafeSlug(name: string): boolean {
+  try {
+    assertSafeResourceName(name);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Deterministic evidence manifest when AI enrich yields nothing.
+ *
+ * Component granularity matches deep-enrich: one slug per top-level module.
+ * If that list is empty, fall back to `kind === 'component'` fact names so a
+ * one-file repo still produces a consumable `components[]`.
+ */
+export function buildFallbackManifest(ctx: {
+  project: string;
+  facts: CodeFact[];
+  modules: Map<string, CodeFact[]>;
+}): CodebaseOutputManifestV2 | null {
+  const moduleNames = [...ctx.modules.keys()].filter(isSafeSlug);
+  const componentNames = [...new Set(
+    ctx.facts.filter(f => f.kind === 'component').map(f => f.name),
+  )].filter(isSafeSlug);
+  const slugs = moduleNames.length > 0 ? moduleNames : componentNames;
+  if (slugs.length === 0) return null;
+
+  const components: ManifestComponentV2[] = slugs.map((name) => {
+    const moduleFacts = ctx.modules.get(name) ?? ctx.facts.filter(f => f.name === name);
+    const entrypoints = moduleFacts
+      .filter(f => f.kind === 'component')
+      .filter(f => /handler|route|controller|endpoint|main|server|app/i.test(f.name))
+      .slice(0, 5)
+      .map(f => `${f.name} (${f.file}:${f.lineStart})`);
+    return {
+      slug: name,
+      docPath: `evidence/code/${ctx.project}/${name}.md`,
+      title: name,
+      category: 'component',
+      confidence: 'EXTRACTED',
+      ...(entrypoints.length > 0 ? { entrypoints } : {}),
+    };
+  });
+
+  return {
+    schemaVersion: 'team-wiki.codebase-output-manifest.v2',
+    project: ctx.project,
+    generatedAt: new Date().toISOString(),
+    components,
+    edges: [],
+  };
+}
+
+export function describeEvidenceManifest(source: 'ai' | 'fallback' | 'none', componentCount: number): string | undefined {
+  if (source === 'fallback') {
+    const noun = componentCount === 1 ? 'component' : 'components';
+    return `Wrote fallback _manifest.json (${componentCount} ${noun}, no AI enrich)`;
+  }
+  if (source === 'none') {
+    return 'AI enrich produced no manifest; deep-enrich will have no components';
+  }
+  return undefined;
 }
 
 export async function enrichWithAI(ctx: EnrichContext): Promise<EnrichResult | null> {

--- a/src/import.ts
+++ b/src/import.ts
@@ -73,8 +73,8 @@ interface ImportOptions extends GlobalOptions {
  * the --from-repo flow.
  *
  * Both stages are non-blocking: failures are logged at debug level and
- * swallowed so they never abort the import. Deep enrich runs only when AI
- * enrichment produced a `_manifest.json` and `skipEnrich` is not set.
+ * swallowed so they never abort the import. Deep enrich runs only when
+ * `_manifest.json` exists (AI or fallback) and `skipEnrich` is not set.
  *
  * @param params - Reconcile/enrich parameters
  * @param params.slug - Project slug, used for evidence dir naming and logging

--- a/src/index.ts
+++ b/src/index.ts
@@ -980,11 +980,12 @@ program
   .option('--wiki-root <path>', 'Teamwiki root path')
   .option('--max-modules <n>', 'Max modules to process (cost control)', parseInt)
   .action(async (cmdOpts: { project: string; wikiRoot?: string; maxModules?: number }) => {
-    const p = await import('node:path');
-    const wikiRoot = cmdOpts.wikiRoot ?? p.join(process.cwd(), '.teamai', 'team-repo', 'teamwiki');
-    const evidenceDir = p.join(wikiRoot, 'evidence', 'code', cmdOpts.project);
-    const { deepEnrich } = await import('./deep-enrich.js');
-    await deepEnrich({ project: cmdOpts.project, evidenceDir, wikiRoot, maxModules: cmdOpts.maxModules });
+    const { runHiddenDeepEnrich } = await import('./deep-enrich.js');
+    await runHiddenDeepEnrich({
+      project: cmdOpts.project,
+      wikiRoot: cmdOpts.wikiRoot,
+      maxModules: cmdOpts.maxModules,
+    });
   });
 
 recallCmd


### PR DESCRIPTION
## Summary

`codebase --extract` reported `kind === 'component'` facts but only wrote `teamwiki/evidence/code/<project>/_manifest.json` when AI enrichment succeeded. Small repos (no module with `>= 5` facts), `--skip-enrich`, and AI failures left that file missing, so `deep-enrich` aborted with `No components in _manifest.json` while `--lint` still passed.

Extract now always writes a usable v2 evidence manifest when it has modules or component facts: AI output when enrich succeeds, otherwise a deterministic fallback (`components[]` with `slug` / `docPath`). User-facing English / `--json` output says when the fallback was written, or that deep-enrich will have no components when nothing can be written. Public empty-manifest errors no longer say to re-run extract. Hidden `teamai deep-enrich` exits non-zero when there are no components (previously exit 0).

Option C (lowering the `>= 5` facts AI threshold) is intentionally not done; fallback covers that case without changing when AI is called.

Fixes #508.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an existing issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing behavior to change)
- [ ] Documentation only
- [ ] Refactor / internal cleanup

## Test Plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — **218 files / 3017 tests passed**
- [x] `npx vitest run src/__tests__/codebase-extract-fallback.test.ts src/__tests__/codebase-deep-enrich.test.ts src/__tests__/deep-enrich-graph-preserve.test.ts src/__tests__/import-dir.test.ts` — 31/31 (includes Widget fixture, `--skip-enrich`, AI-fail, AI-success not overwritten, hidden after extract, empty-manifest exit 1)
- [x] `npm run build` then `npx vitest run --config vitest.e2e.config.ts src/__tests__/e2e/codebase-extract-cli.test.ts` — 9/9
- [x] Built CLI, issue #508 Widget repro (no API key):
  1. `node dist/index.js codebase --extract <fixture> --project widget` — exit 0, `Facts: 1 (component:1)`, `Wrote fallback _manifest.json (1 component, no AI enrich)`, both `source-manifest.json` and `evidence/code/widget/_manifest.json` present (`components[0].slug` + `docPath` set)
  2. `node dist/index.js deep-enrich --project widget --wiki-root <fixture>/teamwiki` — starts `Phase 1 — Generating 1 component design docs`, does **not** abort with `No components in _manifest.json`
  3. `node dist/index.js codebase --lint --output <fixture>` — exit 0, `✓ 无问题`
- [x] Hidden empty wiki: `teamai deep-enrich --project widget --wiki-root <empty>` — exit 1, `No components in _manifest.json, aborting`
- [x] Public empty evidence: `teamai codebase --deep-enrich --project widget --output <empty>` — exit 1, `No components in _manifest.json for project "widget".`, does not say `Run extract first`
- [x] `git diff --check` — clean

### CLI test report

| Check | Result |
| --- | --- |
| Widget extract writes fallback `_manifest.json` | PASS |
| `source-manifest.json` still written | PASS |
| Hidden `deep-enrich` after extract does not abort | PASS |
| `--lint` on the same tree | PASS |
| Hidden empty `_manifest.json` exits 1 | PASS |
| Public empty message does not say re-run extract | PASS |
| Successful AI enrich is not replaced by fallback (unit) | PASS |

## Related Issues

Fixes #508.

## Notes for Reviewers

- Fallback component granularity matches AI enrich (top-level module, e.g. `src` for `src/widget.ts`). If there are no modules, it uses `kind === 'component'` fact names.
- Successful AI enrich output is unchanged (`AI enrich: N modules, domain=...`).
- Hidden `teamai deep-enrich` now sets `process.exitCode = 1` whenever the engine returns `complete: false` (empty manifest **or** missing AI docs), matching the public command from #491. Import still calls `deepEnrich()` directly and does not use that wrapper.
- `import --dir` / `--from-repo` will now run deep-enrich on small repos because a fallback `_manifest.json` exists; `--skip-enrich` still skips that stage.