### PR TITLE
fix: honor enabledAgents on builtin deploy, CLAUDE.md inject, and skip-sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### 🐛 Bug Fixes
 
+- `enabledAgents` now also gates CLI builtin deploy, CLAUDE.md-class injects, and last-pull skip-sync targets, so an already-installed tool outside the whitelist is not written to ([#510](https://github.com/Tencent/teamai-cli/issues/510)).
 - `teamai status` counts rule files in subdirectories recursively ([#437](https://github.com/Tencent/teamai-cli/pull/437)).
 - Codex Stop-phase contribution hints are deferred to the next prompt, so the host no longer rejects `additionalContext` ([#441](https://github.com/Tencent/teamai-cli/pull/441)).
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -1575,6 +1575,8 @@ Shared resources (the env block, docs directory, and `~/.teamai/`) are removed *
 
 The exclusion is durable: `uninstall --agent <tool>` drops the tool from `enabledAgents` and records it in `disabledAgents`, so a later `pull` (or another tool's session-start hook) will not resurrect its skills, rules, agents, CLAUDE.md block, or hooks. Running `init --agent <tool>` again clears the exclusion and re-enables sync for that tool.
 
+The same `enabledAgents` whitelist (from `init --agent`) also gates CLI built-in skills/rules/agents and CLAUDE.md-class injects: an already-installed tool outside the list is not written to, even if its root directory already exists. Editing `enabledAgents` without `init` still invalidates the last-pull skip cache for newly added tools.
+
 To rejoin after uninstalling:
 
 ```bash

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -1541,6 +1541,8 @@ teamai uninstall --agent claude
 
 该排除是持久的：`uninstall --agent <tool>` 会把该工具从 `enabledAgents` 移除并记入 `disabledAgents`，因此之后的 `pull`（或其他工具的 session-start hook）不会再把它的 skills、rules、agents、CLAUDE.md 块或 hooks 重新装回。重新执行 `init --agent <tool>` 会清除该排除、恢复对该工具的同步。
 
+同一套 `enabledAgents` 白名单（来自 `init --agent`）也约束 CLI 内置 skills/rules/agents 以及 CLAUDE.md 类注入：即使工具根目录已经存在，白名单外的已安装工具也不会被写入。不经过 `init` 直接把工具加进 `enabledAgents` 时，last-pull 跳过缓存会对新加入的工具失效。
+
 卸载后如需重新加入：
 
 ```bash

--- a/src/__tests__/builtin-agents.test.ts
+++ b/src/__tests__/builtin-agents.test.ts
@@ -216,4 +216,37 @@ describe('deployBuiltinAgents', () => {
     expect(await fse.pathExists(path.join(homeDir, '.claude', 'agents', 'teamai-recall.md'))).toBe(true);
     expect(await fse.pathExists(staleToml)).toBe(false);
   });
+
+  it('does not copy builtin agents into an installed tool outside the whitelist', async () => {
+    const recallSrc = path.join(builtinAgentsDir, 'teamai-recall.md');
+    if (!fs.existsSync(recallSrc)) return;
+
+    const teamConfig = buildTeamConfig({
+      claude: { agents: '.claude/agents' },
+      codebuddy: { agents: '.codebuddy/agents' },
+    });
+    const deployed = await deployBuiltinAgents(teamConfig, {
+      ...localConfig,
+      enabledAgents: ['claude'],
+    });
+
+    expect(deployed).toBeGreaterThanOrEqual(1);
+    expect(await fse.pathExists(path.join(homeDir, '.claude/agents/teamai-recall.md'))).toBe(true);
+    expect(await fse.pathExists(path.join(homeDir, '.codebuddy/agents/teamai-recall.md'))).toBe(false);
+  });
+
+  it('still deploys to every installed tool when enabledAgents is unset', async () => {
+    const recallSrc = path.join(builtinAgentsDir, 'teamai-recall.md');
+    if (!fs.existsSync(recallSrc)) return;
+
+    const teamConfig = buildTeamConfig({
+      claude: { agents: '.claude/agents' },
+      codebuddy: { agents: '.codebuddy/agents' },
+    });
+    const deployed = await deployBuiltinAgents(teamConfig, localConfig);
+
+    expect(deployed).toBeGreaterThanOrEqual(2);
+    expect(await fse.pathExists(path.join(homeDir, '.claude/agents/teamai-recall.md'))).toBe(true);
+    expect(await fse.pathExists(path.join(homeDir, '.codebuddy/agents/teamai-recall.md'))).toBe(true);
+  });
 });

--- a/src/__tests__/builtin-rules.test.ts
+++ b/src/__tests__/builtin-rules.test.ts
@@ -137,4 +137,59 @@ describe('builtin-rules', () => {
             expect(BUILTIN_RULE_NAMES.has('teamai-recall')).toBe(true);
         });
     });
+
+    describe('enabledAgents whitelist (#510)', () => {
+        it('does not write builtin rules into an installed tool outside the whitelist', async () => {
+            const workbuddyRules = path.join(tmpDir, '.workbuddy', 'rules');
+            const hermesRules = path.join(tmpDir, '.hermes', 'rules');
+            fs.mkdirSync(workbuddyRules, { recursive: true });
+            fs.mkdirSync(hermesRules, { recursive: true });
+
+            const teamConfig = {
+                toolPaths: {
+                    workbuddy: { rules: '.workbuddy/rules' },
+                    hermes: { rules: '.hermes/rules' },
+                },
+            } as any;
+            const localConfig = {
+                repo: { localPath: path.join(tmpDir, 'repo'), remote: 'https://example.com/repo.git' },
+                username: 'testuser',
+                additionalRoles: [],
+                scope: 'user',
+                enabledAgents: ['workbuddy'],
+            } as any;
+
+            const { deployBuiltinRules } = await import('../builtin-rules.js');
+            const deployed = await deployBuiltinRules(teamConfig, localConfig);
+
+            expect(deployed).toBe(1);
+            expect(fs.existsSync(path.join(workbuddyRules, 'teamai-recall.md'))).toBe(true);
+            expect(fs.existsSync(path.join(hermesRules, 'teamai-recall.md'))).toBe(false);
+        });
+
+        it('still deploys to every installed tool when enabledAgents is unset', async () => {
+            fs.mkdirSync(path.join(tmpDir, '.workbuddy', 'rules'), { recursive: true });
+            fs.mkdirSync(path.join(tmpDir, '.hermes', 'rules'), { recursive: true });
+
+            const teamConfig = {
+                toolPaths: {
+                    workbuddy: { rules: '.workbuddy/rules' },
+                    hermes: { rules: '.hermes/rules' },
+                },
+            } as any;
+            const localConfig = {
+                repo: { localPath: path.join(tmpDir, 'repo'), remote: 'https://example.com/repo.git' },
+                username: 'testuser',
+                additionalRoles: [],
+                scope: 'user',
+            } as any;
+
+            const { deployBuiltinRules } = await import('../builtin-rules.js');
+            const deployed = await deployBuiltinRules(teamConfig, localConfig);
+
+            expect(deployed).toBe(2);
+            expect(fs.existsSync(path.join(tmpDir, '.workbuddy', 'rules', 'teamai-recall.md'))).toBe(true);
+            expect(fs.existsSync(path.join(tmpDir, '.hermes', 'rules', 'teamai-recall.md'))).toBe(true);
+        });
+    });
 });

--- a/src/__tests__/e2e/enabled-agents-whitelist.test.ts
+++ b/src/__tests__/e2e/enabled-agents-whitelist.test.ts
@@ -1,0 +1,180 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { execFileSync, spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const CLI = path.join(ROOT, 'dist', 'index.js');
+
+const GIT_ENV = {
+  GIT_AUTHOR_NAME: 'TeamAI CI',
+  GIT_AUTHOR_EMAIL: 'ci@teamai.test',
+  GIT_COMMITTER_NAME: 'TeamAI CI',
+  GIT_COMMITTER_EMAIL: 'ci@teamai.test',
+};
+
+interface RunResult {
+  code: number | null;
+  output: string;
+}
+
+function runCLI(
+  args: string[],
+  env: Record<string, string>,
+  cwd: string,
+): Promise<RunResult> {
+  return new Promise((resolve) => {
+    const child = spawn('node', [CLI, ...args], {
+      env: { ...process.env, FORCE_COLOR: '0', ...env },
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd,
+    });
+    let output = '';
+    child.stdout.on('data', (data: Buffer) => { output += data.toString(); });
+    child.stderr.on('data', (data: Buffer) => { output += data.toString(); });
+    child.stdin.end();
+    child.on('close', (code) => resolve({ code, output }));
+  });
+}
+
+function git(args: string[], cwd: string): void {
+  execFileSync('git', args, {
+    cwd,
+    stdio: 'pipe',
+    env: { ...process.env, ...GIT_ENV },
+  });
+}
+
+describe('enabledAgents whitelist on real CLI pull (#510)', () => {
+  let sandbox: string;
+  let homeDir: string;
+  let localRepo: string;
+  let configPath: string;
+
+  beforeAll(() => {
+    if (!fs.existsSync(CLI)) {
+      throw new Error(`CLI binary not found at ${CLI}. Run "npm run build" first.`);
+    }
+
+    sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-issue510-e2e-'));
+    homeDir = path.join(sandbox, 'home');
+    const remote = path.join(sandbox, 'team-remote');
+    localRepo = path.join(homeDir, '.teamai', 'team-repo');
+    configPath = path.join(homeDir, '.teamai', 'config.yaml');
+
+    fs.mkdirSync(homeDir, { recursive: true });
+    fs.mkdirSync(path.join(remote, 'skills', 'team-skill'), { recursive: true });
+    fs.mkdirSync(path.join(remote, 'claudemd', 'common'), { recursive: true });
+
+    fs.writeFileSync(
+      path.join(remote, 'teamai.yaml'),
+      [
+        'team: issue-510-e2e',
+        `repo: ${remote}`,
+        'provider: git',
+        'sharing:',
+        '  recall:',
+        '    enabled: true',
+      ].join('\n'),
+    );
+    fs.writeFileSync(
+      path.join(remote, 'skills', 'team-skill', 'SKILL.md'),
+      '---\nname: team-skill\ndescription: Team skill fixture\n---\n\n# Team skill\n',
+    );
+    fs.writeFileSync(
+      path.join(remote, 'culture.md'),
+      '---\ncompany:\n  name: Acme\n---\n\nBe kind to teammates.\n',
+    );
+    fs.writeFileSync(
+      path.join(remote, 'claudemd', 'common', 'note.md'),
+      'Shared team instructions.\n',
+    );
+
+    git(['init', '-q'], remote);
+    git(['add', '-A'], remote);
+    git(['commit', '-q', '-m', 'fixture'], remote);
+
+    git(['clone', '-q', remote, localRepo], sandbox);
+
+    fs.mkdirSync(path.join(homeDir, '.workbuddy'), { recursive: true });
+    fs.mkdirSync(path.join(homeDir, '.hermes'), { recursive: true });
+    fs.mkdirSync(path.join(homeDir, '.claude'), { recursive: true });
+    fs.mkdirSync(path.join(homeDir, '.codebuddy'), { recursive: true });
+    fs.writeFileSync(path.join(homeDir, '.codebuddy', 'CODEBUDDY.md'), '# User notes\n');
+
+    fs.writeFileSync(
+      configPath,
+      [
+        'repo:',
+        `  localPath: ${localRepo}`,
+        `  remote: ${remote}`,
+        'username: ci-user',
+        'updatePolicy: auto',
+        'scope: user',
+        'recallEnabled: true',
+        'enabledAgents:',
+        '  - workbuddy',
+      ].join('\n'),
+    );
+  });
+
+  afterAll(() => {
+    if (sandbox) fs.rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  it('does not write builtins, team skills, or CLAUDE.md injects outside the whitelist', async () => {
+    const env = { HOME: homeDir };
+    const first = await runCLI(['pull'], env, sandbox);
+    expect(first.code, first.output).toBe(0);
+    expect(first.output).not.toContain('Already synced');
+
+    expect(fs.existsSync(path.join(homeDir, '.workbuddy', 'skills', 'team-skill', 'SKILL.md'))).toBe(true);
+    expect(fs.existsSync(path.join(homeDir, '.workbuddy', 'skills', 'team-wiki-codebase', 'SKILL.md'))).toBe(true);
+
+    expect(fs.existsSync(path.join(homeDir, '.hermes', 'skills', 'team-skill'))).toBe(false);
+    expect(fs.existsSync(path.join(homeDir, '.hermes', 'skills', 'team-wiki-codebase'))).toBe(false);
+    expect(fs.existsSync(path.join(homeDir, '.claude', 'skills', 'team-skill'))).toBe(false);
+    expect(fs.existsSync(path.join(homeDir, '.codebuddy', 'skills', 'team-skill'))).toBe(false);
+
+    const codebuddyMd = fs.readFileSync(path.join(homeDir, '.codebuddy', 'CODEBUDDY.md'), 'utf8');
+    expect(codebuddyMd).toBe('# User notes\n');
+    expect(codebuddyMd).not.toContain('[teamai:culture:start]');
+    expect(codebuddyMd).not.toContain('[teamai:claudemd:start]');
+    expect(codebuddyMd).not.toContain('[teamai:recall-rules:start]');
+
+    expect(JSON.parse(
+      fs.readFileSync(path.join(homeDir, '.teamai', 'state.json'), 'utf8'),
+    ).lastPullTargets).toEqual(['workbuddy']);
+
+    fs.writeFileSync(
+      configPath,
+      [
+        'repo:',
+        `  localPath: ${localRepo}`,
+        `  remote: ${path.join(sandbox, 'team-remote')}`,
+        'username: ci-user',
+        'updatePolicy: auto',
+        'scope: user',
+        'recallEnabled: true',
+        'enabledAgents:',
+        '  - workbuddy',
+        '  - claude',
+      ].join('\n'),
+    );
+
+    const second = await runCLI(['pull'], env, sandbox);
+    expect(second.code, second.output).toBe(0);
+    expect(second.output).not.toContain('Already synced');
+    expect(fs.existsSync(path.join(homeDir, '.claude', 'skills', 'team-skill', 'SKILL.md'))).toBe(true);
+    expect(JSON.parse(
+      fs.readFileSync(path.join(homeDir, '.teamai', 'state.json'), 'utf8'),
+    ).lastPullTargets).toEqual(['claude', 'workbuddy']);
+
+    const third = await runCLI(['pull'], env, sandbox);
+    expect(third.code, third.output).toBe(0);
+    expect(third.output).toContain('Already synced');
+  }, 60_000);
+});

--- a/src/__tests__/pull-skip-sync.test.ts
+++ b/src/__tests__/pull-skip-sync.test.ts
@@ -72,12 +72,17 @@ vi.mock('../update.js', () => ({
   releaseLock: vi.fn().mockResolvedValue(undefined),
 }));
 
-import { pull, compileRecallRulesBlock } from '../pull.js';
+import { pull, compileRecallRulesBlock, cleanupInactiveNamespaceSkills } from '../pull.js';
 import { loadLocalConfigForScope, loadTeamConfig, detectProjectConfig, loadStateForScope, saveStateForScope } from '../config.js';
 import { getHeadRev } from '../utils/git.js';
 import { log } from '../utils/logger.js';
-import { TEAMAI_RECALL_RULES_START, TEAMAI_RECALL_RULES_END } from '../types.js';
-import type { TeamaiConfig, LocalConfig } from '../types.js';
+import {
+  TEAMAI_RECALL_RULES_START,
+  TEAMAI_RECALL_RULES_END,
+  TEAMAI_CULTURE_START,
+  TEAMAI_CLAUDEMD_START,
+} from '../types.js';
+import type { TeamaiConfig, LocalConfig, State } from '../types.js';
 
 describe('pull skip-sync when repo HEAD unchanged', () => {
   let tmpDir: string;
@@ -428,5 +433,325 @@ describe('pull skip-sync refreshes CLAUDE.md recall block (CLI upgrade)', () => 
     const after = await fse.readFile(claudeMdPath, 'utf8');
     // Untouched: the stale block remains exactly as seeded.
     expect(after).toContain('you **MUST** first invoke the `teamai-recall` subagent');
+  });
+});
+
+function emptyState(overrides: Partial<State> = {}): State {
+  return {
+    lastPull: null,
+    lastPullRev: null,
+    lastPush: null,
+    pushedRules: [],
+    pushedSkills: [],
+    pushedEnvVars: [],
+    pendingPushes: [],
+    lastUpdateCheck: null,
+    availableUpdate: null,
+    ...overrides,
+  };
+}
+
+describe('enabledAgents whitelist on pull inject, skip-sync, and cleanup (#510)', () => {
+  let tmpDir: string;
+  let homeDir: string;
+  let repoPath: string;
+
+  const skillBody = '---\nname: team-skill\ndescription: Team skill fixture\n---\n\n# Team skill\n';
+
+  beforeEach(async () => {
+    tmpDir = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-pull-whitelist-'));
+    homeDir = path.join(tmpDir, 'home');
+    repoPath = path.join(tmpDir, 'team-repo');
+
+    await fse.ensureDir(path.join(repoPath, 'rules'));
+    await fse.ensureDir(path.join(repoPath, 'skills', 'common', 'team-skill'));
+    await fse.writeFile(path.join(repoPath, 'skills', 'common', 'team-skill', 'SKILL.md'), skillBody);
+    await fse.ensureDir(path.join(repoPath, 'learnings', 'common'));
+    await fse.ensureDir(path.join(repoPath, 'manifest'));
+    await fse.writeFile(path.join(repoPath, 'manifest', 'roles.yaml'), 'version: 1\n');
+    await fse.writeFile(
+      path.join(repoPath, 'culture.md'),
+      '---\ncompany:\n  name: Acme\n---\n\nBe kind to teammates.\n',
+    );
+    await fse.ensureDir(path.join(repoPath, 'claudemd', 'common'));
+    await fse.writeFile(path.join(repoPath, 'claudemd', 'common', 'note.md'), 'Shared team instructions.\n');
+
+    vi.stubEnv('HOME', homeDir);
+    vi.mocked(detectProjectConfig).mockResolvedValue(null);
+    vi.mocked(getHeadRev).mockResolvedValue('abc1234');
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+    await fse.remove(tmpDir);
+  });
+
+  it('does not inject culture, shared instructions, or recall into an out-of-whitelist tool', async () => {
+    await fse.ensureDir(path.join(homeDir, '.claude', 'agents'));
+    await fse.ensureDir(path.join(homeDir, '.claude', 'rules'));
+    await fse.ensureDir(path.join(homeDir, '.claude', 'skills'));
+    await fse.ensureDir(path.join(homeDir, '.codebuddy', 'agents'));
+    await fse.ensureDir(path.join(homeDir, '.codebuddy', 'rules'));
+    await fse.writeFile(path.join(homeDir, '.claude', 'CLAUDE.md'), '# Claude\n');
+    await fse.writeFile(path.join(homeDir, '.codebuddy', 'CODEBUDDY.md'), '# User notes\n');
+
+    const teamConfig: TeamaiConfig = {
+      team: 'test',
+      description: '',
+      repo: 'https://git.woa.com/test/repo.git',
+      provider: 'tgit',
+      reviewers: [],
+      sharing: {
+        skills: {},
+        rules: { enforced: [] },
+        docs: { localDir: '' },
+        env: { injectShellProfile: true },
+        recall: { enabled: true },
+      },
+      toolPaths: {
+        claude: {
+          skills: '.claude/skills',
+          rules: '.claude/rules',
+          agents: '.claude/agents',
+          claudemd: '.claude/CLAUDE.md',
+        },
+        codebuddy: {
+          skills: '.codebuddy/skills',
+          rules: '.codebuddy/rules',
+          agents: '.codebuddy/agents',
+          claudemd: '.codebuddy/CODEBUDDY.md',
+        },
+      },
+    };
+    const localConfig: LocalConfig = {
+      repo: { localPath: repoPath, remote: 'https://git.woa.com/test/repo.git' },
+      username: 'testuser',
+      updatePolicy: 'auto',
+      primaryRole: 'hai',
+      additionalRoles: [],
+      resourceProfileVersion: 1,
+      scope: 'user',
+      recallEnabled: true,
+      enabledAgents: ['claude'],
+    };
+
+    vi.mocked(loadLocalConfigForScope).mockResolvedValue(localConfig);
+    vi.mocked(loadTeamConfig).mockResolvedValue(teamConfig);
+    vi.mocked(loadStateForScope).mockResolvedValue(emptyState());
+
+    await pull({});
+
+    const claudeMd = await fse.readFile(path.join(homeDir, '.claude', 'CLAUDE.md'), 'utf8');
+    expect(claudeMd).toContain(TEAMAI_CULTURE_START);
+    expect(claudeMd).toContain(TEAMAI_CLAUDEMD_START);
+    expect(claudeMd).toContain(TEAMAI_RECALL_RULES_START);
+
+    const codebuddyMd = await fse.readFile(path.join(homeDir, '.codebuddy', 'CODEBUDDY.md'), 'utf8');
+    expect(codebuddyMd).toBe('# User notes\n');
+    expect(codebuddyMd).not.toContain(TEAMAI_CULTURE_START);
+    expect(codebuddyMd).not.toContain(TEAMAI_CLAUDEMD_START);
+    expect(codebuddyMd).not.toContain(TEAMAI_RECALL_RULES_START);
+  });
+
+  it('records only whitelist-eligible tools in lastPullTargets', async () => {
+    await fse.ensureDir(path.join(homeDir, '.workbuddy'));
+    await fse.ensureDir(path.join(homeDir, '.claude'));
+
+    const teamConfig: TeamaiConfig = {
+      team: 'test',
+      description: '',
+      repo: 'https://git.woa.com/test/repo.git',
+      provider: 'tgit',
+      reviewers: [],
+      sharing: {
+        skills: {},
+        rules: { enforced: [] },
+        docs: { localDir: '' },
+        env: { injectShellProfile: true },
+      },
+      toolPaths: {
+        workbuddy: { skills: '.workbuddy/skills' },
+        claude: { skills: '.claude/skills' },
+      },
+    };
+    const localConfig: LocalConfig = {
+      repo: { localPath: repoPath, remote: 'https://git.woa.com/test/repo.git' },
+      username: 'testuser',
+      updatePolicy: 'auto',
+      primaryRole: 'hai',
+      additionalRoles: [],
+      resourceProfileVersion: 1,
+      scope: 'user',
+      enabledAgents: ['workbuddy'],
+    };
+
+    vi.mocked(loadLocalConfigForScope).mockResolvedValue(localConfig);
+    vi.mocked(loadTeamConfig).mockResolvedValue(teamConfig);
+    vi.mocked(loadStateForScope).mockResolvedValue(emptyState());
+
+    await pull({});
+
+    expect(vi.mocked(saveStateForScope).mock.calls[0][0].lastPullTargets).toEqual(['workbuddy']);
+    expect(await fse.pathExists(path.join(homeDir, '.workbuddy/skills/team-skill/SKILL.md'))).toBe(true);
+    expect(await fse.pathExists(path.join(homeDir, '.claude/skills/team-skill'))).toBe(false);
+  });
+
+  it('does not skip when a previously installed tool is added to the whitelist', async () => {
+    await fse.ensureDir(path.join(homeDir, '.workbuddy'));
+    await fse.ensureDir(path.join(homeDir, '.claude'));
+
+    const teamConfig: TeamaiConfig = {
+      team: 'test',
+      description: '',
+      repo: 'https://git.woa.com/test/repo.git',
+      provider: 'tgit',
+      reviewers: [],
+      sharing: {
+        skills: {},
+        rules: { enforced: [] },
+        docs: { localDir: '' },
+        env: { injectShellProfile: true },
+      },
+      toolPaths: {
+        workbuddy: { skills: '.workbuddy/skills' },
+        claude: { skills: '.claude/skills' },
+      },
+    };
+    const localConfig: LocalConfig = {
+      repo: { localPath: repoPath, remote: 'https://git.woa.com/test/repo.git' },
+      username: 'testuser',
+      updatePolicy: 'auto',
+      primaryRole: 'hai',
+      additionalRoles: [],
+      resourceProfileVersion: 1,
+      scope: 'user',
+      enabledAgents: ['workbuddy'],
+    };
+
+    vi.mocked(loadLocalConfigForScope).mockResolvedValue(localConfig);
+    vi.mocked(loadTeamConfig).mockResolvedValue(teamConfig);
+    vi.mocked(loadStateForScope).mockResolvedValue(emptyState());
+
+    await pull({});
+    expect(vi.mocked(saveStateForScope).mock.calls[0][0].lastPullTargets).toEqual(['workbuddy']);
+    expect(await fse.pathExists(path.join(homeDir, '.claude/skills/team-skill'))).toBe(false);
+
+    vi.mocked(log.success).mockClear();
+    vi.mocked(saveStateForScope).mockClear();
+    vi.mocked(loadLocalConfigForScope).mockResolvedValue({
+      ...localConfig,
+      enabledAgents: ['workbuddy', 'claude'],
+    });
+    vi.mocked(loadStateForScope).mockResolvedValue(emptyState({
+      lastPull: '2026-04-01',
+      lastPullRev: 'abc1234',
+      lastPullTargets: ['workbuddy'],
+    }));
+
+    await pull({});
+
+    expect(log.success).not.toHaveBeenCalledWith(
+      expect.stringContaining('Already synced'),
+    );
+    expect(await fse.pathExists(path.join(homeDir, '.claude/skills/team-skill/SKILL.md'))).toBe(true);
+  });
+
+  it('skip-sync still deploys builtins only to the whitelist', async () => {
+    await fse.ensureDir(path.join(homeDir, '.workbuddy'));
+    await fse.ensureDir(path.join(homeDir, '.hermes'));
+
+    const teamConfig: TeamaiConfig = {
+      team: 'test',
+      description: '',
+      repo: 'https://git.woa.com/test/repo.git',
+      provider: 'tgit',
+      reviewers: [],
+      sharing: {
+        skills: {},
+        rules: { enforced: [] },
+        docs: { localDir: '' },
+        env: { injectShellProfile: true },
+      },
+      toolPaths: {
+        workbuddy: { skills: '.workbuddy/skills' },
+        hermes: { skills: '.hermes/skills' },
+      },
+    };
+    const localConfig: LocalConfig = {
+      repo: { localPath: repoPath, remote: 'https://git.woa.com/test/repo.git' },
+      username: 'testuser',
+      updatePolicy: 'auto',
+      primaryRole: 'hai',
+      additionalRoles: [],
+      resourceProfileVersion: 1,
+      scope: 'user',
+      enabledAgents: ['workbuddy'],
+    };
+
+    vi.mocked(loadLocalConfigForScope).mockResolvedValue(localConfig);
+    vi.mocked(loadTeamConfig).mockResolvedValue(teamConfig);
+    vi.mocked(loadStateForScope).mockResolvedValue(emptyState({
+      lastPull: '2026-04-01',
+      lastPullRev: 'abc1234',
+      lastPullTargets: ['workbuddy'],
+    }));
+
+    await pull({});
+
+    expect(log.success).toHaveBeenCalledWith(
+      expect.stringContaining('Already synced at abc1234, skipping'),
+    );
+    expect(await fse.pathExists(path.join(homeDir, '.workbuddy/skills/team-wiki-codebase/SKILL.md'))).toBe(true);
+    expect(await fse.pathExists(path.join(homeDir, '.hermes/skills/team-wiki-codebase'))).toBe(false);
+  });
+
+  it('does not delete leftover copies on out-of-whitelist tools', async () => {
+    const leftover = path.join(homeDir, '.hermes', 'skills', 'stale-skill');
+    const workbuddyCopy = path.join(homeDir, '.workbuddy', 'skills', 'stale-skill');
+    const source = path.join(repoPath, 'skills', 'common', 'stale-skill');
+    await fse.ensureDir(leftover);
+    await fse.ensureDir(workbuddyCopy);
+    await fse.ensureDir(source);
+    await fse.writeFile(path.join(source, 'SKILL.md'), '---\nname: stale-skill\ndescription: stale\n---\n# Stale\n');
+    await fse.copy(source, leftover, { overwrite: true });
+    await fse.copy(source, workbuddyCopy, { overwrite: true });
+
+    const teamConfig: TeamaiConfig = {
+      team: 'test',
+      description: '',
+      repo: 'https://git.woa.com/test/repo.git',
+      provider: 'tgit',
+      reviewers: [],
+      sharing: {
+        skills: {},
+        rules: { enforced: [] },
+        docs: { localDir: '' },
+        env: { injectShellProfile: true },
+      },
+      toolPaths: {
+        workbuddy: { skills: '.workbuddy/skills' },
+        hermes: { skills: '.hermes/skills' },
+      },
+    };
+    const localConfig: LocalConfig = {
+      repo: { localPath: repoPath, remote: 'https://git.woa.com/test/repo.git' },
+      username: 'testuser',
+      updatePolicy: 'auto',
+      additionalRoles: [],
+      scope: 'user',
+      enabledAgents: ['workbuddy'],
+    };
+
+    await cleanupInactiveNamespaceSkills(
+      teamConfig,
+      localConfig,
+      new Set(),
+      new Set(['stale-skill']),
+      new Map([['stale-skill', source]]),
+    );
+
+    expect(await fse.pathExists(leftover)).toBe(true);
+    expect(await fse.pathExists(workbuddyCopy)).toBe(false);
   });
 });

--- a/src/__tests__/skip-uninstalled-tools.test.ts
+++ b/src/__tests__/skip-uninstalled-tools.test.ts
@@ -602,3 +602,71 @@ describe('deployBuiltinSkills — skip uninstalled tools', () => {
     expect(await fse.pathExists(path.join(homeDir, '.codex', 'skills', 'team-wiki-codebase'))).toBe(false);
   });
 });
+
+describe('deployBuiltinSkills — enabledAgents whitelist (#510)', () => {
+  let tmpDir: string;
+  let homeDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-builtin-whitelist-'));
+    homeDir = path.join(tmpDir, 'home');
+    await fse.ensureDir(path.join(homeDir, '.workbuddy'));
+    await fse.ensureDir(path.join(homeDir, '.hermes'));
+    vi.stubEnv('HOME', homeDir);
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await fse.remove(tmpDir);
+  });
+
+  function teamConfig() {
+    return {
+      team: 'test',
+      description: '',
+      repo: 'https://git.woa.com/test/repo.git',
+      provider: 'tgit' as const,
+      reviewers: [],
+      sharing: {
+        skills: {},
+        rules: { enforced: [] },
+        docs: { localDir: '' },
+        env: { injectShellProfile: true },
+      },
+      toolPaths: {
+        workbuddy: { skills: '.workbuddy/skills' },
+        hermes: { skills: '.hermes/skills' },
+      },
+    };
+  }
+
+  function localConfig(enabledAgents?: string[]) {
+    return {
+      repo: { localPath: path.join(tmpDir, 'repo'), remote: 'https://git.woa.com/test/repo.git' },
+      username: 'testuser',
+      updatePolicy: 'auto' as const,
+      additionalRoles: [],
+      scope: 'user' as const,
+      ...(enabledAgents ? { enabledAgents } : {}),
+    };
+  }
+
+  it('does not copy builtin skills into an installed tool outside the whitelist', async () => {
+    const { deployBuiltinSkills } = await import('../builtin-skills.js');
+    const deployed = await deployBuiltinSkills(teamConfig(), localConfig(['workbuddy']));
+
+    expect(deployed).toBeGreaterThan(0);
+    expect(await fse.pathExists(path.join(homeDir, '.workbuddy/skills/team-wiki-codebase/SKILL.md'))).toBe(true);
+    expect(await fse.pathExists(path.join(homeDir, '.hermes/skills/team-wiki-codebase'))).toBe(false);
+    expect(await fse.pathExists(path.join(homeDir, '.hermes/skills'))).toBe(false);
+  });
+
+  it('still deploys to every installed tool when enabledAgents is unset', async () => {
+    const { deployBuiltinSkills } = await import('../builtin-skills.js');
+    const deployed = await deployBuiltinSkills(teamConfig(), localConfig());
+
+    expect(deployed).toBeGreaterThan(0);
+    expect(await fse.pathExists(path.join(homeDir, '.workbuddy/skills/team-wiki-codebase/SKILL.md'))).toBe(true);
+    expect(await fse.pathExists(path.join(homeDir, '.hermes/skills/team-wiki-codebase/SKILL.md'))).toBe(true);
+  });
+});

--- a/src/builtin-agents.ts
+++ b/src/builtin-agents.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { ensureDir, pathExists, readFileSafe, writeFile, remove, listFiles } from './utils/fs.js';
 import { log } from './utils/logger.js';
 import type { TeamaiConfig, LocalConfig } from './types.js';
-import { resolveBaseDir, isAgentDisabled, scopedToolPaths } from './types.js';
+import { resolveBaseDir, isAgentExcluded, scopedToolPaths } from './types.js';
 import { ResourceHandler } from './resources/base.js';
 import { getUserHome } from './utils/home.js';
 import { ALL_SUPPORTED_TOOLS, renderForTool, reverseFromClaude } from './resources/agent-format.js';
@@ -126,7 +126,7 @@ export async function deployBuiltinAgents(
       log.debug(`Skipping built-in agent deployment for ${tool}: tool not installed`);
       continue;
     }
-    if (localConfig && isAgentDisabled(localConfig, tool)) continue;
+    if (localConfig && isAgentExcluded(localConfig, tool)) continue;
     if (!(ALL_SUPPORTED_TOOLS as string[]).includes(tool)) {
       log.warn(
         `Skipping built-in agent deployment for ${tool}: unsupported agent format; ` +

--- a/src/builtin-rules.ts
+++ b/src/builtin-rules.ts
@@ -5,7 +5,7 @@ import { ResourceHandler } from './resources/base.js';
 import { ruleFileExtensionForTool, usesCursorMdcRules } from './resources/rule-format.js';
 import { teamRuleToCursorMdc } from './resources/cursor-mdc.js';
 import type { TeamaiConfig, LocalConfig } from './types.js';
-import { resolveBaseDir, isAgentDisabled, scopedToolPaths } from './types.js';
+import { resolveBaseDir, isAgentExcluded, scopedToolPaths } from './types.js';
 import fs from 'node:fs/promises';
 import { getUserHome } from './utils/home.js';
 
@@ -66,7 +66,7 @@ export async function deployBuiltinRules(
             log.debug(`Skipping built-in rules for ${tool}: tool not installed`);
             continue;
         }
-        if (localConfig && isAgentDisabled(localConfig, tool)) continue;
+        if (localConfig && isAgentExcluded(localConfig, tool)) continue;
 
         const rulesDir = path.join(baseDir, toolPath.rules);
         if (!await pathExists(rulesDir)) continue;

--- a/src/builtin-skills.ts
+++ b/src/builtin-skills.ts
@@ -5,7 +5,7 @@ import fse from 'fs-extra';
 import { pathExists } from './utils/fs.js';
 import { log } from './utils/logger.js';
 import type { TeamaiConfig, LocalConfig } from './types.js';
-import { resolveBaseDir, isAgentDisabled, scopedToolPaths } from './types.js';
+import { resolveBaseDir, isAgentExcluded, scopedToolPaths } from './types.js';
 import { ResourceHandler } from './resources/base.js';
 import { ensureSkillFrontmatter, resolveSkillDestination } from './resources/skills.js';
 import { getUserHome } from './utils/home.js';
@@ -115,7 +115,7 @@ export async function deployBuiltinSkills(teamConfig: TeamaiConfig, localConfig?
       log.debug(`Skipping built-in skill deployment for ${tool}: tool not installed`);
       continue;
     }
-    if (localConfig && isAgentDisabled(localConfig, tool)) continue;
+    if (localConfig && isAgentExcluded(localConfig, tool)) continue;
 
     for (const skillName of skillNames) {
       const srcDir = path.join(builtinDir, skillName);

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -25,7 +25,7 @@ import {
   resolveHookScope,
   getDataHome,
   isRecallEnabled,
-  isAgentDisabled,
+  isAgentExcluded,
   scopedToolPaths,
   SYNC_LOCK_FILENAME,
 } from './types.js';
@@ -338,7 +338,7 @@ export async function cleanupInactiveNamespaceSkills(
   const baseDir = resolveBaseDir(localConfig);
 
   for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
-    if (isAgentDisabled(localConfig, tool)) continue;
+    if (isAgentExcluded(localConfig, tool)) continue;
     if (!toolPath.skills) continue;
     if (!await ResourceHandler.isToolInstalled(toolPath.skills, baseDir)) continue;
     if (!await pathExists(path.join(baseDir, toolPath.skills))) continue;
@@ -438,6 +438,9 @@ function logSyncDetail(
 /**
  * Return the installed tool targets that can receive team-owned resources.
  *
+ * Tools in `disabledAgents`, and tools outside `enabledAgents` when that
+ * whitelist is set, are omitted — the same gate resource handlers use.
+ *
  * The revision cache is shared by a scope, while tool roots can appear later
  * (for example, when Cursor creates `.cursor/` on its first launch). Persisting
  * this set alongside the revision prevents a pull for one tool from suppressing
@@ -451,7 +454,7 @@ async function getInstalledResourceTargets(
   const targets: string[] = [];
 
   for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
-    if (isAgentDisabled(localConfig, tool)) continue;
+    if (isAgentExcluded(localConfig, tool)) continue;
 
     const resourcePaths = [toolPath.skills, toolPath.rules, toolPath.agents]
       .filter((resourcePath): resourcePath is string => !!resourcePath);
@@ -735,7 +738,7 @@ async function pullForScope(
         const dir = toolPath[toolPathField];
         if (!dir) continue;
         if (!await ResourceHandler.isToolInstalled(dir, baseDir)) continue;
-        if (isAgentDisabled(localConfig, tool)) continue;
+        if (isAgentExcluded(localConfig, tool)) continue;
 
         // Rules carry a per-tool extension (`.mdc` for compatible tools), and those dirs
         // may still hold a `.md` copy from the layout that predates it, so a
@@ -779,7 +782,7 @@ async function pullForScope(
     const baseDir = resolveBaseDir(localConfig);
 
     for (const [tool, toolPath] of Object.entries(scopedToolPaths(freshConfig, localConfig))) {
-      if (isAgentDisabled(localConfig, tool)) continue;
+      if (isAgentExcluded(localConfig, tool)) continue;
       if (!toolPath.skills) continue;
       if (!await ResourceHandler.isToolInstalled(toolPath.skills, baseDir)) continue;
       const skillsDir = path.join(baseDir, toolPath.skills);
@@ -935,7 +938,7 @@ async function pullForScope(
           if (compiled) {
             const baseDir = resolveBaseDir(localConfig);
             for (const [tool, toolPath] of Object.entries(scopedToolPaths(freshConfig, localConfig))) {
-              if (isAgentDisabled(localConfig, tool)) continue;
+              if (isAgentExcluded(localConfig, tool)) continue;
               if (!toolPath.claudemd) continue;
               if (toolPath.rules && !await ResourceHandler.isToolInstalled(toolPath.rules, baseDir)) continue;
 
@@ -966,7 +969,7 @@ async function pullForScope(
         if (compiled) {
           const baseDir = resolveBaseDir(localConfig);
           for (const [tool, toolPath] of Object.entries(scopedToolPaths(freshConfig, localConfig))) {
-            if (isAgentDisabled(localConfig, tool)) continue;
+            if (isAgentExcluded(localConfig, tool)) continue;
             if (!toolPath.claudemd) continue;
             if (toolPath.rules && !await ResourceHandler.isToolInstalled(toolPath.rules, baseDir)) continue;
             const claudeMdPath = path.join(baseDir, toolPath.claudemd);
@@ -1214,7 +1217,7 @@ export async function injectRecallBlockIntoTools(
         const recallBlock = compileRecallRulesBlock();
         let injected = 0;
         for (const [tool, toolPath] of Object.entries(scopedToolPaths(config, localConfig))) {
-            if (isAgentDisabled(localConfig, tool)) continue;
+            if (isAgentExcluded(localConfig, tool)) continue;
             if (!toolPath.claudemd || !toolPath.agents) continue;
             if (!await ResourceHandler.isToolInstalled(toolPath.agents, baseDir)) continue;
 


### PR DESCRIPTION
## Summary

Follow-up to #504. `init --agent` / `enabledAgents` is already honored by `hooks inject` and the skills/rules/agents **resource handlers**. Several other write paths still gated only on `disabledAgents` (`isAgentDisabled`). On a machine that already has another tool installed, those paths kept writing into it even when the team opted in to a single agent.

This PR routes the remaining resource-write and last-pull target sites through `isAgentExcluded` (disabled **or** outside the whitelist when one exists; unset whitelist = all installed tools):

- `deployBuiltinSkills` / `deployBuiltinRules` / `deployBuiltinAgents`
- `pull.ts` culture / shared-instructions / recall CLAUDE.md injects
- `getInstalledResourceTargets` (feeds `lastPullTargets` / skip-sync)
- tombstone and inactive-namespace cleanup — skip leftover copies on out-of-whitelist trees, do not delete them

The skip-sync fast path still calls `deployBuiltin*` + `injectRecallBlockIntoTools`, so the builtin leak is covered even when team-repo HEAD has not changed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 217 files, 3017 tests green
- [x] Disk-level unit tests for #510 repro 1 and 2 (`skip-uninstalled-tools`, `builtin-rules`, `builtin-agents`, `pull-skip-sync`):
  - `enabledAgents: ['workbuddy']` + existing `~/.hermes` does not receive builtin skills
  - same whitelist does not write builtin rules/agents into an installed out-of-whitelist root
  - unset `enabledAgents` still deploys to every installed tool
  - culture / shared-instructions / recall markers land in `.claude/CLAUDE.md` and not in `.codebuddy/CODEBUDDY.md`
  - first pull records `lastPullTargets: ['workbuddy']` only
  - adding `claude` to the whitelist with unchanged HEAD does **not** print `Already synced`; claude receives the team skill
  - skip-sync still deploys builtins only to the whitelist
  - leftover copies on out-of-whitelist trees are kept (skip-not-delete)
- [x] `npm run build` then real `dist/index.js pull` (isolated HOME, git team-repo fixture matching issue #510):
  - pull 1 (`enabledAgents: [workbuddy]`, hermes/claude/codebuddy already installed): workbuddy got team skill + `team-wiki-codebase`; hermes/claude skills absent; `CODEBUDDY.md` unchanged (no culture/shared/recall markers); `lastPullTargets = ['workbuddy']`
  - pull 2 (add `claude` to whitelist, HEAD unchanged): no `Already synced`; claude received `team-skill`; `lastPullTargets = ['claude', 'workbuddy']`
  - pull 3: `Already synced … skipping`
- [x] `npx vitest run --config vitest.e2e.config.ts src/__tests__/e2e/enabled-agents-whitelist.test.ts` green

## Related Issues

Closes #510

## Notes for Reviewers

- Deliberately did **not** fold exclusion into `scopedToolPaths()` (path-mapping helper stays path-mapping so uninstall/status can still see excluded tools).
- CLAUDE.md inject tests use codebuddy's `CODEBUDDY.md`, not workbuddy/hermes shared home-root `AGENTS.md`.
- Sites that never had an `isAgentDisabled` gate (cross-team `source.ts` deploy, MCP reconcile, `recall enable` CLAUDE.md inject) are left as a later same-class follow-up; they were not in #510's remaining-sites list.