### PR TITLE
docs: add paste-able onboarding prompts for users who have not used Git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 - Align the public usage guides, drop internal-only details, and cover the missing commands and configuration ([#442](https://github.com/Tencent/teamai-cli/pull/442)).
 - Document `teamai projects` in the bilingual READMEs as the lead distribution control, including learnings isolation ([#490](https://github.com/Tencent/teamai-cli/pull/490), for [#487](https://github.com/Tencent/teamai-cli/issues/487)).
+- Add paste-able onboarding prompts for users who have not used Git ([#524](https://github.com/Tencent/teamai-cli/pull/524), for [#517](https://github.com/Tencent/teamai-cli/issues/517)).
 
 ## [0.23.0](https://github.com/Tencent/teamai-cli/compare/v0.22.0...v0.23.0) (2026-09-08)
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Made with [contrib.rocks](https://contrib.rocks).
 npm install -g teamai-cli
 ```
 
+> **Never used Git?** Paste an [onboarding prompt](docs/prompts/README.md) into your current AI tool and let it run the commands.
+
 ### Team admin / solo user
 
 Create a shared-experience repo on your git host (GitHub, GitLab, GitCode, CNB, TGit, or a private Git service), **grant write access to team members**, then run `teamai init https://github.com/yourorg/yourrepo`.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,6 +31,8 @@ TeamAI 统一管理团队的 Skills、Rules、MCP 和知识，驾驭 Claude Code
 npm install -g teamai-cli
 ```
 
+> **没用过 Git？** 把[接入提示词](docs/prompts/README.zh-CN.md)粘贴给当前的 AI 工具，让它代跑命令。
+
 ### 团队管理员 / 个人使用者
 
 在 Git 托管平台（GitHub、GitLab、GitCode、CNB、TGit，或私有 Git 服务）创建共享经验仓库，**授予团队成员写权限**，然后运行 `teamai init https://github.com/yourorg/yourrepo`。

--- a/docs/prompts/README.md
+++ b/docs/prompts/README.md
@@ -2,9 +2,9 @@
 
 > [English](README.md) | [简体中文](README.zh-CN.md)
 
-These prompts are for people who have **not used Git**. Paste one into Claude Code, Codex, Cursor, CodeBuddy, WorkBuddy, OpenCode, Qoder, or any other supported agent. The agent runs `teamai init` / `pull` / `push` / `doctor` for you and only asks when a web login or a choice is required.
+These prompts are for people who have **not used Git**. Copy the fenced block from one file and paste it into Claude Code, Codex, Cursor, CodeBuddy, WorkBuddy, OpenCode, Qoder, or any other supported agent. The agent runs the commands; it should only ask when a web login or a choice is required.
 
-When the agent tells you to start a new session, it should name **the tool you are in now** — not a default such as Cursor or Claude Code.
+When it tells you to start a new session, it should name **the tool you are in now**.
 
 | Situation | Prompt |
 |-----------|--------|
@@ -12,6 +12,6 @@ When the agent tells you to start a new session, it should name **the tool you a
 | Someone already gave you a repo URL | [Member](member.md) |
 | You already ran `teamai init` and need day-to-day admin | [Admin](admin.md) |
 
-Getting started finishes by handing you the repo URL plus the [member prompt](member.md) to forward.
+Getting started finishes by handing you the repo URL plus a short member prompt (prompt B) to forward.
 
-Do not use the `owner/repo` short form (`owner/repo` is treated as GitHub). Do not use `teamai init .` — these prompts keep a separate team repo; they do not cover single-repo mode.
+The paste blocks reuse `init` / `pull` / `push` / `doctor` (admin also uses `members` / `list` / `roles` / `packages` / `env` / `contribute`). They do not teach Git, do not use the `owner/repo` short form, do not recommend a host by region, and do not cover single-repo mode (`teamai init .`).

--- a/docs/prompts/README.md
+++ b/docs/prompts/README.md
@@ -1,0 +1,17 @@
+# Paste-able onboarding prompts
+
+> [English](README.md) | [简体中文](README.zh-CN.md)
+
+These prompts are for people who have **not used Git**. Paste one into Claude Code, Codex, Cursor, CodeBuddy, WorkBuddy, OpenCode, Qoder, or any other supported agent. The agent runs `teamai init` / `pull` / `push` / `doctor` for you and only asks when a web login or a choice is required.
+
+When the agent tells you to start a new session, it should name **the tool you are in now** — not a default such as Cursor or Claude Code.
+
+| Situation | Prompt |
+|-----------|--------|
+| You do not have a team repo URL yet | [Getting started](getting-started.md) |
+| Someone already gave you a repo URL | [Member](member.md) |
+| You already ran `teamai init` and need day-to-day admin | [Admin](admin.md) |
+
+Getting started finishes by handing you the repo URL plus the [member prompt](member.md) to forward.
+
+Do not use the `owner/repo` short form (`owner/repo` is treated as GitHub). Do not use `teamai init .` — these prompts keep a separate team repo; they do not cover single-repo mode.

--- a/docs/prompts/README.zh-CN.md
+++ b/docs/prompts/README.zh-CN.md
@@ -2,9 +2,9 @@
 
 > [English](README.md) | [简体中文](README.zh-CN.md)
 
-这三份提示词面向**没用过 Git** 的人。把对应一段粘贴给 Claude Code、Codex、Cursor、CodeBuddy、WorkBuddy、OpenCode、Qoder 等已支持的 Agent。Agent 代跑 `teamai init` / `pull` / `push` / `doctor`，只在要网页登录或二选一时问你。
+这三份提示词面向**没用过 Git** 的人。从对应文件里复制围栏中的整段，粘贴给 Claude Code、Codex、Cursor、CodeBuddy、WorkBuddy、OpenCode、Qoder 等已支持的 Agent。Agent 代跑命令，只在要网页登录或二选一时问你。
 
-Agent 让你新开会话时，应使用**当前这个**工具的名字，不要默认 Cursor / Claude Code。
+Agent 让你新开会话时，应使用**当前这个**工具的名字。
 
 | 场景 | 提示词 |
 |------|--------|
@@ -12,6 +12,6 @@ Agent 让你新开会话时，应使用**当前这个**工具的名字，不要�
 | 已经拿到仓库 URL | [成员（Member）](member.zh-CN.md) |
 | 已经 init，日常维护 | [管理员（Admin）](admin.zh-CN.md) |
 
-建库结束时会交出仓库 URL，以及转发给同事的[成员提示词](member.zh-CN.md)。
+建库结束时会交出仓库 URL，以及给同事的接入话（提示词 B 的短版）。转发明细见[成员提示词](member.zh-CN.md)。
 
-不要用 `owner/repo` 短地址（会被当成 GitHub）。不要用 `teamai init .` —— 这三份提示词使用独立团队仓，不覆盖单仓模式。
+围栏里的提示词只复用 `init` / `pull` / `push` / `doctor`（管理员日常另有 `members` / `list` / `roles` / `packages` / `env` / `contribute`）。不教 Git，不用 `owner/repo` 短地址，不按地区推荐平台，也不覆盖单仓模式（`teamai init .`）。

--- a/docs/prompts/README.zh-CN.md
+++ b/docs/prompts/README.zh-CN.md
@@ -1,0 +1,17 @@
+# 可粘贴接入提示词
+
+> [English](README.md) | [简体中文](README.zh-CN.md)
+
+这三份提示词面向**没用过 Git** 的人。把对应一段粘贴给 Claude Code、Codex、Cursor、CodeBuddy、WorkBuddy、OpenCode、Qoder 等已支持的 Agent。Agent 代跑 `teamai init` / `pull` / `push` / `doctor`，只在要网页登录或二选一时问你。
+
+Agent 让你新开会话时，应使用**当前这个**工具的名字，不要默认 Cursor / Claude Code。
+
+| 场景 | 提示词 |
+|------|--------|
+| 还没有团队仓库 URL | [建库（Getting started）](getting-started.zh-CN.md) |
+| 已经拿到仓库 URL | [成员（Member）](member.zh-CN.md) |
+| 已经 init，日常维护 | [管理员（Admin）](admin.zh-CN.md) |
+
+建库结束时会交出仓库 URL，以及转发给同事的[成员提示词](member.zh-CN.md)。
+
+不要用 `owner/repo` 短地址（会被当成 GitHub）。不要用 `teamai init .` —— 这三份提示词使用独立团队仓，不覆盖单仓模式。

--- a/docs/prompts/admin.md
+++ b/docs/prompts/admin.md
@@ -2,19 +2,20 @@
 
 > [English](admin.md) | [简体中文](admin.zh-CN.md)
 
-Use this after `teamai init` has already succeeded. Paste the block below when you want the agent to publish resources, add people, or diagnose sync — without creating a second team repo.
+Use this after `teamai init` has already succeeded. Paste the block below when you want the agent to publish resources, add people, or diagnose sync.
+
+The member prompt to forward is [prompt B](member.md).
 
 ```markdown
 I have already run teamai init. Do not register again or run init. Do what I ask, and tell me what you will change before you change it.
-Do not type raw git. Do not create a second team repo. Do not use `teamai init .`.
 When you tell someone to start a new session, name this AI tool — do not default to Cursor or Claude Code.
 
 - Publish a skill / rule / doc → after the edit, `teamai push`
-- Add a person → grant them access to the repo on the git host, then forward the full repo HTTPS URL plus the member prompt
+- Add a person → grant them access on the git host, then give me the repo URL plus prompt B to forward
 - See people and resources → `teamai members` / `teamai list`
 - Roles / team packages / env vars → `teamai roles` / `teamai packages` / `teamai env`
-- Sync failed → `teamai doctor`, then have them start a new session in this tool; if this tool has no session-start hook, `teamai pull`
+- Sync failed → `teamai doctor`, then have them start a new session; if there is no hook, `teamai pull`
 - Capture a lesson learned → `teamai contribute`
-```
 
-The member prompt to forward is in [member.md](member.md).
+Do not type raw git. Do not create a second team repo. If GitHub `push` fails, check whether the default branch is `master`.
+```

--- a/docs/prompts/admin.md
+++ b/docs/prompts/admin.md
@@ -1,0 +1,20 @@
+# Admin — already initialized
+
+> [English](admin.md) | [简体中文](admin.zh-CN.md)
+
+Use this after `teamai init` has already succeeded. Paste the block below when you want the agent to publish resources, add people, or diagnose sync — without creating a second team repo.
+
+```markdown
+I have already run teamai init. Do not register again or run init. Do what I ask, and tell me what you will change before you change it.
+Do not type raw git. Do not create a second team repo. Do not use `teamai init .`.
+When you tell someone to start a new session, name this AI tool — do not default to Cursor or Claude Code.
+
+- Publish a skill / rule / doc → after the edit, `teamai push`
+- Add a person → grant them access to the repo on the git host, then forward the full repo HTTPS URL plus the member prompt
+- See people and resources → `teamai members` / `teamai list`
+- Roles / team packages / env vars → `teamai roles` / `teamai packages` / `teamai env`
+- Sync failed → `teamai doctor`, then have them start a new session in this tool; if this tool has no session-start hook, `teamai pull`
+- Capture a lesson learned → `teamai contribute`
+```
+
+The member prompt to forward is in [member.md](member.md).

--- a/docs/prompts/admin.zh-CN.md
+++ b/docs/prompts/admin.zh-CN.md
@@ -1,0 +1,20 @@
+# 管理员 — 已经 init
+
+> [English](admin.md) | [简体中文](admin.zh-CN.md)
+
+已经跑通 `teamai init` 之后用这一份。需要发布资源、加人、排查同步时，把下面整段粘贴给**当前这个** AI 工具；不要另建第二个团队仓。
+
+```markdown
+我已 init 过，不要重新注册或 init。按我说的做，改东西前先说改什么。
+不要手搓 git，不要新建第二个团队仓，不要用 `teamai init .`。
+让对方新开会话时，用当前这个 AI 工具的名字，不要默认 Cursor / Claude Code。
+
+- 发布 skill/规则/文档 → 改好后 `teamai push`
+- 加人 → 在托管平台给仓库权限，把仓库完整 HTTPS URL + 成员接入提示词转发给对方
+- 看人和资源 → `teamai members` / `teamai list`
+- 角色 / 团队包 / 环境变量 → `teamai roles` / `teamai packages` / `teamai env`
+- 同步失败 → `teamai doctor`，再让对方新开会话；没有 hook 就 `teamai pull`
+- 沉淀踩坑 → `teamai contribute`
+```
+
+转发给同事的成员提示词见 [member.zh-CN.md](member.zh-CN.md)。

--- a/docs/prompts/admin.zh-CN.md
+++ b/docs/prompts/admin.zh-CN.md
@@ -2,19 +2,20 @@
 
 > [English](admin.md) | [简体中文](admin.zh-CN.md)
 
-已经跑通 `teamai init` 之后用这一份。需要发布资源、加人、排查同步时，把下面整段粘贴给**当前这个** AI 工具；不要另建第二个团队仓。
+已经跑通 `teamai init` 之后用这一份。需要发布资源、加人、排查同步时，把下面整段粘贴给**当前这个** AI 工具。
+
+转发给同事的成员提示词（提示词 B）见 [member.zh-CN.md](member.zh-CN.md)。
 
 ```markdown
 我已 init 过，不要重新注册或 init。按我说的做，改东西前先说改什么。
-不要手搓 git，不要新建第二个团队仓，不要用 `teamai init .`。
-让对方新开会话时，用当前这个 AI 工具的名字，不要默认 Cursor / Claude Code。
+重开会话时用当前这个 AI 工具的名字，不要默认 Cursor / Claude Code。
 
 - 发布 skill/规则/文档 → 改好后 `teamai push`
-- 加人 → 在托管平台给仓库权限，把仓库完整 HTTPS URL + 成员接入提示词转发给对方
+- 加人 → 托管平台给仓库权限，把仓库 URL + 提示词 B 给我转发
 - 看人和资源 → `teamai members` / `teamai list`
 - 角色 / 团队包 / 环境变量 → `teamai roles` / `teamai packages` / `teamai env`
 - 同步失败 → `teamai doctor`，再让对方新开会话；没有 hook 就 `teamai pull`
 - 沉淀踩坑 → `teamai contribute`
-```
 
-转发给同事的成员提示词见 [member.zh-CN.md](member.zh-CN.md)。
+不要手搓 git，不要新建第二个团队仓。GitHub push 失败时检查默认分支是否为 `master`。
+```

--- a/docs/prompts/getting-started.md
+++ b/docs/prompts/getting-started.md
@@ -4,10 +4,11 @@
 
 Use this when you **do not** already have a team repo URL. Paste the block below into your current AI tool.
 
+When it finishes, it should give you the repo URL plus a short member prompt. Forward those with [prompt B](member.md).
+
 ```markdown
 Help me set up TeamAI. I do not know Git. You run the commands. Only ask me when a web login or a choice is required.
 When you tell me to start a new session, name this AI tool — do not default to Cursor or Claude Code.
-If the `git` binary is missing, install it quietly. Do not teach me Git.
 
 1. Ask whether I have / have heard of GitHub, GitLab, or CNB (cnb.cool). If yes, use that one.
 2. If none: probe https://github.com, https://gitlab.com, and https://cnb.cool in that order.
@@ -15,30 +16,10 @@ If the `git` binary is missing, install it quietly. Do not teach me Git.
    If none work, stop and ask me to get an existing repo URL from an admin.
    Pick the host from account + reachability only. Do not recommend by region. Do not use intranet / TGit.
 3. Open that host so I can register and sign in. Then tell me: the repo on the website is where team skills/rules live; this computer only holds a copy that teamai syncs; do not move business code into it.
-4. Confirm Node.js ≥ 20, then `npm install -g teamai-cli`. Sign in on the chosen host:
-   - GitHub: install `gh` first (https://cli.github.com/; macOS: `brew install gh`), then `gh auth login`
-   - CNB: `npm install -g @cnbcool/cnb-cli`, then `cnb login` (or skip both and let `teamai init` install `cnb` and log in)
-   - GitLab: create a Personal Access Token with `api` scope, then `export GITLAB_TOKEN=...`
+4. Confirm Node ≥ 20, `npm install -g teamai-cli`. Sign in on the chosen host: CNB → `cnb login` (`teamai init` installs `cnb` if it is missing); GitHub → `gh auth login` (`gh` must already be installed); GitLab → set `GITLAB_TOKEN`.
 5. Ask whether this is personal or a team (suggested repo name `TeamAi-<name>`), and whether to install for this project or the whole machine (`--scope user`). Then:
-   `teamai init https://<host>/<org-or-user>/<repo>`
-   If the repo does not exist, confirm creation when init asks. Must use a full HTTPS URL. Do not use `owner/repo` short form. Do not use `teamai init .`.
-6. Run `teamai doctor` until it passes. Give me the repo web URL, and the member prompt below with that URL filled in so I can forward it.
-   Remind me: resources show up after I start a new session in this AI tool; missing `.claude/` / `.cursor/` right after init is expected. If this tool has no session-start hook, run `teamai pull`.
-
-Member prompt (fill in the URL, then forward the whole block):
-
-Help me join the team TeamAI repo. Repo: <full HTTPS URL>
-I do not know Git. Do not create another repo. Do not ask me to type git.
-When you tell me to start a new session, name this AI tool — do not default to Cursor or Claude Code.
-If the `git` binary is missing, install it quietly. Do not teach me Git.
-
-1. `npm install -g teamai-cli` (needs Node.js ≥ 20)
-2. Ask me: this project, or the whole machine (`--scope user`)
-3. Sign in on the same host as the URL:
-   - cnb.cool → if `cnb` is missing, `npm install -g @cnbcool/cnb-cli`, then `cnb login`
-   - github.com → install `gh` first (https://cli.github.com/; macOS: `brew install gh`), then `gh auth login`
-   - GitLab → create a Personal Access Token with `api` scope, then `export GITLAB_TOKEN=...`
-   If I have no account, open that host so I can register, and have an admin add me to this repo.
-4. Project scope: `cd` into the project, then `teamai init <full URL>`. Whole machine: add `--scope user`. Must use the full HTTPS URL. Do not use `owner/repo` short form. Do not use `teamai init .`.
-5. `teamai doctor`. Day to day: a new session in this tool syncs automatically; sync now with `teamai pull`. If this tool has no session-start hook, only use `teamai pull`. On a permission error, forward the original message to an admin.
+   `teamai init https://<host>/<org>/<repo>`
+   If the repo does not exist, confirm creation when init asks. Must use a full URL. Do not use `owner/repo` short form. Do not use `teamai init .`.
+6. Run `teamai doctor`. Give me the repo web URL, and a short join prompt for teammates (a short version of prompt B).
+   Remind me: resources show up after I start a new session in this AI tool; missing agent directories right after init are expected. If this tool has no session-start hook, run `teamai pull`.
 ```

--- a/docs/prompts/getting-started.md
+++ b/docs/prompts/getting-started.md
@@ -1,0 +1,44 @@
+# Getting started — create the team repo
+
+> [English](getting-started.md) | [简体中文](getting-started.zh-CN.md)
+
+Use this when you **do not** already have a team repo URL. Paste the block below into your current AI tool.
+
+```markdown
+Help me set up TeamAI. I do not know Git. You run the commands. Only ask me when a web login or a choice is required.
+When you tell me to start a new session, name this AI tool — do not default to Cursor or Claude Code.
+If the `git` binary is missing, install it quietly. Do not teach me Git.
+
+1. Ask whether I have / have heard of GitHub, GitLab, or CNB (cnb.cool). If yes, use that one.
+2. If none: probe https://github.com, https://gitlab.com, and https://cnb.cool in that order.
+   Recommend only hosts that respond. If more than one works, list them and let me pick.
+   If none work, stop and ask me to get an existing repo URL from an admin.
+   Pick the host from account + reachability only. Do not recommend by region. Do not use intranet / TGit.
+3. Open that host so I can register and sign in. Then tell me: the repo on the website is where team skills/rules live; this computer only holds a copy that teamai syncs; do not move business code into it.
+4. Confirm Node.js ≥ 20, then `npm install -g teamai-cli`. Sign in on the chosen host:
+   - GitHub: install `gh` first (https://cli.github.com/; macOS: `brew install gh`), then `gh auth login`
+   - CNB: `npm install -g @cnbcool/cnb-cli`, then `cnb login` (or skip both and let `teamai init` install `cnb` and log in)
+   - GitLab: create a Personal Access Token with `api` scope, then `export GITLAB_TOKEN=...`
+5. Ask whether this is personal or a team (suggested repo name `TeamAi-<name>`), and whether to install for this project or the whole machine (`--scope user`). Then:
+   `teamai init https://<host>/<org-or-user>/<repo>`
+   If the repo does not exist, confirm creation when init asks. Must use a full HTTPS URL. Do not use `owner/repo` short form. Do not use `teamai init .`.
+6. Run `teamai doctor` until it passes. Give me the repo web URL, and the member prompt below with that URL filled in so I can forward it.
+   Remind me: resources show up after I start a new session in this AI tool; missing `.claude/` / `.cursor/` right after init is expected. If this tool has no session-start hook, run `teamai pull`.
+
+Member prompt (fill in the URL, then forward the whole block):
+
+Help me join the team TeamAI repo. Repo: <full HTTPS URL>
+I do not know Git. Do not create another repo. Do not ask me to type git.
+When you tell me to start a new session, name this AI tool — do not default to Cursor or Claude Code.
+If the `git` binary is missing, install it quietly. Do not teach me Git.
+
+1. `npm install -g teamai-cli` (needs Node.js ≥ 20)
+2. Ask me: this project, or the whole machine (`--scope user`)
+3. Sign in on the same host as the URL:
+   - cnb.cool → if `cnb` is missing, `npm install -g @cnbcool/cnb-cli`, then `cnb login`
+   - github.com → install `gh` first (https://cli.github.com/; macOS: `brew install gh`), then `gh auth login`
+   - GitLab → create a Personal Access Token with `api` scope, then `export GITLAB_TOKEN=...`
+   If I have no account, open that host so I can register, and have an admin add me to this repo.
+4. Project scope: `cd` into the project, then `teamai init <full URL>`. Whole machine: add `--scope user`. Must use the full HTTPS URL. Do not use `owner/repo` short form. Do not use `teamai init .`.
+5. `teamai doctor`. Day to day: a new session in this tool syncs automatically; sync now with `teamai pull`. If this tool has no session-start hook, only use `teamai pull`. On a permission error, forward the original message to an admin.
+```

--- a/docs/prompts/getting-started.zh-CN.md
+++ b/docs/prompts/getting-started.zh-CN.md
@@ -1,0 +1,44 @@
+# 建库 — 还没有团队仓库
+
+> [English](getting-started.md) | [简体中文](getting-started.zh-CN.md)
+
+还没有团队仓库 URL 时用这一份。把下面整段粘贴给**当前这个** AI 工具。
+
+```markdown
+帮我接入 TeamAI。我不会 Git，你代跑命令；只在要网页登录或二选一时问我。
+重开会话时用当前这个 AI 工具的名字，不要默认 Cursor / Claude Code。
+如果本机没有 git 命令，先安静装好，不要教我 Git。
+
+1. 问我有没有 / 听过：GitHub、GitLab、CNB（cnb.cool）。有就用那个。
+2. 都没有：依次探测 https://github.com、https://gitlab.com、https://cnb.cool。
+   只推荐能通的；多个都能通时列出来让我选一个。
+   三个都不通就停，让我找管理员要现成仓库地址。
+   选平台只看账号和站点能不能打开，不要按地区推荐。不要用内网 / 工蜂。
+3. 打开该平台注册并登录。然后告诉我：网页上的这个仓库就是团队技能/规则的存放处；电脑上只是副本，由 teamai 同步；业务代码不用搬进去。
+4. 确认 Node.js ≥ 20，然后 `npm install -g teamai-cli`。按平台登录：
+   - GitHub：先安装 `gh`（https://cli.github.com/，macOS 可用 `brew install gh`），再 `gh auth login`
+   - CNB：先 `npm install -g @cnbcool/cnb-cli`，再 `cnb login`（也可以直接 `teamai init`，它会安装 `cnb` 并登录）
+   - GitLab：创建带 `api` 权限的 Personal Access Token，然后 `export GITLAB_TOKEN=...`
+5. 问我个人用还是团队用（仓库名建议 `TeamAi-<名字>`），以及当前项目用还是整机用（整机加 `--scope user`）。然后：
+   `teamai init https://<平台>/<组织或用户名>/<仓库名>`
+   没有仓库就按 init 提示创建。必须用完整 HTTPS URL，不要用 `owner/repo` 短地址，也不要用 `teamai init .`。
+6. 跑通 `teamai doctor`。把仓库网页地址给我，并把下面「成员接入」提示词里的 URL 填好后整段交给我转发同事。
+   提醒：在当前这个 AI 工具里新开一轮会话后资源才会出现；init 当时看不到 `.claude/` / `.cursor/` 等目录是正常的。没有会话启动 hook 的工具请执行 `teamai pull`。
+
+成员接入提示词（填好 URL 后整段转发）：
+
+帮我接入团队 TeamAI。仓库：<填入完整 HTTPS URL>
+我不会 Git，不要另建仓库，不要让我敲 git。
+重开会话时用当前这个 AI 工具的名字，不要默认 Cursor / Claude Code。
+如果本机没有 git 命令，先安静装好，不要教我 Git。
+
+1. `npm install -g teamai-cli`（需 Node.js ≥ 20）
+2. 问我：当前项目用，还是整机（`--scope user`）
+3. 按 URL 登录同一平台：
+   - cnb.cool → 若没有 `cnb`，先 `npm install -g @cnbcool/cnb-cli`，再 `cnb login`
+   - github.com → 先安装 `gh`（https://cli.github.com/；macOS：`brew install gh`），再 `gh auth login`
+   - GitLab → 创建带 `api` 权限的 Personal Access Token，然后 `export GITLAB_TOKEN=...`
+   没账号就去该站注册，让管理员把我加进这个仓库。
+4. 项目级：`cd` 到项目后 `teamai init <完整 URL>`；整机加 `--scope user`。必须用完整 HTTPS URL，不要用 `owner/repo` 短地址，不要 `teamai init .`。
+5. `teamai doctor`。日常：当前工具新开会话会自动同步；立刻同步用 `teamai pull`。没有会话启动 hook 就只用 `teamai pull`。权限报错把原话转给管理员。
+```

--- a/docs/prompts/getting-started.zh-CN.md
+++ b/docs/prompts/getting-started.zh-CN.md
@@ -4,41 +4,22 @@
 
 还没有团队仓库 URL 时用这一份。把下面整段粘贴给**当前这个** AI 工具。
 
+结束后应交出仓库网页地址，以及给同事的接入话（提示词 B 的短版）。转发明细见[成员提示词](member.zh-CN.md)。
+
 ```markdown
 帮我接入 TeamAI。我不会 Git，你代跑命令；只在要网页登录或二选一时问我。
 重开会话时用当前这个 AI 工具的名字，不要默认 Cursor / Claude Code。
-如果本机没有 git 命令，先安静装好，不要教我 Git。
 
 1. 问我有没有 / 听过：GitHub、GitLab、CNB（cnb.cool）。有就用那个。
-2. 都没有：依次探测 https://github.com、https://gitlab.com、https://cnb.cool。
+2. 都没有：依次测 https://github.com、https://gitlab.com、https://cnb.cool。
    只推荐能通的；多个都能通时列出来让我选一个。
    三个都不通就停，让我找管理员要现成仓库地址。
-   选平台只看账号和站点能不能打开，不要按地区推荐。不要用内网 / 工蜂。
+   选平台只看账号和站点能不能通，不要按地区推荐。不要用内网 / 工蜂。
 3. 打开该平台注册并登录。然后告诉我：网页上的这个仓库就是团队技能/规则的存放处；电脑上只是副本，由 teamai 同步；业务代码不用搬进去。
-4. 确认 Node.js ≥ 20，然后 `npm install -g teamai-cli`。按平台登录：
-   - GitHub：先安装 `gh`（https://cli.github.com/，macOS 可用 `brew install gh`），再 `gh auth login`
-   - CNB：先 `npm install -g @cnbcool/cnb-cli`，再 `cnb login`（也可以直接 `teamai init`，它会安装 `cnb` 并登录）
-   - GitLab：创建带 `api` 权限的 Personal Access Token，然后 `export GITLAB_TOKEN=...`
-5. 问我个人用还是团队用（仓库名建议 `TeamAi-<名字>`），以及当前项目用还是整机用（整机加 `--scope user`）。然后：
-   `teamai init https://<平台>/<组织或用户名>/<仓库名>`
-   没有仓库就按 init 提示创建。必须用完整 HTTPS URL，不要用 `owner/repo` 短地址，也不要用 `teamai init .`。
-6. 跑通 `teamai doctor`。把仓库网页地址给我，并把下面「成员接入」提示词里的 URL 填好后整段交给我转发同事。
-   提醒：在当前这个 AI 工具里新开一轮会话后资源才会出现；init 当时看不到 `.claude/` / `.cursor/` 等目录是正常的。没有会话启动 hook 的工具请执行 `teamai pull`。
-
-成员接入提示词（填好 URL 后整段转发）：
-
-帮我接入团队 TeamAI。仓库：<填入完整 HTTPS URL>
-我不会 Git，不要另建仓库，不要让我敲 git。
-重开会话时用当前这个 AI 工具的名字，不要默认 Cursor / Claude Code。
-如果本机没有 git 命令，先安静装好，不要教我 Git。
-
-1. `npm install -g teamai-cli`（需 Node.js ≥ 20）
-2. 问我：当前项目用，还是整机（`--scope user`）
-3. 按 URL 登录同一平台：
-   - cnb.cool → 若没有 `cnb`，先 `npm install -g @cnbcool/cnb-cli`，再 `cnb login`
-   - github.com → 先安装 `gh`（https://cli.github.com/；macOS：`brew install gh`），再 `gh auth login`
-   - GitLab → 创建带 `api` 权限的 Personal Access Token，然后 `export GITLAB_TOKEN=...`
-   没账号就去该站注册，让管理员把我加进这个仓库。
-4. 项目级：`cd` 到项目后 `teamai init <完整 URL>`；整机加 `--scope user`。必须用完整 HTTPS URL，不要用 `owner/repo` 短地址，不要 `teamai init .`。
-5. `teamai doctor`。日常：当前工具新开会话会自动同步；立刻同步用 `teamai pull`。没有会话启动 hook 就只用 `teamai pull`。权限报错把原话转给管理员。
+4. 确认 Node ≥ 20，`npm install -g teamai-cli`。按平台登录：CNB → `cnb login`（没有 `cnb` 时交给 `teamai init` 安装）；GitHub → `gh auth login`（需已安装 `gh`）；GitLab → 设 `GITLAB_TOKEN`。
+5. 问我个人用还是团队用（仓库名建议 `TeamAi-<名字>`），以及当前项目用还是整机用（`--scope user`）。然后：
+   `teamai init https://<平台>/<组织>/<仓库名>`
+   没有仓库就按 init 提示创建。必须用完整 URL，不要用 `owner/repo` 短地址，不要 `teamai init .`。
+6. 跑通 `teamai doctor`。把仓库网页地址给我，并生成一段给同事的接入话（用提示词 B 的短版）。
+   提醒：在当前这个 AI 工具里新开一轮会话后资源才会出现；init 当时看不到对应目录是正常的。没有会话启动 hook 就执行 `teamai pull`。
 ```

--- a/docs/prompts/member.md
+++ b/docs/prompts/member.md
@@ -2,21 +2,16 @@
 
 > [English](member.md) | [简体中文](member.zh-CN.md)
 
-Use this when an admin (or the getting-started prompt) already gave you a team repo URL. Replace `<<paste the full HTTPS URL>>` with that URL, then paste the block into your current AI tool.
+Use this when an admin (or the getting-started prompt) already gave you a team repo URL. Replace `<<paste the full URL>>` with that URL, then paste the block into your current AI tool.
 
 ```markdown
-Help me join the team TeamAI repo. Repo: <<paste the full HTTPS URL>>
+Help me join the team TeamAI repo. Repo: <<paste the full URL>>
 I do not know Git. Do not create another repo. Do not ask me to type git.
 When you tell me to start a new session, name this AI tool — do not default to Cursor or Claude Code.
-If the `git` binary is missing, install it quietly. Do not teach me Git.
 
-1. `npm install -g teamai-cli` (needs Node.js ≥ 20)
+1. `npm install -g teamai-cli` (needs Node ≥ 20)
 2. Ask me: this project, or the whole machine (`--scope user`)
-3. Sign in on the same host as the URL:
-   - cnb.cool → if `cnb` is missing, `npm install -g @cnbcool/cnb-cli`, then `cnb login`
-   - github.com → install `gh` first (https://cli.github.com/; macOS: `brew install gh`), then `gh auth login`
-   - GitLab → create a Personal Access Token with `api` scope, then `export GITLAB_TOKEN=...`
-   If I have no account, open that host so I can register, and have an admin add me to this repo.
-4. Project scope: `cd` into the project, then `teamai init <full URL>`. Whole machine: add `--scope user`. Must use the full HTTPS URL. Do not use `owner/repo` short form. Do not use `teamai init .`.
+3. Sign in on the same host as the URL (cnb.cool → `cnb login`; github.com → `gh auth login`; GitLab → `GITLAB_TOKEN`). If I have no account, open that host so I can register, and have an admin add me to this repo.
+4. Project scope: `cd` into the project, then `teamai init <URL>`. Whole machine: add `--scope user`. Must use a full URL. Do not use `owner/repo` short form. Do not use `teamai init .`.
 5. `teamai doctor`. Day to day: a new session in this tool syncs automatically; sync now with `teamai pull`. If this tool has no session-start hook, only use `teamai pull`. On a permission error, forward the original message to an admin.
 ```

--- a/docs/prompts/member.md
+++ b/docs/prompts/member.md
@@ -1,0 +1,22 @@
+# Member — you already have a repo URL
+
+> [English](member.md) | [简体中文](member.zh-CN.md)
+
+Use this when an admin (or the getting-started prompt) already gave you a team repo URL. Replace `<<paste the full HTTPS URL>>` with that URL, then paste the block into your current AI tool.
+
+```markdown
+Help me join the team TeamAI repo. Repo: <<paste the full HTTPS URL>>
+I do not know Git. Do not create another repo. Do not ask me to type git.
+When you tell me to start a new session, name this AI tool — do not default to Cursor or Claude Code.
+If the `git` binary is missing, install it quietly. Do not teach me Git.
+
+1. `npm install -g teamai-cli` (needs Node.js ≥ 20)
+2. Ask me: this project, or the whole machine (`--scope user`)
+3. Sign in on the same host as the URL:
+   - cnb.cool → if `cnb` is missing, `npm install -g @cnbcool/cnb-cli`, then `cnb login`
+   - github.com → install `gh` first (https://cli.github.com/; macOS: `brew install gh`), then `gh auth login`
+   - GitLab → create a Personal Access Token with `api` scope, then `export GITLAB_TOKEN=...`
+   If I have no account, open that host so I can register, and have an admin add me to this repo.
+4. Project scope: `cd` into the project, then `teamai init <full URL>`. Whole machine: add `--scope user`. Must use the full HTTPS URL. Do not use `owner/repo` short form. Do not use `teamai init .`.
+5. `teamai doctor`. Day to day: a new session in this tool syncs automatically; sync now with `teamai pull`. If this tool has no session-start hook, only use `teamai pull`. On a permission error, forward the original message to an admin.
+```

--- a/docs/prompts/member.zh-CN.md
+++ b/docs/prompts/member.zh-CN.md
@@ -8,15 +8,10 @@
 帮我接入团队 TeamAI。仓库：<<粘贴完整 URL>>
 我不会 Git，不要另建仓库，不要让我敲 git。
 重开会话时用当前这个 AI 工具的名字，不要默认 Cursor / Claude Code。
-如果本机没有 git 命令，先安静装好，不要教我 Git。
 
-1. `npm install -g teamai-cli`（需 Node.js ≥ 20）
+1. `npm install -g teamai-cli`（需 Node ≥ 20）
 2. 问我：当前项目用，还是整机（`--scope user`）
-3. 按 URL 登录同一平台：
-   - cnb.cool → 若没有 `cnb`，先 `npm install -g @cnbcool/cnb-cli`，再 `cnb login`
-   - github.com → 先安装 `gh`（https://cli.github.com/；macOS：`brew install gh`），再 `gh auth login`
-   - GitLab → 创建带 `api` 权限的 Personal Access Token，然后 `export GITLAB_TOKEN=...`
-   没账号就去该站注册，让管理员把我加进这个仓库。
-4. 项目级：`cd` 到项目后 `teamai init <完整 URL>`；整机加 `--scope user`。必须用完整 HTTPS URL，不要用 `owner/repo` 短地址，不要 `teamai init .`。
+3. 按 URL 登录同一平台（cnb.cool → `cnb login`；github.com → `gh auth login`；GitLab → `GITLAB_TOKEN`）。没账号就去该站注册，让管理员把我加进这个仓库。
+4. 项目级：`cd` 到项目后 `teamai init <URL>`；整机加 `--scope user`。必须用完整 URL，不要用 `owner/repo` 短地址，不要 `teamai init .`。
 5. `teamai doctor`。日常：当前工具新开会话会自动同步；立刻同步用 `teamai pull`。没有会话启动 hook 就只用 `teamai pull`。权限报错把原话转给管理员。
 ```

--- a/docs/prompts/member.zh-CN.md
+++ b/docs/prompts/member.zh-CN.md
@@ -1,0 +1,22 @@
+# 成员 — 已经有仓库 URL
+
+> [English](member.md) | [简体中文](member.zh-CN.md)
+
+管理员（或建库提示词）已经给了团队仓库 URL 时用这一份。把 `<<粘贴完整 URL>>` 换成那个地址，再把整段粘贴给**当前这个** AI 工具。
+
+```markdown
+帮我接入团队 TeamAI。仓库：<<粘贴完整 URL>>
+我不会 Git，不要另建仓库，不要让我敲 git。
+重开会话时用当前这个 AI 工具的名字，不要默认 Cursor / Claude Code。
+如果本机没有 git 命令，先安静装好，不要教我 Git。
+
+1. `npm install -g teamai-cli`（需 Node.js ≥ 20）
+2. 问我：当前项目用，还是整机（`--scope user`）
+3. 按 URL 登录同一平台：
+   - cnb.cool → 若没有 `cnb`，先 `npm install -g @cnbcool/cnb-cli`，再 `cnb login`
+   - github.com → 先安装 `gh`（https://cli.github.com/；macOS：`brew install gh`），再 `gh auth login`
+   - GitLab → 创建带 `api` 权限的 Personal Access Token，然后 `export GITLAB_TOKEN=...`
+   没账号就去该站注册，让管理员把我加进这个仓库。
+4. 项目级：`cd` 到项目后 `teamai init <完整 URL>`；整机加 `--scope user`。必须用完整 HTTPS URL，不要用 `owner/repo` 短地址，不要 `teamai init .`。
+5. `teamai doctor`。日常：当前工具新开会话会自动同步；立刻同步用 `teamai pull`。没有会话启动 hook 就只用 `teamai pull`。权限报错把原话转给管理员。
+```

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -13,6 +13,7 @@
 - [What TeamAI is](#what-teamai-is)
 - [Core Concepts](#core-concepts)
 - [Installation](#installation)
+  - [Paste-able prompts](#paste-able-prompts)
 - [Admin Initialization](#admin-initialization)
   - [Project Scope](#project-scope)
   - [User Scope](#user-scope)
@@ -92,6 +93,16 @@ teamai --version
 ```
 
 **Prerequisites:** Node.js ≥ 20, Git (TGit users also need the `gf` CLI, and CNB users the `cnb` CLI — `teamai init` installs either automatically)
+
+### Paste-able prompts
+
+If you have not used Git, paste one of the [onboarding prompts](prompts/README.md) into your current AI tool (Claude Code, Codex, Cursor, CodeBuddy, WorkBuddy, OpenCode, Qoder, and other supported agents). The agent runs `teamai init` / `pull` / `push` / `doctor` and only asks when a web login or a choice is required.
+
+| Situation | Prompt |
+|-----------|--------|
+| No team repo URL yet | [Getting started](prompts/getting-started.md) |
+| You already have a repo URL | [Member](prompts/member.md) |
+| Already initialized; day-to-day admin | [Admin](prompts/admin.md) |
 
 ---
 
@@ -358,7 +369,7 @@ With inheritance enabled, `teamai pull` refreshes user `skills`, `rules`, `docs`
 
 ## Member Onboarding
 
-Once the admin shares the team repo URL with members:
+Once the admin shares the team repo URL with members (or forwards the [member prompt](prompts/member.md) with that URL filled in):
 
 **Project-scoped teams (default):**
 
@@ -1585,6 +1596,10 @@ teamai pull
 ---
 
 ## FAQ
+
+**Q: I have never used Git?**
+
+Paste an [onboarding prompt](prompts/README.md) into your current AI tool and let it run the commands. Use [getting started](prompts/getting-started.md) if you do not have a repo URL yet, or [member](prompts/member.md) if you already have one.
 
 **Q: Can user scope and project scope coexist?**
 

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -13,6 +13,7 @@
 - [TeamAI 是什么](#teamai-是什么)
 - [核心概念](#核心概念)
 - [安装](#安装)
+  - [可粘贴接入提示词](#可粘贴接入提示词)
 - [管理员初始化](#管理员初始化)
   - [项目级（Project Scope）](#项目级project-scope)
   - [用户级（User Scope）](#用户级user-scope)
@@ -91,6 +92,16 @@ teamai --version
 ```
 
 **前置依赖：** Node.js ≥ 20、Git（TGit 用户还需 `gf` CLI、CNB 用户还需 `cnb` CLI，`teamai init` 时都会自动安装）
+
+### 可粘贴接入提示词
+
+如果没用过 Git，把[接入提示词](prompts/README.zh-CN.md)粘贴给当前的 AI 工具（Claude Code、Codex、Cursor、CodeBuddy、WorkBuddy、OpenCode、Qoder 等）。Agent 代跑 `teamai init` / `pull` / `push` / `doctor`，只在要网页登录或二选一时问你。
+
+| 场景 | 提示词 |
+|------|--------|
+| 还没有团队仓库 URL | [建库](prompts/getting-started.zh-CN.md) |
+| 已经拿到仓库 URL | [成员](prompts/member.zh-CN.md) |
+| 已经 init，日常维护 | [管理员](prompts/admin.zh-CN.md) |
 
 ---
 
@@ -343,7 +354,7 @@ teamai init https://github.com/yourorg/java-service-teamai --inherit-user-scope
 
 ## 成员接入
 
-管理员将团队仓库地址分享给成员后：
+管理员将团队仓库地址分享给成员后（或把填好 URL 的[成员提示词](prompts/member.zh-CN.md)转发出去）：
 
 **项目级团队（默认）：**
 
@@ -1551,6 +1562,10 @@ teamai pull
 ---
 
 ## 常见问题 FAQ
+
+**Q: 我没用过 Git？**
+
+把[接入提示词](prompts/README.zh-CN.md)粘贴给当前的 AI 工具，让它代跑命令。还没有仓库 URL 用[建库](prompts/getting-started.zh-CN.md)，已经有 URL 用[成员](prompts/member.zh-CN.md)。
 
 **Q: User scope 和 Project scope 可以共存吗？**
 


### PR DESCRIPTION
## Summary

Adds three bilingual, copy-paste onboarding prompts so people who have not used Git can paste one into their current AI tool and let it run `teamai init` / `pull` / `push` / `doctor`. This implements the RFC in #517 as documentation only — no new CLI commands and no `src/` changes.

- **Getting started** (`docs/prompts/getting-started.md` + `.zh-CN.md`): no repo URL yet. Probe GitHub / GitLab / CNB by account + reachability (not region), sign in, `teamai init` with a full HTTPS URL, `teamai doctor`, then hand off the URL plus the member prompt.
- **Member** (`docs/prompts/member.md` + `.zh-CN.md`): already have a URL. Do not create another repo.
- **Admin** (`docs/prompts/admin.md` + `.zh-CN.md`): already initialized. Publish, add people, diagnose; no raw git and no second team repo.

README, the usage guide (install / member onboarding / FAQ), and CHANGELOG Unreleased all link the prompts.

Accuracy notes vs the RFC draft:

- GitHub needs `gh` installed before `gh auth login`; CNB login works after `@cnbcool/cnb-cli` (or `teamai init`, which installs `cnb`).
- GitLab token is documented as needing `api` scope.
- Dropped the RFC's "GitHub default branch must be `master`" line — shipped `getDefaultBranch` uses `origin/HEAD`, then `main`, then `master`.

## Type of Change

- [x] Documentation only

## Test Plan

- [x] Paste-block content audit against RFC #517 required phrases/commands (EN + zh-CN)
- [x] Relative links from README / usage-guide / `docs/prompts/` resolve (68 links, 0 missing)
- [x] `npm run build` then `node dist/index.js --help` (and `--help` for `init` `pull` `push` `doctor` `members` `list` `roles` `packages` `env` `contribute`) — every named command is a real shipped command
- [x] `git diff` has no `src/` files
- [ ] `npx tsc --noEmit` / `npx vitest run` not re-run (docs-only; no code change)

## Related Issues

Closes #517

## Notes for Reviewers

- Prompts stay short and self-contained so they can be pasted whole. Getting started embeds the member prompt so A can hand off B without fetching another file.
- Single-repo mode (`teamai init .`) and `owner/repo` short form are explicitly out of scope in the paste blocks (`owner/repo` is treated as GitHub).
- No TGit / intranet / region-based host recommendation in the three prompts.