### PR TITLE
fix(pull): don't skip sync when a submodule update changed the tree

### DIFF
--- a/src/__tests__/pull-skip-sync.test.ts
+++ b/src/__tests__/pull-skip-sync.test.ts
@@ -352,6 +352,80 @@ describe('pull skip-sync when repo HEAD unchanged', () => {
     const savedState = vi.mocked(saveStateForScope).mock.calls[0][0];
     expect(savedState.lastPullRev).toBe('def5678');
   });
+
+  // A successful `submodule update` can still change the deployed tree while the
+  // PARENT revision stays the same: a member who pulled with a CLI that ignored
+  // `submodules: true` (unknown yaml key stripped) cached the parent SHA with
+  // empty submodule dirs, and upgrading the CLI then fills those dirs without
+  // moving HEAD. The unchanged-rev fast path would skip the deploy and leave
+  // ~/.claude/skills empty until `pull --force`. See issue #525.
+  it('does not skip sync when a successful submodule update changed the tree', async () => {
+    vi.mocked(loadTeamConfig).mockResolvedValue({ ...baseTeamConfig, submodules: true });
+    // `git submodule status` before the update marks the submodule uninitialized
+    // (leading `-`); after it, the submodule is checked out at its pinned SHA.
+    const subModule = vi.fn()
+      .mockResolvedValueOnce('-abc1234 skills/distributed\n')
+      .mockResolvedValueOnce(' abc1234 skills/distributed\n');
+    const submoduleUpdate = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(createGit).mockReturnValue({
+      subModule,
+      submoduleUpdate,
+    } as unknown as ReturnType<typeof createGit>);
+    // Parent SHA is unchanged — the pre-fix fast path would skip here.
+    vi.mocked(getHeadRev).mockResolvedValue('abc1234');
+    vi.mocked(loadStateForScope).mockResolvedValue({
+      lastPull: '2026-04-01',
+      lastPullRev: 'abc1234',
+      lastPullTargets: ['claude'],
+      lastPush: null,
+      pushedRules: [],
+      pushedSkills: [],
+      pushedEnvVars: [],
+      pendingPushes: [],
+      lastUpdateCheck: null,
+      availableUpdate: null,
+    });
+
+    await pull({});
+
+    expect(log.success).not.toHaveBeenCalledWith(
+      expect.stringContaining('Already synced'),
+    );
+    expect(saveStateForScope).toHaveBeenCalled();
+  });
+
+  it('still skips sync when the submodule update changed nothing', async () => {
+    vi.mocked(loadTeamConfig).mockResolvedValue({ ...baseTeamConfig, submodules: true });
+    // Already initialized and current both before and after the update: the
+    // common steady-state case must keep taking the fast path, or every pull in
+    // a submodule-using team pays a full re-deploy.
+    const subModule = vi.fn()
+      .mockResolvedValueOnce(' abc1234 skills/distributed\n')
+      .mockResolvedValueOnce(' abc1234 skills/distributed\n');
+    vi.mocked(createGit).mockReturnValue({
+      subModule,
+      submoduleUpdate: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ReturnType<typeof createGit>);
+    vi.mocked(getHeadRev).mockResolvedValue('abc1234');
+    vi.mocked(loadStateForScope).mockResolvedValue({
+      lastPull: '2026-04-01',
+      lastPullRev: 'abc1234',
+      lastPullTargets: ['claude'],
+      lastPush: null,
+      pushedRules: [],
+      pushedSkills: [],
+      pushedEnvVars: [],
+      pendingPushes: [],
+      lastUpdateCheck: null,
+      availableUpdate: null,
+    });
+
+    await pull({});
+
+    expect(log.success).toHaveBeenCalledWith(
+      expect.stringContaining('Already synced at abc1234, skipping'),
+    );
+  });
 });
 
 // Regression: a CLI upgrade that ships a new recall block must reach CLAUDE.md

--- a/src/__tests__/pull-submodule-skip-sync.test.ts
+++ b/src/__tests__/pull-submodule-skip-sync.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// Real-git integration test for the submodule/skip-sync interaction (issue #525).
+//
+// A successful `git submodule update --init` can change the deployed tree while
+// the PARENT revision stays put, which is invisible to the unchanged-rev fast
+// path. Path: a member pulled with a CLI that predates `submodules: true` (the
+// unknown yaml key was stripped), so the parent SHA was cached with the submodule
+// directory still empty. Upgrading the CLI and pulling fills the submodule, but
+// HEAD has not moved — pre-fix, the fast path reported "Already synced ... skipping"
+// and the tool directories stayed empty until `teamai pull --force`.
+//
+// Runs the real `pull()` against real bare remotes (including a real submodule)
+// rather than mocking simple-git, following the pattern of
+// contribute-self-learnings.test.ts. Lives in its own file because it stubs config
+// and HOME process-wide.
+
+const testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-submodule-'));
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
+const originalGitConfigGlobal = process.env.GIT_CONFIG_GLOBAL;
+const originalTerminalPrompt = process.env.GIT_TERMINAL_PROMPT;
+
+// Resolve the user's REAL global git config BEFORE stubbing HOME below — `git
+// config --global` locates its file via HOME, so asking afterwards points at
+// <tempHome>/.gitconfig, which does not exist.
+const realGlobalConfig = (() => {
+  try {
+    const origin = execFileSync('git', ['config', '--global', '--list', '--show-origin'], { encoding: 'utf-8' })
+      .split('\n')
+      .map((line) => line.split('\t')[0])
+      .find((value) => value?.startsWith('file:'));
+    return origin ? origin.slice('file:'.length) : null;
+  } catch {
+    return null;
+  }
+})();
+
+const homeDir = path.join(testRoot, 'home');
+process.env.HOME = homeDir;
+process.env.USERPROFILE = homeDir;
+// Never let a fixture's git call block on a credential prompt (or a stray fetch
+// to a network remote): fail fast instead of hanging the suite.
+process.env.GIT_TERMINAL_PROMPT = '0';
+
+// `git submodule update --init` on a local-path remote is blocked by default
+// since Git 2.38 (CVE-2022-39253), and the fixture's submodule remote is a local
+// path. simple-git refuses to pass `-c protocol.file.allow=always` on the command
+// line (it guards that override), so the opt-in has to come from a config FILE:
+// a temp global config, which re-includes the user's real one when there is one.
+//
+// This file deliberately lives OUTSIDE testRoot: beforeEach wipes testRoot, and
+// deleting the config would silently drop `protocol.file.allow` — which makes the
+// in-pull submodule update fail, so the fast-path case below would "pass" without
+// the submodule ever being populated.
+const gitConfigRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-submodule-gitcfg-'));
+const globalGitConfig = path.join(gitConfigRoot, 'gitconfig');
+// Written unconditionally: a fresh CI runner may have no global config at all,
+// and skipping the write there would leave the protocol opt-in unset and fail the
+// deploy case for reasons that have nothing to do with the fix.
+fs.writeFileSync(
+  globalGitConfig,
+  [
+    ...(realGlobalConfig && fs.existsSync(realGlobalConfig) && realGlobalConfig !== globalGitConfig
+      ? ['[include]', `\tpath = ${realGlobalConfig.split(path.sep).join('/')}`]
+      : []),
+    '[protocol "file"]',
+    '\tallow = always',
+    '[credential]',
+    '\thelper =',
+    '[user]',
+    '\tname = test',
+    '\temail = t@t.co',
+  ].join('\n') + '\n',
+);
+
+function git(args: string[], cwd: string): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf-8' });
+}
+
+const teamRepo = path.join(testRoot, 'team.git');
+const skillsRepo = path.join(testRoot, 'skills.git');
+// Git-mode install: the team clone is a dedicated checkout under the user home.
+const localPath = path.join(homeDir, '.teamai', 'team-repo');
+const claudeSkills = path.join(homeDir, '.claude', 'skills');
+
+const localConfig = {
+  repo: { localPath, remote: teamRepo, kind: 'git' as const },
+  username: 'test',
+  updatePolicy: 'auto' as const,
+  additionalRoles: [],
+  scope: 'user' as const,
+};
+
+vi.mock('../config.js', () => ({
+  requireInit: vi.fn(),
+  detectProjectConfig: vi.fn().mockResolvedValue(null),
+  loadLocalConfigForScope: vi.fn().mockResolvedValue(localConfig),
+  // Load the REAL teamai.yaml from the clone, so `submodules: true` is read from
+  // the same file the pull under test resolves.
+  loadTeamConfig: vi.fn(async (repoPath: string) => {
+    const { loadTeamConfig } = await vi.importActual<typeof import('../config.js')>('../config.js');
+    return loadTeamConfig(repoPath);
+  }),
+  // The state file IS the fast path's cache key, so these must really read and
+  // write <home>/.teamai/state.json. Omitting them from this factory makes the
+  // fast-path block throw straight into its own `catch { proceed with full sync }`,
+  // which would make the regression test below pass without the fix.
+  loadStateForScope: vi.fn(async () => {
+    try {
+      return JSON.parse(fs.readFileSync(path.join(homeDir, '.teamai', 'state.json'), 'utf-8'));
+    } catch {
+      return {
+        lastPush: null,
+        lastPull: null,
+        lastPullRev: null,
+        pushedRules: [],
+        pushedSkills: [],
+        pushedEnvVars: [],
+        pendingPushes: [],
+        lastUpdateCheck: null,
+        availableUpdate: null,
+      };
+    }
+  }),
+  saveStateForScope: vi.fn(async (state: unknown) => {
+    fs.mkdirSync(path.join(homeDir, '.teamai'), { recursive: true });
+    fs.writeFileSync(path.join(homeDir, '.teamai', 'state.json'), JSON.stringify(state, null, 2));
+  }),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  log: { info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), dim: vi.fn() },
+  spinner: vi.fn(() => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    warn: vi.fn().mockReturnThis(),
+    info: vi.fn().mockReturnThis(),
+    stop: vi.fn().mockReturnThis(),
+  })),
+}));
+
+const { pull } = await import('../pull.js');
+const { log } = await import('../utils/logger.js');
+
+afterAll(() => {
+  fs.rmSync(gitConfigRoot, { recursive: true, force: true });
+});
+
+const TEAM_YAML = [
+  'team: test',
+  'description: submodule fixture',
+  `repo: ${teamRepo}`,
+  'provider: git',
+  'submodules: true',
+  'usageReport: false',
+  'toolPaths:',
+  '  claude:',
+  '    skills: .claude/skills',
+  '    rules: .claude/rules',
+].join('\n') + '\n';
+
+/** Commit a file into a working tree with a throwaway identity. */
+function commitAll(cwd: string, message: string): string {
+  git(['add', '-A'], cwd);
+  git(['-c', 'user.name=t', '-c', 'user.email=t@t.co', 'commit', '-qm', message], cwd);
+  return git(['rev-parse', 'HEAD'], cwd).trim();
+}
+
+describe('pull submodule skip-sync (issue #525)', () => {
+  beforeEach(() => {
+    fs.rmSync(testRoot, { recursive: true, force: true });
+    fs.rmSync(homeDir, { recursive: true, force: true });
+    fs.mkdirSync(homeDir, { recursive: true });
+    // Re-assert every test: afterEach restores the original (usually unset) value,
+    // so without this the second test would run with the file-protocol opt-in
+    // dropped, its submodule update would fail, and the fast-path case below would
+    // pass for the wrong reason.
+    process.env.GIT_CONFIG_GLOBAL = globalGitConfig;
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
+
+    // 1. The distributed-skills repo: one skill, checked out into the team repo
+    //    as a submodule (this is the "skills as git submodules" layout).
+    fs.mkdirSync(skillsRepo, { recursive: true });
+    git(['init', '-q', '--bare', '-b', 'main', skillsRepo], testRoot);
+    const skillsWork = path.join(testRoot, 'skills-work');
+    fs.mkdirSync(skillsWork, { recursive: true });
+    git(['init', '-q', '-b', 'main'], skillsWork);
+    fs.mkdirSync(path.join(skillsWork, 'distributed-skill'), { recursive: true });
+    fs.writeFileSync(
+      path.join(skillsWork, 'distributed-skill', 'SKILL.md'),
+      '---\nname: distributed-skill\ndescription: bundled as a submodule\n---\n\n# distributed-skill\n',
+    );
+    commitAll(skillsWork, 'skill');
+    git(['remote', 'add', 'origin', skillsRepo], skillsWork);
+    git(['push', '-q', 'origin', 'main'], skillsWork);
+
+    // 2. The team repo: teamai.yaml (submodules on) + the submodule at skills/common.
+    fs.mkdirSync(teamRepo, { recursive: true });
+    git(['init', '-q', '--bare', '-b', 'main', teamRepo], testRoot);
+    const teamWork = path.join(testRoot, 'team-work');
+    fs.mkdirSync(path.join(teamWork, 'skills'), { recursive: true });
+    git(['init', '-q', '-b', 'main'], teamWork);
+    fs.writeFileSync(path.join(teamWork, 'teamai.yaml'), TEAM_YAML);
+    fs.writeFileSync(path.join(teamWork, 'skills', '.gitkeep'), '');
+    commitAll(teamWork, 'skeleton');
+    git(['remote', 'add', 'origin', teamRepo], teamWork);
+    git(['push', '-q', 'origin', 'main'], teamWork);
+
+    git(['-c', 'protocol.file.allow=always', 'submodule', 'add', '-q', skillsRepo, 'skills/common'], teamWork);
+    commitAll(teamWork, 'add skills submodule');
+    git(['push', '-q', 'origin', 'main'], teamWork);
+
+    // 3. The member's clone: made WITHOUT --recurse-submodules, so skills/common
+    //    exists as an empty directory and the submodule is uninitialized. This is
+    //    exactly the state the issue describes after a CLI that ignored
+    //    `submodules: true` cached the parent SHA.
+    fs.mkdirSync(path.dirname(localPath), { recursive: true });
+    git(['clone', '-q', teamRepo, localPath], testRoot);
+    git(['config', 'user.name', 't'], localPath);
+    git(['config', 'user.email', 't@t.co'], localPath);
+    expect(fs.readdirSync(path.join(localPath, 'skills'))).not.toContain('distributed-skill');
+
+    // The member is tool-installed (claude) and the empty dir is what the
+    // pre-fix pull would keep deploying.
+    fs.mkdirSync(claudeSkills, { recursive: true });
+  });
+
+  afterEach(() => {
+    process.env.HOME = originalHome;
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originalUserProfile;
+    if (originalGitConfigGlobal === undefined) delete process.env.GIT_CONFIG_GLOBAL;
+    else process.env.GIT_CONFIG_GLOBAL = originalGitConfigGlobal;
+    if (originalTerminalPrompt === undefined) delete process.env.GIT_TERMINAL_PROMPT;
+    else process.env.GIT_TERMINAL_PROMPT = originalTerminalPrompt;
+    vi.clearAllMocks();
+    fs.rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  /**
+   * Cache the CURRENT parent HEAD as the last successful pull, tool target included.
+   * Uses the SHORT rev: `getHeadRev()` (the cache key pull writes and compares)
+   * returns `rev-parse --short HEAD`, so a full SHA would never match and the
+   * fast path this test exercises would never be reached.
+   */
+  function seedSyncedState(): void {
+    const head = git(['rev-parse', '--short', 'HEAD'], localPath).trim();
+    fs.writeFileSync(
+      path.join(homeDir, '.teamai', 'state.json'),
+      JSON.stringify({
+        lastPush: null,
+        lastPull: '2026-04-01T00:00:00.000Z',
+        lastPullRev: head,
+        lastPullTargets: ['claude'],
+        pushedRules: [],
+        pushedSkills: [],
+        pushedEnvVars: [],
+        pendingPushes: [],
+        lastUpdateCheck: null,
+        availableUpdate: null,
+      }, null, 2),
+    );
+  }
+
+  it('deploys submodule content on a pull whose parent rev is already cached', async () => {
+    // The upgrade scenario: the parent SHA was already synced (empty submodule
+    // dir), then the CLI starts honoring `submodules: true`.
+    seedSyncedState();
+
+    await pull({});
+
+    // Pre-fix this logged "Already synced at <rev>, skipping" and the deployed
+    // tool dir stayed empty.
+    expect(log.success).not.toHaveBeenCalledWith(
+      expect.stringContaining('Already synced'),
+    );
+    const deployed = path.join(claudeSkills, 'distributed-skill', 'SKILL.md');
+    expect(fs.existsSync(deployed)).toBe(true);
+    expect(fs.readFileSync(deployed, 'utf-8')).toContain('bundled as a submodule');
+  }, 60_000);
+
+  it('still takes the fast path when the submodule was already populated', async () => {
+    // Populate the submodule and cache the same rev: nothing changed this run,
+    // so the fast path must still apply (no needless full re-deploy).
+    git(['-c', 'protocol.file.allow=always', 'submodule', 'update', '--init'], localPath);
+    seedSyncedState();
+
+    await pull({});
+
+    expect(log.success).toHaveBeenCalledWith(
+      expect.stringContaining('Already synced'),
+    );
+  }, 60_000);
+});

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -63,10 +63,13 @@ interface RolePullContext {
  * whose submodule update failed: the caller must then NOT persist the new rev,
  * or the next pull's unchanged-rev fast path would skip the retry and leave
  * tool directories pointed at stale/empty submodule content forever.
+ * `submodulesChanged` marks a run whose submodule update succeeded but moved the
+ * tree on disk: the caller must then NOT take that same fast path *this* run,
+ * because the parent rev alone cannot see the change (issue #525).
  */
 async function refreshTeamRepo(
   localConfig: LocalConfig,
-): Promise<{ label: string; version: string | null; reportingOnly: boolean; submodulesFailed: boolean }> {
+): Promise<{ label: string; version: string | null; reportingOnly: boolean; submodulesFailed: boolean; submodulesChanged: boolean }> {
   if (localConfig.repo.kind === 'http') {
     const { resolveApiKey } = await import('./api-key.js');
     const apiKey = resolveApiKey();
@@ -75,7 +78,7 @@ async function refreshTeamRepo(
     }
     // HTTP backends deliver resources through report/sync (own hook handler),
     // so there is no repo tree to pull here.
-    return { label: 'HTTP (report/sync delivery)', version: null, reportingOnly: true, submodulesFailed: false };
+    return { label: 'HTTP (report/sync delivery)', version: null, reportingOnly: true, submodulesFailed: false, submodulesChanged: false };
   }
 
   if (localConfig.repo.kind === 'self') {
@@ -99,7 +102,7 @@ async function refreshTeamRepo(
     } catch {
       version = null;
     }
-    return { label: 'single-repo (knowledge on main)', version, reportingOnly: false, submodulesFailed: false };
+    return { label: 'single-repo (knowledge on main)', version, reportingOnly: false, submodulesFailed: false, submodulesChanged: false };
   }
 
   // The shared team clone is mutated here (git pull + flushPendingLearnings'
@@ -136,18 +139,53 @@ async function refreshTeamRepo(
   // would fail with "reference is not a tree". The full history guarantees
   // the pinned commit is always present.
   let submodulesFailed = false;
+  let submodulesChanged = false;
   try {
     const teamConfig = await loadTeamConfig(localConfig.repo.localPath);
     if (teamConfig?.submodules) {
-      await createGit(localConfig.repo.localPath).submoduleUpdate(['--init']);
-      log.debug('Submodules updated');
+      // Capture `git submodule status` before and after the update. The parent
+      // rev is the only cache key the fast path has, and a submodule update does
+      // not move it: a member who capped the parent SHA while the CLI still
+      // ignored `submodules: true` has empty submodule dirs, and the upgrade that
+      // fills them leaves HEAD untouched. Without this signal the fast path skips
+      // the deploy and the tool dirs stay empty until `pull --force` (issue #525).
+      // The leading status char is `-` while uninitialized and ` ` (or `+` when
+      // the checkout is behind its pin) afterwards, so a changed status string
+      // means the on-disk tree the deploy step reads is not what was cached.
+      const git = createGit(localConfig.repo.localPath);
+      // Only the status read is guarded here: an unavailable/unsupported status
+      // must degrade to "changed" (see below), NOT be reported as an update
+      // failure — the update itself is still allowed to fail into the outer
+      // catch and hold the rev back.
+      let before: string | null = null;
+      try {
+        before = await git.subModule(['status']);
+      } catch {
+        before = null;
+      }
+      await git.submoduleUpdate(['--init']);
+      let after: string | null = null;
+      try {
+        after = await git.subModule(['status']);
+      } catch {
+        after = null;
+      }
+      // An unreadable status is treated as "changed": a redundant full sync is
+      // cheap and self-correcting, whereas wrongly skipping re-pins the empty
+      // tool dirs this fix exists to clear.
+      submodulesChanged = before === null || before !== after;
+      log.debug(
+        submodulesChanged
+          ? 'Submodules updated (tree changed — full sync this pull)'
+          : 'Submodules updated (no change)',
+      );
     }
   } catch (e) {
     submodulesFailed = true;
     log.warn(`Submodule update failed for ${localConfig.repo.localPath}: ${(e as Error).message}`);
   }
 
-  return { label: result, version, reportingOnly: false, submodulesFailed };
+  return { label: result, version, reportingOnly: false, submodulesFailed, submodulesChanged };
 }
 
 /** teamai.yaml `usageReport: false` — per-repo opt-out of stat commits. */
@@ -522,11 +560,15 @@ async function pullForScope(
   // A failed submodule update holds the rev back below so the next pull
   // retries (see refreshTeamRepo).
   let submodulesFailed = false;
+  // A successful submodule update that moved the tree must bypass the
+  // unchanged-rev fast path for THIS run — the parent rev cannot see it (#525).
+  let submodulesChanged = false;
   try {
     const refresh = await refreshTeamRepo(localConfig);
     currentRev = refresh.version;
     reportingOnly = refresh.reportingOnly;
     submodulesFailed = refresh.submodulesFailed;
+    submodulesChanged = refresh.submodulesChanged;
     pullSpin.succeed(`[${scopeLabel}] Team repo: ${refresh.label}`);
   } catch (e) {
     pullSpin.fail(`[${scopeLabel}] Pull failed: ${(e as Error).message}`);
@@ -535,7 +577,7 @@ async function pullForScope(
 
   // Step 1b: Skip sync if the repo version hasn't changed since last pull
   let currentTargets: string[] | null = null;
-  if (!options.force && !options.dryRun) {
+  if (!options.force && !options.dryRun && !submodulesChanged) {
     try {
       const state = await loadStateForScope(localConfig);
       if (currentRev && state[revisionField] && state[revisionField] === currentRev) {


### PR DESCRIPTION
## Summary

Fixes the second half of the review note on #501: *don't skip when the update succeeded and the tree changed*.

`refreshTeamRepo` already reports a **failed** submodule update so the caller holds `lastPullRev` back and retries (#501). The **successful** update was not covered. `getInstalledResourceTargets` only records which AI tools are installed, not which skills appeared, so filling an empty submodule leaves the parent SHA — the fast path's only cache key — untouched, and `Already synced at <rev>, skipping` suppresses the deploy.

That is the upgrade footgun described in #525: a member pulls with a CLI that predates `submodules: true` (the unknown yaml key is stripped), so the parent SHA is cached while the submodule directories are still empty. Upgrading the CLI and pulling fills the clone, reports "Already synced", and `~/.claude/skills` (etc.) stay empty until `teamai pull --force` or an unrelated parent commit moves HEAD.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing behavior to change)
- [ ] Documentation only
- [ ] Refactor / internal cleanup

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` passes for the affected suites (`pull-skip-sync`, `pull-submodule-skip-sync`: 15 passed). Full-suite runs on this Windows dev box have pre-existing failures in the suites that shell out to a corporate git host; not related to this change.
- [x] Added/updated tests for the change

**Red → green, unit** (`src/__tests__/pull-skip-sync.test.ts`). New case: parent rev already cached, `git submodule status` moves from `-` (uninitialized) to ` ` (checked out). Reverting only `src/pull.ts` on unmodified `main`:

```
× does not skip sync when a successful submodule update changed the tree
  → expected "spy" to not be called with arguments: [ StringContaining "Already synced" ]
  +   "[user] Already synced at abc1234, skipping"
```

Companion case pins the steady state so the fix cannot silently become "always full sync": an update that changes nothing still takes the fast path.

**Red → green, real CLI pull** (`src/__tests__/pull-submodule-skip-sync.test.ts`, real bare remotes + a real submodule, no simple-git mock, following `contribute-self-learnings.test.ts`). The fixture clones the team repo without `--recurse-submodules` and seeds state with the current parent SHA, i.e. exactly the issue's member. Reverting only `src/pull.ts`:

```
× deploys submodule content on a pull whose parent rev is already cached
  → expected "spy" to not be called with arguments: [ StringContaining "Already synced" ]
  +   "[user] Already synced at db0a308, skipping"
```

With the fix, `skills/common/distributed-skill/SKILL.md` reaches `~/.claude/skills` on that pull. The second case asserts the fast path is still taken when the submodule was already populated.

## Related Issues

Fixes #525

Follow-up to #501.

## Notes for Reviewers

**Only a real change invalidates the fast path.** The obvious fix — always bypass skip-sync when `submodules: true` — would make every pull in a submodule-using team pay a full re-deploy forever. Instead this captures `git submodule status` before and after the update and treats a changed string as "the tree the deploy step reads is not what was cached". The leading status char is `-` while uninitialized and ` `/`+` (checkout behind its pin) afterwards, so both the fill-from-empty and pin-advance cases are covered. A team whose submodules are already current keeps taking the fast path.

**Degradation direction.** An unreadable `submodule status` is treated as *changed*: a redundant full sync is cheap and self-correcting, whereas wrongly skipping re-pins the empty tool directories this fix exists to clear. Only the status read degrades — the update itself still fails into the existing outer `catch`, so the `submodulesFailed` rev hold-back from #501 is untouched.

**Scope.** No behavior change for the HTTP and single-repo backends (both return `submodulesChanged: false`), and none for repos without the `submodules` knob. `submodulesChanged` only gates this run's fast path; it is not persisted, matching `submodulesFailed`.

Verified on Windows; the submodule protocol guard (`protocol.file.allow`) needed by the local-path fixture lives in a temp global config the test writes outside its own temp root, so `beforeEach` cannot drop it.
