### PR TITLE
fix(cnb): persist git credential helper after interactive clone

### DIFF
--- a/src/__tests__/cnb-provider.test.ts
+++ b/src/__tests__/cnb-provider.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
 
 // Provider modules import the logger; stub it so importing has no side effects.
 vi.mock('../utils/logger.js', () => ({
@@ -12,9 +12,20 @@ vi.mock('../utils/logger.js', () => ({
   }),
 }));
 
+// Stub child_process so cnbRepoClone tests can assert git invocations without a
+// real git/cnb binary. execSync is only used by isCnbInstalled (not exercised
+// here) but must exist so the module loads.
+vi.mock('node:child_process', () => ({
+  spawnSync: vi.fn(),
+  execSync: vi.fn(),
+}));
+
+import { spawnSync } from 'node:child_process';
 import { detectProvider, getProvider } from '../providers/registry.js';
 import { CNBProvider } from '../providers/cnb/index.js';
-import { cnbParseRepoInput, CNB_HOST, assertCnbApiOk } from '../providers/cnb/cnb-cli.js';
+import { cnbParseRepoInput, cnbRepoClone, CNB_HOST, assertCnbApiOk } from '../providers/cnb/cnb-cli.js';
+
+const mockedSpawnSync = spawnSync as Mock;
 
 describe('CNB provider registration', () => {
   it('detects cnb.cool URLs (https and ssh) as the cnb provider', () => {
@@ -72,5 +83,63 @@ describe('assertCnbApiOk', () => {
 
   it('is a no-op when the output carries no HTTP status', () => {
     expect(() => assertCnbApiOk('some human text', 'x')).not.toThrow();
+  });
+});
+
+describe('cnbRepoClone credential persistence', () => {
+  beforeEach(() => {
+    mockedSpawnSync.mockReset();
+  });
+  afterEach(() => {
+    delete process.env.CNB_TOKEN;
+    delete process.env.CNB_ACCESS_TOKEN;
+  });
+
+  it('persists the cnb git-credential helper into the cloned repo on the interactive path', () => {
+    // No CNB_TOKEN → interactive path. First spawnSync is `git clone`; the
+    // second is `git config --local credential.helper`.
+    mockedSpawnSync
+      .mockReturnValueOnce({ status: 0, stdout: '', stderr: '' }) // clone
+      .mockReturnValueOnce({ status: 0, stdout: '', stderr: '' }); // config
+
+    cnbRepoClone('acme/harness', '/tmp/clone');
+
+    // First call: the clone itself, scoped to this one invocation via -c.
+    const cloneCall = mockedSpawnSync.mock.calls[0];
+    expect(cloneCall[0]).toEqual('git');
+    expect(cloneCall[1]).toContain('-c');
+    expect(cloneCall[1]).toContain('credential.helper=!cnb git-credential');
+    expect(cloneCall[1]).toContain('clone');
+    expect(cloneCall[1]).toContain(`https://${CNB_HOST}/acme/harness.git`);
+
+    // Second call: persist the helper into the repo's local config so later
+    // push/pull auth without prompting. cwd must point at the clone.
+    const cfgCall = mockedSpawnSync.mock.calls[1];
+    expect(cfgCall[0]).toEqual('git');
+    expect(cfgCall[1]).toEqual(['config', '--local', 'credential.helper', '!cnb git-credential']);
+    expect(cfgCall[2]?.cwd).toBe('/tmp/clone');
+  });
+
+  it('embeds the token in the clone URL and skips the helper-config step (CI path)', () => {
+    process.env.CNB_TOKEN = 'tok123';
+    mockedSpawnSync.mockReturnValue({ status: 0, stdout: '', stderr: '' });
+
+    cnbRepoClone('acme/harness', '/tmp/clone');
+
+    // Only one git invocation — the clone — with creds baked into the URL.
+    expect(mockedSpawnSync).toHaveBeenCalledTimes(1);
+    const cloneCall = mockedSpawnSync.mock.calls[0];
+    expect(cloneCall[1]).toContain(`clone`);
+    expect(cloneCall[1]).toContain(`https://cnb:tok123@${CNB_HOST}/acme/harness.git`);
+    // No `git config --local credential.helper` follow-up.
+    expect(mockedSpawnSync.mock.calls.some(
+      (c) => c[1]?.[0] === 'config' && c[1]?.includes('credential.helper'),
+    )).toBe(false);
+  });
+
+  it('still throws CnbRepoNotFoundError when the remote does not exist', async () => {
+    mockedSpawnSync.mockReturnValue({ status: 128, stdout: '', stderr: 'Repository not found' });
+    const { CnbRepoNotFoundError } = await import('../providers/cnb/cnb-cli.js');
+    expect(() => cnbRepoClone('acme/missing', '/tmp/clone')).toThrow(CnbRepoNotFoundError);
   });
 });

--- a/src/providers/cnb/cnb-cli.ts
+++ b/src/providers/cnb/cnb-cli.ts
@@ -189,6 +189,15 @@ export function cnbParseRepoInput(input: string): RepoInfo {
 /**
  * Clone via git. With a CNB_TOKEN we embed Basic creds in the URL (CI path);
  * otherwise we let git call `cnb git-credential` (interactive-login path).
+ *
+ * In the interactive path the credential helper must persist beyond the clone
+ * itself: `git -c credential.helper=... clone` only applies for that one
+ * invocation, so the cloned repo's `remote.origin.url` carries no credentials
+ * and the next push/pull falls back to an interactive Username/Password prompt.
+ * GitHub/TGit solve this by embedding the token in the clone URL; CNB has no
+ * user-readable token in the interactive path, so we persist the helper into
+ * the repo's local config instead, making every later git operation on it auth
+ * transparently.
  */
 export function cnbRepoClone(repo: string, localPath: string): void {
   const token = getCnbToken();
@@ -207,6 +216,20 @@ export function cnbRepoClone(repo: string, localPath: string): void {
   if (r.status !== 0) {
     const sanitized = out.replace(/cnb:[^@]+@/g, 'cnb:***@').trim();
     throw new Error(`git clone failed: ${sanitized}`);
+  }
+
+  // Persist the credential helper into the cloned repo so push/pull (which init
+  // runs after cloning) authenticate without prompting. Token-path clones bake
+  // creds into remote.origin.url, so only the interactive path needs this.
+  if (!token) {
+    const cfg = spawnSync('git', ['config', '--local', 'credential.helper', '!cnb git-credential'], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd: localPath,
+    });
+    if (cfg.status !== 0) {
+      log.warn(`Could not persist CNB credential helper: ${(cfg.stderr ?? '').trim()}. Push/pull may prompt for credentials.`);
+    }
   }
 }
 


### PR DESCRIPTION
## Problem

`teamai init https://cnb.cool/<owner>/<repo>` prompted for Username/Password during the post-clone push (member registration), and `teamai pull` failed with `couldn't find remote ref main` — despite the user being logged into the `cnb` CLI.

## Root cause

`cnbRepoClone` used `git -c credential.helper='!cnb git-credential' clone`. The `-c` flag only applies to that **single invocation** — it never reaches the cloned repo's `.git/config`. So `remote.origin.url` stays credential-free, and every later git operation (push, pull) falls back to an interactive Username/Password prompt.

GitHub/TGit solve this by embedding the token in the clone URL (persisted into `remote.origin.url`); CNB's CI path (`CNB_TOKEN`) does the same. Only the **interactive-login path** was missing persistence.

## Fix

After a successful interactive clone (no `CNB_TOKEN`), persist the credential helper into the cloned repo's local config:

```
git config --local credential.helper '!cnb git-credential'
```

Token-path clones (CI) already bake creds into the URL, so they skip this step.

## Test plan

- [x] Unit tests: 3 new cases covering helper persistence (interactive path), token-path skip, and not-found error. `tsc --noEmit` clean.
- [x] End-to-end against a real cnb.cool account (logged-in, no `CNB_TOKEN`):
  - [x] `teamai init https://cnb.cool/test1122444/test --force` → `✔ Member registration pushed to team repo` (no prompt)
  - [x] `teamai pull` → `✔ Team repo: already up to date` (was `fatal: couldn't find remote ref main`)
  - [x] `git config --local --get credential.helper` on the clone → `!cnb git-credential`
  - [x] `remote.origin.url` stays clean (no embedded token on the interactive path)

## Scope

Surgical: only `cnbRepoClone` changed (+23 lines); no other providers touched.

## References

- Fixes the CNB path described in #517 — that RFC's onboarding flow (`cnb login` → `teamai init https://cnb.cool/...`) is exactly the interactive-login path this PR makes work without a Username/Password prompt.
