### PR TITLE
fix(cnb): pin login to CNB_HOST so it ignores the current dir git remote

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -133,9 +133,11 @@ CNB（[云原生构建](https://cnb.cool)）provider 是对官方 CLI `@cnbcool/
 **方式 1：`cnb login`（交互式，开发机推荐）**
 
 ```bash
-cnb login   # OAuth2 device flow，登录后 `cnb git-credential` 为 git 提供凭据
+cnb login --host cnb.cool   # OAuth2 device flow，登录后 `cnb git-credential` 为 git 提供凭据
 teamai init https://cnb.cool/yourorg/yourrepo
 ```
+
+> **为什么要带 `--host`**：`cnb` CLI 在未显式指定 host 时，会从当前目录第一个 git remote 推断平台地址。若在一个 remote 指向非 CNB 平台（如内网 git 服务器）的仓库里直接跑 `cnb login`，请求会被打到那个 host 并返回 `401`。显式 `--host cnb.cool` 可避免此问题（自托管实例改用对应域名）。由 `teamai init` 自动触发登录时，teamai 已按 `TEAMAI_CNB_HOST`（默认 `cnb.cool`）带上 `--host`，无需手动处理。
 
 **方式 2：`CNB_TOKEN` 环境变量（headless / CI）**
 

--- a/src/__tests__/cnb-login-host.test.ts
+++ b/src/__tests__/cnb-login-host.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// cnbLogin spawns the real `cnb` binary; stub child_process so we can assert the
+// exact argv without touching the network.
+const spawnSync = vi.fn();
+vi.mock('node:child_process', () => ({
+  spawnSync: (...args: unknown[]) => spawnSync(...args),
+  execSync: vi.fn(),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  log: { info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), dim: vi.fn() },
+  spinner: () => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    info: vi.fn().mockReturnThis(),
+    warn: vi.fn().mockReturnThis(),
+  }),
+}));
+
+describe('cnbLogin pins the platform host', () => {
+  beforeEach(() => {
+    spawnSync.mockReset();
+    spawnSync.mockReturnValue({ status: 0, stdout: '', stderr: '' });
+    delete process.env.TEAMAI_CNB_HOST;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.TEAMAI_CNB_HOST;
+  });
+
+  it('passes --host cnb.cool so login ignores the current dir git remote', async () => {
+    const { cnbLogin } = await import('../providers/cnb/cnb-cli.js');
+    cnbLogin();
+    expect(spawnSync).toHaveBeenCalledTimes(1);
+    const [cmd, args] = spawnSync.mock.calls[0];
+    expect(cmd).toBe('cnb');
+    expect(args).toEqual(['login', '--host', 'cnb.cool']);
+  });
+
+  it('honors TEAMAI_CNB_HOST for a self-hosted instance', async () => {
+    process.env.TEAMAI_CNB_HOST = 'cnb.internal.example.com';
+    const { cnbLogin } = await import('../providers/cnb/cnb-cli.js');
+    cnbLogin();
+    const [, args] = spawnSync.mock.calls[0];
+    expect(args).toEqual(['login', '--host', 'cnb.internal.example.com']);
+  });
+});

--- a/src/providers/cnb/cnb-cli.ts
+++ b/src/providers/cnb/cnb-cli.ts
@@ -135,10 +135,19 @@ export function cnbWhoami(): string | null {
   return process.env.CNB_USERNAME?.trim() || null;
 }
 
-/** Trigger the interactive OAuth2 device-flow login. */
+/**
+ * Trigger the interactive OAuth2 device-flow login.
+ *
+ * Pass `--host ${CNB_HOST}` explicitly: left to its own devices the `cnb` CLI
+ * infers the platform URL from the first `git remote` of the current directory,
+ * so running this inside a repo whose remote points at a non-CNB host (e.g. an
+ * internal git server) sends the device-auth request there and fails with 401.
+ * CNB_HOST is already the single source of truth for every other CNB operation
+ * (clone / create-repo / PR), so anchoring login to it keeps auth consistent.
+ */
 export function cnbLogin(): void {
   log.info('Starting cnb authentication (OAuth2 device flow)...');
-  const r = cnbExec(['login'], { inheritStdio: true });
+  const r = cnbExec(['login', '--host', CNB_HOST], { inheritStdio: true });
   if (r.status !== 0) throw new Error('cnb login failed. Please try again.');
 }
 


### PR DESCRIPTION
## What & why

`cnb login`（`@cnbcool/cnb-cli`）在**未显式指定 `--host`** 时，会从**当前目录第一个 git remote** 推断平台地址（`resolvePlatformUrl` → `getGitRemoteHosts()` 跑 `git remote -v`）。优先级为：`--host` > git remote > `CNB_API_ENDPOINT` > 默认 `cnb.cool`。

因此在一个 remote 指向**非 CNB 平台**（如内网 git 服务器）的仓库里跑 `cnb login`，device-auth 请求会被打到那个 host 并返回 **401**；而在没有该 remote 的目录里同一命令却成功——表现为「同一命令换个目录就登录失败」。

teamai 的 `cnbLogin()` 此前调 `cnb login` 未传 `--host`，在这种仓库里首次 `teamai init`（provider=cnb、且未登录过）会踩同样的坑。本 provider 其他所有操作（clone / create-repo / PR）都已以 `CNB_HOST` 为唯一真相源，唯独 login 例外。

## What changed

- `src/providers/cnb/cnb-cli.ts`：`cnbLogin()` 改为 `cnb login --host ${CNB_HOST}`（`CNB_HOST` = `TEAMAI_CNB_HOST` ?? `cnb.cool`），与 provider 其他操作同源；自托管实例自动带上其域名。
- 新增单测 `src/__tests__/cnb-login-host.test.ts`：断言默认与 `TEAMAI_CNB_HOST` 两种情况下的 argv。
- `docs/providers.md`：手动 `cnb login` 示例改为带 `--host cnb.cool`，并说明原因与 teamai 自动带 host 的行为。

CI 路径（`CNB_TOKEN`）根本不触发 login，不受影响。

## Test plan / report

**环境**：macOS，真实 `@cnbcool/cnb-cli` v1.15.20，在 remote 指向 `git.woa.com`（非 CNB）的仓库目录内。

- [x] `npx tsc --noEmit` — pass
- [x] `npx vitest run` — **221 files / 3040 tests passed**
- [x] `npm run build` — pass（dist 内含 `login", "--host", CNB_HOST`）
- [x] **真实 CLI 复现 + 修复验证**（`cnb ... --debug`，密钥已打码）：

  | 场景 | Platform URL | 结果 |
  |---|---|---|
  | 不带 `--host`（推断 git remote） | `https://git.woa.com` | `status=401` → `登录失败: status=401 body=`（复现报错） |
  | 带 `--host cnb.cool`（修复） | `https://cnb.cool` | device-auth `status=200`，进入 token 轮询（`authorization_pending`，正常等待浏览器授权） |

- [x] **验证 teamai 实际发出的 argv**（用记录参数的假 `cnb` shim 驱动真实 `cnbLogin()`）：
  - 默认：`login --host cnb.cool`
  - `TEAMAI_CNB_HOST=cnb.internal.example.com`：`login --host cnb.internal.example.com`
