### PR TITLE
test(e2e): real-CLI e2e for data-layout migration (#374) and multi-project (#375)

### DIFF
--- a/src/__tests__/e2e/data-layout-migration.test.ts
+++ b/src/__tests__/e2e/data-layout-migration.test.ts
@@ -1,0 +1,164 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { execFileSync, spawn } from 'node:child_process';
+import fs from 'node:fs';
+import { realpathSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { projectSlug } from '../../utils/partition.js';
+
+// ─── data-layout migration e2e (issue #374) ─────────────────────────────────
+//
+// The unit suite (migrate.test.ts) drives planMigration/runMigration directly.
+// This is the missing END-TO-END leg: seed a real legacy `<repo>/.teamai/`
+// layout, run the ACTUAL compiled CLI (`teamai pull`), and assert the preAction
+// hook migrated the data into the partition `~/.teamai/projects/<slug>/`, left
+// the workspace residue-free, and that pull then ran successfully THROUGH the
+// migrated clone (repo.localPath rebased onto the partition).
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const CLI = path.join(ROOT, 'dist', 'index.js');
+
+const GIT_ENV = {
+  GIT_AUTHOR_NAME: 'TeamAI CI',
+  GIT_AUTHOR_EMAIL: 'ci@teamai.test',
+  GIT_COMMITTER_NAME: 'TeamAI CI',
+  GIT_COMMITTER_EMAIL: 'ci@teamai.test',
+};
+
+interface RunResult {
+  code: number | null;
+  output: string;
+}
+
+function git(args: string[], cwd: string): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, ...GIT_ENV },
+  }).trim();
+}
+
+function runCLI(args: string[], cwd: string, home: string): Promise<RunResult> {
+  return new Promise((resolve) => {
+    const child = spawn('node', [CLI, ...args], {
+      cwd,
+      env: { ...process.env, ...GIT_ENV, HOME: home, FORCE_COLOR: '0' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let output = '';
+    child.stdout.on('data', (data: Buffer) => { output += data.toString(); });
+    child.stderr.on('data', (data: Buffer) => { output += data.toString(); });
+    child.on('close', (code) => resolve({ code, output }));
+  });
+}
+
+describe('data-layout auto-migration via the real CLI (issue #374)', () => {
+  let sandbox: string;
+  let home: string;
+  let projectRoot: string;
+  let legacyDir: string;
+  let partitionDir: string;
+
+  beforeAll(async () => {
+    if (!fs.existsSync(CLI)) {
+      throw new Error(`CLI binary not found at ${CLI}. Run "npm run build" first.`);
+    }
+
+    // realpath the base so the anchor the CLI computes (realpath of show-toplevel)
+    // matches the slug we compute here — macOS /tmp and /var are symlinks.
+    sandbox = realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-datalayout-e2e-')));
+    home = path.join(sandbox, 'home');
+    projectRoot = path.join(sandbox, 'project');
+    const remoteRepo = path.join(sandbox, 'remote');
+    legacyDir = path.join(projectRoot, '.teamai');
+    const legacyTeamRepo = path.join(legacyDir, 'team-repo');
+
+    fs.mkdirSync(home, { recursive: true });
+
+    // The business repo MUST be a real git repo — resolveAnchors (hence migration)
+    // stands down outside one.
+    fs.mkdirSync(projectRoot, { recursive: true });
+    git(['init', '-q', '-b', 'main'], projectRoot);
+    git(['commit', '--allow-empty', '-q', '-m', 'business init'], projectRoot);
+
+    // Seed the team remote with a deployable skill so a successful pull proves the
+    // migrated clone is actually usable, not just present.
+    fs.mkdirSync(path.join(remoteRepo, 'skills', 'team', 'mig-proof'), { recursive: true });
+    fs.writeFileSync(path.join(remoteRepo, 'teamai.yaml'), [
+      'team: datalayout-e2e',
+      `repo: ${remoteRepo}`,
+      'provider: git',
+      'toolPaths:',
+      '  claude:',
+      '    skills: .claude/skills',
+      '',
+    ].join('\n'));
+    fs.writeFileSync(
+      path.join(remoteRepo, 'skills', 'team', 'mig-proof', 'SKILL.md'),
+      '---\nname: mig-proof\ndescription: migration e2e fixture\n---\n\n# Mig proof\n',
+    );
+    git(['init', '-q', '-b', 'main'], remoteRepo);
+    git(['add', '-A'], remoteRepo);
+    git(['commit', '-q', '-m', 'seed team'], remoteRepo);
+
+    // Build a genuine LEGACY layout: machine data (incl. a plaintext secret and a
+    // real team-repo clone) under <repo>/.teamai/, with localPath pointing INTO it.
+    git(['clone', '-q', remoteRepo, legacyTeamRepo], projectRoot);
+    fs.mkdirSync(path.join(projectRoot, '.claude', 'skills'), { recursive: true });
+    fs.writeFileSync(path.join(legacyDir, 'config.yaml'), [
+      'repo:',
+      `  localPath: ${legacyTeamRepo}`,
+      `  remote: ${remoteRepo}`,
+      '  kind: git',
+      'username: legacy-user',
+      'updatePolicy: auto',
+      'scope: project',
+      `projectRoot: ${projectRoot}`,
+      '',
+    ].join('\n'));
+    fs.writeFileSync(path.join(legacyDir, 'state.json'), JSON.stringify({ lastPullRev: null }));
+    fs.writeFileSync(path.join(legacyDir, 'env'), 'TEAM_TOKEN=s3cret\n');
+
+    // The partition path the CLI will migrate INTO. projectSlug is HOME-independent,
+    // so join it onto the sandbox HOME the child process will use.
+    partitionDir = path.join(home, '.teamai', 'projects', projectSlug(projectRoot));
+  }, 60_000);
+
+  afterAll(() => {
+    if (sandbox) fs.rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  it('migrates a legacy .teamai into the partition and pulls through it', async () => {
+    const result = await runCLI(['pull', '--force'], projectRoot, home);
+    expect(result.code, result.output).toBe(0);
+
+    // ── Machine data landed in the partition ──
+    expect(fs.existsSync(path.join(partitionDir, 'config.yaml')), result.output).toBe(true);
+    expect(fs.existsSync(path.join(partitionDir, 'state.json'))).toBe(true);
+    expect(fs.existsSync(path.join(partitionDir, 'env'))).toBe(true);
+    // The anchor reverse-lookup file points back at the business repo.
+    expect(fs.readFileSync(path.join(partitionDir, 'anchor'), 'utf8').trim()).toBe(projectRoot);
+
+    // ── The migrated team-repo clone survived intact (raw copy, not .git-filtered) ──
+    const migratedRepo = path.join(partitionDir, 'team-repo');
+    expect(fs.existsSync(path.join(migratedRepo, '.git'))).toBe(true);
+    expect(() => git(['rev-parse', 'HEAD'], migratedRepo)).not.toThrow();
+
+    // ── repo.localPath was rebased from the legacy dir onto the partition ──
+    expect(fs.readFileSync(path.join(partitionDir, 'config.yaml'), 'utf8'))
+      .toContain(`localPath: ${migratedRepo}`);
+
+    // ── Workspace is residue-free: legacy gone, backup present and git-ignored ──
+    expect(fs.existsSync(legacyDir)).toBe(false);
+    const backup = `${legacyDir}.bak`;
+    expect(fs.existsSync(path.join(backup, 'config.yaml'))).toBe(true);
+    expect(fs.existsSync(path.join(backup, 'env'))).toBe(true);
+    expect(fs.readFileSync(path.join(backup, '.gitignore'), 'utf8')).toContain('*');
+
+    // ── Pull ran THROUGH the migrated clone: the team skill deployed ──
+    expect(fs.existsSync(path.join(projectRoot, '.claude', 'skills', 'mig-proof', 'SKILL.md')))
+      .toBe(true);
+  }, 60_000);
+});

--- a/src/__tests__/e2e/multi-project.test.ts
+++ b/src/__tests__/e2e/multi-project.test.ts
@@ -1,0 +1,192 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { execFileSync, spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// ─── multi-project e2e (issue #375) ─────────────────────────────────────────
+//
+// The unit suite (projects.test.ts / members.test.ts / pull-project-cleanup)
+// drives the project resolvers directly. This is the missing END-TO-END leg for
+// the user-facing commands, run through the ACTUAL compiled CLI:
+//   1. `projects set <id>` scopes a directory to one project;
+//   2. `pull --force` deploys ONLY that project's skills namespace and prunes an
+//      inactive project's skills — the isolation guarantee of #375;
+//   3. `push --project <id>` routes a skill into the project's skills namespace
+//      (skills/<ns>/…) on the team remote, agreeing with what pull syncs.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const CLI = path.join(ROOT, 'dist', 'index.js');
+
+const GIT_ENV = {
+  GIT_AUTHOR_NAME: 'TeamAI CI',
+  GIT_AUTHOR_EMAIL: 'ci@teamai.test',
+  GIT_COMMITTER_NAME: 'TeamAI CI',
+  GIT_COMMITTER_EMAIL: 'ci@teamai.test',
+};
+
+interface RunResult {
+  code: number | null;
+  output: string;
+}
+
+function git(args: string[], cwd: string): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, ...GIT_ENV },
+  }).trim();
+}
+
+function runCLI(args: string[], cwd: string, home: string): Promise<RunResult> {
+  return new Promise((resolve) => {
+    const child = spawn('node', [CLI, ...args], {
+      cwd,
+      env: { ...process.env, ...GIT_ENV, HOME: home, FORCE_COLOR: '0' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let output = '';
+    child.stdout.on('data', (data: Buffer) => { output += data.toString(); });
+    child.stderr.on('data', (data: Buffer) => { output += data.toString(); });
+    child.on('close', (code) => resolve({ code, output }));
+  });
+}
+
+function writeSkill(repoPath: string, namespace: string, name: string): void {
+  const skillDir = path.join(repoPath, 'skills', namespace, name);
+  fs.mkdirSync(skillDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(skillDir, 'SKILL.md'),
+    `---\nname: ${name}\ndescription: ${namespace} fixture\n---\n\n# ${name}\n`,
+  );
+}
+
+describe('multi-project resource isolation via the real CLI (issue #375)', () => {
+  let sandbox: string;
+  let home: string;
+  let projectRoot: string;
+  let remote: string;
+
+  beforeAll(() => {
+    if (!fs.existsSync(CLI)) {
+      throw new Error(`CLI binary not found at ${CLI}. Run "npm run build" first.`);
+    }
+
+    sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'teamai-multiproject-e2e-'));
+    home = path.join(sandbox, 'home');
+    projectRoot = path.join(sandbox, 'project');
+    const seed = path.join(sandbox, 'seed');
+    remote = path.join(sandbox, 'team.git');
+    const teamRepo = path.join(projectRoot, '.teamai', 'team-repo');
+
+    fs.mkdirSync(home, { recursive: true });
+    fs.mkdirSync(path.join(projectRoot, '.claude', 'skills'), { recursive: true });
+
+    // Two projects, each owning a distinct skills namespace.
+    fs.mkdirSync(path.join(seed, 'manifest'), { recursive: true });
+    fs.writeFileSync(path.join(seed, 'teamai.yaml'), [
+      'team: multiproject-e2e',
+      `repo: ${remote}`,
+      'provider: git',
+      'reviewers: []',
+      'toolPaths:',
+      '  claude:',
+      '    skills: .claude/skills',
+      '',
+    ].join('\n'));
+    fs.writeFileSync(path.join(seed, 'manifest', 'projects.yaml'), [
+      'version: 1',
+      'projects:',
+      '  - id: alpha',
+      '    name: Alpha',
+      '    resources:',
+      '      skills: [alpha]',
+      '      learnings: [alpha]',
+      '  - id: billing',
+      '    name: Billing',
+      '    resources:',
+      '      skills: [billing]',
+      '      learnings: [billing]',
+      '',
+    ].join('\n'));
+    writeSkill(seed, 'alpha', 'alpha-only');
+    writeSkill(seed, 'billing', 'billing-only');
+
+    git(['init', '-q', '-b', 'main'], seed);
+    git(['add', '-A'], seed);
+    git(['commit', '-q', '-m', 'seed'], seed);
+    git(['clone', '-q', '--bare', seed, remote], sandbox);
+    git(['clone', '-q', remote, teamRepo], projectRoot);
+
+    fs.writeFileSync(path.join(projectRoot, '.teamai', 'config.yaml'), [
+      'repo:',
+      `  localPath: ${teamRepo}`,
+      `  remote: ${remote}`,
+      'username: mp-user',
+      'updatePolicy: auto',
+      'scope: project',
+      `projectRoot: ${projectRoot}`,
+      '',
+    ].join('\n'));
+  });
+
+  afterAll(() => {
+    if (sandbox) fs.rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  it('deploys only the active project\'s skills and prunes an inactivated project', async () => {
+    const skillsDir = path.join(projectRoot, '.claude', 'skills');
+
+    // Activate alpha → only alpha's skill deploys, billing's does not.
+    const setAlpha = await runCLI(['projects', 'set', 'alpha'], projectRoot, home);
+    expect(setAlpha.code, setAlpha.output).toBe(0);
+
+    const pullAlpha = await runCLI(['pull', '--force'], projectRoot, home);
+    expect(pullAlpha.code, pullAlpha.output).toBe(0);
+    expect(fs.existsSync(path.join(skillsDir, 'alpha-only', 'SKILL.md'))).toBe(true);
+    expect(fs.existsSync(path.join(skillsDir, 'billing-only'))).toBe(false);
+
+    // Switch alpha → billing. The now-inactive alpha skill must be PRUNED, and
+    // billing's deployed — the core cross-project isolation guarantee.
+    const setBilling = await runCLI(['projects', 'set', 'billing'], projectRoot, home);
+    expect(setBilling.code, setBilling.output).toBe(0);
+
+    const pullBilling = await runCLI(['pull', '--force'], projectRoot, home);
+    expect(pullBilling.code, pullBilling.output).toBe(0);
+    expect(fs.existsSync(path.join(skillsDir, 'billing-only', 'SKILL.md'))).toBe(true);
+    expect(fs.existsSync(path.join(skillsDir, 'alpha-only'))).toBe(false);
+  }, 60_000);
+
+  it('routes push --project into the project skills namespace on the remote', async () => {
+    // A new local skill pushed with --project billing must land under
+    // skills/billing/ on the pushed branch (the namespace pull reads), proving
+    // push and pull agree on the project → namespace mapping.
+    const skillPath = '.claude/skills/pushed-proof';
+    fs.mkdirSync(path.join(projectRoot, skillPath), { recursive: true });
+    fs.writeFileSync(
+      path.join(projectRoot, skillPath, 'SKILL.md'),
+      '---\nname: pushed-proof\ndescription: push --project e2e\n---\n\n# Pushed proof\n',
+    );
+
+    const pushResult = await runCLI(
+      ['push', '--skill', skillPath, '--project', 'billing', '--all'],
+      projectRoot,
+      home,
+    );
+    // provider: git cannot open a PR, so the command exits non-zero AFTER pushing
+    // the branch — the branch content is what we assert (same contract as the
+    // role-scoped push e2e).
+    expect(pushResult.output).not.toContain('No changes to push');
+    expect(pushResult.output).toContain('Pushed branch teamai/push/mp-user/');
+
+    const branch = git(
+      ['for-each-ref', '--format=%(refname:short)', 'refs/heads/teamai/push/mp-user/'],
+      remote,
+    );
+    expect(branch).toMatch(/^teamai\/push\/mp-user\//);
+    expect(git(['show', `${branch}:skills/billing/pushed-proof/SKILL.md`], remote))
+      .toContain('# Pushed proof');
+  }, 60_000);
+});


### PR DESCRIPTION
## What

Adds the two missing **real-command end-to-end** tests for features that
previously had only function-level unit coverage:

- **`src/__tests__/e2e/data-layout-migration.test.ts` (#374)** — the legacy
  `<repo>/.teamai` → partition migration was only exercised by calling
  `planMigration`/`runMigration` directly (`migrate.test.ts`). This drives the
  **compiled CLI** instead: seed a real legacy layout (real `team-repo` clone +
  plaintext `env` + `localPath` pointing into legacy), run `teamai pull --force`,
  and assert the `preAction` hook actually migrated it.
- **`src/__tests__/e2e/multi-project.test.ts` (#375)** — the user-facing
  `projects` / `push --project` commands had **no** real-CLI e2e (only
  `projects.test.ts` / `members.test.ts` resolver unit tests). This covers the
  activate → pull → prune isolation loop and the push→namespace round-trip.

No production code changes — tests only.

## Why

Audit of `#374`/`#375` coverage found: migration's "legacy → real `pull` →
partition" path was never asserted through the actual CLI, and the multi-project
user commands (`projects set`, `pull --project` isolation, `push --project`) had
zero real-CLI e2e. These two files close both gaps.

## How it's tested (mechanism)

- `spawn('node', [dist/index.js, ...])` — runs the **compiled binary**, exactly
  like a user shell, not imported functions.
- **Sandbox `HOME`** → partition (`~/.teamai/projects/<slug>`) is confined to a
  `mkdtemp` dir, torn down after; never touches the real `~/.teamai`.
- **Local bare git remote** (`provider: git`) → `pull`/`push` are real git ops
  with **no network, no tokens, no PR creation**. Hermetic; runs on fork PRs too.

## Test Plan

| Check | Result |
|---|---|
| `npx tsc --noEmit` | ✅ pass |
| `npm run build` | ✅ pass |
| New e2e via real `dist/index.js` (`vitest --config vitest.e2e.config.ts`) | ✅ 3/3 pass |
| **Negative control**: invert the "alpha is pruned" assertion | ✅ fails as expected, then restored & green (proves assertions verify behavior, not a no-op) |
| Adjacent unit tests (migrate / projects / members / partition / pull-project-cleanup) | ✅ 76/76 unaffected |

```
$ npx vitest run --config vitest.e2e.config.ts \
    src/__tests__/e2e/data-layout-migration.test.ts \
    src/__tests__/e2e/multi-project.test.ts
 ✓ multi-project ... deploys only the active project's skills and prunes an inactivated project
 ✓ multi-project ... routes push --project into the project skills namespace on the remote
 ✓ data-layout ... migrates a legacy .teamai into the partition and pulls through it
 Test Files  2 passed (2)
      Tests  3 passed (3)
```

## Notes

- Both files live in `src/__tests__/e2e/`, so `vitest.e2e.config.ts`'s `include`
  picks them up and CI's "Run E2E (full surface)" job runs them automatically.
- macOS `/tmp` → `/private/tmp` symlink: the migration test `realpathSync`s its
  sandbox so the slug it computes matches the CLI's (`realpath`-based) one.
