### PR TITLE
fix(push): stop empty skill subdirs from becoming a namespace

### DIFF
--- a/src/__tests__/fs-compare.test.ts
+++ b/src/__tests__/fs-compare.test.ts
@@ -8,6 +8,7 @@ import {
   getFileMtime,
   getDirLatestMtime,
   hasVcsMetadataRecursive,
+  pruneEmptyDirs,
 } from '../utils/fs.js';
 
 describe('fileContentEqual', () => {
@@ -346,5 +347,51 @@ describe('hasVcsMetadataRecursive', () => {
 
   it('returns false for a missing directory', async () => {
     expect(await hasVcsMetadataRecursive(path.join(tmpDir, 'nope'))).toBe(false);
+  });
+});
+
+describe('pruneEmptyDirs', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-prune-test-'));
+  });
+
+  afterEach(async () => {
+    await fse.remove(tmpDir);
+  });
+
+  it('removes a directory tree that contains no files', async () => {
+    const target = path.join(tmpDir, 'skills', 'channel-bill-push-test');
+    await fse.ensureDir(path.join(target, 'assets'));
+    await fse.ensureDir(path.join(target, 'references'));
+
+    await pruneEmptyDirs(target);
+
+    expect(await fse.pathExists(target)).toBe(false);
+    expect(await fse.pathExists(path.join(tmpDir, 'skills'))).toBe(true);
+  });
+
+  it('keeps the directory and prunes only its empty subdirectories', async () => {
+    const target = path.join(tmpDir, 'skills', 'my-skill');
+    await fse.outputFile(path.join(target, 'SKILL.md'), '# x');
+    await fse.ensureDir(path.join(target, 'assets'));
+    await fse.outputFile(path.join(target, 'scripts', 'run.sh'), 'echo hi');
+
+    await pruneEmptyDirs(target);
+
+    expect(await fse.pathExists(path.join(target, 'SKILL.md'))).toBe(true);
+    expect(await fse.pathExists(path.join(target, 'scripts', 'run.sh'))).toBe(true);
+    expect(await fse.pathExists(path.join(target, 'assets'))).toBe(false);
+  });
+
+  it('does nothing for a missing path or a file', async () => {
+    const file = path.join(tmpDir, 'teamai.yaml');
+    await fse.outputFile(file, 'team: x');
+
+    await pruneEmptyDirs(path.join(tmpDir, 'nope'));
+    await pruneEmptyDirs(file);
+
+    expect(await fse.pathExists(file)).toBe(true);
   });
 });

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -797,6 +797,20 @@ describe('scanTeamRepoNamespaces', () => {
     expect(namespaces).toEqual([]);
   });
 
+  it('ignores a leftover directory that holds no skills', async () => {
+    // A skill whose source has empty subdirectories (e.g. an unused assets/)
+    // leaves those untracked, empty shells behind in the team repo working tree
+    // once git switches back to the default branch — git tracks files, not
+    // directories. The shell has no SKILL.md, so it used to be reported as a
+    // namespace and the next push nested every new skill inside it.
+    const repoPath = path.join(tmpDir, 'repo');
+    await fse.ensureDir(path.join(repoPath, 'skills', 'channel-bill-push-test', 'assets'));
+    await fse.ensureDir(path.join(repoPath, 'skills', 'channel-bill-push-test', 'references'));
+
+    const namespaces = await scanTeamRepoNamespaces(repoPath);
+    expect(namespaces).toEqual([]);
+  });
+
   it('detects multiple namespaces', async () => {
     const repoPath = path.join(tmpDir, 'repo');
     await fse.ensureDir(path.join(repoPath, 'skills', 'tencent', 'tgit'));

--- a/src/push.ts
+++ b/src/push.ts
@@ -23,7 +23,7 @@ import { acquireLock, releaseLock } from './update.js';
 import { assertSafePath, assertSafeResourceName, defaultAllowedRoots } from './utils/path-safety.js';
 import { loadRolesManifest, resolveRoleResourceNamespaces } from './roles.js';
 import { askQuestion, askSelection } from './utils/prompt.js';
-import { pathExists, readFileSafe, writeFile } from './utils/fs.js';
+import { pathExists, pruneEmptyDirs, readFileSafe, writeFile } from './utils/fs.js';
 
 /**
  * Synthetic toolPaths key used only to make `teamai push` scan the active tree's
@@ -254,6 +254,13 @@ async function pushGroup(args: {
 
     // Switch back to the default branch so the next group starts clean
     await checkoutMaster(localConfig.repo.localPath);
+    // git tracks files, not directories: any empty subdirectory a pushed
+    // resource carried (e.g. an unused `assets/`) survives that checkout as an
+    // untracked shell. A skill-shaped shell has no SKILL.md, so the next push
+    // would read it as a namespace and nest every new skill inside it.
+    for (const rel of pushedFiles) {
+      await pruneEmptyDirs(path.resolve(localConfig.repo.localPath, rel));
+    }
     return true;
   } catch (e) {
     pushSpin.fail(`Push failed: ${(e as Error).message}`);

--- a/src/resources/skills.ts
+++ b/src/resources/skills.ts
@@ -129,7 +129,12 @@ function extractDescriptionFromContent(content: string, skillName: string): stri
 /**
  * Scan the team repo skills/ directory to discover namespace subdirectories.
  * A directory is a namespace if it does NOT contain SKILL.md (i.e. it contains
- * skill subdirectories rather than being a skill itself).
+ * skill subdirectories rather than being a skill itself) AND it actually holds
+ * at least one skill. The second condition matters: git tracks files, not
+ * directories, so a pushed skill whose source had an empty subdirectory (e.g.
+ * an unused `assets/`) leaves an untracked, SKILL.md-less shell behind in the
+ * working tree. Treating that shell as a namespace nested every later push
+ * inside a skill's own name.
  * Returns the list of namespace names found, or [] if layout is purely flat.
  */
 export async function scanTeamRepoNamespaces(repoPath: string): Promise<string[]> {
@@ -142,9 +147,16 @@ export async function scanTeamRepoNamespaces(repoPath: string): Promise<string[]
   for (const dir of topDirs) {
     const dirPath = path.join(teamSkillsDir, dir);
     const hasSkillMd = await pathExists(path.join(dirPath, 'SKILL.md'));
-    if (!hasSkillMd) {
-      namespaces.push(dir);
+    if (hasSkillMd) continue;
+    const subDirs = await listDirs(dirPath);
+    let holdsSkill = false;
+    for (const subDir of subDirs) {
+      if (await pathExists(path.join(dirPath, subDir, 'SKILL.md'))) {
+        holdsSkill = true;
+        break;
+      }
     }
+    if (holdsSkill) namespaces.push(dir);
   }
 
   return namespaces;

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -137,6 +137,45 @@ export async function copyDir(src: string, dest: string): Promise<void> {
 }
 
 /**
+ * Recursively delete directories under `target` that contain no files at any
+ * depth, and `target` itself when it ends up empty.
+ *
+ * Git tracks files, not directories: a copied skill whose source has an empty
+ * subdirectory (e.g. an unused `assets/`) leaves that subdirectory behind as an
+ * untracked shell when git switches back to the default branch after a push.
+ * Such a shell has no SKILL.md, which makes later scans mistake it for a skill
+ * namespace. Missing paths and files are left untouched.
+ */
+export async function pruneEmptyDirs(target: string): Promise<boolean> {
+  const expanded = expandHome(target);
+  let entries;
+  try {
+    const stat = await fse.lstat(expanded);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+    entries = await fse.readdir(expanded, { withFileTypes: true });
+  } catch {
+    return false; // missing or unreadable — nothing to prune
+  }
+
+  let empty = true;
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (!await pruneEmptyDirs(path.join(expanded, entry.name))) empty = false;
+    } else {
+      empty = false;
+    }
+  }
+
+  if (!empty) return false;
+  try {
+    await fse.rmdir(expanded);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Copy a file
  */
 export async function copyFile(src: string, dest: string): Promise<void> {


### PR DESCRIPTION
## Problem

A skill whose source contains an **empty** subdirectory (an unused `assets/`, say)
leaves that subdirectory behind in the team repo working tree after a push. Git
tracks files, not directories, so when `pushGroup` checks the default branch back
out it removes the tracked files but cannot prune a directory it never tracked.

The leftover is named after the skill and has no `SKILL.md`, so
`scanTeamRepoNamespaces()` reports it as a role namespace. With a single candidate
and no TTY, push selects it silently — and every skill in the next push lands under
`skills/<some-skill-name>/<name>/`, one level deeper again on the push after that.

Observed on a real repo: 27 skills nested under `skills/channel-bill-push-test/`,
where `channel-bill-push-test` is one of the user's own skills, not a namespace.
The corruption is silent and compounds.

## Fix

- **`src/utils/fs.ts`** — new `pruneEmptyDirs(target)`: removes directories holding
  no files at any depth. Missing paths, files and symlinks are untouched.
- **`src/push.ts`** — after `checkoutMaster()` on the success path, prune each pushed
  `relativePath`, so a push never leaves an empty-directory shell behind.
- **`src/resources/skills.ts`** — `scanTeamRepoNamespaces()` now requires a candidate
  directory to actually hold at least one skill. Defense in depth: a repo already in
  the broken state stops capturing new skills into the stray shell.

## Test Plan

All items below were actually run; output is quoted, not summarised.

**1. New unit tests, failing first**

- `src/__tests__/skills.test.ts` › `scanTeamRepoNamespaces` › *ignores a leftover
  directory that holds no skills* — failed before the fix with
  `expected [ 'channel-bill-push-test' ] to deeply equal []`.
- `src/__tests__/fs-compare.test.ts` › `pruneEmptyDirs` — 3 cases: prunes a file-less
  tree, prunes only the empty subdirs of a real skill, no-ops on a missing path or a file.

**2. Full suite**

```
$ npx vitest run
 Test Files  216 passed (216)
      Tests  2982 passed (2982)
   Duration  18.58s
```

**3. Type check**

```
$ npx tsc --noEmit
exit 0
```

**4. Build**

```
$ npm run build
ESM dist/index.js     1.54 MB
ESM ⚡️ Build success in 105ms
```

**5. Real-CLI end-to-end, provider `git`, no role configured**

Sandbox HOME, bare local remote, three skills — `channel-bill-push-test` with
**empty** `assets/` and `references/`, the other two with files in theirs — then
`teamai push --all` twice, with `state.json` cleared between runs to simulate the
unmerged-PR / next-session case.

*Before the fix*, the working tree on `main` after push #1 kept the shell:

```
skills/channel-bill-push-test
skills/channel-bill-push-test/assets
skills/channel-bill-push-test/references
```

and push #2's branch reproduced the production shape exactly:

```
skills/channel-bill-push-test/beta-skill/SKILL.md
skills/channel-bill-push-test/channel-bill-push-test/SKILL.md
skills/channel-bill-push-test/gamma-skill/SKILL.md
```

*After the fix*, push #2's branch is flat:

```
skills/beta-skill/SKILL.md
skills/beta-skill/assets/a.txt
skills/channel-bill-push-test/SKILL.md
skills/channel-bill-push-test/scripts/s.sh
skills/gamma-skill/SKILL.md
skills/gamma-skill/assets/a.txt
```

and the working tree after push #2 holds no shell:

```
skills
skills/.gitkeep
```

Note the empty `assets/` and `references/` of `channel-bill-push-test` are absent
from the branch — git could never have carried them — while the other two skills
keep theirs, because theirs contain files.

The `Failed to create PR: Invalid Git repo URL` line in that run is expected: the
generic `git` provider does not implement PR creation. Unrelated to this change.

## Notes

Docs were not touched: this fixes behaviour that no document describes, and the
user-visible contract is unchanged — pushes simply stay flat, as they were always
meant to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4cW3p176qKkNwh7zWAohv
