### PR TITLE
fix(recall): gate the CLAUDE.md recall block on enabledAgents

### DIFF
--- a/src/__tests__/recall-toggle.test.ts
+++ b/src/__tests__/recall-toggle.test.ts
@@ -23,6 +23,7 @@ vi.mock('../utils/logger.js', () => ({
 }));
 
 import { recallDisable, recallEnable } from '../recall-toggle.js';
+import { TEAMAI_RECALL_RULES_START } from '../types.js';
 import type { LocalConfig, TeamaiConfig } from '../types.js';
 
 describe('recall toggle native agent cleanup', () => {
@@ -90,5 +91,93 @@ describe('recall toggle native agent cleanup', () => {
     await recallDisable({});
 
     expect(await fse.readFile(backup, 'utf8')).toBe('user backup');
+  });
+});
+
+// `enabledAgents` (from `teamai init --agent`) is documented as gating the CLI
+// built-in skills/rules/agents and CLAUDE.md-class injects. recallEnable deploys
+// all four, but only the first three went through the whitelist — the CLAUDE.md
+// recall block was still injected into excluded tools. Same loop and guard as
+// injectRecallBlockIntoTools (src/pull.ts).
+describe('recall toggle honors the enabledAgents whitelist', () => {
+  let tmpDir: string;
+  let homeDir: string;
+  let claudeMd: string;
+  let teamConfig: TeamaiConfig;
+
+  const claudePaths = {
+    skills: '.claude/skills',
+    rules: '.claude/rules',
+    agents: '.claude/agents',
+    claudemd: '.claude/CLAUDE.md',
+  };
+
+  /** Stub autoDetectInit for a given whitelist, Claude installed either way. */
+  function stubWhitelist(enabledAgents: string[]): void {
+    const localConfig: LocalConfig = {
+      repo: {
+        localPath: path.join(tmpDir, 'team-repo'),
+        remote: 'https://example.com/test/repo.git',
+      },
+      username: 'testuser',
+      updatePolicy: 'auto',
+      additionalRoles: [],
+      scope: 'user',
+      enabledAgents,
+      recallEnabled: true,
+    };
+    mockAutoDetectInit.mockResolvedValue({ localConfig, teamConfig });
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    tmpDir = await fse.mkdtemp(path.join(os.tmpdir(), 'teamai-recall-whitelist-'));
+    homeDir = path.join(tmpDir, 'home');
+    // An already-installed Claude: the root exists, so only the whitelist can
+    // keep recall out of it.
+    await fse.ensureDir(path.join(homeDir, '.claude', 'agents'));
+    vi.stubEnv('HOME', homeDir);
+    claudeMd = path.join(homeDir, '.claude', 'CLAUDE.md');
+
+    teamConfig = {
+      team: 'test',
+      description: '',
+      repo: 'https://example.com/test/repo.git',
+      provider: 'tgit',
+      reviewers: [],
+      sharing: {
+        skills: {},
+        rules: { enforced: [] },
+        docs: { localDir: '' },
+        env: { injectShellProfile: true },
+      },
+      toolPaths: { claude: claudePaths },
+    } as unknown as TeamaiConfig;
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await fse.remove(tmpDir);
+  });
+
+  it('does not inject the recall block into a tool outside enabledAgents', async () => {
+    stubWhitelist(['codex']);
+
+    await recallEnable({});
+
+    const content = await fse.pathExists(claudeMd)
+      ? await fse.readFile(claudeMd, 'utf8')
+      : '';
+    expect(content).not.toContain(TEAMAI_RECALL_RULES_START);
+  });
+
+  it('injects the recall block for a tool inside enabledAgents', async () => {
+    // Same harness, Claude opted in — so the case above skips for the right
+    // reason rather than the fixture never injecting at all.
+    stubWhitelist(['claude']);
+
+    await recallEnable({});
+
+    expect(await fse.readFile(claudeMd, 'utf8')).toContain(TEAMAI_RECALL_RULES_START);
   });
 });

--- a/src/recall-toggle.ts
+++ b/src/recall-toggle.ts
@@ -13,6 +13,7 @@ import { RECALL_DEPENDENT_SKILLS } from './builtin-skills.js';
 import {
   resolveBaseDir,
   isRecallEnabled,
+  isAgentExcluded,
   scopedToolPaths,
   TEAMAI_RECALL_RULES_START,
   TEAMAI_RECALL_RULES_END,
@@ -104,6 +105,7 @@ async function deployRecallArtifacts(teamConfig: TeamaiConfig, localConfig: Loca
   const recallBlock = compileRecallRulesBlock();
 
   for (const [tool, toolPath] of Object.entries(scopedToolPaths(teamConfig, localConfig))) {
+    if (isAgentExcluded(localConfig, tool)) continue;
     if (!toolPath.claudemd || !toolPath.agents) continue;
     if (!await ResourceHandler.isToolInstalled(toolPath.agents, baseDir)) continue;
 


### PR DESCRIPTION
## Summary

`enabledAgents` (from `teamai init --agent`) is documented as gating the CLI built-in skills/rules/agents **and CLAUDE.md-class injects** (`docs/usage-guide.md`, "The same `enabledAgents` whitelist … also gates … CLAUDE.md-class injects"). `teamai recall enable` deploys all four, but only the first three go through the whitelist: `deployRecallArtifacts` still injected the recall block into a tool the user had excluded, as long as that tool's root directory already existed.

Add the same `isAgentExcluded` guard the sibling deploys use. The identical inject loop in `injectRecallBlockIntoTools` (`src/pull.ts`) already has it, so this brings `recall enable` in line with `pull` and `init`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing behavior to change)
- [ ] Documentation only
- [ ] Refactor / internal cleanup

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run src/__tests__/recall-toggle.test.ts` passes (4/4). Full-suite runs on this Windows dev box have pre-existing failures in suites that shell out to a corporate git host; unrelated to this change.
- [x] Added/updated tests for the change

**Red → green** (`src/__tests__/recall-toggle.test.ts`). Claude installed (`~/.claude/agents` exists), `enabledAgents: ['codex']`, then `recallEnable()`. Reverting only `src/recall-toggle.ts` on unmodified `main`:

```
× recall toggle honors the enabledAgents whitelist › does not inject the recall block into a tool outside enabledAgents
    → expected true to be false
```

The companion case (`enabledAgents: ['claude']`) asserts the block **is** injected, and passes both before and after, so the harness observes injection and the red above is a real skip failure rather than a dead fixture.

**Real CLI**, built `dist/index.js`, isolated `HOME` with Claude installed and a `teamai.yaml` that turns recall on:

| `enabledAgents` | unmodified `main` | this PR |
|---|---|---|
| `[codex]` (Claude excluded) | `~/.claude/CLAUDE.md` **created with the recall block** | not created |
| `[claude]` | recall block injected | recall block injected |

## Related Issues

Follow-up to #510 / #523. No separate issue filed; happy to open one if preferred.

## Notes for Reviewers

- Deploy side only. `removeRecallArtifacts` (the `recall disable` path) still walks every configured tool. Cleaning up an excluded tool's leftovers on disable is arguably still correct, and an unguarded removal cannot write anything, so I left that loop alone rather than fold a second behavior change into this one.
- No doc or CHANGELOG change: the behavior is already documented and the `[Unreleased]` entry for #510 already describes it; this is the code catching up to that text.
