### PR TITLE
feat(cnb): guide users to the web UI when the CLI token can't create an org or repo

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -157,6 +157,14 @@ teamai init https://cnb.cool/yourorg/yourrepo
 | 创建 PR   | `cnb pulls post-pull`                                             |
 | 用户名    | `cnb users get-user-info`（或 `CNB_USERNAME`）                    |
 
+> **组织和仓库都需在网页创建**：`cnb login` 的 OAuth 令牌不含创建组织（`group-manage:rw`）
+> 或创建仓库（`group-resource:rw`）的权限，无法通过 CLI 创建。`teamai init` 遇到以下情况会打印
+> 网页链接引导你创建后重新运行：
+> - 组织不存在 → `https://cnb.cool/new/groups`
+> - 组织存在但无权限建仓库 → `https://cnb.cool/new/repos`
+>
+> 若要让 CLI 直接创建，需改用带 `group-manage:rw` / `group-resource:rw` 权限的 access token（经 `CNB_TOKEN`）。
+
 ### 多级命名空间
 
 与 TGit 类似，CNB 支持 `org/subgroup/repo` 这种嵌套路径。

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -101,6 +101,8 @@ teamai --version
 
 Create an empty repository on GitHub, GitLab (gitlab.com or a self-hosted instance), GitCode (gitcode.com), CNB (cnb.cool), TGit, or any private/self-hosted Git service (suggested naming: `TeamAi-<team-name>`). For providers that support repository creation, you can also run `teamai init` and create a missing repo when prompted.
 
+> **CNB exception:** the `cnb login` token can create neither an organization (`group-manage:rw`) nor a repo (`group-resource:rw`), so `init` prints a web link to create them instead — `https://cnb.cool/new/groups` for a missing org, `https://cnb.cool/new/repos` for a repo — then you re-run. Use a `CNB_TOKEN` access token carrying those scopes to let the CLI create them directly.
+
 For self-hosted GitLab, configure the instance and a Personal Access Token with `api` scope first:
 
 ```bash

--- a/docs/usage-guide.zh-CN.md
+++ b/docs/usage-guide.zh-CN.md
@@ -100,6 +100,8 @@ teamai --version
 
 在 GitHub、GitLab（gitlab.com 或自建实例）、GitCode（gitcode.com）、CNB（cnb.cool）、TGit，或任意私有/自建 Git 服务上创建一个空仓库（命名建议：`TeamAi-<团队名>`）。对于支持自动建仓的 provider，也可直接执行 `teamai init`，按提示创建尚不存在的仓库。
 
+> **CNB 例外：** `cnb login` 令牌既不能建组织（`group-manage:rw`）也不能建仓库（`group-resource:rw`），`init` 会改为打印网页链接引导你创建后重新运行——组织不存在用 `https://cnb.cool/new/groups`，无权限建仓库用 `https://cnb.cool/new/repos`；如需 CLI 直接创建，请改用带这些权限的 `CNB_TOKEN` access token。
+
 使用自建 GitLab 时，先配置实例地址和具有 `api` 权限的 Personal Access Token：
 
 ```bash

--- a/src/__tests__/cnb-create.test.ts
+++ b/src/__tests__/cnb-create.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Stub the logger so importing the provider module has no side effects.
+vi.mock('../utils/logger.js', () => ({
+  log: { info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), dim: vi.fn() },
+  spinner: () => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    info: vi.fn().mockReturnThis(),
+    warn: vi.fn().mockReturnThis(),
+  }),
+}));
+
+// `cnbExec` shells out via spawnSync('cnb', ...). Mock node:child_process so we
+// can feed back canned CLI output without invoking the real binary.
+const mockSpawnSync = vi.fn();
+vi.mock('node:child_process', () => ({
+  spawnSync: (...args: unknown[]) => mockSpawnSync(...args),
+  execSync: vi.fn(),
+}));
+
+import { cnbCreateRepo, cnbOrganizationExists, CNB_HOST } from '../providers/cnb/cnb-cli.js';
+import { OrganizationNotFoundError, RepoCreatePermissionError } from '../providers/types.js';
+
+/** Shape a cnb CLI response: { stdout, stderr, status }. */
+function cnbResponse(stdout = '', status = 0, stderr = ''): void {
+  mockSpawnSync.mockReturnValue({ stdout, stderr, status });
+}
+
+describe('cnbCreateRepo', () => {
+  beforeEach(() => {
+    mockSpawnSync.mockReset();
+  });
+
+  it('calls cnb repositories create-repo with slug and name', async () => {
+    cnbResponse('{"status": 201}', 0);
+
+    await expect(cnbCreateRepo('acme', 'widget')).resolves.toBeUndefined();
+    expect(mockSpawnSync).toHaveBeenCalledTimes(1);
+    const [, args] = mockSpawnSync.mock.calls[0];
+    expect(args).toEqual(['repositories', 'create-repo', '--slug', 'acme', '--name', 'widget']);
+  });
+
+  it('throws OrganizationNotFoundError with a web create URL when the org is missing (404)', async () => {
+    // CNB CLI exits 0 even on API errors; the status is in the response body.
+    cnbResponse('status: 404\ndata:\n  errmsg: Resource not found.', 0);
+
+    await expect(cnbCreateRepo('missing-org', 'widget')).rejects.toMatchObject({
+      name: 'OrganizationNotFoundError',
+      org: 'missing-org',
+      createUrl: `https://${CNB_HOST}/new/groups`,
+    });
+  });
+
+  it('throws RepoCreatePermissionError with a web create URL on a 403 scope error', async () => {
+    cnbResponse(
+      'status: 403\ndata:\n  errmsg: Missing required scopes: group-resource:rw',
+      0,
+    );
+
+    const err = await cnbCreateRepo('acme', 'widget').catch((e) => e);
+    expect(err).toBeInstanceOf(RepoCreatePermissionError);
+    expect(err).toMatchObject({
+      repo: 'acme/widget',
+      createUrl: `https://${CNB_HOST}/new/repos`,
+    });
+  });
+
+  it('re-throws unrelated errors unchanged (not treated as a missing org)', async () => {
+    cnbResponse('unexpected', 2, 'boom');
+
+    const err = await cnbCreateRepo('acme', 'widget').catch((e) => e);
+    expect(err).not.toBeInstanceOf(OrganizationNotFoundError);
+    expect((err as Error).message).toMatch(/cnb create-repo failed/);
+  });
+});
+
+describe('cnbOrganizationExists', () => {
+  beforeEach(() => {
+    mockSpawnSync.mockReset();
+  });
+
+  it('calls cnb organizations get-group with the org path', () => {
+    cnbResponse('status: 200\nname: acme\npath: acme', 0);
+
+    expect(cnbOrganizationExists('acme')).toBe(true);
+    const [, args] = mockSpawnSync.mock.calls[0];
+    expect(args).toEqual(['organizations', 'get-group', '--group', 'acme']);
+  });
+
+  it('returns true on HTTP 200', () => {
+    cnbResponse('status: 200\nname: acme', 0);
+    expect(cnbOrganizationExists('acme')).toBe(true);
+  });
+
+  it('returns false on HTTP 404', () => {
+    cnbResponse('status: 404\ndata:\n  errmsg: Resource not found.', 0);
+    expect(cnbOrganizationExists('missing-org')).toBe(false);
+  });
+
+  it('passes a nested group path through unchanged', () => {
+    cnbResponse('status: 200\npath: acme/backend', 0);
+    expect(cnbOrganizationExists('acme/backend')).toBe(true);
+    const [, args] = mockSpawnSync.mock.calls[0];
+    expect(args).toEqual(['organizations', 'get-group', '--group', 'acme/backend']);
+  });
+
+  it('throws on an indeterminate result (e.g. 403) rather than reporting "missing"', () => {
+    cnbResponse('status: 403\ndata:\n  errmsg: forbidden', 0);
+    expect(() => cnbOrganizationExists('acme')).toThrow(/get-group failed/);
+  });
+});
+

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -59,6 +59,12 @@ const mockGfIsAuthenticated = vi.fn().mockReturnValue(true);
 const mockGfAuthWhoami = vi.fn().mockReturnValue('testuser');
 const mockEnsureGfInstalled = vi.fn();
 
+// ── CNB provider mocks ───────────────────────────────────
+const mockCnbRepoClone = vi.fn();
+const mockCnbCreateRepo = vi.fn();
+const mockCnbOrganizationExists = vi.fn();
+const mockEnsureCnbInstalled = vi.fn();
+
 // Mock the provider-level gf-cli module (init.ts now uses providers)
 vi.mock('../providers/tgit/gf-cli.js', () => {
   class RepoNotFoundError extends Error {
@@ -77,6 +83,21 @@ vi.mock('../providers/tgit/gf-cli.js', () => {
     ensureAuthenticated: vi.fn().mockReturnValue('testuser'),
     isGfInstalled: vi.fn().mockReturnValue(true),
     RepoNotFoundError,
+  };
+});
+
+vi.mock('../providers/cnb/cnb-cli.js', async (importOriginal) => {
+  const original = await importOriginal() as Record<string, unknown>;
+  return {
+    ...original,
+    cnbRepoClone: (...args: unknown[]) => mockCnbRepoClone(...args),
+    cnbCreateRepo: (...args: unknown[]) => mockCnbCreateRepo(...args),
+    cnbOrganizationExists: (...args: unknown[]) => mockCnbOrganizationExists(...args),
+    cnbOrganizationCreateUrl: () => 'https://cnb.cool/new/groups',
+    cnbIsAuthenticated: () => true,
+    cnbWhoami: () => 'testuser',
+    ensureCnbAuthenticated: () => 'testuser',
+    ensureCnbInstalled: () => mockEnsureCnbInstalled(),
   };
 });
 
@@ -192,7 +213,8 @@ vi.mock('../utils/prompt.js', () => ({
 const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
 
 import { init } from '../init.js';
-import { RepoNotFoundError } from '../providers/types.js';
+import { RepoNotFoundError, OrganizationNotFoundError, RepoCreatePermissionError } from '../providers/types.js';
+import { CnbRepoNotFoundError } from '../providers/cnb/cnb-cli.js';
 import { saveLocalConfig } from '../config.js';
 import fse from 'fs-extra';
 
@@ -381,6 +403,84 @@ describe('init', () => {
 
       expect(mockGfCreateRepo).toHaveBeenCalledWith('HyperAI', 'new-repo');
       expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('organization not found — guide to web UI (CNB)', () => {
+    /** Collect all log.info lines emitted during a run. */
+    const infoLines = async (): Promise<string[]> => {
+      const { log } = await import('../utils/logger.js');
+      return vi.mocked(log.info).mock.calls.map((c) => String(c[0]));
+    };
+
+    it('detects the missing org before prompting to create the repo, prints the URL, and never calls createRepo', async () => {
+      mockExit.mockImplementationOnce(() => {
+        throw new Error('EXIT');
+      });
+      mockCnbRepoClone.mockImplementation(() => {
+        throw new CnbRepoNotFoundError('my-org/new-repo');
+      });
+      mockCnbOrganizationExists.mockReturnValue(false); // org missing
+      pathExistsFn = () => false;
+
+      await expect(
+        init({ repo: 'https://cnb.cool/my-org/new-repo.git', scope: 'user' }),
+      ).rejects.toThrow('EXIT');
+
+      // Org checked up front; repo creation never attempted; URL surfaced.
+      expect(mockCnbOrganizationExists).toHaveBeenCalledWith('my-org');
+      expect(mockCnbCreateRepo).not.toHaveBeenCalled();
+      expect(mockExit).toHaveBeenCalledWith(1);
+      expect((await infoLines()).some((l) => l.includes('https://cnb.cool/new/groups'))).toBe(true);
+    });
+
+    it('proceeds to create the repo when the org exists', async () => {
+      let cloneCallCount = 0;
+      let cloneDone = false;
+      mockCnbRepoClone.mockImplementation(() => {
+        cloneCallCount++;
+        if (cloneCallCount === 1) {
+          throw new CnbRepoNotFoundError('my-org/new-repo');
+        }
+        cloneDone = true;
+      });
+      mockCnbOrganizationExists.mockReturnValue(true); // org exists
+      mockCnbCreateRepo.mockResolvedValue(undefined);
+      pathExistsFn = (p: string) => (p === localPath ? cloneDone : false);
+
+      // Answers: confirm repo creation (Y), skip reviewers (n), primary role (1).
+      questionAnswers = ['Y', 'n', '1'];
+
+      await init({ repo: 'https://cnb.cool/my-org/new-repo.git', scope: 'user' });
+
+      expect(mockCnbOrganizationExists).toHaveBeenCalledWith('my-org');
+      expect(mockCnbCreateRepo).toHaveBeenCalledWith('my-org', 'new-repo');
+      expect(mockExit).not.toHaveBeenCalled();
+    });
+
+    it('prints the repo create URL and exits when the org exists but the token cannot create the repo (403)', async () => {
+      mockExit.mockImplementationOnce(() => {
+        throw new Error('EXIT');
+      });
+      mockCnbRepoClone.mockImplementation(() => {
+        throw new CnbRepoNotFoundError('my-org/new-repo');
+      });
+      mockCnbOrganizationExists.mockReturnValue(true); // org exists
+      mockCnbCreateRepo.mockRejectedValue(
+        new RepoCreatePermissionError('my-org/new-repo', 'https://cnb.cool/new/repos'),
+      );
+      pathExistsFn = () => false;
+
+      // Answer: confirm repo creation (Y). No browser prompt any more.
+      questionAnswers = ['Y'];
+
+      await expect(
+        init({ repo: 'https://cnb.cool/my-org/new-repo.git', scope: 'user' }),
+      ).rejects.toThrow('EXIT');
+
+      expect(mockCnbCreateRepo).toHaveBeenCalledWith('my-org', 'new-repo');
+      expect(mockExit).toHaveBeenCalledWith(1);
+      expect((await infoLines()).some((l) => l.includes('https://cnb.cool/new/repos'))).toBe(true);
     });
   });
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -5,7 +5,7 @@ import { saveLocalConfig, loadTeamConfig, saveLocalConfigForScope, loadLocalConf
 import { reconcileTeamHooksForConfig } from './hooks.js';
 import { configureGitUser, initRepo, isGitRepo, getRemoteUrl, remotesMatch, redactGitCredentials } from './utils/git.js';
 import { pushRepoDirectly } from './utils/git.js';
-import { getProvider, detectProviderForInit, RepoNotFoundError } from './providers/index.js';
+import { getProvider, detectProviderForInit, RepoNotFoundError, OrganizationNotFoundError, RepoCreatePermissionError } from './providers/index.js';
 import { ensureDir, writeFile, pathExists, expandHome, readFileSafe, remove } from './utils/fs.js';
 import { log, spinner } from './utils/logger.js';
 import {
@@ -976,6 +976,27 @@ export async function initSelfRepo(options: GlobalOptions & {
   closePrompt();
 }
 
+/**
+ * Tell the user a resource (organization or repo) must be created on the
+ * platform's website, then let the caller exit. The CLI token often can't
+ * perform these writes (e.g. CNB needs `group-manage:rw` for orgs and
+ * `group-resource:rw` for repos, neither granted by the login flow), so we
+ * print the create page URL and stop rather than failing obscurely.
+ *
+ * @param kind  human-readable resource name, e.g. "organization" or "repo"
+ * @param name  the resource identifier being created (org path or owner/repo)
+ * @param url   the platform's web create page, or null if none is known
+ */
+function guideWebCreation(kind: string, name: string, url: string | null): void {
+  log.info(`${kind} "${name}" can't be created from the CLI (insufficient token permission).`);
+  if (url) {
+    log.info(`Create it here, then re-run this command:`);
+    log.info(`  ${url}`);
+  } else {
+    log.info(`Create the ${kind} on the platform, then re-run this command.`);
+  }
+}
+
 export async function init(options: GlobalOptions & {
   repo?: string;
   repoPositional?: string;
@@ -1174,6 +1195,29 @@ export async function init(options: GlobalOptions & {
     } catch (e) {
       if (e instanceof RepoNotFoundError) {
         cloneSpin.info(`Repo ${repoInfo.owner}/${repoInfo.repo} does not exist`);
+        // Before offering to create the repo, check the owning organization
+        // exists. Creating a repo under a missing org fails anyway, and the CLI
+        // token cannot create an org, so detect it up front and guide the user
+        // to the web UI instead of a confusing create-repo failure.
+        if (typeof provider.organizationExists === 'function') {
+          let orgMissing = false;
+          try {
+            orgMissing = !provider.organizationExists(repoInfo.owner);
+          } catch (checkErr) {
+            // Existence couldn't be determined (network/auth) — fall through to
+            // the normal create flow rather than blocking on an unknown.
+            log.debug(`Organization check failed: ${(checkErr as Error).message}`);
+          }
+          if (orgMissing) {
+            cloneSpin.info(`Organization "${repoInfo.owner}" does not exist`);
+            guideWebCreation(
+              'organization',
+              repoInfo.owner,
+              provider.getOrganizationCreateUrl?.() ?? null,
+            );
+            process.exit(1);
+          }
+        }
         const confirmed = await askConfirmation(
           `Create repo ${repoInfo.owner}/${repoInfo.repo}? [Y/n] `,
           true,
@@ -1187,6 +1231,20 @@ export async function init(options: GlobalOptions & {
           await provider.createRepo(repoInfo.owner, repoInfo.repo);
           createSpin.succeed(`Repo ${repoInfo.owner}/${repoInfo.repo} created`);
         } catch (ce) {
+          if (ce instanceof OrganizationNotFoundError) {
+            // Reached when org existence couldn't be pre-checked (provider has no
+            // check, or the check errored). Guide to the web UI and stop.
+            createSpin.fail(`Organization "${ce.org}" does not exist`);
+            guideWebCreation('organization', ce.org, ce.createUrl ?? null);
+            process.exit(1);
+          }
+          if (ce instanceof RepoCreatePermissionError) {
+            // The token cannot create the repo (e.g. CNB group-resource:rw).
+            // Guide the user to create it in the browser instead.
+            createSpin.fail(`No permission to create repo "${ce.repo}" from the CLI`);
+            guideWebCreation('repo', ce.repo, ce.createUrl ?? null);
+            process.exit(1);
+          }
           const msg = (ce as Error).message;
           if (/already been taken|already exists/i.test(msg)) {
             // Repo already exists — not fatal; fall through to retry the clone.

--- a/src/providers/cnb/cnb-cli.ts
+++ b/src/providers/cnb/cnb-cli.ts
@@ -1,6 +1,7 @@
 import { execSync, spawnSync } from 'node:child_process';
 import { log, spinner } from '../../utils/logger.js';
 import type { RepoInfo } from '../types.js';
+import { OrganizationNotFoundError, RepoCreatePermissionError } from '../types.js';
 
 /**
  * Thin wrapper around the CNB (cnb.cool) OpenAPI CLI — `@cnbcool/cnb-cli`.
@@ -242,13 +243,61 @@ export function cnbRepoClone(repo: string, localPath: string): void {
   }
 }
 
-/** Create a repo: `cnb repositories create-repo --slug <owner> --name <repo>`. */
+/** Web page for creating a CNB organization (group). */
+export function cnbOrganizationCreateUrl(): string {
+  return `https://${CNB_HOST}/new/groups`;
+}
+
+/** Web page for creating a CNB repository. */
+export function cnbRepoCreateUrl(): string {
+  return `https://${CNB_HOST}/new/repos`;
+}
+
+/**
+ * Check whether an organization/group exists: `cnb organizations get-group
+ * --group <path>`. This is a read-only lookup (`group-resource:r`) available to
+ * the ordinary login token, unlike creating an org. Returns true on HTTP 200,
+ * false on 404; throws on any other outcome so a transient/auth error is not
+ * mistaken for "missing".
+ */
+export function cnbOrganizationExists(org: string): boolean {
+  const r = cnbExec(['organizations', 'get-group', '--group', org]);
+  const out = r.stdout || r.stderr;
+  if (/(?:^|["\s])status["\s:]+\s*200\b/.test(out)) return true;
+  if (/(?:^|["\s])status["\s:]+\s*404\b/.test(out) || /not found|不存在/i.test(out)) return false;
+  throw new Error(`cnb get-group failed for "${org}": ${out || `exit ${r.status}`}`);
+}
+
+/**
+ * Create a repo: `cnb repositories create-repo --slug <owner> --name <repo>`.
+ *
+ * When the owning organization/group does not exist, the CNB API rejects the
+ * call with a 404 ("Resource not found"); we surface that as
+ * {@link OrganizationNotFoundError} so `init` can point the user at the CNB web
+ * UI to create the organization (the `cnb` CLI's OAuth token cannot create one —
+ * that needs the `group-manage:rw` scope, which the device-flow login never
+ * grants).
+ */
 export async function cnbCreateRepo(owner: string, repo: string): Promise<void> {
-  const r = cnbExec(['repositories', 'create-repo', '--slug', owner, '--name', repo]);
-  if (r.status !== 0) {
-    throw new Error(`cnb create-repo failed: ${r.stderr || r.stdout}`);
+  try {
+    const r = cnbExec(['repositories', 'create-repo', '--slug', owner, '--name', repo]);
+    if (r.status !== 0) {
+      throw new Error(`cnb create-repo failed: ${r.stderr || r.stdout}`);
+    }
+    assertCnbApiOk(r.stdout, 'create-repo');
+  } catch (e) {
+    const msg = (e as Error).message;
+    if (/HTTP 404|not found|不存在/i.test(msg)) {
+      throw new OrganizationNotFoundError(owner, cnbOrganizationCreateUrl());
+    }
+    // The login token lacks the group-resource:rw scope needed to create a repo
+    // (403). It cannot be granted via `cnb login`, so guide the user to the web
+    // UI instead of surfacing a raw scope error.
+    if (/HTTP 403|scope|permission|forbidden|权限/i.test(msg)) {
+      throw new RepoCreatePermissionError(`${owner}/${repo}`, cnbRepoCreateUrl());
+    }
+    throw e;
   }
-  assertCnbApiOk(r.stdout, 'create-repo');
 }
 
 // ─── Pull requests ───────────────────────────────────────

--- a/src/providers/cnb/index.ts
+++ b/src/providers/cnb/index.ts
@@ -8,6 +8,8 @@ import {
   ensureCnbInstalled,
   cnbRepoClone,
   cnbCreateRepo,
+  cnbOrganizationExists,
+  cnbOrganizationCreateUrl,
   cnbPullCreate,
   CnbRepoNotFoundError,
 } from './cnb-cli.js';
@@ -52,6 +54,14 @@ export class CNBProvider implements GitProvider {
 
   async createRepo(owner: string, repo: string): Promise<void> {
     await cnbCreateRepo(owner, repo);
+  }
+
+  organizationExists(org: string): boolean {
+    return cnbOrganizationExists(org);
+  }
+
+  getOrganizationCreateUrl(): string | null {
+    return cnbOrganizationCreateUrl();
   }
 
   async createPullRequest(opts: PrCreateOptions): Promise<string> {

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,5 +1,5 @@
 export type { GitProvider, RepoInfo, PrCreateOptions } from './types.js';
-export { RepoNotFoundError } from './types.js';
+export { RepoNotFoundError, OrganizationNotFoundError, RepoCreatePermissionError } from './types.js';
 export { getProvider, getProviderFromUrl, detectProvider, detectProviderForInit } from './registry.js';
 export { TGitProvider } from './tgit/index.js';
 export { GitHubProvider } from './github/index.js';

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -133,6 +133,26 @@ export interface GitProvider {
    */
   listOrgRepos?(org: string, opts?: { maxRepos?: number }): Promise<OrgRepoInfo[]>;
 
+  /**
+   * Check whether an organization / group exists on the platform.
+   *
+   * Optional: providers whose platform exposes a cheap read-only lookup (e.g.
+   * CNB's `get-group`) implement this so `init` can detect a missing org
+   * *before* prompting to create the repo, and guide the user to create the org
+   * first. Providers that omit it fall back to the create-repo error path.
+   *
+   * @param org  organization / group path (may be a nested `group/subgroup`)
+   * @returns true if it exists, false if not found
+   * @throws Error if existence cannot be determined (e.g. network/auth failure)
+   */
+  organizationExists?(org: string): boolean;
+
+  /**
+   * Web URL where a user can create an organization on this platform, or null
+   * if there is no such page. `init` prints/opens it when the org is missing.
+   */
+  getOrganizationCreateUrl?(): string | null;
+
   // ─── Utilities ────────────────────────────────────────
 
   /**
@@ -147,5 +167,42 @@ export class RepoNotFoundError extends Error {
   constructor(repo: string) {
     super(`Repo "${repo}" not found.`);
     this.name = 'RepoNotFoundError';
+  }
+}
+
+/**
+ * Error indicating an organization / group was not found on the remote
+ * platform. Thrown by `createRepo` when the target namespace does not exist.
+ *
+ * `createUrl`, when set, is the platform's web page for creating an
+ * organization. `init` prints it so the user can create the org in the browser
+ * — CNB's CLI token cannot create organizations itself (that needs the
+ * `group-manage:rw` scope, which the device-flow login does not grant).
+ */
+export class OrganizationNotFoundError extends Error {
+  readonly org: string;
+  readonly createUrl?: string;
+  constructor(org: string, createUrl?: string) {
+    super(`Organization "${org}" not found.`);
+    this.name = 'OrganizationNotFoundError';
+    this.org = org;
+    this.createUrl = createUrl;
+  }
+}
+
+/**
+ * Error indicating the authenticated token lacks permission to create a repo
+ * (e.g. CNB requires the `group-resource:rw` scope for org repos, which the
+ * device-flow login does not grant). `createUrl`, when set, is the platform's
+ * web page for creating the repo so `init` can guide the user to the browser.
+ */
+export class RepoCreatePermissionError extends Error {
+  readonly repo: string;
+  readonly createUrl?: string;
+  constructor(repo: string, createUrl?: string) {
+    super(`No permission to create repo "${repo}".`);
+    this.name = 'RepoCreatePermissionError';
+    this.repo = repo;
+    this.createUrl = createUrl;
   }
 }


### PR DESCRIPTION
## Problem

On CNB (cnb.cool), `teamai init` failed with an unhelpful raw error when a repo couldn't be created:

- Missing organization → `cnb create-repo failed (HTTP 404): Resource not found.`
- Org exists but no permission → `cnb create-repo failed (HTTP 403): Missing required scopes: group-resource:rw`

Neither told the user what to do next. The root cause: the `cnb login` OAuth device-flow token carries **neither** `group-manage:rw` (create org) **nor** `group-resource:rw` (create repo) — these writes simply cannot be done from the CLI token, only from the web UI (or a scoped `CNB_TOKEN` access token).

## Change

`teamai init` now detects these cases and guides the user to the web UI instead of surfacing a raw scope error:

- **Detect a missing org up front** via `cnb organizations get-group` (a read-only `group-resource:r` scope the login token *does* have), before prompting to create the repo — so the flow no longer asks "Create repo? [Y/n]" only to fail afterwards.
- Surface `OrganizationNotFoundError` / `RepoCreatePermissionError` from the CNB provider, each carrying the platform's web create URL.
- `init` prints the create page and exits:
  - Missing org → `https://cnb.cool/new/groups`
  - Repo permission denied → `https://cnb.cool/new/repos`

New optional `GitProvider` hooks (`organizationExists?`, `getOrganizationCreateUrl?`), implemented for CNB only. Other providers are unaffected.

## Files

- `src/providers/types.ts` — `OrganizationNotFoundError` (+ `createUrl`), `RepoCreatePermissionError`; optional interface methods
- `src/providers/cnb/cnb-cli.ts` — `cnbOrganizationExists`, create-URL helpers, 404/403 detection in `cnbCreateRepo`
- `src/providers/cnb/index.ts`, `src/providers/index.ts` — wire-up & exports
- `src/init.ts` — up-front org check + `guideWebCreation` helper
- Tests: `src/__tests__/cnb-create.test.ts` (new), `src/__tests__/init.test.ts`
- Docs: `docs/providers.md`, `docs/usage-guide.md`, `docs/usage-guide.zh-CN.md`

## Test Plan

- [x] `npx tsc --noEmit` — no errors in changed files
- [x] `npx vitest run` — **3052 passed** (222 files)
- [x] `npm run build` — success
- [x] Real CLI e2e against cnb.cool with a `cnb login` token:
  - Missing org → prints `Organization "..." does not exist` + `https://cnb.cool/new/groups`, exits
  - Existing org (`test1122444`), repo create 403 → prints `No permission to create repo ...` + `https://cnb.cool/new/repos`, exits


## Related

Related to #517 — that RFC's onboarding prompts list CNB (cnb.cool) as a platform and tell non-Git users to "create the repo when `init` prompts". This PR makes that CNB path give a clear, actionable message (web create link) when the login token can't create the org/repo, instead of a raw scope error. (Reference only — does not close the RFC.)
